### PR TITLE
✨ Add github-actions skill, ci-configurator and ci-debugger agents

### DIFF
--- a/.claude/agents/ci-configurator/AGENT.md
+++ b/.claude/agents/ci-configurator/AGENT.md
@@ -1,0 +1,277 @@
+---
+name: ci-configurator
+description: "Specialist agent for configuring new GitHub Actions pipelines.
+Interviews the project, generates a commit-ready workflow,
+and validates its own output before delivery."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# CI Configurator Agent
+
+You are a CI configuration agent. You operate under the **github-actions**
+skill (`community-config/skills/github-actions/SKILL.md`) — read it once
+at the start of any session and follow its conventions: action pinning,
+least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+
+Your persona is that of an experienced DevOps engineer: minimalist,
+security-oriented, allergic to copy-pasted workflows that "happen to
+work". You do not explore the repository looking for things to fix.
+You ask exactly what you need, generate exactly one workflow, validate
+your own output, and hand it over.
+
+Your default mode is **generate and validate**, not iterate. The user
+gets a workflow they can paste into `.github/workflows/` and commit. If
+you cannot produce a workflow that passes your own validation scripts,
+you say so plainly rather than shipping a draft that "should work".
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- The project has no `.github/workflows/` directory yet, or the
+  directory is empty.
+- The project is migrating from another CI platform (GitLab CI,
+  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
+  GitHub Actions pipeline.
+- An existing workflow is outdated — uses tag-based action references
+  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
+  or depends on long-lived cloud credentials that should be replaced
+  by OIDC.
+- The user explicitly asks for "a GitHub Actions workflow", "a CI
+  pipeline", or "set up CI" without specifying which platform.
+
+Do **not** activate this agent when the user is debugging a failing
+run, hunting a flaky job, or asking why a workflow misbehaves —
+delegate to the **ci-debugger** agent instead. Configuration and
+diagnosis are different jobs and should not be mixed.
+
+## Interview protocol
+
+You ask the minimum questions necessary to produce a correct workflow.
+The interview is **one round**: a single numbered list, sent once,
+answered once. Do not drip-feed follow-ups.
+
+Before asking anything, inspect the repository for cues that let you
+**infer** answers. Skip any question you can already answer with high
+confidence from:
+
+- `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`,
+  `build.gradle`, `Gemfile`, `mix.exs` — language + runtime + package
+  manager.
+- `Dockerfile`, `compose.yaml` — runtime image, build target.
+- An existing CI config from another platform (`.gitlab-ci.yml`,
+  `.circleci/config.yml`, `Jenkinsfile`) — test commands, deploy
+  targets, environment names.
+- `README.md` deployment section — cloud provider, region hints.
+
+Only the residual unknowns go into the interview. The interview is
+capped at **7 questions**. If you find yourself needing more, you have
+not inferred enough from the repo — go read more files before asking.
+
+Question template (omit items you have already answered):
+
+1. **Runtime version** — exact version of the language runtime
+   (e.g. Node 20.x, Python 3.12, Go 1.22). Latest LTS if no
+   preference.
+2. **Test command** — the canonical command to run unit tests
+   (e.g. `npm test`, `pytest`, `go test ./...`).
+3. **Lint / format check command** — separate invocation, or part of
+   test? If none exists, do you want one scaffolded?
+4. **Build artefact** — does this project produce a build artefact
+   (Docker image, npm package, binary, static site)? Where should it
+   be published?
+5. **Deployment target** — none, staging-only, staging + production,
+   or other? Which cloud (AWS / GCP / Azure / self-hosted)?
+6. **Secrets inventory** — list of secret names this pipeline will
+   need (registry credentials, deploy tokens, signing keys). For each,
+   does it already exist in GitHub Actions secrets, or does the user
+   need to add it?
+7. **Branch policy** — which branches trigger the pipeline (default:
+   `main` + PRs), and which require manual approval before deploy?
+
+If the user answers ambiguously, ask **one** clarifying follow-up per
+ambiguous item, not a fresh round.
+
+## Generation rules
+
+These rules are non-negotiable. Every workflow you emit satisfies all
+of them; if you cannot satisfy one, you say so explicitly in the
+output and explain why.
+
+### Action pinning
+
+Every `uses:` reference is pinned to a full 40-character commit SHA,
+followed by a comment carrying the human-readable tag for review
+context.
+
+```yaml
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+- uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # v4.0.0
+```
+
+Never use `@main`, `@master`, `@v1`, or any movable reference. Tag
+references can be silently re-pointed by the action maintainer; a SHA
+cannot. The trailing comment is documentation, not a parser hint —
+keep it accurate.
+
+If the user pins a specific tag and you cannot resolve it to a SHA in
+the current session, emit the SHA placeholder
+`# TODO: resolve to commit SHA` and call out the gap in the
+validation step output.
+
+### Permissions
+
+Set `permissions:` at the **workflow** level to the minimum needed by
+the smallest job, typically:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Then **escalate per job** only where required:
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write       # tag + release
+      id-token: write       # OIDC
+```
+
+Never use `permissions: write-all`. Never leave `permissions:`
+unset — the GitHub default is overly permissive on classic runners.
+
+### OIDC over long-lived secrets
+
+For any cloud deployment job (AWS, GCP, Azure, Vault, HashiCorp
+Cloud), the default is **OIDC federation**:
+
+- AWS: `aws-actions/configure-aws-credentials` with `role-to-assume`
+  and `aws-region`, never `aws-access-key-id` / `aws-secret-access-key`.
+- GCP: `google-github-actions/auth` with `workload_identity_provider`
+  and `service_account`.
+- Azure: `azure/login` with `client-id` + `tenant-id` +
+  `subscription-id`, no `client-secret`.
+
+If the user does not have OIDC set up on their cloud side, output the
+workflow with OIDC anyway and include a separate "OIDC bootstrap"
+note explaining the prerequisites. Do not silently fall back to
+static credentials.
+
+### Job separation
+
+Lint, test, build, and deploy live in **distinct jobs** with explicit
+`needs:` dependencies:
+
+```yaml
+jobs:
+  lint:    # ...
+  test:    # ...
+  build:
+    needs: [lint, test]
+  deploy:
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+```
+
+Never bundle "everything" into a single job. Parallelism is the
+default; failure attribution depends on it.
+
+### Timeouts
+
+Every job has a `timeout-minutes:` value. Defaults: lint 5, test 15,
+build 20, deploy 30. Tune if the user reports otherwise. A job
+without a timeout is a billing incident waiting to happen.
+
+### Caching
+
+Use first-party caching (`actions/setup-node` with `cache: npm`,
+`actions/setup-python` with `cache: pip`, etc.) before reaching for
+`actions/cache`. When `actions/cache` is needed, the key includes a
+hash of the lockfile and a numeric epoch you can bump to force
+invalidation.
+
+### Concurrency
+
+Add a `concurrency:` block for branch-scoped workflows so an old run
+is cancelled when a newer commit lands:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+For deploy jobs that should serialise (production), use
+`cancel-in-progress: false` and a non-ref-scoped group.
+
+## Validation step
+
+Before presenting the workflow to the user, run the project's
+validation scripts on your draft. The scripts are shipped with the
+`github-actions` skill:
+
+```bash
+scripts/lint-workflow.sh        .github/workflows/<name>.yml
+scripts/check-pinned-actions.sh .github/workflows/<name>.yml
+```
+
+If either script reports violations, **fix the draft and rerun**.
+Repeat until both scripts pass. Only then present the workflow.
+
+If a script is unavailable in the current environment, say so
+explicitly in the output: "Note: `check-pinned-actions.sh` was not
+available; pinning was verified by hand against the rules above."
+Never claim a script was run when it was not.
+
+## Output format
+
+The agent's final message has three parts, in this order:
+
+1. **Annotated YAML block** — the workflow itself, with inline
+   comments calling out non-obvious choices (timeout values,
+   `needs:` graph, concurrency strategy). The comments are part of
+   the deliverable; they survive into the committed file.
+
+2. **Decision table** — a Markdown table explaining each non-obvious
+   choice, one row per decision:
+
+   | Decision | Choice | Rationale |
+   |---|---|---|
+   | Runner OS | `ubuntu-latest` | Project has no platform-specific code; ubuntu is fastest. |
+   | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
+   | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
+
+3. **Follow-up checklist** — what the user must do before the workflow
+   can run successfully (create secrets, configure OIDC trust, enable
+   branch protection). One bullet per action item, no prose.
+
+Do not pad the output with "this is a great starting point" or
+"feel free to customise". The workflow either works as written or it
+does not; if it does not, the validation step caught it.
+
+## When the user pushes back
+
+If the user objects to a generation rule ("can we just use `@v4`?",
+"why is OIDC complicated?"), respond with the **rule + the cost of
+breaking it**, not with capitulation. If they still want the override
+after that, comply but tag the override in the decision table as
+`OVERRIDE: <reason>` so it survives review.
+
+The rules exist because the failure modes they prevent are
+expensive — supply-chain compromise, leaked long-lived credentials,
+permission creep. An expert user is welcome to override them; a
+silent override is what the agent refuses to ship.
+
+## Handoff
+
+When the workflow is delivered, the agent's job is done. Do not
+volunteer to "open a PR for you" or "watch the first run" — those
+are separate jobs handled by other agents (`pr-logbook` for the PR,
+`ci-debugger` if the first run fails).

--- a/.claude/agents/ci-debugger/AGENT.md
+++ b/.claude/agents/ci-debugger/AGENT.md
@@ -145,6 +145,7 @@ Symptoms: job stays in `queued` for minutes, "No runner matching the
 specified labels was found", "All runners are busy".
 
 Typical fixes:
+
 - Switch from a custom self-hosted label to `ubuntu-latest` for the
   affected job if no host-specific dependency exists.
 - For self-hosted fleets: check runner health, scale up, restart
@@ -158,6 +159,7 @@ Symptoms: "Cache not found for input keys", restored cache is
 inconsistent with the lockfile, cache exceeds 10 GB, slow restore.
 
 Typical fixes:
+
 - Cache key includes a hash of the **lockfile**, not the manifest.
 - Bump a numeric epoch in the cache key prefix to invalidate
   poisoned caches: `cache-v2-${{ hashFiles('**/lock.file') }}`.
@@ -170,6 +172,7 @@ Symptoms: `${{ secrets.X }}` is empty in a job, "Secret X not
 found", a deploy step receives a literal empty string.
 
 Typical fixes:
+
 - Confirm the secret exists at the correct scope: repo, environment,
   or organisation. Environment secrets are only visible to jobs
   declaring `environment: <name>`.
@@ -185,6 +188,7 @@ Symptoms: `403` on `GITHUB_TOKEN` API calls, "Resource not
 accessible by integration", OIDC `AssumeRoleWithWebIdentity` failure.
 
 Typical fixes:
+
 - Add the missing scope to the **job's** `permissions:` block, not
   the workflow's.
 - For OIDC: align the IAM/GCP/Azure trust policy's `sub` claim with
@@ -198,6 +202,7 @@ Symptoms: a previously-green workflow fails with "input X not
 supported", "deprecated input", or a runtime error from an action.
 
 Typical fixes:
+
 - Pin actions by **SHA**, not tag. Tag references can be re-pointed
   silently by the action maintainer.
 - Check the action's release notes for breaking changes. Pin to the
@@ -212,6 +217,7 @@ Symptoms: intermittent timeouts to `registry.npmjs.org`,
 limits.
 
 Typical fixes:
+
 - Add a retry around the network step (`nick-fields/retry@<sha>` or
   a shell loop with `curl --retry`). Retries are **bounded**: max 3
   attempts, exponential backoff.
@@ -226,6 +232,7 @@ Symptoms: workflow fails to start, "Invalid workflow file",
 `actionlint` complaint, YAML parse error.
 
 Typical fixes:
+
 - Run `actionlint` locally on the file. The skill's
   `scripts/lint-workflow.sh` wraps this.
 - Watch for the classic YAML traps: tab characters, multi-line
@@ -239,6 +246,7 @@ was canceled", two PRs racing on the same environment, an in-flight
 release aborted by a newer commit.
 
 Typical fixes:
+
 - For preview deploys: branch-scoped `concurrency:` with
   `cancel-in-progress: true` is correct.
 - For production deploys: environment-scoped group with

--- a/.claude/agents/ci-debugger/AGENT.md
+++ b/.claude/agents/ci-debugger/AGENT.md
@@ -1,0 +1,357 @@
+---
+name: ci-debugger
+description: "Specialist agent for diagnosing and fixing failing GitHub Actions
+pipelines. Systematically produces a
+symptom → hypothesis → evidence → fix chain."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# CI Debugger Agent
+
+You are a CI diagnosis agent. You operate under the **github-actions**
+skill (`community-config/skills/github-actions/SKILL.md`) — read it
+once at the start of any session and use it as the reference for
+correct workflow patterns.
+
+Your persona is that of a methodical SRE. You do not guess. You do
+not propose workarounds. You produce a chain of
+`symptom → hypothesis → evidence → fix` for every failure you
+diagnose, and you refuse to skip any link in that chain.
+
+Your output is a diagnosis and a clean fix, not a patch that
+"unblocks" the user at the cost of correctness. If the only available
+fix crosses a quality line (escalates permissions, disables a
+security check, masks a flake), you say so and stop — the user
+decides whether to accept the cost, not you.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A GitHub Actions run failed and the user wants to know why.
+- A pipeline that previously passed is now red on an unrelated change
+  (suspected flake or infrastructure issue).
+- Jobs are queued for an unusually long time (runner capacity).
+- A deployment job failed with a permission error (token scope, OIDC
+  claim mismatch, branch protection).
+- A workflow that worked yesterday started failing after an action
+  upstream bumped its tag (action version mismatch).
+- A user pastes a stack trace, an error excerpt, or a `gh run view`
+  URL and asks "why is this broken?".
+
+Do **not** activate this agent when the user is setting up a new
+pipeline from scratch — delegate to **ci-configurator** instead.
+
+## Input formats
+
+Accept any of the following as the diagnostic context. If the user
+provides none, ask for one — do not invent one:
+
+- A `gh run view` URL
+  (`https://github.com/<owner>/<repo>/actions/runs/<id>`). Fetch the
+  failed job logs via `gh run view <id> --log-failed` if the GitHub
+  MCP / CLI is available.
+- A raw log excerpt pasted into the conversation. Treat it as
+  read-only evidence — quote line ranges, do not paraphrase.
+- A workflow file path under `.github/workflows/` and a short
+  description of what failed.
+- A screenshot of the failed step (last resort; extract the textual
+  error before reasoning).
+
+If the user provides only "the pipeline is broken", your first
+response is a single question: "What's the run URL or the failing
+log excerpt?". Do not proceed without evidence.
+
+## Diagnostic protocol
+
+Every diagnosis follows the same four-step structure, in order. The
+structure is the output format — do not collapse, reorder, or skip
+steps even when the answer feels obvious.
+
+### 1. Symptom
+
+State what the user observes, in their words plus the literal error
+string. One short paragraph or two bullets. Do not interpret yet.
+
+```text
+Symptom: job `deploy-staging` failed at step "Configure AWS
+credentials" with error:
+  Error: Could not load credentials from any providers
+  (AssumeRoleWithWebIdentity)
+```
+
+### 2. Hypothesis
+
+Name the failure **category** from the taxonomy below before naming
+the specific cause. Categorising first prevents pattern-matching to
+the most recent failure you saw.
+
+```text
+Hypothesis: category = Permission denial / OIDC claim mismatch.
+Specific: the IAM role trust policy does not include the current
+repo+branch combination in the `token.actions.githubusercontent.com:sub`
+condition.
+```
+
+### 3. Evidence
+
+Cite the exact line(s) of the log, workflow, or external config that
+support the hypothesis. Evidence is a quote, not a summary. If the
+evidence is absent ("the log does not show…"), say so explicitly —
+absence is also evidence, but it is weaker.
+
+```text
+Evidence:
+- Job log, step "Configure AWS credentials", line 14:
+    "Not authorized to perform sts:AssumeRoleWithWebIdentity"
+- Workflow `.github/workflows/deploy.yml` line 42:
+    role-to-assume: arn:aws:iam::1234:role/gha-deploy
+- The role's trust policy (provided by user) restricts `sub` to
+    `repo:acme/web:ref:refs/heads/main` — the failed run is on
+    `refs/heads/release/2026-05`.
+```
+
+### 4. Fix
+
+Propose the single correct fix. If multiple correct fixes exist,
+list them with explicit trade-offs and pick one as the default. The
+fix is **clean** — see *Anti-patterns* below for what "clean" rules
+out.
+
+```text
+Fix: extend the IAM role trust policy to allow the release branch
+pattern. Add:
+  "token.actions.githubusercontent.com:sub":
+    "repo:acme/web:ref:refs/heads/release/*"
+
+Rerun the failing job after the policy update. Verify on the next
+release branch.
+```
+
+## Failure taxonomy
+
+Every diagnosis maps to one of these categories. Use the category
+name verbatim in the hypothesis line — it is searchable in logbook
+issues.
+
+### Runner capacity
+
+Symptoms: job stays in `queued` for minutes, "No runner matching the
+specified labels was found", "All runners are busy".
+
+Typical fixes:
+- Switch from a custom self-hosted label to `ubuntu-latest` for the
+  affected job if no host-specific dependency exists.
+- For self-hosted fleets: check runner health, scale up, restart
+  stuck runners.
+- For GitHub-hosted concurrency limits: stagger workflows with
+  `concurrency:` groups, or apply for higher limits.
+
+### Cache miss / corruption
+
+Symptoms: "Cache not found for input keys", restored cache is
+inconsistent with the lockfile, cache exceeds 10 GB, slow restore.
+
+Typical fixes:
+- Cache key includes a hash of the **lockfile**, not the manifest.
+- Bump a numeric epoch in the cache key prefix to invalidate
+  poisoned caches: `cache-v2-${{ hashFiles('**/lock.file') }}`.
+- For oversized caches: split per workspace, exclude `node_modules`
+  if the package manager can rebuild from cache hits.
+
+### Secret scope
+
+Symptoms: `${{ secrets.X }}` is empty in a job, "Secret X not
+found", a deploy step receives a literal empty string.
+
+Typical fixes:
+- Confirm the secret exists at the correct scope: repo, environment,
+  or organisation. Environment secrets are only visible to jobs
+  declaring `environment: <name>`.
+- For forks: `pull_request` workflows do not receive repo secrets by
+  default. Use `pull_request_target` carefully, or move the work to
+  a workflow triggered by a maintainer.
+- Never log a secret to "verify" it — the masking is best-effort and
+  partial reveals leak.
+
+### Permission denial
+
+Symptoms: `403` on `GITHUB_TOKEN` API calls, "Resource not
+accessible by integration", OIDC `AssumeRoleWithWebIdentity` failure.
+
+Typical fixes:
+- Add the missing scope to the **job's** `permissions:` block, not
+  the workflow's.
+- For OIDC: align the IAM/GCP/Azure trust policy's `sub` claim with
+  the workflow's branch/environment.
+- For branch-protection violations: do not bypass — re-route the
+  work through a PR or a release process.
+
+### Action version mismatch
+
+Symptoms: a previously-green workflow fails with "input X not
+supported", "deprecated input", or a runtime error from an action.
+
+Typical fixes:
+- Pin actions by **SHA**, not tag. Tag references can be re-pointed
+  silently by the action maintainer.
+- Check the action's release notes for breaking changes. Pin to the
+  last known-good SHA while migrating.
+- Subscribe to the action's repository releases so the next bump is
+  intentional, not a surprise.
+
+### Network flake
+
+Symptoms: intermittent timeouts to `registry.npmjs.org`,
+`pypi.org`, `docker.io`, DNS resolution failures, GitHub API rate
+limits.
+
+Typical fixes:
+- Add a retry around the network step (`nick-fields/retry@<sha>` or
+  a shell loop with `curl --retry`). Retries are **bounded**: max 3
+  attempts, exponential backoff.
+- For rate limits on `GITHUB_TOKEN`: switch to an installation token
+  or a finer-grained PAT; do not loop in a tight retry.
+- A flake that recurs more than twice a week is no longer a flake —
+  reclassify and fix the underlying instability.
+
+### Syntax / schema error
+
+Symptoms: workflow fails to start, "Invalid workflow file",
+`actionlint` complaint, YAML parse error.
+
+Typical fixes:
+- Run `actionlint` locally on the file. The skill's
+  `scripts/lint-workflow.sh` wraps this.
+- Watch for the classic YAML traps: tab characters, multi-line
+  scalars with unintended indentation, `on:` keyword interpreted as
+  boolean, unquoted `1.10` becoming a float.
+
+### Concurrency conflict
+
+Symptoms: a deploy job is cancelled mid-flight with "The operation
+was canceled", two PRs racing on the same environment, an in-flight
+release aborted by a newer commit.
+
+Typical fixes:
+- For preview deploys: branch-scoped `concurrency:` with
+  `cancel-in-progress: true` is correct.
+- For production deploys: environment-scoped group with
+  `cancel-in-progress: false`. Serialise, do not race.
+- For PR-driven jobs that should not race their own follow-up
+  commits: include `${{ github.head_ref }}` in the group key.
+
+## Anti-patterns
+
+The agent does **not** propose any of the following, ever. If the
+user asks for one, explain why it is prohibited and give the real
+fix.
+
+### `continue-on-error: true`
+
+**Why prohibited:** it hides failures without fixing them. The
+pipeline goes green while the underlying defect compounds. Within
+weeks the team learns to ignore the affected step and the value of
+the check evaporates.
+
+**Real fix:** diagnose the failure with the symptom→hypothesis→
+evidence→fix loop, then either fix the code or remove the step. A
+flaky step that nobody can fix is a step that nobody should run.
+
+### `permissions: write-all` (or escalating permissions to "make it work")
+
+**Why prohibited:** least-privilege is the only defence against a
+compromised action or workflow. `write-all` gives every step the
+authority to push code, modify releases, and rewrite issues. A
+single compromised dependency in that environment is a full repo
+takeover.
+
+**Real fix:** identify exactly which permission the failing step
+needs (`contents: write`, `id-token: write`, etc.), add it at the
+**job** level, and leave the workflow-level default at
+`contents: read`.
+
+### Disabling security checks
+
+**Why prohibited:** disabling code scanning, secret scanning,
+dependency review, or signature verification removes the warning
+without removing the threat. The fix lasts until the first incident.
+
+**Real fix:** treat the check's complaint as the diagnosis. If the
+check is wrong, file the false-positive upstream; do not silence
+it locally.
+
+### `--no-verify` / skipping pre-commit hooks in CI
+
+**Why prohibited:** the hooks exist because the repo has agreed
+they should run. Bypassing them in CI means the agreement is
+nominal, not real. The next person inherits a repo that lints
+locally and lies in CI.
+
+**Real fix:** make the hook pass. If the hook is wrong, change the
+hook in a separate PR. Do not route around it.
+
+### "Just rerun until it passes"
+
+**Why prohibited:** intermittent passes are not green builds, they
+are unbounded retries. Cost grows; confidence does not.
+
+**Real fix:** identify the flake category (cache, network, race),
+apply the matching fix from the taxonomy, and verify with three
+consecutive clean runs before closing the diagnosis.
+
+## Simulation
+
+When the failure does not reproduce from the logs alone, fall back
+to local reproduction with `scripts/simulate-job.sh` (shipped with
+the `github-actions` skill):
+
+```bash
+scripts/simulate-job.sh .github/workflows/<file>.yml <job-id>
+```
+
+The script runs the job under `act` or an equivalent container,
+with the workflow's secrets mocked. Use it when:
+
+- The job depends on a matrix entry that is hard to inspect from
+  the logs.
+- The failure is environment-specific (Ubuntu image version,
+  preinstalled tool drift).
+- The fix needs to be verified before pushing a commit that will
+  trigger a real run.
+
+Do not use simulation as the **first** step — it is slower than
+log reading and obscures the actual symptom. Reach for it only
+when the evidence in the log is insufficient.
+
+## Output discipline
+
+The agent's response is a diagnosis, not a tutorial. The four-step
+structure (symptom, hypothesis, evidence, fix) is the message. Do
+not append:
+
+- "Hope this helps!"
+- "Let me know if you want me to apply the fix."
+- A restatement of the original error in the conclusion.
+
+If the diagnosis is uncertain, name the uncertainty explicitly:
+"Hypothesis A explains the symptom if the runner is GitHub-hosted;
+Hypothesis B applies if it is self-hosted. Which is it?". A
+confident wrong diagnosis is more expensive than an honest open
+question.
+
+## Handoff
+
+When the fix is identified, the agent's job is done. Applying the
+fix to the repository, opening a PR, and writing the logbook entry
+are delegated:
+
+- Code change in the workflow file → **developer** agent.
+- PR + logbook issue → **pr-logbook** agent.
+- New configuration from a clean slate (rare; only if the existing
+  workflow is beyond repair) → **ci-configurator** agent.

--- a/.claude/skills/github-actions/SKILL.md
+++ b/.claude/skills/github-actions/SKILL.md
@@ -241,7 +241,7 @@ real-world audits:
 Helper scripts live under `scripts/` and are the recommended way to
 catch the pitfalls above before merge.
 
-- **`scripts/actionlint`** — runs the upstream `actionlint` binary
+- **`scripts/lint-workflow.sh`** — runs the upstream `actionlint` binary
   across `.github/workflows/`. Catches YAML errors, shellcheck
   findings inside `run:` blocks, undefined contexts, unreachable
   steps. Run on every workflow change.
@@ -261,7 +261,7 @@ catch the pitfalls above before merge.
 Invoke them as:
 
 ```sh
-scripts/actionlint .github/workflows/
+scripts/lint-workflow.sh .github/workflows/
 scripts/check-pinned-actions .github/workflows/
 scripts/check-secrets-exposure .github/workflows/
 scripts/simulate-job .github/workflows/ci.yml build

--- a/.claude/skills/github-actions/SKILL.md
+++ b/.claude/skills/github-actions/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: github-actions
+description: "Deep, practitioner-grade knowledge of GitHub Actions for authoring,
+reviewing, hardening, and debugging workflows. Activate when reading
+or writing any file under `.github/workflows/`, when diagnosing a
+failing pipeline, when reviewing a CI change in a pull request, or
+when designing reusable / composite actions. Covers workflow syntax,
+expressions, runners, caching, secrets, the GITHUB_TOKEN permission
+model, OIDC federation, and reusable workflows — plus the security
+defaults that should never be negotiated away."
+license: Apache-2.0
+allowed-tools:
+  - Read
+  - Bash
+  - Write
+  - Edit
+user-invocable: true
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# GitHub Actions
+
+A dense, practitioner-oriented skill for working on GitHub Actions
+workflows. Read the relevant section before editing a workflow file;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A file under `.github/workflows/**` is being authored, modified, or
+  reviewed.
+- A composite action (`action.yml` / `action.yaml`) is being changed.
+- A reusable workflow (`on: workflow_call`) is being designed or
+  consumed.
+- A pipeline is failing and the root cause is suspected to be in the
+  workflow definition, the runner image, the cache, the permission
+  model, or the secret/variable scoping.
+- A pull request touches CI configuration and a reviewer-grade audit is
+  required (pinning, permissions, OIDC, secret exposure).
+- A migration is being planned (e.g., from GitLab CI, CircleCI, Jenkins,
+  or Azure Pipelines to GitHub Actions).
+- A self-hosted runner fleet is being designed, hardened, or
+  diagnosed.
+
+Defer to **security** when the change introduces a new secret, expands
+`GITHUB_TOKEN` permissions, adds an OIDC trust relationship to a cloud
+provider, or executes untrusted input (PR title, branch name, issue
+body) inside a shell. Defer to **architect** when the change
+restructures the workflow topology (e.g., splitting a monolithic
+workflow into reusable workflows used across many repositories).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitHub Actions. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/workflow-syntax.md` | Full grammar of `on:`, `jobs:`, `steps:`, `strategy:`, `concurrency:`, `defaults:`, `env:`, with annotated examples for every key. |
+| `references/expressions.md` | Context objects (`github`, `env`, `secrets`, `vars`, `needs`, `inputs`, `steps`, `job`, `runner`, `matrix`), built-in functions, operators, and `if:` evaluation rules. |
+| `references/runners.md` | GitHub-hosted runner matrix (OS, CPU, memory, disk, pre-installed software), self-hosted runner architecture, label/group selection, composite-action constraints, ARC (Actions Runner Controller). |
+| `references/caching.md` | `actions/cache` semantics — key construction, `restore-keys` fallback chain, cross-branch and cross-ref visibility, eviction, 10 GB repo limit, language-specific recipes (npm, pnpm, Yarn, Maven, Gradle, pip, Poetry, Go modules, Cargo). |
+| `references/secrets-and-vars.md` | Secrets vs. variables, scope precedence (org → repo → environment), OIDC federation patterns for AWS / GCP / Azure / Vault, masking, common exfiltration anti-patterns. |
+| `references/permissions.md` | `GITHUB_TOKEN` permission model, repository default policy, the `permissions:` key at workflow and job level, least-privilege recipes per use case (release, push container, comment on PR, deploy). |
+| `references/reusable-workflows.md` | `workflow_call` triggers, `inputs:` / `outputs:` / `secrets:` contracts, `secrets: inherit`, calling conventions, `strategy.matrix` interaction, nesting limits, versioning strategies. |
+
+## Core concepts
+
+A workflow is a YAML file under `.github/workflows/` triggered by one
+or more **events** (`on:`). Each workflow contains one or more
+**jobs**, which run in parallel by default on independent **runners**.
+A job is an ordered sequence of **steps**; each step is either a shell
+script (`run:`) or an invocation of an **action** (`uses:`). State
+between steps in a job is shared through the filesystem and through
+**outputs**; state between jobs travels through `needs.<job>.outputs`
+or through **artifacts**.
+
+### Triggers (`on:`)
+
+Common triggers and the trap that comes with each:
+
+- **`push`** / **`pull_request`** — the workhorses. `pull_request`
+  runs with the **base** repository's permissions but the **head**
+  ref's code; this is the headline supply-chain risk.
+- **`pull_request_target`** — runs with **base** code and **base**
+  secrets. Useful for labelling, dangerous for anything that checks out
+  the PR head. Never `actions/checkout` the PR head in a
+  `pull_request_target` workflow without a separate, sandboxed
+  evaluation step.
+- **`workflow_dispatch`** — manual trigger with typed `inputs`. Always
+  validate enum-style inputs.
+- **`workflow_call`** — turns the workflow into a callable function;
+  see `references/reusable-workflows.md`.
+- **`workflow_run`** — fires when another workflow finishes. Inherits
+  no secrets from the upstream workflow. Often used to expose results
+  to a higher-privilege context — extreme care required.
+- **`schedule`** — cron expressions, UTC. Skewed and not guaranteed
+  on the dot. The default branch only.
+- **`repository_dispatch`** / **`issues`** / **`issue_comment`** /
+  **`release`** — event-shaped triggers; check the `event.action` to
+  filter sub-events.
+
+### Jobs and steps
+
+A **job** declares `runs-on:` (the runner), an optional `needs:` list
+(dependency edges), an optional `strategy.matrix:` (fan-out), and a
+sequence of `steps:`. Each step has either `run:` or `uses:`,
+optionally `with:`, `env:`, `if:`, `id:`, `continue-on-error:`, and
+`timeout-minutes:`.
+
+Steps in the same job share the workspace (`$GITHUB_WORKSPACE`) and
+environment file (`$GITHUB_ENV`). Steps in different jobs do not — use
+`actions/upload-artifact` and `actions/download-artifact` to move
+files, and `outputs:` to move scalars.
+
+### Expressions and contexts
+
+The `${{ … }}` syntax evaluates expressions. The evaluator has
+seven first-class context objects (`github`, `env`, `vars`,
+`secrets`, `inputs`, `needs`, `steps`, `job`, `runner`, `matrix`) and
+a small set of functions (`contains`, `startsWith`, `endsWith`,
+`format`, `join`, `toJSON`, `fromJSON`, `hashFiles`, `success`,
+`always`, `cancelled`, `failure`). See `references/expressions.md` for
+the full enumeration and evaluation order.
+
+The single most important rule: **never** interpolate user-controlled
+strings (PR title, branch name, issue body, commit message) directly
+into a `run:` block via `${{ }}`. Pipe them through `env:` instead and
+read them as shell variables — the runner masks them properly and the
+shell parser does not re-evaluate them.
+
+### Runners
+
+Two flavours: GitHub-hosted (ephemeral VMs maintained by GitHub) and
+self-hosted (your hardware, your responsibility). GitHub-hosted runners
+are pre-warmed with common toolchains; the inventory shifts — pin a
+specific Ubuntu/Windows/macOS image (e.g., `ubuntu-24.04`, not
+`ubuntu-latest`) for reproducibility on long-lived workflows. See
+`references/runners.md` for resource limits and the pre-installed
+software matrix.
+
+### Caching
+
+`actions/cache` reduces install time by persisting directories
+identified by a **key**. Cache keys are immutable: once written under
+a key, content cannot be overwritten. `restore-keys` provides a
+prefix-fallback chain for partial hits. The cache scope is the
+repository; entries are reachable across refs with a base-ref fallback
+rule documented in `references/caching.md`. Total cache per repository
+is 10 GB; LRU eviction.
+
+### Secrets and variables
+
+**Secrets** are encrypted at rest, masked in logs, and never exposed
+via the API. **Variables** are plaintext, visible in logs, and meant
+for non-sensitive configuration. Both have three scopes: organisation,
+repository, environment. Environment scope binds to a deployment
+**environment** that can require approvals and wait timers — the
+correct primitive for promotion gates.
+
+For cloud credentials, **prefer OIDC** over long-lived secrets. OIDC
+issues a short-lived token signed by GitHub's OIDC provider; the cloud
+side validates the token's `sub`, `repository`, `ref`, and
+`environment` claims. No rotation, no leakage window. See
+`references/secrets-and-vars.md` for canonical AWS / GCP / Azure
+trust-policy snippets.
+
+### Permissions
+
+`GITHUB_TOKEN` is an automatically minted, job-scoped token whose
+scope is governed by the `permissions:` key. The org/repo default can
+be **permissive** (read-write to everything) or **restricted** (only
+`contents: read` and `metadata: read`). Always set
+`permissions:` explicitly at the workflow level, even if only to
+`contents: read`. Grant additional scopes at the job level on a
+need-to-know basis.
+
+### Reusable workflows
+
+A workflow with `on: workflow_call` becomes invocable from another
+workflow via `uses: owner/repo/.github/workflows/file.yml@ref`. The
+contract is declared via `inputs:`, `outputs:`, and `secrets:`. Nesting
+is limited to four levels deep; reusable workflows cannot call
+themselves (no recursion); a matrix in the **caller** can fan-out a
+reusable workflow but the **callee**'s matrix is independent. See
+`references/reusable-workflows.md`.
+
+## Common pitfalls
+
+The top ten failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned third-party actions.** `uses: someorg/some-action@v3`
+   is a moving target. Pin by full commit SHA
+   (`uses: someorg/some-action@abc123def456…`) and add a comment with
+   the human-readable version. Renovate / Dependabot will track
+   updates.
+2. **Over-scoped `GITHUB_TOKEN`.** Inheriting `write-all` because the
+   repository default was never tightened. Set
+   `permissions: contents: read` at the workflow level and elevate per
+   job.
+3. **Script injection via untrusted input.** `run: echo "${{ github.event.pull_request.title }}"`
+   is remote code execution. Pipe through `env:` and use
+   `"$PR_TITLE"`.
+4. **`pull_request_target` checking out the PR head.** The classic
+   path to leaking org-level secrets. Either drop the
+   `actions/checkout` of the head, or fence the privileged steps
+   behind an explicit approval (label gating + environment).
+5. **Cache poisoning across branches.** A malicious PR can write a
+   cache entry that the main branch later restores. Restrict cache
+   restore to the same ref family, or include a security-sensitive
+   discriminator in the key.
+6. **`hashFiles()` over the wrong glob.** `hashFiles('**/package-lock.json')`
+   in a monorepo with vendored copies returns a key that changes
+   constantly. Pin to the actual lockfile path.
+7. **`continue-on-error: true` masking failures.** Used to silence a
+   flaky step, ends up silencing a real regression. Replace with retry
+   logic and explicit failure handling.
+8. **`if: always()` on cleanup steps that depend on `secrets`.**
+   `always()` runs on cancellation; secrets may not be hydrated.
+   Combine with `if: ${{ !cancelled() }}` if needed.
+9. **`workflow_dispatch` inputs typed as `string` when they are
+   booleans/enums.** No client-side validation; enforce with
+   `type: choice` and `options:` or `type: boolean`.
+10. **Self-hosted runners accepting jobs from public forks.** A fork
+    PR can run arbitrary code on your hardware. Set
+    `Require approval for all outside collaborators` on the
+    repository, and never attach self-hosted runners to a public
+    repository without an additional approval gate.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge.
+
+- **`scripts/actionlint`** — runs the upstream `actionlint` binary
+  across `.github/workflows/`. Catches YAML errors, shellcheck
+  findings inside `run:` blocks, undefined contexts, unreachable
+  steps. Run on every workflow change.
+- **`scripts/check-pinned-actions`** — fails the build if any
+  `uses:` references a tag/branch rather than a 40-character commit
+  SHA. The first-line defence against supply-chain compromise.
+- **`scripts/check-secrets-exposure`** — greps for
+  `${{ secrets.* }}` patterns that flow into `run:` blocks without
+  going through `env:`, and flags `echo $SECRET` style mistakes.
+- **`scripts/simulate-job`** / **`scripts/simulate-workflow`** —
+  thin wrappers around `act` that run a job or the whole workflow
+  locally in Docker. Useful for fast iteration on `run:` logic, but
+  remember that `act` does not faithfully reproduce the full
+  GitHub-hosted runner image; treat green local runs as necessary,
+  not sufficient.
+
+Invoke them as:
+
+```sh
+scripts/actionlint .github/workflows/
+scripts/check-pinned-actions .github/workflows/
+scripts/check-secrets-exposure .github/workflows/
+scripts/simulate-job .github/workflows/ci.yml build
+scripts/simulate-workflow .github/workflows/ci.yml
+```
+
+CI should fail closed on any of these. If a script does not exist in
+the current fork, add it as part of the same PR that introduces a new
+workflow.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every third-party action by 40-character commit SHA.** No
+   `@v3`, no `@main`. First-party (`actions/*`) may be pinned by SHA or
+   by major-version tag — prefer SHA. Document the pin with a comment
+   carrying the human-readable version.
+2. **Set `permissions:` at the workflow level**, defaulting to
+   `contents: read`. Elevate per job. Never leave the workflow with
+   the implicit org/repo default.
+3. **Prefer OIDC over long-lived cloud credentials.** A long-lived AWS
+   access key in `secrets.AWS_SECRET_ACCESS_KEY` is acceptable only
+   when the cloud provider does not yet support OIDC for the target
+   resource. Document the exception.
+4. **Never define secrets in `env:` at the top level of a workflow.**
+   Top-level `env` is inherited by every job; secrets should be
+   bound to the smallest scope that needs them — the specific step,
+   or at most the specific job.
+5. **Never interpolate untrusted input into `run:` via `${{ }}`.**
+   Use `env:` to bind the value to a shell variable; reference it as
+   `"$VAR"` with quotes.
+6. **`pull_request_target` workflows must not check out the PR head**
+   unless behind an explicit human approval gate and never with access
+   to secrets.
+7. **Set `concurrency:` on long-running jobs** to prevent runaway cost
+   from rapid pushes — typically
+   `group: ${{ github.workflow }}-${{ github.ref }}` with
+   `cancel-in-progress: true` for non-deployment workflows.
+8. **Set `timeout-minutes:` on every job.** The default is six hours.
+   A reasonable upper bound is the 95th percentile of historical
+   runtime times two.
+9. **Use environments for deployment gates.** Production deployments
+   should target a GitHub Environment with required reviewers and a
+   wait timer. The environment is also the correct scope for
+   production secrets.
+10. **Enable required status checks** on protected branches for the
+    workflows that enforce these defaults. A skill rule that is not
+    mechanically enforced will drift.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure CI skeleton
+
+```yaml
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<sha>  # v4.2.x
+      - uses: actions/setup-node@<sha>  # v4.x
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+permissions:
+  id-token: write   # required for OIDC token issuance
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      - uses: actions/checkout@<sha>
+      - uses: aws-actions/configure-aws-credentials@<sha>  # v4.x
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/gha-deploy
+          aws-region: eu-west-3
+      - run: ./scripts/deploy.sh
+```
+
+### Safe handling of untrusted PR title
+
+```yaml
+- name: Comment on PR
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    # Quoted, no re-evaluation, masked if it happens to match a secret
+    printf 'Title: %s\n' "$PR_TITLE"
+```
+
+### Cache key with safe fallback
+
+```yaml
+- uses: actions/cache@<sha>  # v4.x
+  with:
+    path: ~/.npm
+    key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    restore-keys: |
+      npm-${{ runner.os }}-
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/.claude/skills/github-actions/references/caching.md
+++ b/.claude/skills/github-actions/references/caching.md
@@ -1,0 +1,273 @@
+# Caching reference
+
+`actions/cache` and its first-party language wrappers reduce install
+time by persisting directories across runs. The mechanism is simple on
+the surface and full of footguns underneath. This document covers the
+key/restore-key semantics, scoping rules, eviction, the 10 GB
+per-repository limit, and proven recipes for each major language.
+
+## How `actions/cache` works
+
+A step using `actions/cache`:
+
+```yaml
+- uses: actions/cache@<sha>  # v4.x
+  id: cache
+  with:
+    path: ~/.npm
+    key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    restore-keys: |
+      npm-${{ runner.os }}-
+```
+
+The runner performs two operations:
+
+1. **Pre-job restore.** Looks up `key` exactly. If hit, the
+   directories at `path:` are restored, `steps.<id>.outputs.cache-hit`
+   is set to `'true'`, and the install step can be skipped or
+   shortened. If miss, the `restore-keys:` are tried as **prefixes**
+   in order; on first prefix match, partial content is restored and
+   `cache-hit` stays `'false'`.
+2. **Post-job save.** If the pre-job lookup did not hit the exact
+   `key`, the cache is uploaded after the job succeeds. Uploads happen
+   in a `post:` step that runs even if a later step fails — as long as
+   the cache step itself succeeded.
+
+The save is conditional on **exact-key miss**. If you want to refresh
+a cache whose content is sensitive to inputs not covered by the key
+(e.g., transitive dep changes that the lockfile already pinned), bump
+a discriminator in the key.
+
+## Key construction
+
+A cache key is just a string. Build it from:
+
+- A namespace (the cache "kind": `npm`, `maven`, `pip`, …).
+- The runner OS (`runner.os`), to avoid cross-OS restores of binary
+  caches.
+- The architecture (`runner.arch`), if your toolchain ships
+  arch-specific binaries.
+- A content hash (`hashFiles`) over the lock file(s) that pin
+  dependency content.
+- Optionally a version discriminator (`v2`, …) to invalidate the
+  cache wholesale during a migration.
+
+Worked example for a monorepo with multiple lockfiles:
+
+```yaml
+key: pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'packages/*/pnpm-lock.yaml') }}
+```
+
+`hashFiles` returns SHA-256 of the concatenated, sorted file contents.
+If no file matches the glob, the function returns `''` and the key
+becomes degenerate — verify the glob locally before merging.
+
+## `restore-keys` fallback chain
+
+`restore-keys` is a newline-separated list of **prefix** patterns.
+The runner walks the list top-down, returning the first cache entry
+whose key starts with the given prefix (ordered by recency for ties).
+
+```yaml
+restore-keys: |
+  pnpm-${{ runner.os }}-${{ runner.arch }}-
+  pnpm-${{ runner.os }}-
+```
+
+Use restore-keys to get a partial hit on lockfile changes — the saved
+`node_modules` is mostly correct, the install step does the
+incremental work. Trade-off: a partial restore that ends up with
+stale content is its own debugging nightmare. Reset `restore-keys`
+when in doubt.
+
+## Scope and visibility
+
+A cache entry is scoped to the **repository**. Cross-ref restore
+rules:
+
+- A job on branch `feature/x` can restore caches created on
+  `feature/x` **and** on the **default branch** (typically `main`).
+- A job on `main` restores only `main` caches.
+- A job triggered by a `pull_request` from a fork uses the
+  **base** repository's cache scope, but **cannot write** to it —
+  prevents cache poisoning by an outside contributor.
+
+The base-branch fallback means caches built on `main` are the
+canonical source for feature branches. Build a "warm-up" workflow on
+`main` if your default branch rarely runs the slow install path.
+
+## Limits
+
+- **10 GB total per repository.** Eviction is least-recently-used
+  once the cap is hit.
+- **A cache entry is immutable.** You cannot overwrite a key; you must
+  invalidate by changing the key.
+- **Unused entries are evicted after 7 days.** A cache that hasn't
+  been read in a week is gone, regardless of total usage.
+
+Monitor usage via the Actions UI (`Caches` tab in repo settings) or
+the REST API (`GET /repos/{owner}/{repo}/actions/caches`). The CLI
+`gh cache list` enumerates entries; `gh cache delete <id>` removes
+one.
+
+## Cross-OS pitfalls
+
+A cache built on Linux often does not work on macOS or Windows
+because of native binaries (`node-sass`, `node-gyp` outputs,
+`puppeteer` Chromium, `tsx`'s `esbuild` binary, etc.). Always include
+`runner.os` in the key. For mixed-arch (x64 + arm64) matrices, also
+include `runner.arch`.
+
+## Cache poisoning
+
+A malicious PR cannot write to a cache (forks have read-only cache
+access), but a contributor with push access to a feature branch can
+write a cache that the default branch later restores (via the
+base-branch fallback).
+
+Mitigations:
+
+- Keep the default branch isolated: use a `restore-keys:` set that
+  only matches keys built on `main`. Easiest pattern: scope the key
+  with `${{ github.ref_name == github.event.repository.default_branch && 'main' || 'fork' }}`
+  so fork content never falls within `main`'s prefix chain.
+- Treat cached binaries as untrusted. Re-verify checksums after
+  restore for security-sensitive tools.
+
+## Language recipes
+
+### npm
+
+```yaml
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: npm
+    cache-dependency-path: package-lock.json
+```
+
+`actions/setup-node` does cache management for you when `cache: npm`
+is set — keys by lockfile hash, restores to `~/.npm`. Prefer this to
+hand-rolled `actions/cache` for the common case.
+
+### pnpm
+
+`pnpm` keeps a content-addressable store; cache `~/.local/share/pnpm/store`
+(Linux) / equivalent path on other OSes.
+
+```yaml
+- uses: pnpm/action-setup@<sha>  # v4.x
+  with:
+    run_install: false
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: pnpm
+```
+
+### Yarn (Classic and Berry)
+
+```yaml
+- uses: actions/setup-node@<sha>
+  with:
+    node-version-file: .nvmrc
+    cache: yarn
+    cache-dependency-path: yarn.lock
+```
+
+For Yarn Berry with zero-installs, the `.yarn/cache` directory is
+checked into the repo — no `actions/cache` needed.
+
+### Maven
+
+```yaml
+- uses: actions/setup-java@<sha>  # v4.x
+  with:
+    distribution: temurin
+    java-version: 21
+    cache: maven
+```
+
+Keys on `**/pom.xml`. For Gradle, set `cache: gradle` instead — keys
+on `**/*.gradle*` and `**/gradle-wrapper.properties`.
+
+### pip
+
+```yaml
+- uses: actions/setup-python@<sha>  # v5.x
+  with:
+    python-version: "3.12"
+    cache: pip
+    cache-dependency-path: |
+      requirements*.txt
+      requirements/*.txt
+```
+
+For Poetry, drop the built-in cache and use `actions/cache` directly
+over `~/.cache/pypoetry` keyed on `poetry.lock`.
+
+### Go modules
+
+```yaml
+- uses: actions/setup-go@<sha>  # v5.x
+  with:
+    go-version-file: go.mod
+    cache: true   # default: true
+```
+
+`setup-go` caches `~/.cache/go-build` and `~/go/pkg/mod` keyed on
+`go.sum`.
+
+### Cargo (Rust)
+
+`Swatinem/rust-cache` is the de facto pattern; it handles the
+crate-registry, git deps, target directory, and adapts the key to
+the Rust toolchain version.
+
+```yaml
+- uses: dtolnay/rust-toolchain@<sha>
+  with:
+    toolchain: stable
+- uses: Swatinem/rust-cache@<sha>
+  with:
+    workspaces: . -> target
+```
+
+### Docker layer cache
+
+Pure `actions/cache` over BuildKit's `--cache-to type=local` is
+brittle (it grows unbounded). Prefer the GitHub-native cache backend:
+
+```yaml
+- uses: docker/setup-buildx-action@<sha>
+- uses: docker/build-push-action@<sha>
+  with:
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+`type=gha` uses the same 10 GB pool — be conscious of layered-cache
+growth and prune periodically by changing the `scope` argument.
+
+### Bazel / Nix / Pants
+
+For Bazel, prefer a remote cache (BuildBuddy, Google Cloud, internal
+backend) over `actions/cache` — the local repo cache changes
+constantly and overflows the 10 GB cap quickly. For Nix, use the
+`cachix/cachix-action` to push to a Cachix store. Pants and Buck2
+have similar remote-cache stories.
+
+## Debugging
+
+`cache-hit` is the first thing to check. If always `'false'`, the
+key is changing every run — usually a `hashFiles` glob that picks up
+generated files. Print the key in a debug step:
+
+```yaml
+- run: echo "Computed key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}"
+```
+
+If `cache-hit` is `'true'` but the install step still rebuilds from
+scratch, the restored directory is incomplete — verify the `path:`
+covers everything the toolchain reads (e.g., npm's `~/.npm` versus
+`node_modules` versus the workspace's `.next/`).

--- a/.claude/skills/github-actions/references/expressions.md
+++ b/.claude/skills/github-actions/references/expressions.md
@@ -1,0 +1,309 @@
+# Expressions reference
+
+The expression language used inside `${{ … }}` interpolation and in
+the `if:` key. Read this before writing any non-trivial condition or
+output reference. Memorising the truthiness and short-circuit rules
+avoids the bulk of "the step ran when I told it not to" bugs.
+
+## Evaluation surface
+
+Expressions appear in three places:
+
+1. **Interpolated** via `${{ expr }}` inside string values (most
+   keys: `name`, `run`, `with`, `env`, `runs-on`, etc.).
+2. **As the entire value** of certain keys: `if:`, `continue-on-error:`,
+   `timeout-minutes:` — here the `${{ }}` wrapper is optional and
+   omitted by convention.
+3. **Inside `${{ }}` blocks that produce a YAML value**, including
+   for arrays via `fromJSON('[…]')`.
+
+Expressions are evaluated **before** the job starts (for keys
+resolved at workflow load — `runs-on`, `name`, etc.) or **just before
+the step runs** (for step-scoped keys). Some contexts (notably
+`steps`, `needs`, `job.status`) are populated incrementally during
+the job lifecycle.
+
+## Context objects
+
+### `github`
+
+Metadata about the event and the run. Selected fields (full list in
+GitHub docs, but these cover 95 % of usage):
+
+| Field | Description |
+|-------|-------------|
+| `github.event_name` | The triggering event (`push`, `pull_request`, `workflow_dispatch`, …). |
+| `github.event` | The full webhook payload. Shape varies by event. |
+| `github.ref` | The fully qualified ref (`refs/heads/main`, `refs/tags/v1.2.3`). |
+| `github.ref_name` | The short ref (`main`, `v1.2.3`). |
+| `github.ref_type` | `branch` or `tag`. |
+| `github.sha` | The commit SHA. For `pull_request`, the merge commit on the base. |
+| `github.head_ref` | Source branch (only on `pull_request`). |
+| `github.base_ref` | Target branch (only on `pull_request`). |
+| `github.actor` | Login of the user that triggered the run. |
+| `github.triggering_actor` | For re-runs: the user that pressed re-run. |
+| `github.repository` | `owner/repo`. |
+| `github.repository_owner` | `owner`. |
+| `github.workflow` | The workflow `name:`. |
+| `github.run_id` / `github.run_number` / `github.run_attempt` | Run identity. |
+| `github.workspace` | Absolute path of `$GITHUB_WORKSPACE`. |
+| `github.token` | Same as `secrets.GITHUB_TOKEN`. |
+| `github.api_url` / `github.server_url` / `github.graphql_url` | API endpoints (different on GHES). |
+
+### `env`
+
+Environment variables defined via `env:` at workflow/job/step level
+**plus** anything written to `$GITHUB_ENV`. Does **not** include
+variables exported by `export VAR=…` in a `run:` block — those live
+only in that step's shell.
+
+### `vars`
+
+Plaintext repository / org / environment variables. `${{ vars.X }}`.
+
+### `secrets`
+
+Encrypted repository / org / environment secrets. Includes
+`secrets.GITHUB_TOKEN`. Values are masked in logs. Do not interpolate
+into `run:` blocks directly.
+
+### `inputs`
+
+Populated on `workflow_dispatch:` and `workflow_call:`. Typed per the
+input declaration; `boolean` inputs are real booleans, not the strings
+`"true"` / `"false"`.
+
+### `needs`
+
+Outputs and status of dependency jobs. Shape:
+
+```text
+needs.<job-id>.result    # 'success' | 'failure' | 'cancelled' | 'skipped'
+needs.<job-id>.outputs.<output-name>
+```
+
+### `steps`
+
+Outputs and status of prior steps in the same job. Shape:
+
+```text
+steps.<step-id>.outcome     # before continue-on-error
+steps.<step-id>.conclusion  # after continue-on-error
+steps.<step-id>.outputs.<name>
+```
+
+`outcome` is what the step actually did; `conclusion` is what the
+workflow sees. They differ only when `continue-on-error: true` turned
+a failure into a success.
+
+### `job`
+
+Current job state. `job.status` is `'success'` / `'failure'` /
+`'cancelled'`. `job.container.id` / `job.container.network` /
+`job.services.<id>.id` for container metadata.
+
+### `runner`
+
+The runner the job is on. `runner.os` (`Linux`, `macOS`, `Windows`),
+`runner.arch` (`X86`, `X64`, `ARM`, `ARM64`), `runner.name`,
+`runner.temp` (writable temp dir), `runner.tool_cache` (path to the
+pre-installed toolchain cache).
+
+### `matrix`
+
+The values for the current matrix cell. `matrix.<axis>` for each axis
+defined in `strategy.matrix`.
+
+### `strategy`
+
+`strategy.fail-fast`, `strategy.job-index`, `strategy.job-total`,
+`strategy.max-parallel`.
+
+## Operators
+
+In approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `[ ]` `.` | Indexing and property access. `github['event']['pull_request']` is equivalent to `github.event.pull_request`. |
+| `!` | Logical NOT. |
+| `<`, `<=`, `>`, `>=` | Numeric and string comparison. |
+| `==`, `!=` | Equality. Loose comparison: `'1' == 1` is `true`. |
+| `&&`, `||` | Short-circuit logical AND / OR. |
+
+Strings are single-quoted; double quotes are not valid in expressions
+(they belong to YAML's quoting layer). Numbers and booleans are
+literal.
+
+## Functions
+
+### `contains(haystack, needle)`
+
+`true` if `haystack` contains `needle`. Works on strings (substring),
+arrays (element membership), and objects (key membership).
+
+```yaml
+if: contains(github.event.pull_request.labels.*.name, 'ship-it')
+```
+
+The `*` is an **object filter** — it collects the named property from
+each element of an array.
+
+### `startsWith(string, prefix)` / `endsWith(string, suffix)`
+
+Self-explanatory. Case-sensitive.
+
+### `format(template, arg0, arg1, …)`
+
+Positional formatting with `{N}` placeholders.
+
+```yaml
+name: ${{ format('Deploy {0} ({1})', inputs.environment, github.actor) }}
+```
+
+### `join(array, separator)`
+
+Concatenates an array. Default separator is `,`. Useful for matrix
+labels.
+
+### `toJSON(value)` / `fromJSON(string)`
+
+Serialise / deserialise. `fromJSON` is the canonical way to inject a
+typed value (number, boolean, array) into a key that would otherwise
+receive a string.
+
+```yaml
+strategy:
+  matrix:
+    target: ${{ fromJSON(needs.plan.outputs.targets) }}
+```
+
+### `hashFiles(pattern, …)`
+
+SHA-256 of the concatenated contents of files matching the glob
+pattern(s). The cornerstone of cache keys.
+
+```yaml
+key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/*/package-lock.json') }}
+```
+
+Returns an empty string if no files match — beware of accidentally
+sharing a cache between unrelated branches because the lockfile path
+moved.
+
+### Status check functions
+
+The four functions that drive `if:` chains:
+
+| Function | Returns `true` when… |
+|----------|----------------------|
+| `success()` | All previous steps in the job (and all `needs:` for jobs) succeeded. |
+| `failure()` | Any previous step failed (and the failure was not handled). |
+| `cancelled()` | The workflow was cancelled. |
+| `always()` | Always — even on cancellation. |
+
+The default `if:` is implicit `success()`. To run a cleanup step on
+failure but not on cancellation:
+
+```yaml
+if: ${{ failure() && !cancelled() }}
+```
+
+To run an artifact-upload step regardless of outcome:
+
+```yaml
+if: ${{ !cancelled() }}
+```
+
+`always()` is hazardous — secrets and the runner network may be in
+the process of being torn down on cancellation.
+
+## Truthiness
+
+| Value | Truthy? |
+|-------|---------|
+| `true` (boolean) | yes |
+| Non-empty string | yes |
+| Non-zero number | yes |
+| Non-empty array | yes |
+| Object with at least one key | yes |
+| `false` / `''` / `0` / `null` / `[]` / `{}` | no |
+
+The empty-string trap: `if: env.FOO` evaluates `''` to `false`. If
+you want "the variable exists at all", you have to check explicitly
+(`if: env.FOO != ''`).
+
+## Common patterns
+
+### Run only on the default branch push
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+```
+
+### Skip drafts
+
+```yaml
+if: github.event.pull_request.draft == false
+```
+
+### Run when a specific label is present
+
+```yaml
+if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+```
+
+### Run a cleanup regardless of upstream success
+
+```yaml
+if: ${{ !cancelled() }}
+```
+
+### Use a matrix value as a conditional
+
+```yaml
+if: matrix.coverage
+```
+
+(works because `matrix.coverage: true` is the boolean `true` when set
+via `include:`.)
+
+### Dynamic matrix from a previous job
+
+```yaml
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      targets: ${{ steps.set.outputs.targets }}
+    steps:
+      - id: set
+        run: echo "targets=[\"a\",\"b\",\"c\"]" >> "$GITHUB_OUTPUT"
+  fan-out:
+    needs: plan
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.plan.outputs.targets) }}
+    steps:
+      - run: ./deploy.sh ${{ matrix.target }}
+```
+
+## Pitfalls
+
+- **`secrets.X` inside `run:` directly.** Use `env:` to bind, then
+  reference `"$X"`. Direct interpolation is a script-injection
+  channel.
+- **Comparing a boolean input to a string.** `if: inputs.dry_run ==
+  'true'` works only because GitHub's evaluator loosely-compares; the
+  correct form is `if: inputs.dry_run`.
+- **`hashFiles` matching nothing.** Returns `''`, which silently
+  changes the cache key. Verify the glob path before relying on it.
+- **`steps.<id>.outputs.<name>` returns empty for a skipped step.**
+  Chain conditions with `&&` rather than relying on a value that may
+  not have been produced.
+- **`always()` on a cleanup step that uses secrets.** The job may be
+  cancelling; the secret may already be unbound. Use
+  `if: ${{ !cancelled() }}` if you really mean "any outcome except
+  cancellation".

--- a/.claude/skills/github-actions/references/expressions.md
+++ b/.claude/skills/github-actions/references/expressions.md
@@ -130,7 +130,7 @@ In approximate precedence order (tightest first):
 | `!` | Logical NOT. |
 | `<`, `<=`, `>`, `>=` | Numeric and string comparison. |
 | `==`, `!=` | Equality. Loose comparison: `'1' == 1` is `true`. |
-| `&&`, `||` | Short-circuit logical AND / OR. |
+| `&&`, `\|\|` | Short-circuit logical AND / OR. |
 
 Strings are single-quoted; double quotes are not valid in expressions
 (they belong to YAML's quoting layer). Numbers and booleans are

--- a/.claude/skills/github-actions/references/permissions.md
+++ b/.claude/skills/github-actions/references/permissions.md
@@ -1,0 +1,266 @@
+# Permissions reference
+
+The `permissions:` key controls the scope of `GITHUB_TOKEN`, the
+automatically minted token that GitHub injects into every job. Getting
+this right is the single highest-leverage defence against supply-chain
+compromise — a workflow with `contents: read` and nothing else cannot
+push code, cannot publish a package, cannot open a PR, cannot tag a
+release, no matter what an action it calls tries to do.
+
+## The `GITHUB_TOKEN`
+
+A short-lived (max 24 h, but the job's lifetime in practice) installation
+token for the GitHub App `github-actions[bot]`. It is:
+
+- Minted at job start, exposed as `secrets.GITHUB_TOKEN`,
+  `github.token`, and the environment variable `GITHUB_TOKEN` (if
+  set).
+- Scoped to the **repository** running the workflow. It cannot reach
+  other repositories in the org by default.
+- Subject to the `permissions:` key for granular per-scope control.
+- Revoked at job end.
+
+The token can:
+
+- Read and write repo content (per the `permissions:` map).
+- Authenticate to `ghcr.io` (the GitHub Container Registry) for the
+  same repo's namespace.
+- Make API calls against the repo and its issues/PRs.
+
+It **cannot**:
+
+- Push to a different repository.
+- Trigger workflows by pushing to the repo (cycle prevention) — the
+  workflow that pushes does not cause its own next run.
+- Approve a PR it opened.
+
+## Default policy
+
+The org / repo setting `Workflow permissions` controls the default
+scope when `permissions:` is omitted. Two values:
+
+- **`read-write` (legacy default).** All scopes set to `write`. The
+  reason a 2021-vintage workflow can `git push` without any explicit
+  permission grant.
+- **`read-only` (recommended default).** `contents: read` and
+  `metadata: read`. All other scopes are `none`.
+
+Set the org to `read-only` and grant additional scopes in each
+workflow that needs them. Audit which repos still default to
+`read-write` — those are the highest-risk surface.
+
+The same settings page controls **"Allow GitHub Actions to create
+and approve pull requests"**. Leave it off unless a specific bot
+workflow needs it; even then, scope the approval mechanism (e.g.,
+require a separate identity, not `GITHUB_TOKEN`).
+
+## The `permissions:` key
+
+A map from scope name to access level (`read`, `write`, `none`):
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+```
+
+Shorthands:
+
+- `permissions: read-all` — every scope `read`.
+- `permissions: write-all` — every scope `write`.
+- `permissions: {}` — every scope `none` (no API access at all).
+
+Set at workflow level for the default; override at job level for
+exceptions. Job-level `permissions:` **replaces** the workflow-level
+map — it does not merge. A job that needs an extra scope must
+re-declare the ones it still wants.
+
+## Scope inventory
+
+The full list of scopes, with the common operations they unlock:
+
+| Scope | `read` enables | `write` enables |
+|-------|---------------|-----------------|
+| `actions` | List workflow runs, download artifacts. | Cancel runs, delete artifacts. |
+| `attestations` | Read provenance attestations. | Create attestations (sigstore). |
+| `checks` | Read check runs. | Create / update check runs (custom CI integration). |
+| `contents` | Clone code, read tags/releases. | Push commits, create tags, create releases. |
+| `deployments` | Read deployment statuses. | Create deployments and statuses (powers the Environments UI). |
+| `discussions` | Read discussions. | Comment on / create discussions. |
+| `id-token` | Mint OIDC token (for cloud federation). | (`write` is required to request a token.) |
+| `issues` | Read issues. | Create / comment / close / label issues. |
+| `models` | Use GitHub Models API (read). | — |
+| `packages` | Read GitHub Packages (pull container, npm, …). | Publish packages. |
+| `pages` | Read Pages config. | Deploy to Pages. |
+| `pull-requests` | Read PRs and their reviews. | Create / comment / close / label / merge PRs. |
+| `repository-projects` | Read classic Projects. | Modify classic Projects. |
+| `security-events` | Read code scanning alerts. | Upload SARIF, dismiss alerts. |
+| `statuses` | Read commit statuses. | Create / update commit statuses. |
+
+Two scopes deserve special mention:
+
+- **`id-token: write`** — required to request the OIDC token used
+  for cloud federation. Has no read counterpart; the token itself is
+  always generated on demand.
+- **`contents: write`** — broad. Allows pushing to any branch,
+  creating tags, creating releases, modifying the wiki. If the only
+  thing you actually need is "create a release", consider using a
+  dedicated PAT or App token with a tighter scope instead.
+
+## Least-privilege recipes
+
+The minimum `permissions:` for each common workflow shape.
+
+### Read-only CI
+
+```yaml
+permissions:
+  contents: read
+```
+
+Lints, tests, type-checks. The vast majority of CI workflows.
+
+### CI that comments on PRs
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+For test-report comments, coverage diffs, screenshot bots.
+
+### Pushing a container to GHCR
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+```
+
+`packages: write` is required to push to the
+`ghcr.io/<owner>/<repo>` namespace authenticated as
+`GITHUB_TOKEN`.
+
+### Creating a GitHub Release
+
+```yaml
+permissions:
+  contents: write
+```
+
+`softprops/action-gh-release` and friends need `contents: write` to
+create the release and upload assets.
+
+### Deploying to GitHub Pages
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+```
+
+The modern Pages deployment flow uses an artifact + OIDC handshake;
+`id-token: write` is mandatory.
+
+### OIDC deployment to a cloud provider
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+`id-token: write` to mint the JWT; `contents: read` to checkout.
+No other scope is needed unless a follow-up step calls the GitHub
+API.
+
+### Uploading SARIF for code scanning
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+```
+
+For `github/codeql-action/upload-sarif` and any third-party scanner
+publishing alerts.
+
+### Approving / merging a Dependabot PR
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+Combined with the org setting "Allow GitHub Actions to approve PRs"
+enabled. Note that `GITHUB_TOKEN` cannot approve a PR opened by the
+same `GITHUB_TOKEN` (Dependabot is a separate identity, so this
+works).
+
+### Posting a check run from a custom CI
+
+```yaml
+permissions:
+  contents: read
+  checks: write
+```
+
+For non-Actions CI integrations posting back to GitHub.
+
+## Workflow- vs. job-level `permissions:`
+
+The workflow-level block is the **default for all jobs**. A job-level
+block **replaces** (does not merge with) the workflow default.
+
+Common pattern: keep the workflow at the read-only floor, elevate
+specific jobs:
+
+```yaml
+permissions:
+  contents: read     # default for all jobs
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    # inherits contents: read
+    steps: [...]
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # this job alone can write
+      packages: write
+    needs: test
+    steps: [...]
+```
+
+The release job above gets exactly `contents: write` and
+`packages: write` — everything else (including `pull-requests`)
+is `none`.
+
+## Org-level restrictions
+
+The org admin can constrain the allowable maximum across all repos
+via `Actions → General → Workflow permissions` at org level. If the
+org sets the cap to `read-only`, no workflow in the org can grant
+write to itself — only a PAT or App token can bypass.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Grep for `write-all` and `read-all` across all `.github/workflows/`
+  in the org.
+- Grep for workflows missing a workflow-level `permissions:` block
+  entirely.
+- Cross-reference each `permissions:` entry against the actual API
+  calls the workflow makes. Drop unused scopes.
+- For workflows using `id-token: write`, verify the OIDC trust
+  policy on the cloud side is scoped to the specific
+  `repo:<owner>/<repo>:environment:<env>` subject.
+
+The `scripts/actionlint` validator (with the `--shellcheck` flag)
+catches the obvious cases. A hand-written check that fails the build
+on `write-all` is worth adding to the same pre-merge gate.

--- a/.claude/skills/github-actions/references/reusable-workflows.md
+++ b/.claude/skills/github-actions/references/reusable-workflows.md
@@ -1,0 +1,374 @@
+# Reusable workflows reference
+
+A reusable workflow is a workflow file that can be invoked from
+another workflow as if it were a step. It is GitHub Actions's answer
+to function abstraction: a contract of inputs, secrets, and outputs,
+with the body executing in a clean job (or jobs) of its own.
+
+This document covers the `workflow_call` trigger, the contract
+definition syntax, calling conventions, the interaction with matrices
+and concurrency, and the limitations that distinguish reusable
+workflows from composite actions.
+
+## Reusable workflow vs. composite action
+
+A frequent question. The trade-off:
+
+| Property | Reusable workflow | Composite action |
+|----------|-------------------|------------------|
+| Trigger | `workflow_call`. | Called via `uses:` in a step. |
+| Granularity | One or more jobs. | A sequence of steps inside an existing job. |
+| Runs on | Its own runner(s). | The caller's runner. |
+| Can declare `runs-on:` | Yes. | No (inherits). |
+| Can use `services:` / `container:` | Yes. | No. |
+| Secrets | Explicit input, or `secrets: inherit`. | Pass as `inputs:` (visible in logs unless masked). |
+| Strategy / matrix | Yes (at caller or callee). | No (loop manually). |
+| Nesting | Up to 4 levels deep. | Up to 10 levels deep (no recursion). |
+| Versioning | By ref (`@<sha>`). | Same. |
+| Visibility | Private repo: same repo or org. Public repo: anywhere. | Same. |
+
+Rule of thumb: reach for a **reusable workflow** when the unit of
+reuse is "a whole pipeline stage" (build-and-push, deploy, release).
+Reach for a **composite action** when the unit of reuse is "three
+steps that always go together" (setup-toolchain-and-cache).
+
+## Declaring a reusable workflow
+
+The file is a regular workflow under `.github/workflows/` with
+`workflow_call` as a trigger (often the only one):
+
+```yaml
+name: Reusable Build
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Semver to build.
+        type: string
+        required: true
+      environment:
+        type: string
+        default: staging
+      publish:
+        type: boolean
+        default: false
+    outputs:
+      artifact_url:
+        description: URL of the published artifact.
+        value: ${{ jobs.build.outputs.url }}
+    secrets:
+      NPM_TOKEN:
+        required: true
+      GHCR_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      url: ${{ steps.publish.outputs.url }}
+    steps:
+      - uses: actions/checkout@<sha>
+      - id: publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          ./scripts/build.sh "${{ inputs.version }}"
+          echo "url=https://npm.example.com/${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+```
+
+### `inputs:`
+
+Typed inputs. Supported types:
+
+- `string` — default.
+- `boolean` — real boolean in the `inputs.X` context.
+- `number` — numeric.
+- `choice` (only on `workflow_dispatch`, not on `workflow_call`).
+
+Each input has `description`, `required`, `default`. **Required
+inputs without a default** must be passed by the caller.
+
+### `outputs:`
+
+The reusable workflow's outputs are mapped from job outputs. The
+`value:` expression is evaluated **after** all jobs complete.
+
+```yaml
+outputs:
+  artifact_url:
+    value: ${{ jobs.build.outputs.url }}
+```
+
+Outputs can come from any job in the reusable workflow, not just the
+last one.
+
+### `secrets:`
+
+Secrets are not implicitly inherited. The reusable workflow declares
+which secrets it expects:
+
+```yaml
+secrets:
+  NPM_TOKEN:
+    required: true
+```
+
+The caller either lists secrets explicitly or uses
+`secrets: inherit` (same-org only).
+
+## Calling a reusable workflow
+
+The caller uses `uses:` at the **job** level (not step):
+
+```yaml
+jobs:
+  release:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      version: "1.2.3"
+      publish: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: read
+      packages: write
+```
+
+The `uses:` value identifies the workflow file by ref. Forms:
+
+- `owner/repo/.github/workflows/file.yml@<ref>` — cross-repo.
+- `./.github/workflows/file.yml` — same-repo (no ref needed).
+
+**Pin by SHA**, the same as any other third-party action. A tag
+(`@v1`) is mutable.
+
+### `with:`
+
+Passes inputs. Must match the callee's `inputs:` declaration —
+required inputs are mandatory, types are checked.
+
+### `secrets:`
+
+Two forms:
+
+```yaml
+# Explicit pass-through (most common, makes the dependency visible)
+secrets:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+```
+
+```yaml
+# Inherit all caller secrets (same-org only)
+secrets: inherit
+```
+
+`secrets: inherit` is convenient but breaks visibility — a reader of
+the caller cannot tell which secrets the callee actually consumes.
+Prefer explicit pass-through when the callee's secret list is short.
+
+### `permissions:`
+
+The caller's job-level `permissions:` are passed to the callee. The
+callee **cannot grant itself more than the caller granted** — a
+reusable workflow with internal `permissions: write-all` is silently
+capped at the caller's grant. To audit, look at the **caller**'s
+permissions; the callee's are advisory.
+
+### Reading outputs
+
+```yaml
+jobs:
+  build:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      version: "1.2.3"
+  notify:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Artifact at ${{ needs.build.outputs.artifact_url }}"
+```
+
+## Matrix interactions
+
+Two distinct patterns:
+
+### Matrix in the caller, fan-out across reusable workflow
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        target: [linux, macos, windows]
+    uses: ./.github/workflows/build-target.yml
+    with:
+      target: ${{ matrix.target }}
+```
+
+Each matrix cell calls the reusable workflow independently. The
+callee sees a single `inputs.target` value per call.
+
+### Matrix in the callee
+
+A reusable workflow can declare its own `strategy.matrix` inside its
+jobs. The matrix is independent of the caller — there is no way to
+"flatten" a callee matrix into a caller matrix.
+
+Combining matrices is the cleanest way to express "fan out, fan in":
+the caller's matrix produces N callee invocations, each with its own
+internal matrix.
+
+## Concurrency
+
+`concurrency:` is supported at the reusable workflow level and at the
+caller level. The caller's `concurrency:` applies to the calling job;
+the callee's applies to its own jobs. Both fire — be careful not to
+accidentally serialise more than intended.
+
+For deploy workflows, the typical pattern is to set `concurrency:`
+only at the caller, on the entire deploy job, so concurrent calls to
+the reusable workflow are serialised at the call site.
+
+## Limitations
+
+- **Nesting depth: 4.** A reusable workflow can call another reusable
+  workflow up to three more levels deep.
+- **No recursion.** A workflow cannot call itself, directly or
+  transitively.
+- **No environment passing** from caller to callee. The callee
+  declares its own `environment:` per job; the caller's
+  `environment:` does not propagate.
+- **`secrets: inherit` requires same-org.** Cross-org callers must
+  list every secret explicitly.
+- **No conditional `with:` keys.** A `with:` block is evaluated
+  before the callee starts; you cannot omit a key based on a
+  condition (use a default on the callee side instead).
+- **The callee runs on its own runners**, billed to the **caller**'s
+  account. A reusable workflow in a public template repo consumed
+  from a private repo bills the private repo.
+- **`workflow_call` cannot coexist with `pull_request_target` in a
+  caller** if the caller is in a public repo and the callee modifies
+  the repo — the fork-PR safety model breaks down. Audit the trigger
+  combination explicitly.
+- **Reusable workflows do not appear as separate steps in the run
+  log** — they show up as a nested job. Debugging is one level
+  deeper than for composite actions.
+
+## Versioning strategy
+
+The same considerations as for any third-party action, with one
+twist: a reusable workflow is itself a workflow, so its dependencies
+(actions called inside, runner labels) are part of the contract.
+
+Recommended approach:
+
+1. Tag releases of the reusable workflow with `v<major>.<minor>.<patch>`.
+2. Maintain a `v<major>` tag that floats to the latest minor/patch.
+3. Consumers pin to a specific commit SHA, with a comment indicating
+   the human-readable version.
+4. Use Dependabot or Renovate to track upstream releases.
+
+Avoid the temptation to pin to a branch (`@main`). The reusable
+workflow can change under you mid-day; pinning by SHA is the only way
+to get reproducibility.
+
+## Worked example: build-and-deploy
+
+A common factoring: one reusable workflow for build, one for deploy,
+a caller wiring them up.
+
+`shared/.github/workflows/build.yml`:
+
+```yaml
+name: Build
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+    outputs:
+      image:
+        value: ${{ jobs.build.outputs.image }}
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.push.outputs.image }}
+    steps:
+      - uses: actions/checkout@<sha>
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: docker/login-action@<sha>
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: push
+        run: |
+          IMG="ghcr.io/${{ github.repository }}:${{ inputs.ref }}"
+          docker build -t "$IMG" .
+          docker push "$IMG"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+```
+
+`shared/.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy
+on:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        required: true
+      environment:
+        type: string
+        required: true
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@<sha>
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE }}
+          aws-region: eu-west-3
+      - run: ./deploy.sh "${{ inputs.image }}"
+```
+
+Caller `myapp/.github/workflows/release.yml`:
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ["v*.*.*"]
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+jobs:
+  build:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      ref: ${{ github.ref_name }}
+  deploy:
+    needs: build
+    uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+    with:
+      image: ${{ needs.build.outputs.image }}
+      environment: production
+```
+
+This factoring keeps the caller declarative and concentrates the
+operational complexity in two well-tested reusable workflows.

--- a/.claude/skills/github-actions/references/runners.md
+++ b/.claude/skills/github-actions/references/runners.md
@@ -1,0 +1,257 @@
+# Runners reference
+
+Reference for the execution substrate of GitHub Actions: the
+GitHub-hosted runner inventory, self-hosted runner architecture, label
+and group selection, runner security model, and the constraints that
+apply to composite actions and container jobs.
+
+## GitHub-hosted runners
+
+GitHub provisions ephemeral VMs per job, destroyed after the job
+completes. Each job starts from a clean image — no state leaks
+between jobs.
+
+### Image inventory
+
+The current general-availability images, with the labels that resolve
+to them:
+
+| Label | OS | Notes |
+|-------|----|----|
+| `ubuntu-24.04`, `ubuntu-latest` | Ubuntu 24.04 LTS | `latest` follows the most recent LTS; pin the explicit version for reproducibility. |
+| `ubuntu-22.04` | Ubuntu 22.04 LTS | Still supported; expect retirement on the upstream LTS cadence. |
+| `windows-2025`, `windows-latest` | Windows Server 2025 | `latest` follows the most recent supported version. |
+| `windows-2022` | Windows Server 2022 | Older but stable. |
+| `macos-15`, `macos-latest` | macOS Sequoia (Apple silicon) | Apple-silicon by default on the recent `macos-*` labels. |
+| `macos-14` | macOS Sonoma (Apple silicon) | |
+| `macos-13` | macOS Ventura (Intel) | The last Intel macOS label; verify availability before relying on it. |
+
+For long-lived workflows, pin the explicit version label
+(`ubuntu-24.04`, not `ubuntu-latest`). `*-latest` rolls forward
+silently and has broken previously green pipelines on every prior
+transition.
+
+### Hardware
+
+Standard (free for public repos, paid for private):
+
+- **Linux / Windows standard:** 4 vCPU, 16 GB RAM, 14 GB SSD.
+- **macOS standard:** 3 vCPU, 7 GB RAM (Intel) / 4 vCPU, 7 GB RAM
+  (Apple silicon).
+
+Larger runners (paid, opt-in per repo or org):
+
+- 8 / 16 / 32 / 64 vCPU variants on Linux and Windows.
+- GPU variants (T4) on Linux.
+- ARM64 variants on Linux and Windows (`ubuntu-24.04-arm`,
+  `windows-11-arm`).
+
+Verify the current inventory at the runner-images repository; the
+table above drifts.
+
+### Pre-installed software
+
+Each image ships with a curated toolchain — Node.js, Python, Ruby,
+Go, .NET, Java, Docker, kubectl, common Linux build tools, the GitHub
+CLI, etc. Two important consequences:
+
+- Tool versions drift across image releases. `actions/setup-<tool>`
+  is the supported way to pin a version regardless of what is
+  pre-installed.
+- The pre-installed tool versions are cached on the runner under
+  `runner.tool_cache`. `actions/setup-<tool>` first checks the cache
+  before downloading.
+
+For the authoritative list, consult the runner-images repo
+(`actions/runner-images`) and the `Tool Versions` section of each
+image's release notes.
+
+### Network
+
+GitHub-hosted runners have unrestricted outbound IPv4/IPv6. Inbound is
+blocked. The runner pulls jobs from `github.com` over HTTPS.
+
+For workflows that need to reach internal services, options are:
+
+- A self-hosted runner inside the network.
+- An OIDC-federated cloud role with a NAT route.
+- A `tailscale` / `cloudflare-tunnel` style action that opens a
+  short-lived ingress.
+
+### Disk and memory limits
+
+A job that exhausts the 14 GB disk fails with an opaque error during
+the next file write. Common offenders: Docker layer caches, full
+`node_modules`, downloaded model weights. Mitigations:
+
+- `docker system prune -af` early in the job.
+- Use `easimon/maximize-build-space` to reclaim ~30 GB by removing
+  pre-installed bloat (when targeting Linux runners and you accept the
+  trade-off).
+- Move large artifacts to remote storage rather than the workspace.
+
+## Self-hosted runners
+
+### Architecture
+
+A self-hosted runner is a long-running process (`Runner.Listener`)
+that polls GitHub for jobs, downloads the workflow YAML and the
+action source, and executes inside its working directory. By default
+the process runs as the OS user that started it; the workspace and the
+runner toolchain cache persist between jobs unless explicitly cleaned.
+
+### Labels and groups
+
+A runner advertises a set of **labels** — `self-hosted` (mandatory),
+plus the OS (`linux` / `windows` / `macOS`), the architecture (`x64` /
+`arm64`), and any custom labels added at registration time.
+
+`runs-on:` with an array matches all listed labels:
+
+```yaml
+runs-on: [self-hosted, linux, x64, gpu]
+```
+
+**Runner groups** (Enterprise / Org tier) bind runners to a named
+group, with access controls per repository. Use the object form:
+
+```yaml
+runs-on:
+  group: gpu-runners
+  labels: [self-hosted, linux, gpu]
+```
+
+Group membership constrains which repositories may target the
+runner; labels select within the group. The combination defends
+against accidental cross-team consumption.
+
+### Security model
+
+The headline rule: **never attach a self-hosted runner to a public
+repository** unless you accept that any fork-submitted PR can execute
+arbitrary code on it.
+
+Defensive measures, in order of effectiveness:
+
+1. **Ephemeral runners.** Spin up a fresh VM per job (Actions Runner
+   Controller / ARC on Kubernetes, or
+   `philips-labs/terraform-aws-github-runner` on EC2). The runner is
+   destroyed after one job — no state carries over.
+2. **`Require approval for all outside collaborators`** at repo
+   settings. First-time contributor PRs require maintainer click to
+   run.
+3. **Private repo only.** The simplest defence is to keep the repo
+   private and trust the contributor set.
+4. **Restrict runner-group repo access.** A GPU runner pool should
+   not be visible to repositories that have no business using it.
+5. **Network isolation.** Place runners on a subnet without
+   write access to production secrets / state stores.
+6. **Read-only `$HOME`** and a wiped workspace per job (ARC handles
+   this; raw self-hosted runners do not).
+7. **No sudo, no Docker socket access** unless required. A
+   container-running runner with `/var/run/docker.sock` mounted is a
+   root escalation primitive.
+
+### Actions Runner Controller (ARC)
+
+The canonical Kubernetes-native deployment. Two flavours:
+
+- **Legacy ARC** (`actions-runner-controller/actions-runner-controller`)
+  — operator-managed, PAT-based authentication. Maintenance mode.
+- **Official ARC** (`actions/actions-runner-controller`) — GitHub's
+  own implementation, GitHub-App-based auth, scale-set abstraction.
+  Prefer this for new deployments.
+
+A scale set materialises a pool of pods that come up on demand, claim
+one job each, and terminate. The `runs-on:` value matches the scale
+set name; no label management required.
+
+## Containers and services
+
+### Job container
+
+A job may declare `container:` to run all its steps inside an image:
+
+```yaml
+container:
+  image: golang:1.23-bookworm
+  env:
+    CGO_ENABLED: "0"
+  options: --user 1001:1001
+  credentials:
+    username: ${{ secrets.REGISTRY_USER }}
+    password: ${{ secrets.REGISTRY_TOKEN }}
+```
+
+The runner mounts the workspace and `$HOME` into the container, runs
+`docker exec` for each step. Action steps run inside the container
+too — Node.js actions require Node to exist in the image (or use
+`actions/setup-node` first).
+
+### Service containers
+
+Sidecars for the job duration, on a shared Docker network. Reach them
+by the service key as hostname:
+
+```yaml
+services:
+  redis:
+    image: redis:7
+    ports: ["6379:6379"]
+    options: --health-cmd "redis-cli ping" --health-interval 5s --health-retries 5
+```
+
+`options:` accepts any `docker run` flag. Health-check options gate
+the start of step execution: the runner waits until the container
+reports healthy.
+
+## Composite-action constraints
+
+Composite actions (`runs.using: composite`) run on whatever runner
+the calling workflow is on. Limitations:
+
+- Every `run:` step **must** declare `shell:` — no inheritance from
+  the workflow's `defaults.run.shell`.
+- `continue-on-error:` and `timeout-minutes:` are unsupported on
+  steps within the composite action.
+- The composite action cannot declare its own `container:` or
+  `services:` — those live at the calling job's level.
+- `secrets` are not directly accessible inside the composite; pass
+  them in as `inputs:` (with the caveat that input values are visible
+  in logs unless masked manually via `::add-mask::`).
+
+## Workflow commands
+
+The runner exposes a control channel through stdout. Selected
+commands:
+
+| Command | Effect |
+|---------|--------|
+| `echo "::add-mask::$VALUE"` | Masks the value in subsequent log output. |
+| `echo "key=value" >> "$GITHUB_OUTPUT"` | Step output. |
+| `echo "VAR=value" >> "$GITHUB_ENV"` | Persistent env var. |
+| `echo "$DIR" >> "$GITHUB_PATH"` | Prepend to `PATH`. |
+| `echo "::group::Title"` / `::endgroup::` | Collapse log section. |
+| `echo "::notice::msg"` / `::warning::` / `::error::` | Annotation surface. |
+| `echo "## Heading" >> "$GITHUB_STEP_SUMMARY"` | Markdown summary on the run page. |
+
+`::set-output` and `::set-env` (the old in-line forms) are deprecated
+and disabled by default since the 2022 CVE — use the file-based
+channels above.
+
+## Runner diagnostics
+
+When a self-hosted runner misbehaves:
+
+- `_diag/` directory under the runner install root has `Runner_*.log`
+  and `Worker_*.log` files per job. Worker log is where step-level
+  diagnostics live.
+- Enabling **step debug logging** requires repository secret
+  `ACTIONS_STEP_DEBUG=true`. Verbose, exposes context values — keep
+  it off by default.
+- Enabling **runner diagnostic logs** requires
+  `ACTIONS_RUNNER_DEBUG=true`. Useful for runner-side failures
+  (network, auth, image pull).
+
+For GitHub-hosted runners, the same two secrets unlock the verbose
+logging on the next run.

--- a/.claude/skills/github-actions/references/secrets-and-vars.md
+++ b/.claude/skills/github-actions/references/secrets-and-vars.md
@@ -1,0 +1,294 @@
+# Secrets and variables reference
+
+Secrets and variables are the two channels GitHub Actions offers for
+injecting configuration into a workflow run. The choice between them
+is the choice between confidentiality and observability. Use the
+wrong one and you either leak credentials to logs or accidentally
+encrypt a value you needed to debug.
+
+## Secrets vs. variables
+
+| Property | Secrets | Variables |
+|----------|---------|-----------|
+| Storage | Encrypted at rest (libsodium sealed box). | Plaintext. |
+| Reachable via API after creation | No (write-only). | Yes (read/write). |
+| Log masking | Yes — masked automatically. | No. |
+| Available to fork PRs | No. | Yes (read-only). |
+| Intended use | Credentials, tokens, signing keys. | URLs, flags, non-sensitive config. |
+| Expression | `${{ secrets.NAME }}` | `${{ vars.NAME }}` |
+
+Variables exist because misusing secrets for non-sensitive config is
+both inconvenient (you can't read them back) and dangerous (you train
+people to ignore the "masked" tag). Use variables for everything that
+is not a credential.
+
+## Scope and precedence
+
+Both secrets and variables have three scopes:
+
+1. **Organisation.** Visible to a configurable set of repositories.
+   Best for shared credentials (Docker registry, npm publish token).
+2. **Repository.** Repository-wide, visible to all environments.
+3. **Environment.** Scoped to a deployment environment (`staging`,
+   `production`). Combined with required reviewers and wait timers,
+   environments are the correct primitive for promotion gates.
+
+Precedence on name collision: **environment > repository > organisation**.
+A `secrets.AWS_ROLE` defined at all three levels resolves to the
+environment value.
+
+## Defining and consuming
+
+### Repository-level
+
+`Settings → Secrets and variables → Actions → New repository secret` (or
+`New variable`). From a workflow:
+
+```yaml
+- env:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    LOG_LEVEL: ${{ vars.LOG_LEVEL }}
+  run: npm publish
+```
+
+### Organisation-level
+
+`Org settings → Secrets and variables → Actions`. Specify the
+repository access policy: all, private only, or a selected list.
+
+### Environment-level
+
+The job declares `environment:`:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: production
+      url: https://app.example.com
+    steps:
+      - env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: ./scripts/deploy.sh
+```
+
+Environments support:
+
+- **Required reviewers.** Up to 6 users/teams whose approval is
+  needed before the job runs.
+- **Wait timer.** Delay between PR approval and job execution
+  (useful for canary rollouts).
+- **Deployment branches.** Restrict which refs may target the
+  environment.
+
+## Masking
+
+GitHub masks any **literal substring** of a secret in log output and
+in the run summary. Three caveats:
+
+- Masking is **substring-based**, not token-based. A 4-character
+  secret will mask every occurrence of that 4-character sequence,
+  including in unrelated output — and conversely, splitting a secret
+  with `echo "${SECRET:0:8}…${SECRET:8}"` bypasses masking.
+- Masking does **not** redact secrets from artifacts, from caches,
+  or from external systems your job writes to. A secret printed into
+  a file and uploaded as an artifact is leaked in plaintext.
+- The runner masks `secrets.*` values automatically. To mask a
+  derived value, use the workflow command
+  `echo "::add-mask::$VALUE"` before printing it.
+
+## OIDC federation
+
+For cloud credentials, **prefer OIDC over long-lived secrets**. The
+runner mints a short-lived JWT signed by GitHub's OIDC provider; the
+cloud side validates the token's claims (`sub`, `repository`, `ref`,
+`environment`, `job_workflow_ref`) and issues a temporary cloud
+credential.
+
+Benefits:
+
+- No long-lived secret to rotate or leak.
+- Per-job, per-environment scoping — a `production` deploy job gets
+  a token whose `sub` includes `environment:production`.
+- Audit trail in both GitHub and the cloud provider.
+
+### AWS
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+      },
+      "StringLike": {
+        "token.actions.githubusercontent.com:sub":
+          "repo:my-org/my-repo:environment:production"
+      }
+    }
+  }]
+}
+```
+
+In the workflow:
+
+```yaml
+permissions:
+  id-token: write   # required to request the OIDC token
+  contents: read
+steps:
+  - uses: aws-actions/configure-aws-credentials@<sha>  # v4.x
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/gha-deploy
+      aws-region: eu-west-3
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+steps:
+  - uses: google-github-actions/auth@<sha>  # v2.x
+    with:
+      workload_identity_provider: projects/123/locations/global/workloadIdentityPools/gha/providers/github
+      service_account: gha-deploy@my-project.iam.gserviceaccount.com
+```
+
+The WIF provider declares attribute mappings (e.g., `attribute.repository`)
+and an attribute condition pinning the allowed repos / environments.
+
+### Azure
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+steps:
+  - uses: azure/login@<sha>  # v2.x
+    with:
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+```
+
+The Azure side configures a **federated credential** on the app
+registration with the matching subject (`repo:my-org/my-repo:environment:production`).
+
+### HashiCorp Vault
+
+Use the JWT/OIDC auth method with a role whose
+`bound_subject` / `bound_claims` match the GitHub token.
+
+```yaml
+- uses: hashicorp/vault-action@<sha>  # v3.x
+  with:
+    url: https://vault.example.com
+    method: jwt
+    role: gha-deploy
+    secrets: |
+      kv/data/prod/db password | DB_PASSWORD
+```
+
+## Common pitfalls
+
+### Secrets in top-level `env:`
+
+```yaml
+# BAD: every job and every step in the workflow sees the secret
+env:
+  DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+```
+
+Bind secrets to the smallest scope that needs them — a specific
+step's `env:` is ideal.
+
+### Interpolating secrets into `run:`
+
+```yaml
+# BAD: the secret is evaluated by the YAML expression layer and
+# pasted into the shell verbatim. Quoting is brittle, and if the
+# secret contains shell metacharacters the script breaks (or worse).
+- run: echo "${{ secrets.API_TOKEN }}" | gh auth login --with-token
+
+# GOOD: bind via env, reference as a shell variable.
+- env:
+    API_TOKEN: ${{ secrets.API_TOKEN }}
+  run: printf '%s' "$API_TOKEN" | gh auth login --with-token
+```
+
+### Passing secrets to reusable workflows
+
+```yaml
+# BAD: re-listing every secret manually invites omissions.
+- uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+  secrets:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+
+# GOOD when the callee is trusted: inherit all caller secrets.
+- uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+  secrets: inherit
+```
+
+`secrets: inherit` only works when both workflows are in the **same
+organisation**. For cross-org consumption, list explicitly.
+
+### Echoing a secret to debug
+
+```yaml
+# BAD: the runner masks the echoed value, but the secret is still
+# present in the artifact / cache / step summary you write next.
+- run: echo "DEBUG: token is $TOKEN"
+```
+
+Never debug a workflow by printing a secret. Print a checksum or a
+length instead:
+
+```yaml
+- run: echo "Token length: ${#TOKEN}"
+```
+
+### Storing structured data in a single secret
+
+A JSON blob in `secrets.CLOUD_CONFIG` is convenient for setup but
+defeats per-key rotation. Split into individual secrets, or use a
+secret-manager action (`hashicorp/vault-action`,
+`aws-actions/aws-secretsmanager-get-secrets`) to fetch a structured
+secret at runtime — the per-key value is then masked individually.
+
+### Variables that should be secrets
+
+A `vars.WEBHOOK_URL` whose URL embeds a token is a secret in
+disguise. If the value is sensitive on inspection, it is a secret.
+
+### Secrets visible to fork PRs
+
+By default, fork PRs receive **no secrets**. `pull_request_target`
+gives them the **base** repository's secrets, which is why it is
+dangerous to combine with `actions/checkout` of the PR head. If you
+must run privileged work against a fork PR, gate it behind an
+environment with required reviewers.
+
+## Auditing
+
+Periodic audit checklist:
+
+- List repository secrets: `gh secret list` — flag any that have not
+  been read in 90 days; rotate or delete.
+- List org-wide secrets and their repo access list. Tighten scope.
+- Inspect workflows for top-level `env:` referencing `secrets.*`.
+- Search for `${{ secrets.` patterns in `run:` blocks (the
+  `scripts/check-secrets-exposure` validator does this).
+- For each cloud provider, audit the OIDC trust conditions and ensure
+  every long-lived access key has a migration plan.

--- a/.claude/skills/github-actions/references/workflow-syntax.md
+++ b/.claude/skills/github-actions/references/workflow-syntax.md
@@ -1,0 +1,443 @@
+# Workflow syntax reference
+
+Canonical reference for the YAML grammar of a GitHub Actions workflow.
+Each top-level and nested key is enumerated with semantics, defaults,
+and a worked example. Read the section that matches the key you are
+editing — do not guess from memory.
+
+## File location and naming
+
+Workflow files live under `.github/workflows/` and end in `.yml` or
+`.yaml`. The basename has no semantic meaning beyond the workflow UI;
+the `name:` key is what appears in the Actions tab and the commit
+status.
+
+A repository may contain any number of workflow files. They are
+discovered on every push to the default branch (for `schedule:` and
+`workflow_dispatch:`) and on every event for the matching triggers.
+
+## Top-level keys
+
+### `name`
+
+Display name in the Actions UI and in commit statuses. Optional; if
+omitted, the file path is shown.
+
+```yaml
+name: CI
+```
+
+### `run-name`
+
+Dynamic display name for an individual run. Supports expression
+interpolation. Useful for surfacing the actor or the input that
+triggered the run.
+
+```yaml
+run-name: "Deploy ${{ inputs.environment }} by @${{ github.actor }}"
+```
+
+### `on`
+
+The trigger specification. Accepts:
+
+- A single event name: `on: push`.
+- A list of event names: `on: [push, pull_request]`.
+- A map of event names to filters:
+
+```yaml
+on:
+  push:
+    branches: [main, "release/**"]
+    paths-ignore: ["docs/**"]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: "17 3 * * 1-5"   # 03:17 UTC, Mon–Fri
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options: [staging, production]
+        default: staging
+        required: true
+      dry_run:
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+    outputs:
+      artifact_url:
+        value: ${{ jobs.build.outputs.url }}
+    secrets:
+      NPM_TOKEN:
+        required: true
+```
+
+Filter semantics:
+
+- `branches` / `branches-ignore` — glob list. Mutually exclusive.
+- `tags` / `tags-ignore` — same shape, applied to tag pushes.
+- `paths` / `paths-ignore` — path-glob filter on the changed files
+  in the push or PR. Combined with `branches`, both must match.
+- `types` — for `pull_request`, defaults to
+  `[opened, synchronize, reopened]`. Add `ready_for_review` if you
+  want the run to fire when a draft becomes a real PR; or skip
+  drafts explicitly with `if: github.event.pull_request.draft == false`.
+
+### `permissions`
+
+Sets the scope of `GITHUB_TOKEN`. Either a shorthand
+(`read-all` / `write-all` / `{}`) or an explicit map. See
+`permissions.md` for the per-scope semantics.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+```
+
+Applied at workflow level becomes the default for all jobs; can be
+overridden (further restricted or expanded within repo policy) at the
+job level.
+
+### `env`
+
+Workflow-wide environment variables. **Never** put secrets here; the
+value is inherited by every step in every job.
+
+```yaml
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+  CI: "true"
+```
+
+### `defaults`
+
+Default `run:` configuration for every step in every job. The only
+two keys are `run.shell` and `run.working-directory`.
+
+```yaml
+defaults:
+  run:
+    shell: bash
+    working-directory: ./app
+```
+
+The default shell on Linux/macOS is `bash -e -o pipefail {0}`; on
+Windows it is `pwsh -command ". '{0}'"`. Setting `shell: bash`
+explicitly on Windows runners pulls in Git Bash.
+
+### `concurrency`
+
+Concurrency control group. Runs sharing a group are serialised; the
+optional `cancel-in-progress` boolean cancels older runs in the same
+group when a new one queues.
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+Use cases: avoid wasting compute on rapid pushes; serialise
+deployments so only one ever runs to a given environment.
+
+### `jobs`
+
+A map of job-id → job definition. Job IDs are alphanumeric plus `_`
+and `-`; the first character must be a letter or `_`. They are
+referenced from `needs:` and from the `jobs.<id>.outputs` context.
+
+## Job-level keys
+
+### `runs-on`
+
+The runner selector. A string (`ubuntu-24.04`) or an array of labels
+(`[self-hosted, linux, x64, prod]`) — all labels must match. For
+runner groups (Enterprise/Org), the object form is required:
+
+```yaml
+runs-on:
+  group: ubuntu-runners
+  labels: [self-hosted, large]
+```
+
+Pin the OS version. `ubuntu-latest` drifts on a rolling schedule.
+
+### `needs`
+
+Dependency edges, single ID or array. The job runs after all listed
+jobs complete with a non-failure status (unless `if:` overrides). The
+outputs of `needs` jobs are exposed under
+`${{ needs.<id>.outputs.<name> }}`.
+
+```yaml
+needs: [build, lint]
+```
+
+### `if`
+
+Conditional execution. Evaluated against the same expression syntax
+as steps; see `expressions.md`. Pay attention to truthiness of empty
+strings.
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+```
+
+### `strategy`
+
+Fan-out specification. Three keys:
+
+- `matrix:` — Cartesian product of axes. Combined with `include:`
+  (additive) and `exclude:` (subtractive).
+- `fail-fast:` — default `true`. When `true`, a single failing
+  matrix cell cancels the others.
+- `max-parallel:` — concurrency cap across the matrix.
+
+```yaml
+strategy:
+  fail-fast: false
+  max-parallel: 4
+  matrix:
+    os: [ubuntu-24.04, macos-14, windows-2022]
+    node: ["20", "22"]
+    include:
+      - os: ubuntu-24.04
+        node: "22"
+        coverage: true
+    exclude:
+      - os: windows-2022
+        node: "20"
+```
+
+Each cell runs as an independent job; `matrix.<axis>` is available in
+expressions inside the job. The default job name is
+`<job-id> (<axis-values-joined>)`; override with `name:` on the job.
+
+### `outputs`
+
+Job-level outputs, surfaced to dependents via `needs.<id>.outputs`.
+Values come from step outputs.
+
+```yaml
+outputs:
+  version: ${{ steps.bump.outputs.version }}
+```
+
+### `env`, `defaults`, `permissions`, `concurrency`
+
+Same shape as the workflow-level equivalents, scoped to the job.
+
+### `timeout-minutes`
+
+Per-job timeout. Default 360 (six hours). **Always set this.** A
+reasonable upper bound is the 95th percentile of historical runtime
+times two.
+
+### `continue-on-error`
+
+When `true`, a failure in this job does not fail the workflow. Useful
+for opt-in matrix cells (experimental Node version, beta OS) — combine
+with `strategy.fail-fast: false`.
+
+### `container` and `services`
+
+Run the job inside a container image (`container:`) and/or alongside
+sidecar service containers (`services:`). Both reference Docker
+images.
+
+```yaml
+container:
+  image: node:22-bookworm
+  options: --user 1001
+services:
+  postgres:
+    image: postgres:16
+    env:
+      POSTGRES_PASSWORD: postgres
+    ports: ["5432:5432"]
+    options: >-
+      --health-cmd "pg_isready"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+```
+
+Service containers share a Docker network with the job container; the
+service hostname is the service key (`postgres` above).
+
+### `environment`
+
+Binds the job to a GitHub deployment **environment**. The environment
+can require manual approval, a wait timer, or restrict to specific
+branches. Secrets/variables scoped to the environment become available
+to the job.
+
+```yaml
+environment:
+  name: production
+  url: https://app.example.com
+```
+
+## Step-level keys
+
+A step has either `run:` or `uses:`, never both.
+
+### `id`
+
+Step identifier. Required to reference step outputs from later steps
+(`steps.<id>.outputs.<name>`).
+
+### `name`
+
+Display name. Optional; falls back to the `run:` first line or the
+`uses:` reference.
+
+### `if`
+
+Step-level conditional. Skipping a step does not skip the rest of the
+job. Combine with `steps.<earlier>.outcome` to chain.
+
+### `uses`
+
+Action reference. Forms:
+
+- `actions/checkout@v4` — versioned tag (mutable; **do not use** for
+  third-party actions).
+- `actions/checkout@<40-char-sha>` — pinned by commit SHA
+  (immutable; **always prefer** this).
+- `./.github/actions/my-local-action` — local action in the same
+  repo.
+- `docker://alpine:3.20` — Docker action (the image is the action).
+
+### `with`
+
+Action input map. Inputs are declared by the action's `action.yml`;
+the value is a string (numbers and booleans are coerced).
+
+```yaml
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: npm
+    cache-dependency-path: package-lock.json
+```
+
+### `run`
+
+Shell script. Multiline via YAML block scalar (`|` or `>`). Shell is
+the workflow / job default unless overridden with `shell:` on the
+step.
+
+```yaml
+- name: Build
+  shell: bash
+  working-directory: app
+  run: |
+    set -euo pipefail
+    npm ci
+    npm run build
+```
+
+### `env`
+
+Per-step environment. The recommended channel for moving secrets and
+untrusted input into `run:`.
+
+```yaml
+- env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    gh pr comment "$PR_NUMBER" --body "Title: $PR_TITLE"
+```
+
+### `continue-on-error`
+
+Same semantics as the job-level key, applied to a single step.
+
+### `timeout-minutes`
+
+Step-level timeout. Default: no limit beyond the job timeout.
+
+### Step outputs
+
+A step writes to `$GITHUB_OUTPUT` to expose values to later steps and
+to job outputs.
+
+```yaml
+- id: bump
+  run: |
+    echo "version=1.2.3" >> "$GITHUB_OUTPUT"
+- run: echo "${{ steps.bump.outputs.version }}"
+```
+
+`$GITHUB_ENV` writes an environment variable visible to all
+subsequent steps in the job:
+
+```yaml
+- run: echo "BUILD_ID=$(date +%s)" >> "$GITHUB_ENV"
+```
+
+`$GITHUB_STEP_SUMMARY` writes Markdown to the run summary page; useful
+for surfacing test results without digging through logs.
+
+## Composite action syntax
+
+A composite action lives in its own repo (or under
+`.github/actions/<name>/`) with an `action.yml`:
+
+```yaml
+name: My composite action
+description: …
+inputs:
+  region:
+    description: AWS region
+    required: true
+    default: eu-west-3
+outputs:
+  cluster:
+    description: EKS cluster name
+    value: ${{ steps.lookup.outputs.cluster }}
+runs:
+  using: composite
+  steps:
+    - id: lookup
+      shell: bash
+      run: echo "cluster=prod" >> "$GITHUB_OUTPUT"
+```
+
+Composite actions have notable constraints:
+
+- `shell:` is mandatory on every `run:` step (no inheritance from
+  workflow defaults).
+- `continue-on-error:` is not supported on steps.
+- Conditional `if:` is supported.
+- No `services:` or `container:`.
+- Cannot use `secrets` directly; pass them as `inputs:`.
+
+## Edge cases and quirks
+
+- **YAML booleans.** `on: pull_request` parses cleanly, but a key
+  named `on` at the top level of a YAML 1.1 parser can be coerced to
+  the boolean `true`. GitHub's parser handles this, but external
+  linters may complain — quote with `"on":` if needed.
+- **`uses:` and `run:` mutually exclusive** in the same step.
+- **`env:` precedence**: step > job > workflow. The deepest binding
+  wins.
+- **`if:` and `${{ }}`**: the `if:` key accepts an expression
+  without the `${{ }}` wrapper; adding it is allowed but redundant.
+- **`needs:` semantics**: a job with `needs:` runs only if all
+  upstream jobs **succeed**. To run on failure, use
+  `if: ${{ always() }}` or `if: ${{ failure() }}`.
+- **`strategy.matrix` empty include**: a matrix containing only
+  `include:` (no axes) generates one job per `include:` entry — useful
+  for hand-curated combinations.

--- a/.claude/skills/github-actions/scripts/check-pinned-actions.sh
+++ b/.claude/skills/github-actions/scripts/check-pinned-actions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check-pinned-actions.sh — flag GitHub Actions references that are not pinned
+# to a 40-char commit SHA.
+#
+# Usage: check-pinned-actions.sh <workflow-file-or-directory>
+#
+# Rationale: pinning to a tag or branch lets an upstream maintainer push a
+# new commit that silently runs in your pipeline. Pinning to a full SHA
+# makes the reference immutable.
+#
+# Local actions (./path) are ignored — they are part of the repository.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no workflow files found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# Match: <indent>uses: <owner>/<repo>[/path]@<ref>
+# Capture group 1 = the value after "uses: ".
+uses_re='^[[:space:]]*uses:[[:space:]]*([^[:space:]#][^[:space:]#]*)'
+# A pinned reference ends with @<40 hex chars>.
+sha_re='@[0-9a-fA-F]{40}$'
+
+for f in "${files[@]}"; do
+    lineno=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+        if [[ "$line" =~ $uses_re ]]; then
+            value="${BASH_REMATCH[1]}"
+            # Strip surrounding quotes if any.
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            # Skip local actions.
+            case "$value" in
+                ./*|../*) continue ;;
+                docker://*) continue ;;
+            esac
+            # Must contain '@' and end with a 40-char hex SHA.
+            if [[ "$value" != *@* ]] || ! [[ "$value" =~ $sha_re ]]; then
+                echo "${C_RED}[UNPINNED]${C_RESET} ${f}:${lineno}: ${value}"
+                violations=$((violations + 1))
+            fi
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all action references are pinned to a SHA"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned action reference(s) found${C_RESET}" >&2
+exit 1

--- a/.claude/skills/github-actions/scripts/check-pinned-actions.sh
+++ b/.claude/skills/github-actions/scripts/check-pinned-actions.sh
@@ -9,6 +9,9 @@
 # makes the reference immutable.
 #
 # Local actions (./path) are ignored — they are part of the repository.
+#
+# Limitation: only inline `uses: owner/repo@ref` forms (value on the same
+# line) are matched. Multi-line YAML scalars for `uses:` are not detected.
 
 set -euo pipefail
 

--- a/.claude/skills/github-actions/scripts/check-secrets-exposure.sh
+++ b/.claude/skills/github-actions/scripts/check-secrets-exposure.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in GitHub Actions workflows that
+# may leak secrets into logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <workflow-file-or-directory>
+#
+# Patterns flagged:
+#   1. `echo ${{ secrets.* }}`           — secret echoed directly to stdout.
+#   2. workflow-level `env:`             — env values accessible to every job.
+#   3. `set -x` / `set +x` in `run:`     — shell trace expands env values.
+#   4. `toJSON(secrets)` anywhere        — serialises every secret as JSON.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no workflow files found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    saw_top_level_env=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # 1. echo of a secret expression.
+        if [[ "$line" =~ echo[[:space:]].*\$\{\{[[:space:]]*secrets\. ]]; then
+            report "$current_file" "$lineno" "echo \${{ secrets.* }}" \
+                "secret value is written to stdout and persisted in the run log"
+        fi
+
+        # 2. workflow-level env: — a line starting at column 0 that is "env:".
+        if [[ "$line" =~ ^env:[[:space:]]*$ ]] && [ "$saw_top_level_env" -eq 0 ]; then
+            report "$current_file" "$lineno" "top-level env:" \
+                "values defined here are inherited by every job and step (broad blast radius)"
+            saw_top_level_env=1
+        fi
+
+        # 3. set -x / set +x in a shell step.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret env values"
+        fi
+
+        # 4. toJSON(secrets) — full secret bag serialisation.
+        if [[ "$line" =~ toJSON\([[:space:]]*secrets[[:space:]]*\) ]]; then
+            report "$current_file" "$lineno" "toJSON(secrets)" \
+                "serialises the entire secrets context — any later echo, env, or file write leaks them all"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/.claude/skills/github-actions/scripts/check-secrets-exposure.sh
+++ b/.claude/skills/github-actions/scripts/check-secrets-exposure.sh
@@ -5,10 +5,10 @@
 # Usage: check-secrets-exposure.sh <workflow-file-or-directory>
 #
 # Patterns flagged:
-#   1. `echo ${{ secrets.* }}`           — secret echoed directly to stdout.
-#   2. workflow-level `env:`             — env values accessible to every job.
-#   3. `set -x` / `set +x` in `run:`     — shell trace expands env values.
-#   4. `toJSON(secrets)` anywhere        — serialises every secret as JSON.
+#   1. `echo ${{ secrets.* }}`                          — secret echoed directly to stdout.
+#   2. workflow-level `env:` referencing `secrets.*`    — broad blast radius across all jobs.
+#   3. `set -x` / `set +x` in `run:`                   — shell trace expands env values.
+#   4. `toJSON(secrets)` anywhere                       — serialises every secret as JSON.
 
 set -euo pipefail
 
@@ -67,6 +67,8 @@ report() {
 
 for current_file in "${files[@]}"; do
     lineno=0
+    in_top_level_env=0
+    top_level_env_lineno=0
     saw_top_level_env=0
     # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
     while IFS= read -r line || [ -n "$line" ]; do
@@ -78,11 +80,21 @@ for current_file in "${files[@]}"; do
                 "secret value is written to stdout and persisted in the run log"
         fi
 
-        # 2. workflow-level env: — a line starting at column 0 that is "env:".
+        # 2. workflow-level env: that contains ${{ secrets.* }} — broad blast radius.
+        # Only enter tracking on the first top-level (column-0) "env:" line.
         if [[ "$line" =~ ^env:[[:space:]]*$ ]] && [ "$saw_top_level_env" -eq 0 ]; then
-            report "$current_file" "$lineno" "top-level env:" \
-                "values defined here are inherited by every job and step (broad blast radius)"
+            in_top_level_env=1
+            top_level_env_lineno=$lineno
             saw_top_level_env=1
+        elif [ "$in_top_level_env" -eq 1 ] && [ "$lineno" -gt "$top_level_env_lineno" ]; then
+            # Exit the block on the first non-indented, non-blank, non-comment line.
+            if [[ "$line" =~ ^[^[:space:]#] ]] && [[ -n "$line" ]]; then
+                in_top_level_env=0
+            elif [[ "$line" =~ \$\{\{[[:space:]]*secrets\. ]]; then
+                report "$current_file" "$top_level_env_lineno" "top-level env: references \${{ secrets.* }}" \
+                    "secrets defined at workflow level are inherited by every job (broad blast radius)"
+                in_top_level_env=0
+            fi
         fi
 
         # 3. set -x / set +x in a shell step.

--- a/.claude/skills/github-actions/scripts/lint-workflow.sh
+++ b/.claude/skills/github-actions/scripts/lint-workflow.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# lint-workflow.sh — validate GitHub Actions workflow files via actionlint.
+#
+# Usage: lint-workflow.sh <workflow-file-or-directory>
+#
+# If a directory is passed, every .yml/.yaml under .github/workflows/ inside
+# that directory is linted. If actionlint is missing, the script exits 0 with
+# a friendly hint — it is not a hard blocker.
+
+set -euo pipefail
+
+# ANSI colours (disabled when stdout is not a TTY).
+if [ -t 1 ]; then
+    C_GREEN=$'\033[0;32m'
+    C_RED=$'\033[0;31m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_GREEN=""
+    C_RED=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+if ! command -v actionlint >/dev/null 2>&1; then
+    echo "${C_YELLOW}[SKIP] actionlint not found — install: brew install actionlint${C_RESET}"
+    exit 0
+fi
+
+# Build the list of files to lint.
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "${C_YELLOW}[SKIP] no workflow files found under: $TARGET${C_RESET}"
+    exit 0
+fi
+
+rc=0
+for f in "${files[@]}"; do
+    if actionlint -no-color "$f"; then
+        echo "${C_GREEN}[OK]${C_RESET} $f"
+    else
+        echo "${C_RED}[FAIL]${C_RESET} $f"
+        rc=1
+    fi
+done
+
+exit "$rc"

--- a/.claude/skills/github-actions/scripts/simulate-job.sh
+++ b/.claude/skills/github-actions/scripts/simulate-job.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# simulate-job.sh — dry-run a single workflow job locally via `act`.
+#
+# Usage: simulate-job.sh <workflow-file> <job-id> [event-type]
+#
+# Defaults: event-type = push.
+# Requires: `act` and a running Docker daemon. If either is missing the
+# script exits 0 with an explanatory message — it is not a hard blocker.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file> <job-id> [event-type]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+WORKFLOW="$1"
+JOB_ID="$2"
+EVENT="${3:-push}"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "[FAIL] workflow file not found: $WORKFLOW" >&2
+    exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "[SKIP] act not found — install: brew install act"
+    echo "       act runs GitHub Actions locally inside Docker containers."
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[SKIP] docker CLI not found — act needs Docker to run containers."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[SKIP] Docker daemon not reachable — start Docker Desktop or the docker service."
+    exit 0
+fi
+
+cmd=(act "$EVENT" --workflows "$WORKFLOW" --job "$JOB_ID" --dryrun)
+
+echo "+ ${cmd[*]}"
+"${cmd[@]}"

--- a/.claude/skills/github-actions/scripts/simulate-workflow.sh
+++ b/.claude/skills/github-actions/scripts/simulate-workflow.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# simulate-workflow.sh — dry-run a full workflow locally via `act`, with
+# optional event-payload injection.
+#
+# Usage: simulate-workflow.sh <workflow-file> [event-type] [event-payload-json-file]
+#
+# Defaults: event-type = push. When no payload file is given, a minimal
+# default payload matching the event-type is synthesised in a tempfile.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file> [event-type] [event-payload-json-file]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+WORKFLOW="$1"
+EVENT="${2:-push}"
+PAYLOAD="${3:-}"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "[FAIL] workflow file not found: $WORKFLOW" >&2
+    exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "[SKIP] act not found — install: brew install act"
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[SKIP] docker CLI not found — act needs Docker to run containers."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[SKIP] Docker daemon not reachable — start Docker Desktop or the docker service."
+    exit 0
+fi
+
+cleanup_payload=""
+cleanup() {
+    if [ -n "$cleanup_payload" ] && [ -f "$cleanup_payload" ]; then
+        rm -f "$cleanup_payload"
+    fi
+}
+trap cleanup EXIT
+
+default_payload_for() {
+    case "$1" in
+        push)               echo '{"ref":"refs/heads/main"}' ;;
+        pull_request)       echo '{"action":"opened","pull_request":{"number":1,"head":{"ref":"feature"},"base":{"ref":"main"}}}' ;;
+        workflow_dispatch)  echo '{"inputs":{}}' ;;
+        release)            echo '{"action":"published","release":{"tag_name":"v0.0.0"}}' ;;
+        schedule)           echo '{}' ;;
+        *)                  echo '{}' ;;
+    esac
+}
+
+if [ -z "$PAYLOAD" ]; then
+    cleanup_payload="$(mktemp -t act-payload.XXXXXX.json)"
+    default_payload_for "$EVENT" > "$cleanup_payload"
+    PAYLOAD="$cleanup_payload"
+elif [ ! -f "$PAYLOAD" ]; then
+    echo "[FAIL] event payload file not found: $PAYLOAD" >&2
+    exit 1
+fi
+
+cmd=(act "$EVENT" --workflows "$WORKFLOW" --eventpath "$PAYLOAD" --dryrun)
+
+echo "+ ${cmd[*]}"
+"${cmd[@]}"

--- a/.gemini/agents/ci-configurator.md
+++ b/.gemini/agents/ci-configurator.md
@@ -1,0 +1,277 @@
+---
+name: ci-configurator
+description: "Specialist agent for configuring new GitHub Actions pipelines.
+Interviews the project, generates a commit-ready workflow,
+and validates its own output before delivery."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# CI Configurator Agent
+
+You are a CI configuration agent. You operate under the **github-actions**
+skill (`community-config/skills/github-actions/SKILL.md`) — read it once
+at the start of any session and follow its conventions: action pinning,
+least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+
+Your persona is that of an experienced DevOps engineer: minimalist,
+security-oriented, allergic to copy-pasted workflows that "happen to
+work". You do not explore the repository looking for things to fix.
+You ask exactly what you need, generate exactly one workflow, validate
+your own output, and hand it over.
+
+Your default mode is **generate and validate**, not iterate. The user
+gets a workflow they can paste into `.github/workflows/` and commit. If
+you cannot produce a workflow that passes your own validation scripts,
+you say so plainly rather than shipping a draft that "should work".
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- The project has no `.github/workflows/` directory yet, or the
+  directory is empty.
+- The project is migrating from another CI platform (GitLab CI,
+  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
+  GitHub Actions pipeline.
+- An existing workflow is outdated — uses tag-based action references
+  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
+  or depends on long-lived cloud credentials that should be replaced
+  by OIDC.
+- The user explicitly asks for "a GitHub Actions workflow", "a CI
+  pipeline", or "set up CI" without specifying which platform.
+
+Do **not** activate this agent when the user is debugging a failing
+run, hunting a flaky job, or asking why a workflow misbehaves —
+delegate to the **ci-debugger** agent instead. Configuration and
+diagnosis are different jobs and should not be mixed.
+
+## Interview protocol
+
+You ask the minimum questions necessary to produce a correct workflow.
+The interview is **one round**: a single numbered list, sent once,
+answered once. Do not drip-feed follow-ups.
+
+Before asking anything, inspect the repository for cues that let you
+**infer** answers. Skip any question you can already answer with high
+confidence from:
+
+- `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`,
+  `build.gradle`, `Gemfile`, `mix.exs` — language + runtime + package
+  manager.
+- `Dockerfile`, `compose.yaml` — runtime image, build target.
+- An existing CI config from another platform (`.gitlab-ci.yml`,
+  `.circleci/config.yml`, `Jenkinsfile`) — test commands, deploy
+  targets, environment names.
+- `README.md` deployment section — cloud provider, region hints.
+
+Only the residual unknowns go into the interview. The interview is
+capped at **7 questions**. If you find yourself needing more, you have
+not inferred enough from the repo — go read more files before asking.
+
+Question template (omit items you have already answered):
+
+1. **Runtime version** — exact version of the language runtime
+   (e.g. Node 20.x, Python 3.12, Go 1.22). Latest LTS if no
+   preference.
+2. **Test command** — the canonical command to run unit tests
+   (e.g. `npm test`, `pytest`, `go test ./...`).
+3. **Lint / format check command** — separate invocation, or part of
+   test? If none exists, do you want one scaffolded?
+4. **Build artefact** — does this project produce a build artefact
+   (Docker image, npm package, binary, static site)? Where should it
+   be published?
+5. **Deployment target** — none, staging-only, staging + production,
+   or other? Which cloud (AWS / GCP / Azure / self-hosted)?
+6. **Secrets inventory** — list of secret names this pipeline will
+   need (registry credentials, deploy tokens, signing keys). For each,
+   does it already exist in GitHub Actions secrets, or does the user
+   need to add it?
+7. **Branch policy** — which branches trigger the pipeline (default:
+   `main` + PRs), and which require manual approval before deploy?
+
+If the user answers ambiguously, ask **one** clarifying follow-up per
+ambiguous item, not a fresh round.
+
+## Generation rules
+
+These rules are non-negotiable. Every workflow you emit satisfies all
+of them; if you cannot satisfy one, you say so explicitly in the
+output and explain why.
+
+### Action pinning
+
+Every `uses:` reference is pinned to a full 40-character commit SHA,
+followed by a comment carrying the human-readable tag for review
+context.
+
+```yaml
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+- uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # v4.0.0
+```
+
+Never use `@main`, `@master`, `@v1`, or any movable reference. Tag
+references can be silently re-pointed by the action maintainer; a SHA
+cannot. The trailing comment is documentation, not a parser hint —
+keep it accurate.
+
+If the user pins a specific tag and you cannot resolve it to a SHA in
+the current session, emit the SHA placeholder
+`# TODO: resolve to commit SHA` and call out the gap in the
+validation step output.
+
+### Permissions
+
+Set `permissions:` at the **workflow** level to the minimum needed by
+the smallest job, typically:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Then **escalate per job** only where required:
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write       # tag + release
+      id-token: write       # OIDC
+```
+
+Never use `permissions: write-all`. Never leave `permissions:`
+unset — the GitHub default is overly permissive on classic runners.
+
+### OIDC over long-lived secrets
+
+For any cloud deployment job (AWS, GCP, Azure, Vault, HashiCorp
+Cloud), the default is **OIDC federation**:
+
+- AWS: `aws-actions/configure-aws-credentials` with `role-to-assume`
+  and `aws-region`, never `aws-access-key-id` / `aws-secret-access-key`.
+- GCP: `google-github-actions/auth` with `workload_identity_provider`
+  and `service_account`.
+- Azure: `azure/login` with `client-id` + `tenant-id` +
+  `subscription-id`, no `client-secret`.
+
+If the user does not have OIDC set up on their cloud side, output the
+workflow with OIDC anyway and include a separate "OIDC bootstrap"
+note explaining the prerequisites. Do not silently fall back to
+static credentials.
+
+### Job separation
+
+Lint, test, build, and deploy live in **distinct jobs** with explicit
+`needs:` dependencies:
+
+```yaml
+jobs:
+  lint:    # ...
+  test:    # ...
+  build:
+    needs: [lint, test]
+  deploy:
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+```
+
+Never bundle "everything" into a single job. Parallelism is the
+default; failure attribution depends on it.
+
+### Timeouts
+
+Every job has a `timeout-minutes:` value. Defaults: lint 5, test 15,
+build 20, deploy 30. Tune if the user reports otherwise. A job
+without a timeout is a billing incident waiting to happen.
+
+### Caching
+
+Use first-party caching (`actions/setup-node` with `cache: npm`,
+`actions/setup-python` with `cache: pip`, etc.) before reaching for
+`actions/cache`. When `actions/cache` is needed, the key includes a
+hash of the lockfile and a numeric epoch you can bump to force
+invalidation.
+
+### Concurrency
+
+Add a `concurrency:` block for branch-scoped workflows so an old run
+is cancelled when a newer commit lands:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+For deploy jobs that should serialise (production), use
+`cancel-in-progress: false` and a non-ref-scoped group.
+
+## Validation step
+
+Before presenting the workflow to the user, run the project's
+validation scripts on your draft. The scripts are shipped with the
+`github-actions` skill:
+
+```bash
+scripts/lint-workflow.sh        .github/workflows/<name>.yml
+scripts/check-pinned-actions.sh .github/workflows/<name>.yml
+```
+
+If either script reports violations, **fix the draft and rerun**.
+Repeat until both scripts pass. Only then present the workflow.
+
+If a script is unavailable in the current environment, say so
+explicitly in the output: "Note: `check-pinned-actions.sh` was not
+available; pinning was verified by hand against the rules above."
+Never claim a script was run when it was not.
+
+## Output format
+
+The agent's final message has three parts, in this order:
+
+1. **Annotated YAML block** — the workflow itself, with inline
+   comments calling out non-obvious choices (timeout values,
+   `needs:` graph, concurrency strategy). The comments are part of
+   the deliverable; they survive into the committed file.
+
+2. **Decision table** — a Markdown table explaining each non-obvious
+   choice, one row per decision:
+
+   | Decision | Choice | Rationale |
+   |---|---|---|
+   | Runner OS | `ubuntu-latest` | Project has no platform-specific code; ubuntu is fastest. |
+   | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
+   | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
+
+3. **Follow-up checklist** — what the user must do before the workflow
+   can run successfully (create secrets, configure OIDC trust, enable
+   branch protection). One bullet per action item, no prose.
+
+Do not pad the output with "this is a great starting point" or
+"feel free to customise". The workflow either works as written or it
+does not; if it does not, the validation step caught it.
+
+## When the user pushes back
+
+If the user objects to a generation rule ("can we just use `@v4`?",
+"why is OIDC complicated?"), respond with the **rule + the cost of
+breaking it**, not with capitulation. If they still want the override
+after that, comply but tag the override in the decision table as
+`OVERRIDE: <reason>` so it survives review.
+
+The rules exist because the failure modes they prevent are
+expensive — supply-chain compromise, leaked long-lived credentials,
+permission creep. An expert user is welcome to override them; a
+silent override is what the agent refuses to ship.
+
+## Handoff
+
+When the workflow is delivered, the agent's job is done. Do not
+volunteer to "open a PR for you" or "watch the first run" — those
+are separate jobs handled by other agents (`pr-logbook` for the PR,
+`ci-debugger` if the first run fails).

--- a/.gemini/agents/ci-debugger.md
+++ b/.gemini/agents/ci-debugger.md
@@ -145,6 +145,7 @@ Symptoms: job stays in `queued` for minutes, "No runner matching the
 specified labels was found", "All runners are busy".
 
 Typical fixes:
+
 - Switch from a custom self-hosted label to `ubuntu-latest` for the
   affected job if no host-specific dependency exists.
 - For self-hosted fleets: check runner health, scale up, restart
@@ -158,6 +159,7 @@ Symptoms: "Cache not found for input keys", restored cache is
 inconsistent with the lockfile, cache exceeds 10 GB, slow restore.
 
 Typical fixes:
+
 - Cache key includes a hash of the **lockfile**, not the manifest.
 - Bump a numeric epoch in the cache key prefix to invalidate
   poisoned caches: `cache-v2-${{ hashFiles('**/lock.file') }}`.
@@ -170,6 +172,7 @@ Symptoms: `${{ secrets.X }}` is empty in a job, "Secret X not
 found", a deploy step receives a literal empty string.
 
 Typical fixes:
+
 - Confirm the secret exists at the correct scope: repo, environment,
   or organisation. Environment secrets are only visible to jobs
   declaring `environment: <name>`.
@@ -185,6 +188,7 @@ Symptoms: `403` on `GITHUB_TOKEN` API calls, "Resource not
 accessible by integration", OIDC `AssumeRoleWithWebIdentity` failure.
 
 Typical fixes:
+
 - Add the missing scope to the **job's** `permissions:` block, not
   the workflow's.
 - For OIDC: align the IAM/GCP/Azure trust policy's `sub` claim with
@@ -198,6 +202,7 @@ Symptoms: a previously-green workflow fails with "input X not
 supported", "deprecated input", or a runtime error from an action.
 
 Typical fixes:
+
 - Pin actions by **SHA**, not tag. Tag references can be re-pointed
   silently by the action maintainer.
 - Check the action's release notes for breaking changes. Pin to the
@@ -212,6 +217,7 @@ Symptoms: intermittent timeouts to `registry.npmjs.org`,
 limits.
 
 Typical fixes:
+
 - Add a retry around the network step (`nick-fields/retry@<sha>` or
   a shell loop with `curl --retry`). Retries are **bounded**: max 3
   attempts, exponential backoff.
@@ -226,6 +232,7 @@ Symptoms: workflow fails to start, "Invalid workflow file",
 `actionlint` complaint, YAML parse error.
 
 Typical fixes:
+
 - Run `actionlint` locally on the file. The skill's
   `scripts/lint-workflow.sh` wraps this.
 - Watch for the classic YAML traps: tab characters, multi-line
@@ -239,6 +246,7 @@ was canceled", two PRs racing on the same environment, an in-flight
 release aborted by a newer commit.
 
 Typical fixes:
+
 - For preview deploys: branch-scoped `concurrency:` with
   `cancel-in-progress: true` is correct.
 - For production deploys: environment-scoped group with

--- a/.gemini/agents/ci-debugger.md
+++ b/.gemini/agents/ci-debugger.md
@@ -1,0 +1,357 @@
+---
+name: ci-debugger
+description: "Specialist agent for diagnosing and fixing failing GitHub Actions
+pipelines. Systematically produces a
+symptom → hypothesis → evidence → fix chain."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# CI Debugger Agent
+
+You are a CI diagnosis agent. You operate under the **github-actions**
+skill (`community-config/skills/github-actions/SKILL.md`) — read it
+once at the start of any session and use it as the reference for
+correct workflow patterns.
+
+Your persona is that of a methodical SRE. You do not guess. You do
+not propose workarounds. You produce a chain of
+`symptom → hypothesis → evidence → fix` for every failure you
+diagnose, and you refuse to skip any link in that chain.
+
+Your output is a diagnosis and a clean fix, not a patch that
+"unblocks" the user at the cost of correctness. If the only available
+fix crosses a quality line (escalates permissions, disables a
+security check, masks a flake), you say so and stop — the user
+decides whether to accept the cost, not you.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A GitHub Actions run failed and the user wants to know why.
+- A pipeline that previously passed is now red on an unrelated change
+  (suspected flake or infrastructure issue).
+- Jobs are queued for an unusually long time (runner capacity).
+- A deployment job failed with a permission error (token scope, OIDC
+  claim mismatch, branch protection).
+- A workflow that worked yesterday started failing after an action
+  upstream bumped its tag (action version mismatch).
+- A user pastes a stack trace, an error excerpt, or a `gh run view`
+  URL and asks "why is this broken?".
+
+Do **not** activate this agent when the user is setting up a new
+pipeline from scratch — delegate to **ci-configurator** instead.
+
+## Input formats
+
+Accept any of the following as the diagnostic context. If the user
+provides none, ask for one — do not invent one:
+
+- A `gh run view` URL
+  (`https://github.com/<owner>/<repo>/actions/runs/<id>`). Fetch the
+  failed job logs via `gh run view <id> --log-failed` if the GitHub
+  MCP / CLI is available.
+- A raw log excerpt pasted into the conversation. Treat it as
+  read-only evidence — quote line ranges, do not paraphrase.
+- A workflow file path under `.github/workflows/` and a short
+  description of what failed.
+- A screenshot of the failed step (last resort; extract the textual
+  error before reasoning).
+
+If the user provides only "the pipeline is broken", your first
+response is a single question: "What's the run URL or the failing
+log excerpt?". Do not proceed without evidence.
+
+## Diagnostic protocol
+
+Every diagnosis follows the same four-step structure, in order. The
+structure is the output format — do not collapse, reorder, or skip
+steps even when the answer feels obvious.
+
+### 1. Symptom
+
+State what the user observes, in their words plus the literal error
+string. One short paragraph or two bullets. Do not interpret yet.
+
+```text
+Symptom: job `deploy-staging` failed at step "Configure AWS
+credentials" with error:
+  Error: Could not load credentials from any providers
+  (AssumeRoleWithWebIdentity)
+```
+
+### 2. Hypothesis
+
+Name the failure **category** from the taxonomy below before naming
+the specific cause. Categorising first prevents pattern-matching to
+the most recent failure you saw.
+
+```text
+Hypothesis: category = Permission denial / OIDC claim mismatch.
+Specific: the IAM role trust policy does not include the current
+repo+branch combination in the `token.actions.githubusercontent.com:sub`
+condition.
+```
+
+### 3. Evidence
+
+Cite the exact line(s) of the log, workflow, or external config that
+support the hypothesis. Evidence is a quote, not a summary. If the
+evidence is absent ("the log does not show…"), say so explicitly —
+absence is also evidence, but it is weaker.
+
+```text
+Evidence:
+- Job log, step "Configure AWS credentials", line 14:
+    "Not authorized to perform sts:AssumeRoleWithWebIdentity"
+- Workflow `.github/workflows/deploy.yml` line 42:
+    role-to-assume: arn:aws:iam::1234:role/gha-deploy
+- The role's trust policy (provided by user) restricts `sub` to
+    `repo:acme/web:ref:refs/heads/main` — the failed run is on
+    `refs/heads/release/2026-05`.
+```
+
+### 4. Fix
+
+Propose the single correct fix. If multiple correct fixes exist,
+list them with explicit trade-offs and pick one as the default. The
+fix is **clean** — see *Anti-patterns* below for what "clean" rules
+out.
+
+```text
+Fix: extend the IAM role trust policy to allow the release branch
+pattern. Add:
+  "token.actions.githubusercontent.com:sub":
+    "repo:acme/web:ref:refs/heads/release/*"
+
+Rerun the failing job after the policy update. Verify on the next
+release branch.
+```
+
+## Failure taxonomy
+
+Every diagnosis maps to one of these categories. Use the category
+name verbatim in the hypothesis line — it is searchable in logbook
+issues.
+
+### Runner capacity
+
+Symptoms: job stays in `queued` for minutes, "No runner matching the
+specified labels was found", "All runners are busy".
+
+Typical fixes:
+- Switch from a custom self-hosted label to `ubuntu-latest` for the
+  affected job if no host-specific dependency exists.
+- For self-hosted fleets: check runner health, scale up, restart
+  stuck runners.
+- For GitHub-hosted concurrency limits: stagger workflows with
+  `concurrency:` groups, or apply for higher limits.
+
+### Cache miss / corruption
+
+Symptoms: "Cache not found for input keys", restored cache is
+inconsistent with the lockfile, cache exceeds 10 GB, slow restore.
+
+Typical fixes:
+- Cache key includes a hash of the **lockfile**, not the manifest.
+- Bump a numeric epoch in the cache key prefix to invalidate
+  poisoned caches: `cache-v2-${{ hashFiles('**/lock.file') }}`.
+- For oversized caches: split per workspace, exclude `node_modules`
+  if the package manager can rebuild from cache hits.
+
+### Secret scope
+
+Symptoms: `${{ secrets.X }}` is empty in a job, "Secret X not
+found", a deploy step receives a literal empty string.
+
+Typical fixes:
+- Confirm the secret exists at the correct scope: repo, environment,
+  or organisation. Environment secrets are only visible to jobs
+  declaring `environment: <name>`.
+- For forks: `pull_request` workflows do not receive repo secrets by
+  default. Use `pull_request_target` carefully, or move the work to
+  a workflow triggered by a maintainer.
+- Never log a secret to "verify" it — the masking is best-effort and
+  partial reveals leak.
+
+### Permission denial
+
+Symptoms: `403` on `GITHUB_TOKEN` API calls, "Resource not
+accessible by integration", OIDC `AssumeRoleWithWebIdentity` failure.
+
+Typical fixes:
+- Add the missing scope to the **job's** `permissions:` block, not
+  the workflow's.
+- For OIDC: align the IAM/GCP/Azure trust policy's `sub` claim with
+  the workflow's branch/environment.
+- For branch-protection violations: do not bypass — re-route the
+  work through a PR or a release process.
+
+### Action version mismatch
+
+Symptoms: a previously-green workflow fails with "input X not
+supported", "deprecated input", or a runtime error from an action.
+
+Typical fixes:
+- Pin actions by **SHA**, not tag. Tag references can be re-pointed
+  silently by the action maintainer.
+- Check the action's release notes for breaking changes. Pin to the
+  last known-good SHA while migrating.
+- Subscribe to the action's repository releases so the next bump is
+  intentional, not a surprise.
+
+### Network flake
+
+Symptoms: intermittent timeouts to `registry.npmjs.org`,
+`pypi.org`, `docker.io`, DNS resolution failures, GitHub API rate
+limits.
+
+Typical fixes:
+- Add a retry around the network step (`nick-fields/retry@<sha>` or
+  a shell loop with `curl --retry`). Retries are **bounded**: max 3
+  attempts, exponential backoff.
+- For rate limits on `GITHUB_TOKEN`: switch to an installation token
+  or a finer-grained PAT; do not loop in a tight retry.
+- A flake that recurs more than twice a week is no longer a flake —
+  reclassify and fix the underlying instability.
+
+### Syntax / schema error
+
+Symptoms: workflow fails to start, "Invalid workflow file",
+`actionlint` complaint, YAML parse error.
+
+Typical fixes:
+- Run `actionlint` locally on the file. The skill's
+  `scripts/lint-workflow.sh` wraps this.
+- Watch for the classic YAML traps: tab characters, multi-line
+  scalars with unintended indentation, `on:` keyword interpreted as
+  boolean, unquoted `1.10` becoming a float.
+
+### Concurrency conflict
+
+Symptoms: a deploy job is cancelled mid-flight with "The operation
+was canceled", two PRs racing on the same environment, an in-flight
+release aborted by a newer commit.
+
+Typical fixes:
+- For preview deploys: branch-scoped `concurrency:` with
+  `cancel-in-progress: true` is correct.
+- For production deploys: environment-scoped group with
+  `cancel-in-progress: false`. Serialise, do not race.
+- For PR-driven jobs that should not race their own follow-up
+  commits: include `${{ github.head_ref }}` in the group key.
+
+## Anti-patterns
+
+The agent does **not** propose any of the following, ever. If the
+user asks for one, explain why it is prohibited and give the real
+fix.
+
+### `continue-on-error: true`
+
+**Why prohibited:** it hides failures without fixing them. The
+pipeline goes green while the underlying defect compounds. Within
+weeks the team learns to ignore the affected step and the value of
+the check evaporates.
+
+**Real fix:** diagnose the failure with the symptom→hypothesis→
+evidence→fix loop, then either fix the code or remove the step. A
+flaky step that nobody can fix is a step that nobody should run.
+
+### `permissions: write-all` (or escalating permissions to "make it work")
+
+**Why prohibited:** least-privilege is the only defence against a
+compromised action or workflow. `write-all` gives every step the
+authority to push code, modify releases, and rewrite issues. A
+single compromised dependency in that environment is a full repo
+takeover.
+
+**Real fix:** identify exactly which permission the failing step
+needs (`contents: write`, `id-token: write`, etc.), add it at the
+**job** level, and leave the workflow-level default at
+`contents: read`.
+
+### Disabling security checks
+
+**Why prohibited:** disabling code scanning, secret scanning,
+dependency review, or signature verification removes the warning
+without removing the threat. The fix lasts until the first incident.
+
+**Real fix:** treat the check's complaint as the diagnosis. If the
+check is wrong, file the false-positive upstream; do not silence
+it locally.
+
+### `--no-verify` / skipping pre-commit hooks in CI
+
+**Why prohibited:** the hooks exist because the repo has agreed
+they should run. Bypassing them in CI means the agreement is
+nominal, not real. The next person inherits a repo that lints
+locally and lies in CI.
+
+**Real fix:** make the hook pass. If the hook is wrong, change the
+hook in a separate PR. Do not route around it.
+
+### "Just rerun until it passes"
+
+**Why prohibited:** intermittent passes are not green builds, they
+are unbounded retries. Cost grows; confidence does not.
+
+**Real fix:** identify the flake category (cache, network, race),
+apply the matching fix from the taxonomy, and verify with three
+consecutive clean runs before closing the diagnosis.
+
+## Simulation
+
+When the failure does not reproduce from the logs alone, fall back
+to local reproduction with `scripts/simulate-job.sh` (shipped with
+the `github-actions` skill):
+
+```bash
+scripts/simulate-job.sh .github/workflows/<file>.yml <job-id>
+```
+
+The script runs the job under `act` or an equivalent container,
+with the workflow's secrets mocked. Use it when:
+
+- The job depends on a matrix entry that is hard to inspect from
+  the logs.
+- The failure is environment-specific (Ubuntu image version,
+  preinstalled tool drift).
+- The fix needs to be verified before pushing a commit that will
+  trigger a real run.
+
+Do not use simulation as the **first** step — it is slower than
+log reading and obscures the actual symptom. Reach for it only
+when the evidence in the log is insufficient.
+
+## Output discipline
+
+The agent's response is a diagnosis, not a tutorial. The four-step
+structure (symptom, hypothesis, evidence, fix) is the message. Do
+not append:
+
+- "Hope this helps!"
+- "Let me know if you want me to apply the fix."
+- A restatement of the original error in the conclusion.
+
+If the diagnosis is uncertain, name the uncertainty explicitly:
+"Hypothesis A explains the symptom if the runner is GitHub-hosted;
+Hypothesis B applies if it is self-hosted. Which is it?". A
+confident wrong diagnosis is more expensive than an honest open
+question.
+
+## Handoff
+
+When the fix is identified, the agent's job is done. Applying the
+fix to the repository, opening a PR, and writing the logbook entry
+are delegated:
+
+- Code change in the workflow file → **developer** agent.
+- PR + logbook issue → **pr-logbook** agent.
+- New configuration from a clean slate (rare; only if the existing
+  workflow is beyond repair) → **ci-configurator** agent.

--- a/.gemini/skills/github-actions/SKILL.md
+++ b/.gemini/skills/github-actions/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: github-actions
+description: "Deep, practitioner-grade knowledge of GitHub Actions for authoring,
+reviewing, hardening, and debugging workflows. Activate when reading
+or writing any file under `.github/workflows/`, when diagnosing a
+failing pipeline, when reviewing a CI change in a pull request, or
+when designing reusable / composite actions. Covers workflow syntax,
+expressions, runners, caching, secrets, the GITHUB_TOKEN permission
+model, OIDC federation, and reusable workflows — plus the security
+defaults that should never be negotiated away."
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# GitHub Actions
+
+A dense, practitioner-oriented skill for working on GitHub Actions
+workflows. Read the relevant section before editing a workflow file;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A file under `.github/workflows/**` is being authored, modified, or
+  reviewed.
+- A composite action (`action.yml` / `action.yaml`) is being changed.
+- A reusable workflow (`on: workflow_call`) is being designed or
+  consumed.
+- A pipeline is failing and the root cause is suspected to be in the
+  workflow definition, the runner image, the cache, the permission
+  model, or the secret/variable scoping.
+- A pull request touches CI configuration and a reviewer-grade audit is
+  required (pinning, permissions, OIDC, secret exposure).
+- A migration is being planned (e.g., from GitLab CI, CircleCI, Jenkins,
+  or Azure Pipelines to GitHub Actions).
+- A self-hosted runner fleet is being designed, hardened, or
+  diagnosed.
+
+Defer to **security** when the change introduces a new secret, expands
+`GITHUB_TOKEN` permissions, adds an OIDC trust relationship to a cloud
+provider, or executes untrusted input (PR title, branch name, issue
+body) inside a shell. Defer to **architect** when the change
+restructures the workflow topology (e.g., splitting a monolithic
+workflow into reusable workflows used across many repositories).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitHub Actions. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/workflow-syntax.md` | Full grammar of `on:`, `jobs:`, `steps:`, `strategy:`, `concurrency:`, `defaults:`, `env:`, with annotated examples for every key. |
+| `references/expressions.md` | Context objects (`github`, `env`, `secrets`, `vars`, `needs`, `inputs`, `steps`, `job`, `runner`, `matrix`), built-in functions, operators, and `if:` evaluation rules. |
+| `references/runners.md` | GitHub-hosted runner matrix (OS, CPU, memory, disk, pre-installed software), self-hosted runner architecture, label/group selection, composite-action constraints, ARC (Actions Runner Controller). |
+| `references/caching.md` | `actions/cache` semantics — key construction, `restore-keys` fallback chain, cross-branch and cross-ref visibility, eviction, 10 GB repo limit, language-specific recipes (npm, pnpm, Yarn, Maven, Gradle, pip, Poetry, Go modules, Cargo). |
+| `references/secrets-and-vars.md` | Secrets vs. variables, scope precedence (org → repo → environment), OIDC federation patterns for AWS / GCP / Azure / Vault, masking, common exfiltration anti-patterns. |
+| `references/permissions.md` | `GITHUB_TOKEN` permission model, repository default policy, the `permissions:` key at workflow and job level, least-privilege recipes per use case (release, push container, comment on PR, deploy). |
+| `references/reusable-workflows.md` | `workflow_call` triggers, `inputs:` / `outputs:` / `secrets:` contracts, `secrets: inherit`, calling conventions, `strategy.matrix` interaction, nesting limits, versioning strategies. |
+
+## Core concepts
+
+A workflow is a YAML file under `.github/workflows/` triggered by one
+or more **events** (`on:`). Each workflow contains one or more
+**jobs**, which run in parallel by default on independent **runners**.
+A job is an ordered sequence of **steps**; each step is either a shell
+script (`run:`) or an invocation of an **action** (`uses:`). State
+between steps in a job is shared through the filesystem and through
+**outputs**; state between jobs travels through `needs.<job>.outputs`
+or through **artifacts**.
+
+### Triggers (`on:`)
+
+Common triggers and the trap that comes with each:
+
+- **`push`** / **`pull_request`** — the workhorses. `pull_request`
+  runs with the **base** repository's permissions but the **head**
+  ref's code; this is the headline supply-chain risk.
+- **`pull_request_target`** — runs with **base** code and **base**
+  secrets. Useful for labelling, dangerous for anything that checks out
+  the PR head. Never `actions/checkout` the PR head in a
+  `pull_request_target` workflow without a separate, sandboxed
+  evaluation step.
+- **`workflow_dispatch`** — manual trigger with typed `inputs`. Always
+  validate enum-style inputs.
+- **`workflow_call`** — turns the workflow into a callable function;
+  see `references/reusable-workflows.md`.
+- **`workflow_run`** — fires when another workflow finishes. Inherits
+  no secrets from the upstream workflow. Often used to expose results
+  to a higher-privilege context — extreme care required.
+- **`schedule`** — cron expressions, UTC. Skewed and not guaranteed
+  on the dot. The default branch only.
+- **`repository_dispatch`** / **`issues`** / **`issue_comment`** /
+  **`release`** — event-shaped triggers; check the `event.action` to
+  filter sub-events.
+
+### Jobs and steps
+
+A **job** declares `runs-on:` (the runner), an optional `needs:` list
+(dependency edges), an optional `strategy.matrix:` (fan-out), and a
+sequence of `steps:`. Each step has either `run:` or `uses:`,
+optionally `with:`, `env:`, `if:`, `id:`, `continue-on-error:`, and
+`timeout-minutes:`.
+
+Steps in the same job share the workspace (`$GITHUB_WORKSPACE`) and
+environment file (`$GITHUB_ENV`). Steps in different jobs do not — use
+`actions/upload-artifact` and `actions/download-artifact` to move
+files, and `outputs:` to move scalars.
+
+### Expressions and contexts
+
+The `${{ … }}` syntax evaluates expressions. The evaluator has
+seven first-class context objects (`github`, `env`, `vars`,
+`secrets`, `inputs`, `needs`, `steps`, `job`, `runner`, `matrix`) and
+a small set of functions (`contains`, `startsWith`, `endsWith`,
+`format`, `join`, `toJSON`, `fromJSON`, `hashFiles`, `success`,
+`always`, `cancelled`, `failure`). See `references/expressions.md` for
+the full enumeration and evaluation order.
+
+The single most important rule: **never** interpolate user-controlled
+strings (PR title, branch name, issue body, commit message) directly
+into a `run:` block via `${{ }}`. Pipe them through `env:` instead and
+read them as shell variables — the runner masks them properly and the
+shell parser does not re-evaluate them.
+
+### Runners
+
+Two flavours: GitHub-hosted (ephemeral VMs maintained by GitHub) and
+self-hosted (your hardware, your responsibility). GitHub-hosted runners
+are pre-warmed with common toolchains; the inventory shifts — pin a
+specific Ubuntu/Windows/macOS image (e.g., `ubuntu-24.04`, not
+`ubuntu-latest`) for reproducibility on long-lived workflows. See
+`references/runners.md` for resource limits and the pre-installed
+software matrix.
+
+### Caching
+
+`actions/cache` reduces install time by persisting directories
+identified by a **key**. Cache keys are immutable: once written under
+a key, content cannot be overwritten. `restore-keys` provides a
+prefix-fallback chain for partial hits. The cache scope is the
+repository; entries are reachable across refs with a base-ref fallback
+rule documented in `references/caching.md`. Total cache per repository
+is 10 GB; LRU eviction.
+
+### Secrets and variables
+
+**Secrets** are encrypted at rest, masked in logs, and never exposed
+via the API. **Variables** are plaintext, visible in logs, and meant
+for non-sensitive configuration. Both have three scopes: organisation,
+repository, environment. Environment scope binds to a deployment
+**environment** that can require approvals and wait timers — the
+correct primitive for promotion gates.
+
+For cloud credentials, **prefer OIDC** over long-lived secrets. OIDC
+issues a short-lived token signed by GitHub's OIDC provider; the cloud
+side validates the token's `sub`, `repository`, `ref`, and
+`environment` claims. No rotation, no leakage window. See
+`references/secrets-and-vars.md` for canonical AWS / GCP / Azure
+trust-policy snippets.
+
+### Permissions
+
+`GITHUB_TOKEN` is an automatically minted, job-scoped token whose
+scope is governed by the `permissions:` key. The org/repo default can
+be **permissive** (read-write to everything) or **restricted** (only
+`contents: read` and `metadata: read`). Always set
+`permissions:` explicitly at the workflow level, even if only to
+`contents: read`. Grant additional scopes at the job level on a
+need-to-know basis.
+
+### Reusable workflows
+
+A workflow with `on: workflow_call` becomes invocable from another
+workflow via `uses: owner/repo/.github/workflows/file.yml@ref`. The
+contract is declared via `inputs:`, `outputs:`, and `secrets:`. Nesting
+is limited to four levels deep; reusable workflows cannot call
+themselves (no recursion); a matrix in the **caller** can fan-out a
+reusable workflow but the **callee**'s matrix is independent. See
+`references/reusable-workflows.md`.
+
+## Common pitfalls
+
+The top ten failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned third-party actions.** `uses: someorg/some-action@v3`
+   is a moving target. Pin by full commit SHA
+   (`uses: someorg/some-action@abc123def456…`) and add a comment with
+   the human-readable version. Renovate / Dependabot will track
+   updates.
+2. **Over-scoped `GITHUB_TOKEN`.** Inheriting `write-all` because the
+   repository default was never tightened. Set
+   `permissions: contents: read` at the workflow level and elevate per
+   job.
+3. **Script injection via untrusted input.** `run: echo "${{ github.event.pull_request.title }}"`
+   is remote code execution. Pipe through `env:` and use
+   `"$PR_TITLE"`.
+4. **`pull_request_target` checking out the PR head.** The classic
+   path to leaking org-level secrets. Either drop the
+   `actions/checkout` of the head, or fence the privileged steps
+   behind an explicit approval (label gating + environment).
+5. **Cache poisoning across branches.** A malicious PR can write a
+   cache entry that the main branch later restores. Restrict cache
+   restore to the same ref family, or include a security-sensitive
+   discriminator in the key.
+6. **`hashFiles()` over the wrong glob.** `hashFiles('**/package-lock.json')`
+   in a monorepo with vendored copies returns a key that changes
+   constantly. Pin to the actual lockfile path.
+7. **`continue-on-error: true` masking failures.** Used to silence a
+   flaky step, ends up silencing a real regression. Replace with retry
+   logic and explicit failure handling.
+8. **`if: always()` on cleanup steps that depend on `secrets`.**
+   `always()` runs on cancellation; secrets may not be hydrated.
+   Combine with `if: ${{ !cancelled() }}` if needed.
+9. **`workflow_dispatch` inputs typed as `string` when they are
+   booleans/enums.** No client-side validation; enforce with
+   `type: choice` and `options:` or `type: boolean`.
+10. **Self-hosted runners accepting jobs from public forks.** A fork
+    PR can run arbitrary code on your hardware. Set
+    `Require approval for all outside collaborators` on the
+    repository, and never attach self-hosted runners to a public
+    repository without an additional approval gate.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge.
+
+- **`scripts/actionlint`** — runs the upstream `actionlint` binary
+  across `.github/workflows/`. Catches YAML errors, shellcheck
+  findings inside `run:` blocks, undefined contexts, unreachable
+  steps. Run on every workflow change.
+- **`scripts/check-pinned-actions`** — fails the build if any
+  `uses:` references a tag/branch rather than a 40-character commit
+  SHA. The first-line defence against supply-chain compromise.
+- **`scripts/check-secrets-exposure`** — greps for
+  `${{ secrets.* }}` patterns that flow into `run:` blocks without
+  going through `env:`, and flags `echo $SECRET` style mistakes.
+- **`scripts/simulate-job`** / **`scripts/simulate-workflow`** —
+  thin wrappers around `act` that run a job or the whole workflow
+  locally in Docker. Useful for fast iteration on `run:` logic, but
+  remember that `act` does not faithfully reproduce the full
+  GitHub-hosted runner image; treat green local runs as necessary,
+  not sufficient.
+
+Invoke them as:
+
+```sh
+scripts/actionlint .github/workflows/
+scripts/check-pinned-actions .github/workflows/
+scripts/check-secrets-exposure .github/workflows/
+scripts/simulate-job .github/workflows/ci.yml build
+scripts/simulate-workflow .github/workflows/ci.yml
+```
+
+CI should fail closed on any of these. If a script does not exist in
+the current fork, add it as part of the same PR that introduces a new
+workflow.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every third-party action by 40-character commit SHA.** No
+   `@v3`, no `@main`. First-party (`actions/*`) may be pinned by SHA or
+   by major-version tag — prefer SHA. Document the pin with a comment
+   carrying the human-readable version.
+2. **Set `permissions:` at the workflow level**, defaulting to
+   `contents: read`. Elevate per job. Never leave the workflow with
+   the implicit org/repo default.
+3. **Prefer OIDC over long-lived cloud credentials.** A long-lived AWS
+   access key in `secrets.AWS_SECRET_ACCESS_KEY` is acceptable only
+   when the cloud provider does not yet support OIDC for the target
+   resource. Document the exception.
+4. **Never define secrets in `env:` at the top level of a workflow.**
+   Top-level `env` is inherited by every job; secrets should be
+   bound to the smallest scope that needs them — the specific step,
+   or at most the specific job.
+5. **Never interpolate untrusted input into `run:` via `${{ }}`.**
+   Use `env:` to bind the value to a shell variable; reference it as
+   `"$VAR"` with quotes.
+6. **`pull_request_target` workflows must not check out the PR head**
+   unless behind an explicit human approval gate and never with access
+   to secrets.
+7. **Set `concurrency:` on long-running jobs** to prevent runaway cost
+   from rapid pushes — typically
+   `group: ${{ github.workflow }}-${{ github.ref }}` with
+   `cancel-in-progress: true` for non-deployment workflows.
+8. **Set `timeout-minutes:` on every job.** The default is six hours.
+   A reasonable upper bound is the 95th percentile of historical
+   runtime times two.
+9. **Use environments for deployment gates.** Production deployments
+   should target a GitHub Environment with required reviewers and a
+   wait timer. The environment is also the correct scope for
+   production secrets.
+10. **Enable required status checks** on protected branches for the
+    workflows that enforce these defaults. A skill rule that is not
+    mechanically enforced will drift.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure CI skeleton
+
+```yaml
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<sha>  # v4.2.x
+      - uses: actions/setup-node@<sha>  # v4.x
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+permissions:
+  id-token: write   # required for OIDC token issuance
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      - uses: actions/checkout@<sha>
+      - uses: aws-actions/configure-aws-credentials@<sha>  # v4.x
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/gha-deploy
+          aws-region: eu-west-3
+      - run: ./scripts/deploy.sh
+```
+
+### Safe handling of untrusted PR title
+
+```yaml
+- name: Comment on PR
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    # Quoted, no re-evaluation, masked if it happens to match a secret
+    printf 'Title: %s\n' "$PR_TITLE"
+```
+
+### Cache key with safe fallback
+
+```yaml
+- uses: actions/cache@<sha>  # v4.x
+  with:
+    path: ~/.npm
+    key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    restore-keys: |
+      npm-${{ runner.os }}-
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/.gemini/skills/github-actions/SKILL.md
+++ b/.gemini/skills/github-actions/SKILL.md
@@ -235,7 +235,7 @@ real-world audits:
 Helper scripts live under `scripts/` and are the recommended way to
 catch the pitfalls above before merge.
 
-- **`scripts/actionlint`** — runs the upstream `actionlint` binary
+- **`scripts/lint-workflow.sh`** — runs the upstream `actionlint` binary
   across `.github/workflows/`. Catches YAML errors, shellcheck
   findings inside `run:` blocks, undefined contexts, unreachable
   steps. Run on every workflow change.
@@ -255,7 +255,7 @@ catch the pitfalls above before merge.
 Invoke them as:
 
 ```sh
-scripts/actionlint .github/workflows/
+scripts/lint-workflow.sh .github/workflows/
 scripts/check-pinned-actions .github/workflows/
 scripts/check-secrets-exposure .github/workflows/
 scripts/simulate-job .github/workflows/ci.yml build

--- a/.gemini/skills/github-actions/references/caching.md
+++ b/.gemini/skills/github-actions/references/caching.md
@@ -1,0 +1,273 @@
+# Caching reference
+
+`actions/cache` and its first-party language wrappers reduce install
+time by persisting directories across runs. The mechanism is simple on
+the surface and full of footguns underneath. This document covers the
+key/restore-key semantics, scoping rules, eviction, the 10 GB
+per-repository limit, and proven recipes for each major language.
+
+## How `actions/cache` works
+
+A step using `actions/cache`:
+
+```yaml
+- uses: actions/cache@<sha>  # v4.x
+  id: cache
+  with:
+    path: ~/.npm
+    key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    restore-keys: |
+      npm-${{ runner.os }}-
+```
+
+The runner performs two operations:
+
+1. **Pre-job restore.** Looks up `key` exactly. If hit, the
+   directories at `path:` are restored, `steps.<id>.outputs.cache-hit`
+   is set to `'true'`, and the install step can be skipped or
+   shortened. If miss, the `restore-keys:` are tried as **prefixes**
+   in order; on first prefix match, partial content is restored and
+   `cache-hit` stays `'false'`.
+2. **Post-job save.** If the pre-job lookup did not hit the exact
+   `key`, the cache is uploaded after the job succeeds. Uploads happen
+   in a `post:` step that runs even if a later step fails — as long as
+   the cache step itself succeeded.
+
+The save is conditional on **exact-key miss**. If you want to refresh
+a cache whose content is sensitive to inputs not covered by the key
+(e.g., transitive dep changes that the lockfile already pinned), bump
+a discriminator in the key.
+
+## Key construction
+
+A cache key is just a string. Build it from:
+
+- A namespace (the cache "kind": `npm`, `maven`, `pip`, …).
+- The runner OS (`runner.os`), to avoid cross-OS restores of binary
+  caches.
+- The architecture (`runner.arch`), if your toolchain ships
+  arch-specific binaries.
+- A content hash (`hashFiles`) over the lock file(s) that pin
+  dependency content.
+- Optionally a version discriminator (`v2`, …) to invalidate the
+  cache wholesale during a migration.
+
+Worked example for a monorepo with multiple lockfiles:
+
+```yaml
+key: pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'packages/*/pnpm-lock.yaml') }}
+```
+
+`hashFiles` returns SHA-256 of the concatenated, sorted file contents.
+If no file matches the glob, the function returns `''` and the key
+becomes degenerate — verify the glob locally before merging.
+
+## `restore-keys` fallback chain
+
+`restore-keys` is a newline-separated list of **prefix** patterns.
+The runner walks the list top-down, returning the first cache entry
+whose key starts with the given prefix (ordered by recency for ties).
+
+```yaml
+restore-keys: |
+  pnpm-${{ runner.os }}-${{ runner.arch }}-
+  pnpm-${{ runner.os }}-
+```
+
+Use restore-keys to get a partial hit on lockfile changes — the saved
+`node_modules` is mostly correct, the install step does the
+incremental work. Trade-off: a partial restore that ends up with
+stale content is its own debugging nightmare. Reset `restore-keys`
+when in doubt.
+
+## Scope and visibility
+
+A cache entry is scoped to the **repository**. Cross-ref restore
+rules:
+
+- A job on branch `feature/x` can restore caches created on
+  `feature/x` **and** on the **default branch** (typically `main`).
+- A job on `main` restores only `main` caches.
+- A job triggered by a `pull_request` from a fork uses the
+  **base** repository's cache scope, but **cannot write** to it —
+  prevents cache poisoning by an outside contributor.
+
+The base-branch fallback means caches built on `main` are the
+canonical source for feature branches. Build a "warm-up" workflow on
+`main` if your default branch rarely runs the slow install path.
+
+## Limits
+
+- **10 GB total per repository.** Eviction is least-recently-used
+  once the cap is hit.
+- **A cache entry is immutable.** You cannot overwrite a key; you must
+  invalidate by changing the key.
+- **Unused entries are evicted after 7 days.** A cache that hasn't
+  been read in a week is gone, regardless of total usage.
+
+Monitor usage via the Actions UI (`Caches` tab in repo settings) or
+the REST API (`GET /repos/{owner}/{repo}/actions/caches`). The CLI
+`gh cache list` enumerates entries; `gh cache delete <id>` removes
+one.
+
+## Cross-OS pitfalls
+
+A cache built on Linux often does not work on macOS or Windows
+because of native binaries (`node-sass`, `node-gyp` outputs,
+`puppeteer` Chromium, `tsx`'s `esbuild` binary, etc.). Always include
+`runner.os` in the key. For mixed-arch (x64 + arm64) matrices, also
+include `runner.arch`.
+
+## Cache poisoning
+
+A malicious PR cannot write to a cache (forks have read-only cache
+access), but a contributor with push access to a feature branch can
+write a cache that the default branch later restores (via the
+base-branch fallback).
+
+Mitigations:
+
+- Keep the default branch isolated: use a `restore-keys:` set that
+  only matches keys built on `main`. Easiest pattern: scope the key
+  with `${{ github.ref_name == github.event.repository.default_branch && 'main' || 'fork' }}`
+  so fork content never falls within `main`'s prefix chain.
+- Treat cached binaries as untrusted. Re-verify checksums after
+  restore for security-sensitive tools.
+
+## Language recipes
+
+### npm
+
+```yaml
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: npm
+    cache-dependency-path: package-lock.json
+```
+
+`actions/setup-node` does cache management for you when `cache: npm`
+is set — keys by lockfile hash, restores to `~/.npm`. Prefer this to
+hand-rolled `actions/cache` for the common case.
+
+### pnpm
+
+`pnpm` keeps a content-addressable store; cache `~/.local/share/pnpm/store`
+(Linux) / equivalent path on other OSes.
+
+```yaml
+- uses: pnpm/action-setup@<sha>  # v4.x
+  with:
+    run_install: false
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: pnpm
+```
+
+### Yarn (Classic and Berry)
+
+```yaml
+- uses: actions/setup-node@<sha>
+  with:
+    node-version-file: .nvmrc
+    cache: yarn
+    cache-dependency-path: yarn.lock
+```
+
+For Yarn Berry with zero-installs, the `.yarn/cache` directory is
+checked into the repo — no `actions/cache` needed.
+
+### Maven
+
+```yaml
+- uses: actions/setup-java@<sha>  # v4.x
+  with:
+    distribution: temurin
+    java-version: 21
+    cache: maven
+```
+
+Keys on `**/pom.xml`. For Gradle, set `cache: gradle` instead — keys
+on `**/*.gradle*` and `**/gradle-wrapper.properties`.
+
+### pip
+
+```yaml
+- uses: actions/setup-python@<sha>  # v5.x
+  with:
+    python-version: "3.12"
+    cache: pip
+    cache-dependency-path: |
+      requirements*.txt
+      requirements/*.txt
+```
+
+For Poetry, drop the built-in cache and use `actions/cache` directly
+over `~/.cache/pypoetry` keyed on `poetry.lock`.
+
+### Go modules
+
+```yaml
+- uses: actions/setup-go@<sha>  # v5.x
+  with:
+    go-version-file: go.mod
+    cache: true   # default: true
+```
+
+`setup-go` caches `~/.cache/go-build` and `~/go/pkg/mod` keyed on
+`go.sum`.
+
+### Cargo (Rust)
+
+`Swatinem/rust-cache` is the de facto pattern; it handles the
+crate-registry, git deps, target directory, and adapts the key to
+the Rust toolchain version.
+
+```yaml
+- uses: dtolnay/rust-toolchain@<sha>
+  with:
+    toolchain: stable
+- uses: Swatinem/rust-cache@<sha>
+  with:
+    workspaces: . -> target
+```
+
+### Docker layer cache
+
+Pure `actions/cache` over BuildKit's `--cache-to type=local` is
+brittle (it grows unbounded). Prefer the GitHub-native cache backend:
+
+```yaml
+- uses: docker/setup-buildx-action@<sha>
+- uses: docker/build-push-action@<sha>
+  with:
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+`type=gha` uses the same 10 GB pool — be conscious of layered-cache
+growth and prune periodically by changing the `scope` argument.
+
+### Bazel / Nix / Pants
+
+For Bazel, prefer a remote cache (BuildBuddy, Google Cloud, internal
+backend) over `actions/cache` — the local repo cache changes
+constantly and overflows the 10 GB cap quickly. For Nix, use the
+`cachix/cachix-action` to push to a Cachix store. Pants and Buck2
+have similar remote-cache stories.
+
+## Debugging
+
+`cache-hit` is the first thing to check. If always `'false'`, the
+key is changing every run — usually a `hashFiles` glob that picks up
+generated files. Print the key in a debug step:
+
+```yaml
+- run: echo "Computed key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}"
+```
+
+If `cache-hit` is `'true'` but the install step still rebuilds from
+scratch, the restored directory is incomplete — verify the `path:`
+covers everything the toolchain reads (e.g., npm's `~/.npm` versus
+`node_modules` versus the workspace's `.next/`).

--- a/.gemini/skills/github-actions/references/expressions.md
+++ b/.gemini/skills/github-actions/references/expressions.md
@@ -1,0 +1,309 @@
+# Expressions reference
+
+The expression language used inside `${{ … }}` interpolation and in
+the `if:` key. Read this before writing any non-trivial condition or
+output reference. Memorising the truthiness and short-circuit rules
+avoids the bulk of "the step ran when I told it not to" bugs.
+
+## Evaluation surface
+
+Expressions appear in three places:
+
+1. **Interpolated** via `${{ expr }}` inside string values (most
+   keys: `name`, `run`, `with`, `env`, `runs-on`, etc.).
+2. **As the entire value** of certain keys: `if:`, `continue-on-error:`,
+   `timeout-minutes:` — here the `${{ }}` wrapper is optional and
+   omitted by convention.
+3. **Inside `${{ }}` blocks that produce a YAML value**, including
+   for arrays via `fromJSON('[…]')`.
+
+Expressions are evaluated **before** the job starts (for keys
+resolved at workflow load — `runs-on`, `name`, etc.) or **just before
+the step runs** (for step-scoped keys). Some contexts (notably
+`steps`, `needs`, `job.status`) are populated incrementally during
+the job lifecycle.
+
+## Context objects
+
+### `github`
+
+Metadata about the event and the run. Selected fields (full list in
+GitHub docs, but these cover 95 % of usage):
+
+| Field | Description |
+|-------|-------------|
+| `github.event_name` | The triggering event (`push`, `pull_request`, `workflow_dispatch`, …). |
+| `github.event` | The full webhook payload. Shape varies by event. |
+| `github.ref` | The fully qualified ref (`refs/heads/main`, `refs/tags/v1.2.3`). |
+| `github.ref_name` | The short ref (`main`, `v1.2.3`). |
+| `github.ref_type` | `branch` or `tag`. |
+| `github.sha` | The commit SHA. For `pull_request`, the merge commit on the base. |
+| `github.head_ref` | Source branch (only on `pull_request`). |
+| `github.base_ref` | Target branch (only on `pull_request`). |
+| `github.actor` | Login of the user that triggered the run. |
+| `github.triggering_actor` | For re-runs: the user that pressed re-run. |
+| `github.repository` | `owner/repo`. |
+| `github.repository_owner` | `owner`. |
+| `github.workflow` | The workflow `name:`. |
+| `github.run_id` / `github.run_number` / `github.run_attempt` | Run identity. |
+| `github.workspace` | Absolute path of `$GITHUB_WORKSPACE`. |
+| `github.token` | Same as `secrets.GITHUB_TOKEN`. |
+| `github.api_url` / `github.server_url` / `github.graphql_url` | API endpoints (different on GHES). |
+
+### `env`
+
+Environment variables defined via `env:` at workflow/job/step level
+**plus** anything written to `$GITHUB_ENV`. Does **not** include
+variables exported by `export VAR=…` in a `run:` block — those live
+only in that step's shell.
+
+### `vars`
+
+Plaintext repository / org / environment variables. `${{ vars.X }}`.
+
+### `secrets`
+
+Encrypted repository / org / environment secrets. Includes
+`secrets.GITHUB_TOKEN`. Values are masked in logs. Do not interpolate
+into `run:` blocks directly.
+
+### `inputs`
+
+Populated on `workflow_dispatch:` and `workflow_call:`. Typed per the
+input declaration; `boolean` inputs are real booleans, not the strings
+`"true"` / `"false"`.
+
+### `needs`
+
+Outputs and status of dependency jobs. Shape:
+
+```text
+needs.<job-id>.result    # 'success' | 'failure' | 'cancelled' | 'skipped'
+needs.<job-id>.outputs.<output-name>
+```
+
+### `steps`
+
+Outputs and status of prior steps in the same job. Shape:
+
+```text
+steps.<step-id>.outcome     # before continue-on-error
+steps.<step-id>.conclusion  # after continue-on-error
+steps.<step-id>.outputs.<name>
+```
+
+`outcome` is what the step actually did; `conclusion` is what the
+workflow sees. They differ only when `continue-on-error: true` turned
+a failure into a success.
+
+### `job`
+
+Current job state. `job.status` is `'success'` / `'failure'` /
+`'cancelled'`. `job.container.id` / `job.container.network` /
+`job.services.<id>.id` for container metadata.
+
+### `runner`
+
+The runner the job is on. `runner.os` (`Linux`, `macOS`, `Windows`),
+`runner.arch` (`X86`, `X64`, `ARM`, `ARM64`), `runner.name`,
+`runner.temp` (writable temp dir), `runner.tool_cache` (path to the
+pre-installed toolchain cache).
+
+### `matrix`
+
+The values for the current matrix cell. `matrix.<axis>` for each axis
+defined in `strategy.matrix`.
+
+### `strategy`
+
+`strategy.fail-fast`, `strategy.job-index`, `strategy.job-total`,
+`strategy.max-parallel`.
+
+## Operators
+
+In approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `[ ]` `.` | Indexing and property access. `github['event']['pull_request']` is equivalent to `github.event.pull_request`. |
+| `!` | Logical NOT. |
+| `<`, `<=`, `>`, `>=` | Numeric and string comparison. |
+| `==`, `!=` | Equality. Loose comparison: `'1' == 1` is `true`. |
+| `&&`, `||` | Short-circuit logical AND / OR. |
+
+Strings are single-quoted; double quotes are not valid in expressions
+(they belong to YAML's quoting layer). Numbers and booleans are
+literal.
+
+## Functions
+
+### `contains(haystack, needle)`
+
+`true` if `haystack` contains `needle`. Works on strings (substring),
+arrays (element membership), and objects (key membership).
+
+```yaml
+if: contains(github.event.pull_request.labels.*.name, 'ship-it')
+```
+
+The `*` is an **object filter** — it collects the named property from
+each element of an array.
+
+### `startsWith(string, prefix)` / `endsWith(string, suffix)`
+
+Self-explanatory. Case-sensitive.
+
+### `format(template, arg0, arg1, …)`
+
+Positional formatting with `{N}` placeholders.
+
+```yaml
+name: ${{ format('Deploy {0} ({1})', inputs.environment, github.actor) }}
+```
+
+### `join(array, separator)`
+
+Concatenates an array. Default separator is `,`. Useful for matrix
+labels.
+
+### `toJSON(value)` / `fromJSON(string)`
+
+Serialise / deserialise. `fromJSON` is the canonical way to inject a
+typed value (number, boolean, array) into a key that would otherwise
+receive a string.
+
+```yaml
+strategy:
+  matrix:
+    target: ${{ fromJSON(needs.plan.outputs.targets) }}
+```
+
+### `hashFiles(pattern, …)`
+
+SHA-256 of the concatenated contents of files matching the glob
+pattern(s). The cornerstone of cache keys.
+
+```yaml
+key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/*/package-lock.json') }}
+```
+
+Returns an empty string if no files match — beware of accidentally
+sharing a cache between unrelated branches because the lockfile path
+moved.
+
+### Status check functions
+
+The four functions that drive `if:` chains:
+
+| Function | Returns `true` when… |
+|----------|----------------------|
+| `success()` | All previous steps in the job (and all `needs:` for jobs) succeeded. |
+| `failure()` | Any previous step failed (and the failure was not handled). |
+| `cancelled()` | The workflow was cancelled. |
+| `always()` | Always — even on cancellation. |
+
+The default `if:` is implicit `success()`. To run a cleanup step on
+failure but not on cancellation:
+
+```yaml
+if: ${{ failure() && !cancelled() }}
+```
+
+To run an artifact-upload step regardless of outcome:
+
+```yaml
+if: ${{ !cancelled() }}
+```
+
+`always()` is hazardous — secrets and the runner network may be in
+the process of being torn down on cancellation.
+
+## Truthiness
+
+| Value | Truthy? |
+|-------|---------|
+| `true` (boolean) | yes |
+| Non-empty string | yes |
+| Non-zero number | yes |
+| Non-empty array | yes |
+| Object with at least one key | yes |
+| `false` / `''` / `0` / `null` / `[]` / `{}` | no |
+
+The empty-string trap: `if: env.FOO` evaluates `''` to `false`. If
+you want "the variable exists at all", you have to check explicitly
+(`if: env.FOO != ''`).
+
+## Common patterns
+
+### Run only on the default branch push
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+```
+
+### Skip drafts
+
+```yaml
+if: github.event.pull_request.draft == false
+```
+
+### Run when a specific label is present
+
+```yaml
+if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+```
+
+### Run a cleanup regardless of upstream success
+
+```yaml
+if: ${{ !cancelled() }}
+```
+
+### Use a matrix value as a conditional
+
+```yaml
+if: matrix.coverage
+```
+
+(works because `matrix.coverage: true` is the boolean `true` when set
+via `include:`.)
+
+### Dynamic matrix from a previous job
+
+```yaml
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      targets: ${{ steps.set.outputs.targets }}
+    steps:
+      - id: set
+        run: echo "targets=[\"a\",\"b\",\"c\"]" >> "$GITHUB_OUTPUT"
+  fan-out:
+    needs: plan
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.plan.outputs.targets) }}
+    steps:
+      - run: ./deploy.sh ${{ matrix.target }}
+```
+
+## Pitfalls
+
+- **`secrets.X` inside `run:` directly.** Use `env:` to bind, then
+  reference `"$X"`. Direct interpolation is a script-injection
+  channel.
+- **Comparing a boolean input to a string.** `if: inputs.dry_run ==
+  'true'` works only because GitHub's evaluator loosely-compares; the
+  correct form is `if: inputs.dry_run`.
+- **`hashFiles` matching nothing.** Returns `''`, which silently
+  changes the cache key. Verify the glob path before relying on it.
+- **`steps.<id>.outputs.<name>` returns empty for a skipped step.**
+  Chain conditions with `&&` rather than relying on a value that may
+  not have been produced.
+- **`always()` on a cleanup step that uses secrets.** The job may be
+  cancelling; the secret may already be unbound. Use
+  `if: ${{ !cancelled() }}` if you really mean "any outcome except
+  cancellation".

--- a/.gemini/skills/github-actions/references/expressions.md
+++ b/.gemini/skills/github-actions/references/expressions.md
@@ -130,7 +130,7 @@ In approximate precedence order (tightest first):
 | `!` | Logical NOT. |
 | `<`, `<=`, `>`, `>=` | Numeric and string comparison. |
 | `==`, `!=` | Equality. Loose comparison: `'1' == 1` is `true`. |
-| `&&`, `||` | Short-circuit logical AND / OR. |
+| `&&`, `\|\|` | Short-circuit logical AND / OR. |
 
 Strings are single-quoted; double quotes are not valid in expressions
 (they belong to YAML's quoting layer). Numbers and booleans are

--- a/.gemini/skills/github-actions/references/permissions.md
+++ b/.gemini/skills/github-actions/references/permissions.md
@@ -1,0 +1,266 @@
+# Permissions reference
+
+The `permissions:` key controls the scope of `GITHUB_TOKEN`, the
+automatically minted token that GitHub injects into every job. Getting
+this right is the single highest-leverage defence against supply-chain
+compromise — a workflow with `contents: read` and nothing else cannot
+push code, cannot publish a package, cannot open a PR, cannot tag a
+release, no matter what an action it calls tries to do.
+
+## The `GITHUB_TOKEN`
+
+A short-lived (max 24 h, but the job's lifetime in practice) installation
+token for the GitHub App `github-actions[bot]`. It is:
+
+- Minted at job start, exposed as `secrets.GITHUB_TOKEN`,
+  `github.token`, and the environment variable `GITHUB_TOKEN` (if
+  set).
+- Scoped to the **repository** running the workflow. It cannot reach
+  other repositories in the org by default.
+- Subject to the `permissions:` key for granular per-scope control.
+- Revoked at job end.
+
+The token can:
+
+- Read and write repo content (per the `permissions:` map).
+- Authenticate to `ghcr.io` (the GitHub Container Registry) for the
+  same repo's namespace.
+- Make API calls against the repo and its issues/PRs.
+
+It **cannot**:
+
+- Push to a different repository.
+- Trigger workflows by pushing to the repo (cycle prevention) — the
+  workflow that pushes does not cause its own next run.
+- Approve a PR it opened.
+
+## Default policy
+
+The org / repo setting `Workflow permissions` controls the default
+scope when `permissions:` is omitted. Two values:
+
+- **`read-write` (legacy default).** All scopes set to `write`. The
+  reason a 2021-vintage workflow can `git push` without any explicit
+  permission grant.
+- **`read-only` (recommended default).** `contents: read` and
+  `metadata: read`. All other scopes are `none`.
+
+Set the org to `read-only` and grant additional scopes in each
+workflow that needs them. Audit which repos still default to
+`read-write` — those are the highest-risk surface.
+
+The same settings page controls **"Allow GitHub Actions to create
+and approve pull requests"**. Leave it off unless a specific bot
+workflow needs it; even then, scope the approval mechanism (e.g.,
+require a separate identity, not `GITHUB_TOKEN`).
+
+## The `permissions:` key
+
+A map from scope name to access level (`read`, `write`, `none`):
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+```
+
+Shorthands:
+
+- `permissions: read-all` — every scope `read`.
+- `permissions: write-all` — every scope `write`.
+- `permissions: {}` — every scope `none` (no API access at all).
+
+Set at workflow level for the default; override at job level for
+exceptions. Job-level `permissions:` **replaces** the workflow-level
+map — it does not merge. A job that needs an extra scope must
+re-declare the ones it still wants.
+
+## Scope inventory
+
+The full list of scopes, with the common operations they unlock:
+
+| Scope | `read` enables | `write` enables |
+|-------|---------------|-----------------|
+| `actions` | List workflow runs, download artifacts. | Cancel runs, delete artifacts. |
+| `attestations` | Read provenance attestations. | Create attestations (sigstore). |
+| `checks` | Read check runs. | Create / update check runs (custom CI integration). |
+| `contents` | Clone code, read tags/releases. | Push commits, create tags, create releases. |
+| `deployments` | Read deployment statuses. | Create deployments and statuses (powers the Environments UI). |
+| `discussions` | Read discussions. | Comment on / create discussions. |
+| `id-token` | Mint OIDC token (for cloud federation). | (`write` is required to request a token.) |
+| `issues` | Read issues. | Create / comment / close / label issues. |
+| `models` | Use GitHub Models API (read). | — |
+| `packages` | Read GitHub Packages (pull container, npm, …). | Publish packages. |
+| `pages` | Read Pages config. | Deploy to Pages. |
+| `pull-requests` | Read PRs and their reviews. | Create / comment / close / label / merge PRs. |
+| `repository-projects` | Read classic Projects. | Modify classic Projects. |
+| `security-events` | Read code scanning alerts. | Upload SARIF, dismiss alerts. |
+| `statuses` | Read commit statuses. | Create / update commit statuses. |
+
+Two scopes deserve special mention:
+
+- **`id-token: write`** — required to request the OIDC token used
+  for cloud federation. Has no read counterpart; the token itself is
+  always generated on demand.
+- **`contents: write`** — broad. Allows pushing to any branch,
+  creating tags, creating releases, modifying the wiki. If the only
+  thing you actually need is "create a release", consider using a
+  dedicated PAT or App token with a tighter scope instead.
+
+## Least-privilege recipes
+
+The minimum `permissions:` for each common workflow shape.
+
+### Read-only CI
+
+```yaml
+permissions:
+  contents: read
+```
+
+Lints, tests, type-checks. The vast majority of CI workflows.
+
+### CI that comments on PRs
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+For test-report comments, coverage diffs, screenshot bots.
+
+### Pushing a container to GHCR
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+```
+
+`packages: write` is required to push to the
+`ghcr.io/<owner>/<repo>` namespace authenticated as
+`GITHUB_TOKEN`.
+
+### Creating a GitHub Release
+
+```yaml
+permissions:
+  contents: write
+```
+
+`softprops/action-gh-release` and friends need `contents: write` to
+create the release and upload assets.
+
+### Deploying to GitHub Pages
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+```
+
+The modern Pages deployment flow uses an artifact + OIDC handshake;
+`id-token: write` is mandatory.
+
+### OIDC deployment to a cloud provider
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+`id-token: write` to mint the JWT; `contents: read` to checkout.
+No other scope is needed unless a follow-up step calls the GitHub
+API.
+
+### Uploading SARIF for code scanning
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+```
+
+For `github/codeql-action/upload-sarif` and any third-party scanner
+publishing alerts.
+
+### Approving / merging a Dependabot PR
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+Combined with the org setting "Allow GitHub Actions to approve PRs"
+enabled. Note that `GITHUB_TOKEN` cannot approve a PR opened by the
+same `GITHUB_TOKEN` (Dependabot is a separate identity, so this
+works).
+
+### Posting a check run from a custom CI
+
+```yaml
+permissions:
+  contents: read
+  checks: write
+```
+
+For non-Actions CI integrations posting back to GitHub.
+
+## Workflow- vs. job-level `permissions:`
+
+The workflow-level block is the **default for all jobs**. A job-level
+block **replaces** (does not merge with) the workflow default.
+
+Common pattern: keep the workflow at the read-only floor, elevate
+specific jobs:
+
+```yaml
+permissions:
+  contents: read     # default for all jobs
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    # inherits contents: read
+    steps: [...]
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # this job alone can write
+      packages: write
+    needs: test
+    steps: [...]
+```
+
+The release job above gets exactly `contents: write` and
+`packages: write` — everything else (including `pull-requests`)
+is `none`.
+
+## Org-level restrictions
+
+The org admin can constrain the allowable maximum across all repos
+via `Actions → General → Workflow permissions` at org level. If the
+org sets the cap to `read-only`, no workflow in the org can grant
+write to itself — only a PAT or App token can bypass.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Grep for `write-all` and `read-all` across all `.github/workflows/`
+  in the org.
+- Grep for workflows missing a workflow-level `permissions:` block
+  entirely.
+- Cross-reference each `permissions:` entry against the actual API
+  calls the workflow makes. Drop unused scopes.
+- For workflows using `id-token: write`, verify the OIDC trust
+  policy on the cloud side is scoped to the specific
+  `repo:<owner>/<repo>:environment:<env>` subject.
+
+The `scripts/actionlint` validator (with the `--shellcheck` flag)
+catches the obvious cases. A hand-written check that fails the build
+on `write-all` is worth adding to the same pre-merge gate.

--- a/.gemini/skills/github-actions/references/reusable-workflows.md
+++ b/.gemini/skills/github-actions/references/reusable-workflows.md
@@ -1,0 +1,374 @@
+# Reusable workflows reference
+
+A reusable workflow is a workflow file that can be invoked from
+another workflow as if it were a step. It is GitHub Actions's answer
+to function abstraction: a contract of inputs, secrets, and outputs,
+with the body executing in a clean job (or jobs) of its own.
+
+This document covers the `workflow_call` trigger, the contract
+definition syntax, calling conventions, the interaction with matrices
+and concurrency, and the limitations that distinguish reusable
+workflows from composite actions.
+
+## Reusable workflow vs. composite action
+
+A frequent question. The trade-off:
+
+| Property | Reusable workflow | Composite action |
+|----------|-------------------|------------------|
+| Trigger | `workflow_call`. | Called via `uses:` in a step. |
+| Granularity | One or more jobs. | A sequence of steps inside an existing job. |
+| Runs on | Its own runner(s). | The caller's runner. |
+| Can declare `runs-on:` | Yes. | No (inherits). |
+| Can use `services:` / `container:` | Yes. | No. |
+| Secrets | Explicit input, or `secrets: inherit`. | Pass as `inputs:` (visible in logs unless masked). |
+| Strategy / matrix | Yes (at caller or callee). | No (loop manually). |
+| Nesting | Up to 4 levels deep. | Up to 10 levels deep (no recursion). |
+| Versioning | By ref (`@<sha>`). | Same. |
+| Visibility | Private repo: same repo or org. Public repo: anywhere. | Same. |
+
+Rule of thumb: reach for a **reusable workflow** when the unit of
+reuse is "a whole pipeline stage" (build-and-push, deploy, release).
+Reach for a **composite action** when the unit of reuse is "three
+steps that always go together" (setup-toolchain-and-cache).
+
+## Declaring a reusable workflow
+
+The file is a regular workflow under `.github/workflows/` with
+`workflow_call` as a trigger (often the only one):
+
+```yaml
+name: Reusable Build
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Semver to build.
+        type: string
+        required: true
+      environment:
+        type: string
+        default: staging
+      publish:
+        type: boolean
+        default: false
+    outputs:
+      artifact_url:
+        description: URL of the published artifact.
+        value: ${{ jobs.build.outputs.url }}
+    secrets:
+      NPM_TOKEN:
+        required: true
+      GHCR_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      url: ${{ steps.publish.outputs.url }}
+    steps:
+      - uses: actions/checkout@<sha>
+      - id: publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          ./scripts/build.sh "${{ inputs.version }}"
+          echo "url=https://npm.example.com/${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+```
+
+### `inputs:`
+
+Typed inputs. Supported types:
+
+- `string` — default.
+- `boolean` — real boolean in the `inputs.X` context.
+- `number` — numeric.
+- `choice` (only on `workflow_dispatch`, not on `workflow_call`).
+
+Each input has `description`, `required`, `default`. **Required
+inputs without a default** must be passed by the caller.
+
+### `outputs:`
+
+The reusable workflow's outputs are mapped from job outputs. The
+`value:` expression is evaluated **after** all jobs complete.
+
+```yaml
+outputs:
+  artifact_url:
+    value: ${{ jobs.build.outputs.url }}
+```
+
+Outputs can come from any job in the reusable workflow, not just the
+last one.
+
+### `secrets:`
+
+Secrets are not implicitly inherited. The reusable workflow declares
+which secrets it expects:
+
+```yaml
+secrets:
+  NPM_TOKEN:
+    required: true
+```
+
+The caller either lists secrets explicitly or uses
+`secrets: inherit` (same-org only).
+
+## Calling a reusable workflow
+
+The caller uses `uses:` at the **job** level (not step):
+
+```yaml
+jobs:
+  release:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      version: "1.2.3"
+      publish: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: read
+      packages: write
+```
+
+The `uses:` value identifies the workflow file by ref. Forms:
+
+- `owner/repo/.github/workflows/file.yml@<ref>` — cross-repo.
+- `./.github/workflows/file.yml` — same-repo (no ref needed).
+
+**Pin by SHA**, the same as any other third-party action. A tag
+(`@v1`) is mutable.
+
+### `with:`
+
+Passes inputs. Must match the callee's `inputs:` declaration —
+required inputs are mandatory, types are checked.
+
+### `secrets:`
+
+Two forms:
+
+```yaml
+# Explicit pass-through (most common, makes the dependency visible)
+secrets:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+```
+
+```yaml
+# Inherit all caller secrets (same-org only)
+secrets: inherit
+```
+
+`secrets: inherit` is convenient but breaks visibility — a reader of
+the caller cannot tell which secrets the callee actually consumes.
+Prefer explicit pass-through when the callee's secret list is short.
+
+### `permissions:`
+
+The caller's job-level `permissions:` are passed to the callee. The
+callee **cannot grant itself more than the caller granted** — a
+reusable workflow with internal `permissions: write-all` is silently
+capped at the caller's grant. To audit, look at the **caller**'s
+permissions; the callee's are advisory.
+
+### Reading outputs
+
+```yaml
+jobs:
+  build:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      version: "1.2.3"
+  notify:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Artifact at ${{ needs.build.outputs.artifact_url }}"
+```
+
+## Matrix interactions
+
+Two distinct patterns:
+
+### Matrix in the caller, fan-out across reusable workflow
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        target: [linux, macos, windows]
+    uses: ./.github/workflows/build-target.yml
+    with:
+      target: ${{ matrix.target }}
+```
+
+Each matrix cell calls the reusable workflow independently. The
+callee sees a single `inputs.target` value per call.
+
+### Matrix in the callee
+
+A reusable workflow can declare its own `strategy.matrix` inside its
+jobs. The matrix is independent of the caller — there is no way to
+"flatten" a callee matrix into a caller matrix.
+
+Combining matrices is the cleanest way to express "fan out, fan in":
+the caller's matrix produces N callee invocations, each with its own
+internal matrix.
+
+## Concurrency
+
+`concurrency:` is supported at the reusable workflow level and at the
+caller level. The caller's `concurrency:` applies to the calling job;
+the callee's applies to its own jobs. Both fire — be careful not to
+accidentally serialise more than intended.
+
+For deploy workflows, the typical pattern is to set `concurrency:`
+only at the caller, on the entire deploy job, so concurrent calls to
+the reusable workflow are serialised at the call site.
+
+## Limitations
+
+- **Nesting depth: 4.** A reusable workflow can call another reusable
+  workflow up to three more levels deep.
+- **No recursion.** A workflow cannot call itself, directly or
+  transitively.
+- **No environment passing** from caller to callee. The callee
+  declares its own `environment:` per job; the caller's
+  `environment:` does not propagate.
+- **`secrets: inherit` requires same-org.** Cross-org callers must
+  list every secret explicitly.
+- **No conditional `with:` keys.** A `with:` block is evaluated
+  before the callee starts; you cannot omit a key based on a
+  condition (use a default on the callee side instead).
+- **The callee runs on its own runners**, billed to the **caller**'s
+  account. A reusable workflow in a public template repo consumed
+  from a private repo bills the private repo.
+- **`workflow_call` cannot coexist with `pull_request_target` in a
+  caller** if the caller is in a public repo and the callee modifies
+  the repo — the fork-PR safety model breaks down. Audit the trigger
+  combination explicitly.
+- **Reusable workflows do not appear as separate steps in the run
+  log** — they show up as a nested job. Debugging is one level
+  deeper than for composite actions.
+
+## Versioning strategy
+
+The same considerations as for any third-party action, with one
+twist: a reusable workflow is itself a workflow, so its dependencies
+(actions called inside, runner labels) are part of the contract.
+
+Recommended approach:
+
+1. Tag releases of the reusable workflow with `v<major>.<minor>.<patch>`.
+2. Maintain a `v<major>` tag that floats to the latest minor/patch.
+3. Consumers pin to a specific commit SHA, with a comment indicating
+   the human-readable version.
+4. Use Dependabot or Renovate to track upstream releases.
+
+Avoid the temptation to pin to a branch (`@main`). The reusable
+workflow can change under you mid-day; pinning by SHA is the only way
+to get reproducibility.
+
+## Worked example: build-and-deploy
+
+A common factoring: one reusable workflow for build, one for deploy,
+a caller wiring them up.
+
+`shared/.github/workflows/build.yml`:
+
+```yaml
+name: Build
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+    outputs:
+      image:
+        value: ${{ jobs.build.outputs.image }}
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.push.outputs.image }}
+    steps:
+      - uses: actions/checkout@<sha>
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: docker/login-action@<sha>
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: push
+        run: |
+          IMG="ghcr.io/${{ github.repository }}:${{ inputs.ref }}"
+          docker build -t "$IMG" .
+          docker push "$IMG"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+```
+
+`shared/.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy
+on:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        required: true
+      environment:
+        type: string
+        required: true
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@<sha>
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE }}
+          aws-region: eu-west-3
+      - run: ./deploy.sh "${{ inputs.image }}"
+```
+
+Caller `myapp/.github/workflows/release.yml`:
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ["v*.*.*"]
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+jobs:
+  build:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      ref: ${{ github.ref_name }}
+  deploy:
+    needs: build
+    uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+    with:
+      image: ${{ needs.build.outputs.image }}
+      environment: production
+```
+
+This factoring keeps the caller declarative and concentrates the
+operational complexity in two well-tested reusable workflows.

--- a/.gemini/skills/github-actions/references/runners.md
+++ b/.gemini/skills/github-actions/references/runners.md
@@ -1,0 +1,257 @@
+# Runners reference
+
+Reference for the execution substrate of GitHub Actions: the
+GitHub-hosted runner inventory, self-hosted runner architecture, label
+and group selection, runner security model, and the constraints that
+apply to composite actions and container jobs.
+
+## GitHub-hosted runners
+
+GitHub provisions ephemeral VMs per job, destroyed after the job
+completes. Each job starts from a clean image — no state leaks
+between jobs.
+
+### Image inventory
+
+The current general-availability images, with the labels that resolve
+to them:
+
+| Label | OS | Notes |
+|-------|----|----|
+| `ubuntu-24.04`, `ubuntu-latest` | Ubuntu 24.04 LTS | `latest` follows the most recent LTS; pin the explicit version for reproducibility. |
+| `ubuntu-22.04` | Ubuntu 22.04 LTS | Still supported; expect retirement on the upstream LTS cadence. |
+| `windows-2025`, `windows-latest` | Windows Server 2025 | `latest` follows the most recent supported version. |
+| `windows-2022` | Windows Server 2022 | Older but stable. |
+| `macos-15`, `macos-latest` | macOS Sequoia (Apple silicon) | Apple-silicon by default on the recent `macos-*` labels. |
+| `macos-14` | macOS Sonoma (Apple silicon) | |
+| `macos-13` | macOS Ventura (Intel) | The last Intel macOS label; verify availability before relying on it. |
+
+For long-lived workflows, pin the explicit version label
+(`ubuntu-24.04`, not `ubuntu-latest`). `*-latest` rolls forward
+silently and has broken previously green pipelines on every prior
+transition.
+
+### Hardware
+
+Standard (free for public repos, paid for private):
+
+- **Linux / Windows standard:** 4 vCPU, 16 GB RAM, 14 GB SSD.
+- **macOS standard:** 3 vCPU, 7 GB RAM (Intel) / 4 vCPU, 7 GB RAM
+  (Apple silicon).
+
+Larger runners (paid, opt-in per repo or org):
+
+- 8 / 16 / 32 / 64 vCPU variants on Linux and Windows.
+- GPU variants (T4) on Linux.
+- ARM64 variants on Linux and Windows (`ubuntu-24.04-arm`,
+  `windows-11-arm`).
+
+Verify the current inventory at the runner-images repository; the
+table above drifts.
+
+### Pre-installed software
+
+Each image ships with a curated toolchain — Node.js, Python, Ruby,
+Go, .NET, Java, Docker, kubectl, common Linux build tools, the GitHub
+CLI, etc. Two important consequences:
+
+- Tool versions drift across image releases. `actions/setup-<tool>`
+  is the supported way to pin a version regardless of what is
+  pre-installed.
+- The pre-installed tool versions are cached on the runner under
+  `runner.tool_cache`. `actions/setup-<tool>` first checks the cache
+  before downloading.
+
+For the authoritative list, consult the runner-images repo
+(`actions/runner-images`) and the `Tool Versions` section of each
+image's release notes.
+
+### Network
+
+GitHub-hosted runners have unrestricted outbound IPv4/IPv6. Inbound is
+blocked. The runner pulls jobs from `github.com` over HTTPS.
+
+For workflows that need to reach internal services, options are:
+
+- A self-hosted runner inside the network.
+- An OIDC-federated cloud role with a NAT route.
+- A `tailscale` / `cloudflare-tunnel` style action that opens a
+  short-lived ingress.
+
+### Disk and memory limits
+
+A job that exhausts the 14 GB disk fails with an opaque error during
+the next file write. Common offenders: Docker layer caches, full
+`node_modules`, downloaded model weights. Mitigations:
+
+- `docker system prune -af` early in the job.
+- Use `easimon/maximize-build-space` to reclaim ~30 GB by removing
+  pre-installed bloat (when targeting Linux runners and you accept the
+  trade-off).
+- Move large artifacts to remote storage rather than the workspace.
+
+## Self-hosted runners
+
+### Architecture
+
+A self-hosted runner is a long-running process (`Runner.Listener`)
+that polls GitHub for jobs, downloads the workflow YAML and the
+action source, and executes inside its working directory. By default
+the process runs as the OS user that started it; the workspace and the
+runner toolchain cache persist between jobs unless explicitly cleaned.
+
+### Labels and groups
+
+A runner advertises a set of **labels** — `self-hosted` (mandatory),
+plus the OS (`linux` / `windows` / `macOS`), the architecture (`x64` /
+`arm64`), and any custom labels added at registration time.
+
+`runs-on:` with an array matches all listed labels:
+
+```yaml
+runs-on: [self-hosted, linux, x64, gpu]
+```
+
+**Runner groups** (Enterprise / Org tier) bind runners to a named
+group, with access controls per repository. Use the object form:
+
+```yaml
+runs-on:
+  group: gpu-runners
+  labels: [self-hosted, linux, gpu]
+```
+
+Group membership constrains which repositories may target the
+runner; labels select within the group. The combination defends
+against accidental cross-team consumption.
+
+### Security model
+
+The headline rule: **never attach a self-hosted runner to a public
+repository** unless you accept that any fork-submitted PR can execute
+arbitrary code on it.
+
+Defensive measures, in order of effectiveness:
+
+1. **Ephemeral runners.** Spin up a fresh VM per job (Actions Runner
+   Controller / ARC on Kubernetes, or
+   `philips-labs/terraform-aws-github-runner` on EC2). The runner is
+   destroyed after one job — no state carries over.
+2. **`Require approval for all outside collaborators`** at repo
+   settings. First-time contributor PRs require maintainer click to
+   run.
+3. **Private repo only.** The simplest defence is to keep the repo
+   private and trust the contributor set.
+4. **Restrict runner-group repo access.** A GPU runner pool should
+   not be visible to repositories that have no business using it.
+5. **Network isolation.** Place runners on a subnet without
+   write access to production secrets / state stores.
+6. **Read-only `$HOME`** and a wiped workspace per job (ARC handles
+   this; raw self-hosted runners do not).
+7. **No sudo, no Docker socket access** unless required. A
+   container-running runner with `/var/run/docker.sock` mounted is a
+   root escalation primitive.
+
+### Actions Runner Controller (ARC)
+
+The canonical Kubernetes-native deployment. Two flavours:
+
+- **Legacy ARC** (`actions-runner-controller/actions-runner-controller`)
+  — operator-managed, PAT-based authentication. Maintenance mode.
+- **Official ARC** (`actions/actions-runner-controller`) — GitHub's
+  own implementation, GitHub-App-based auth, scale-set abstraction.
+  Prefer this for new deployments.
+
+A scale set materialises a pool of pods that come up on demand, claim
+one job each, and terminate. The `runs-on:` value matches the scale
+set name; no label management required.
+
+## Containers and services
+
+### Job container
+
+A job may declare `container:` to run all its steps inside an image:
+
+```yaml
+container:
+  image: golang:1.23-bookworm
+  env:
+    CGO_ENABLED: "0"
+  options: --user 1001:1001
+  credentials:
+    username: ${{ secrets.REGISTRY_USER }}
+    password: ${{ secrets.REGISTRY_TOKEN }}
+```
+
+The runner mounts the workspace and `$HOME` into the container, runs
+`docker exec` for each step. Action steps run inside the container
+too — Node.js actions require Node to exist in the image (or use
+`actions/setup-node` first).
+
+### Service containers
+
+Sidecars for the job duration, on a shared Docker network. Reach them
+by the service key as hostname:
+
+```yaml
+services:
+  redis:
+    image: redis:7
+    ports: ["6379:6379"]
+    options: --health-cmd "redis-cli ping" --health-interval 5s --health-retries 5
+```
+
+`options:` accepts any `docker run` flag. Health-check options gate
+the start of step execution: the runner waits until the container
+reports healthy.
+
+## Composite-action constraints
+
+Composite actions (`runs.using: composite`) run on whatever runner
+the calling workflow is on. Limitations:
+
+- Every `run:` step **must** declare `shell:` — no inheritance from
+  the workflow's `defaults.run.shell`.
+- `continue-on-error:` and `timeout-minutes:` are unsupported on
+  steps within the composite action.
+- The composite action cannot declare its own `container:` or
+  `services:` — those live at the calling job's level.
+- `secrets` are not directly accessible inside the composite; pass
+  them in as `inputs:` (with the caveat that input values are visible
+  in logs unless masked manually via `::add-mask::`).
+
+## Workflow commands
+
+The runner exposes a control channel through stdout. Selected
+commands:
+
+| Command | Effect |
+|---------|--------|
+| `echo "::add-mask::$VALUE"` | Masks the value in subsequent log output. |
+| `echo "key=value" >> "$GITHUB_OUTPUT"` | Step output. |
+| `echo "VAR=value" >> "$GITHUB_ENV"` | Persistent env var. |
+| `echo "$DIR" >> "$GITHUB_PATH"` | Prepend to `PATH`. |
+| `echo "::group::Title"` / `::endgroup::` | Collapse log section. |
+| `echo "::notice::msg"` / `::warning::` / `::error::` | Annotation surface. |
+| `echo "## Heading" >> "$GITHUB_STEP_SUMMARY"` | Markdown summary on the run page. |
+
+`::set-output` and `::set-env` (the old in-line forms) are deprecated
+and disabled by default since the 2022 CVE — use the file-based
+channels above.
+
+## Runner diagnostics
+
+When a self-hosted runner misbehaves:
+
+- `_diag/` directory under the runner install root has `Runner_*.log`
+  and `Worker_*.log` files per job. Worker log is where step-level
+  diagnostics live.
+- Enabling **step debug logging** requires repository secret
+  `ACTIONS_STEP_DEBUG=true`. Verbose, exposes context values — keep
+  it off by default.
+- Enabling **runner diagnostic logs** requires
+  `ACTIONS_RUNNER_DEBUG=true`. Useful for runner-side failures
+  (network, auth, image pull).
+
+For GitHub-hosted runners, the same two secrets unlock the verbose
+logging on the next run.

--- a/.gemini/skills/github-actions/references/secrets-and-vars.md
+++ b/.gemini/skills/github-actions/references/secrets-and-vars.md
@@ -1,0 +1,294 @@
+# Secrets and variables reference
+
+Secrets and variables are the two channels GitHub Actions offers for
+injecting configuration into a workflow run. The choice between them
+is the choice between confidentiality and observability. Use the
+wrong one and you either leak credentials to logs or accidentally
+encrypt a value you needed to debug.
+
+## Secrets vs. variables
+
+| Property | Secrets | Variables |
+|----------|---------|-----------|
+| Storage | Encrypted at rest (libsodium sealed box). | Plaintext. |
+| Reachable via API after creation | No (write-only). | Yes (read/write). |
+| Log masking | Yes — masked automatically. | No. |
+| Available to fork PRs | No. | Yes (read-only). |
+| Intended use | Credentials, tokens, signing keys. | URLs, flags, non-sensitive config. |
+| Expression | `${{ secrets.NAME }}` | `${{ vars.NAME }}` |
+
+Variables exist because misusing secrets for non-sensitive config is
+both inconvenient (you can't read them back) and dangerous (you train
+people to ignore the "masked" tag). Use variables for everything that
+is not a credential.
+
+## Scope and precedence
+
+Both secrets and variables have three scopes:
+
+1. **Organisation.** Visible to a configurable set of repositories.
+   Best for shared credentials (Docker registry, npm publish token).
+2. **Repository.** Repository-wide, visible to all environments.
+3. **Environment.** Scoped to a deployment environment (`staging`,
+   `production`). Combined with required reviewers and wait timers,
+   environments are the correct primitive for promotion gates.
+
+Precedence on name collision: **environment > repository > organisation**.
+A `secrets.AWS_ROLE` defined at all three levels resolves to the
+environment value.
+
+## Defining and consuming
+
+### Repository-level
+
+`Settings → Secrets and variables → Actions → New repository secret` (or
+`New variable`). From a workflow:
+
+```yaml
+- env:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    LOG_LEVEL: ${{ vars.LOG_LEVEL }}
+  run: npm publish
+```
+
+### Organisation-level
+
+`Org settings → Secrets and variables → Actions`. Specify the
+repository access policy: all, private only, or a selected list.
+
+### Environment-level
+
+The job declares `environment:`:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: production
+      url: https://app.example.com
+    steps:
+      - env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: ./scripts/deploy.sh
+```
+
+Environments support:
+
+- **Required reviewers.** Up to 6 users/teams whose approval is
+  needed before the job runs.
+- **Wait timer.** Delay between PR approval and job execution
+  (useful for canary rollouts).
+- **Deployment branches.** Restrict which refs may target the
+  environment.
+
+## Masking
+
+GitHub masks any **literal substring** of a secret in log output and
+in the run summary. Three caveats:
+
+- Masking is **substring-based**, not token-based. A 4-character
+  secret will mask every occurrence of that 4-character sequence,
+  including in unrelated output — and conversely, splitting a secret
+  with `echo "${SECRET:0:8}…${SECRET:8}"` bypasses masking.
+- Masking does **not** redact secrets from artifacts, from caches,
+  or from external systems your job writes to. A secret printed into
+  a file and uploaded as an artifact is leaked in plaintext.
+- The runner masks `secrets.*` values automatically. To mask a
+  derived value, use the workflow command
+  `echo "::add-mask::$VALUE"` before printing it.
+
+## OIDC federation
+
+For cloud credentials, **prefer OIDC over long-lived secrets**. The
+runner mints a short-lived JWT signed by GitHub's OIDC provider; the
+cloud side validates the token's claims (`sub`, `repository`, `ref`,
+`environment`, `job_workflow_ref`) and issues a temporary cloud
+credential.
+
+Benefits:
+
+- No long-lived secret to rotate or leak.
+- Per-job, per-environment scoping — a `production` deploy job gets
+  a token whose `sub` includes `environment:production`.
+- Audit trail in both GitHub and the cloud provider.
+
+### AWS
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+      },
+      "StringLike": {
+        "token.actions.githubusercontent.com:sub":
+          "repo:my-org/my-repo:environment:production"
+      }
+    }
+  }]
+}
+```
+
+In the workflow:
+
+```yaml
+permissions:
+  id-token: write   # required to request the OIDC token
+  contents: read
+steps:
+  - uses: aws-actions/configure-aws-credentials@<sha>  # v4.x
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/gha-deploy
+      aws-region: eu-west-3
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+steps:
+  - uses: google-github-actions/auth@<sha>  # v2.x
+    with:
+      workload_identity_provider: projects/123/locations/global/workloadIdentityPools/gha/providers/github
+      service_account: gha-deploy@my-project.iam.gserviceaccount.com
+```
+
+The WIF provider declares attribute mappings (e.g., `attribute.repository`)
+and an attribute condition pinning the allowed repos / environments.
+
+### Azure
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+steps:
+  - uses: azure/login@<sha>  # v2.x
+    with:
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+```
+
+The Azure side configures a **federated credential** on the app
+registration with the matching subject (`repo:my-org/my-repo:environment:production`).
+
+### HashiCorp Vault
+
+Use the JWT/OIDC auth method with a role whose
+`bound_subject` / `bound_claims` match the GitHub token.
+
+```yaml
+- uses: hashicorp/vault-action@<sha>  # v3.x
+  with:
+    url: https://vault.example.com
+    method: jwt
+    role: gha-deploy
+    secrets: |
+      kv/data/prod/db password | DB_PASSWORD
+```
+
+## Common pitfalls
+
+### Secrets in top-level `env:`
+
+```yaml
+# BAD: every job and every step in the workflow sees the secret
+env:
+  DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+```
+
+Bind secrets to the smallest scope that needs them — a specific
+step's `env:` is ideal.
+
+### Interpolating secrets into `run:`
+
+```yaml
+# BAD: the secret is evaluated by the YAML expression layer and
+# pasted into the shell verbatim. Quoting is brittle, and if the
+# secret contains shell metacharacters the script breaks (or worse).
+- run: echo "${{ secrets.API_TOKEN }}" | gh auth login --with-token
+
+# GOOD: bind via env, reference as a shell variable.
+- env:
+    API_TOKEN: ${{ secrets.API_TOKEN }}
+  run: printf '%s' "$API_TOKEN" | gh auth login --with-token
+```
+
+### Passing secrets to reusable workflows
+
+```yaml
+# BAD: re-listing every secret manually invites omissions.
+- uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+  secrets:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+
+# GOOD when the callee is trusted: inherit all caller secrets.
+- uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+  secrets: inherit
+```
+
+`secrets: inherit` only works when both workflows are in the **same
+organisation**. For cross-org consumption, list explicitly.
+
+### Echoing a secret to debug
+
+```yaml
+# BAD: the runner masks the echoed value, but the secret is still
+# present in the artifact / cache / step summary you write next.
+- run: echo "DEBUG: token is $TOKEN"
+```
+
+Never debug a workflow by printing a secret. Print a checksum or a
+length instead:
+
+```yaml
+- run: echo "Token length: ${#TOKEN}"
+```
+
+### Storing structured data in a single secret
+
+A JSON blob in `secrets.CLOUD_CONFIG` is convenient for setup but
+defeats per-key rotation. Split into individual secrets, or use a
+secret-manager action (`hashicorp/vault-action`,
+`aws-actions/aws-secretsmanager-get-secrets`) to fetch a structured
+secret at runtime — the per-key value is then masked individually.
+
+### Variables that should be secrets
+
+A `vars.WEBHOOK_URL` whose URL embeds a token is a secret in
+disguise. If the value is sensitive on inspection, it is a secret.
+
+### Secrets visible to fork PRs
+
+By default, fork PRs receive **no secrets**. `pull_request_target`
+gives them the **base** repository's secrets, which is why it is
+dangerous to combine with `actions/checkout` of the PR head. If you
+must run privileged work against a fork PR, gate it behind an
+environment with required reviewers.
+
+## Auditing
+
+Periodic audit checklist:
+
+- List repository secrets: `gh secret list` — flag any that have not
+  been read in 90 days; rotate or delete.
+- List org-wide secrets and their repo access list. Tighten scope.
+- Inspect workflows for top-level `env:` referencing `secrets.*`.
+- Search for `${{ secrets.` patterns in `run:` blocks (the
+  `scripts/check-secrets-exposure` validator does this).
+- For each cloud provider, audit the OIDC trust conditions and ensure
+  every long-lived access key has a migration plan.

--- a/.gemini/skills/github-actions/references/workflow-syntax.md
+++ b/.gemini/skills/github-actions/references/workflow-syntax.md
@@ -1,0 +1,443 @@
+# Workflow syntax reference
+
+Canonical reference for the YAML grammar of a GitHub Actions workflow.
+Each top-level and nested key is enumerated with semantics, defaults,
+and a worked example. Read the section that matches the key you are
+editing — do not guess from memory.
+
+## File location and naming
+
+Workflow files live under `.github/workflows/` and end in `.yml` or
+`.yaml`. The basename has no semantic meaning beyond the workflow UI;
+the `name:` key is what appears in the Actions tab and the commit
+status.
+
+A repository may contain any number of workflow files. They are
+discovered on every push to the default branch (for `schedule:` and
+`workflow_dispatch:`) and on every event for the matching triggers.
+
+## Top-level keys
+
+### `name`
+
+Display name in the Actions UI and in commit statuses. Optional; if
+omitted, the file path is shown.
+
+```yaml
+name: CI
+```
+
+### `run-name`
+
+Dynamic display name for an individual run. Supports expression
+interpolation. Useful for surfacing the actor or the input that
+triggered the run.
+
+```yaml
+run-name: "Deploy ${{ inputs.environment }} by @${{ github.actor }}"
+```
+
+### `on`
+
+The trigger specification. Accepts:
+
+- A single event name: `on: push`.
+- A list of event names: `on: [push, pull_request]`.
+- A map of event names to filters:
+
+```yaml
+on:
+  push:
+    branches: [main, "release/**"]
+    paths-ignore: ["docs/**"]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: "17 3 * * 1-5"   # 03:17 UTC, Mon–Fri
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options: [staging, production]
+        default: staging
+        required: true
+      dry_run:
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+    outputs:
+      artifact_url:
+        value: ${{ jobs.build.outputs.url }}
+    secrets:
+      NPM_TOKEN:
+        required: true
+```
+
+Filter semantics:
+
+- `branches` / `branches-ignore` — glob list. Mutually exclusive.
+- `tags` / `tags-ignore` — same shape, applied to tag pushes.
+- `paths` / `paths-ignore` — path-glob filter on the changed files
+  in the push or PR. Combined with `branches`, both must match.
+- `types` — for `pull_request`, defaults to
+  `[opened, synchronize, reopened]`. Add `ready_for_review` if you
+  want the run to fire when a draft becomes a real PR; or skip
+  drafts explicitly with `if: github.event.pull_request.draft == false`.
+
+### `permissions`
+
+Sets the scope of `GITHUB_TOKEN`. Either a shorthand
+(`read-all` / `write-all` / `{}`) or an explicit map. See
+`permissions.md` for the per-scope semantics.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+```
+
+Applied at workflow level becomes the default for all jobs; can be
+overridden (further restricted or expanded within repo policy) at the
+job level.
+
+### `env`
+
+Workflow-wide environment variables. **Never** put secrets here; the
+value is inherited by every step in every job.
+
+```yaml
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+  CI: "true"
+```
+
+### `defaults`
+
+Default `run:` configuration for every step in every job. The only
+two keys are `run.shell` and `run.working-directory`.
+
+```yaml
+defaults:
+  run:
+    shell: bash
+    working-directory: ./app
+```
+
+The default shell on Linux/macOS is `bash -e -o pipefail {0}`; on
+Windows it is `pwsh -command ". '{0}'"`. Setting `shell: bash`
+explicitly on Windows runners pulls in Git Bash.
+
+### `concurrency`
+
+Concurrency control group. Runs sharing a group are serialised; the
+optional `cancel-in-progress` boolean cancels older runs in the same
+group when a new one queues.
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+Use cases: avoid wasting compute on rapid pushes; serialise
+deployments so only one ever runs to a given environment.
+
+### `jobs`
+
+A map of job-id → job definition. Job IDs are alphanumeric plus `_`
+and `-`; the first character must be a letter or `_`. They are
+referenced from `needs:` and from the `jobs.<id>.outputs` context.
+
+## Job-level keys
+
+### `runs-on`
+
+The runner selector. A string (`ubuntu-24.04`) or an array of labels
+(`[self-hosted, linux, x64, prod]`) — all labels must match. For
+runner groups (Enterprise/Org), the object form is required:
+
+```yaml
+runs-on:
+  group: ubuntu-runners
+  labels: [self-hosted, large]
+```
+
+Pin the OS version. `ubuntu-latest` drifts on a rolling schedule.
+
+### `needs`
+
+Dependency edges, single ID or array. The job runs after all listed
+jobs complete with a non-failure status (unless `if:` overrides). The
+outputs of `needs` jobs are exposed under
+`${{ needs.<id>.outputs.<name> }}`.
+
+```yaml
+needs: [build, lint]
+```
+
+### `if`
+
+Conditional execution. Evaluated against the same expression syntax
+as steps; see `expressions.md`. Pay attention to truthiness of empty
+strings.
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+```
+
+### `strategy`
+
+Fan-out specification. Three keys:
+
+- `matrix:` — Cartesian product of axes. Combined with `include:`
+  (additive) and `exclude:` (subtractive).
+- `fail-fast:` — default `true`. When `true`, a single failing
+  matrix cell cancels the others.
+- `max-parallel:` — concurrency cap across the matrix.
+
+```yaml
+strategy:
+  fail-fast: false
+  max-parallel: 4
+  matrix:
+    os: [ubuntu-24.04, macos-14, windows-2022]
+    node: ["20", "22"]
+    include:
+      - os: ubuntu-24.04
+        node: "22"
+        coverage: true
+    exclude:
+      - os: windows-2022
+        node: "20"
+```
+
+Each cell runs as an independent job; `matrix.<axis>` is available in
+expressions inside the job. The default job name is
+`<job-id> (<axis-values-joined>)`; override with `name:` on the job.
+
+### `outputs`
+
+Job-level outputs, surfaced to dependents via `needs.<id>.outputs`.
+Values come from step outputs.
+
+```yaml
+outputs:
+  version: ${{ steps.bump.outputs.version }}
+```
+
+### `env`, `defaults`, `permissions`, `concurrency`
+
+Same shape as the workflow-level equivalents, scoped to the job.
+
+### `timeout-minutes`
+
+Per-job timeout. Default 360 (six hours). **Always set this.** A
+reasonable upper bound is the 95th percentile of historical runtime
+times two.
+
+### `continue-on-error`
+
+When `true`, a failure in this job does not fail the workflow. Useful
+for opt-in matrix cells (experimental Node version, beta OS) — combine
+with `strategy.fail-fast: false`.
+
+### `container` and `services`
+
+Run the job inside a container image (`container:`) and/or alongside
+sidecar service containers (`services:`). Both reference Docker
+images.
+
+```yaml
+container:
+  image: node:22-bookworm
+  options: --user 1001
+services:
+  postgres:
+    image: postgres:16
+    env:
+      POSTGRES_PASSWORD: postgres
+    ports: ["5432:5432"]
+    options: >-
+      --health-cmd "pg_isready"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+```
+
+Service containers share a Docker network with the job container; the
+service hostname is the service key (`postgres` above).
+
+### `environment`
+
+Binds the job to a GitHub deployment **environment**. The environment
+can require manual approval, a wait timer, or restrict to specific
+branches. Secrets/variables scoped to the environment become available
+to the job.
+
+```yaml
+environment:
+  name: production
+  url: https://app.example.com
+```
+
+## Step-level keys
+
+A step has either `run:` or `uses:`, never both.
+
+### `id`
+
+Step identifier. Required to reference step outputs from later steps
+(`steps.<id>.outputs.<name>`).
+
+### `name`
+
+Display name. Optional; falls back to the `run:` first line or the
+`uses:` reference.
+
+### `if`
+
+Step-level conditional. Skipping a step does not skip the rest of the
+job. Combine with `steps.<earlier>.outcome` to chain.
+
+### `uses`
+
+Action reference. Forms:
+
+- `actions/checkout@v4` — versioned tag (mutable; **do not use** for
+  third-party actions).
+- `actions/checkout@<40-char-sha>` — pinned by commit SHA
+  (immutable; **always prefer** this).
+- `./.github/actions/my-local-action` — local action in the same
+  repo.
+- `docker://alpine:3.20` — Docker action (the image is the action).
+
+### `with`
+
+Action input map. Inputs are declared by the action's `action.yml`;
+the value is a string (numbers and booleans are coerced).
+
+```yaml
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: npm
+    cache-dependency-path: package-lock.json
+```
+
+### `run`
+
+Shell script. Multiline via YAML block scalar (`|` or `>`). Shell is
+the workflow / job default unless overridden with `shell:` on the
+step.
+
+```yaml
+- name: Build
+  shell: bash
+  working-directory: app
+  run: |
+    set -euo pipefail
+    npm ci
+    npm run build
+```
+
+### `env`
+
+Per-step environment. The recommended channel for moving secrets and
+untrusted input into `run:`.
+
+```yaml
+- env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    gh pr comment "$PR_NUMBER" --body "Title: $PR_TITLE"
+```
+
+### `continue-on-error`
+
+Same semantics as the job-level key, applied to a single step.
+
+### `timeout-minutes`
+
+Step-level timeout. Default: no limit beyond the job timeout.
+
+### Step outputs
+
+A step writes to `$GITHUB_OUTPUT` to expose values to later steps and
+to job outputs.
+
+```yaml
+- id: bump
+  run: |
+    echo "version=1.2.3" >> "$GITHUB_OUTPUT"
+- run: echo "${{ steps.bump.outputs.version }}"
+```
+
+`$GITHUB_ENV` writes an environment variable visible to all
+subsequent steps in the job:
+
+```yaml
+- run: echo "BUILD_ID=$(date +%s)" >> "$GITHUB_ENV"
+```
+
+`$GITHUB_STEP_SUMMARY` writes Markdown to the run summary page; useful
+for surfacing test results without digging through logs.
+
+## Composite action syntax
+
+A composite action lives in its own repo (or under
+`.github/actions/<name>/`) with an `action.yml`:
+
+```yaml
+name: My composite action
+description: …
+inputs:
+  region:
+    description: AWS region
+    required: true
+    default: eu-west-3
+outputs:
+  cluster:
+    description: EKS cluster name
+    value: ${{ steps.lookup.outputs.cluster }}
+runs:
+  using: composite
+  steps:
+    - id: lookup
+      shell: bash
+      run: echo "cluster=prod" >> "$GITHUB_OUTPUT"
+```
+
+Composite actions have notable constraints:
+
+- `shell:` is mandatory on every `run:` step (no inheritance from
+  workflow defaults).
+- `continue-on-error:` is not supported on steps.
+- Conditional `if:` is supported.
+- No `services:` or `container:`.
+- Cannot use `secrets` directly; pass them as `inputs:`.
+
+## Edge cases and quirks
+
+- **YAML booleans.** `on: pull_request` parses cleanly, but a key
+  named `on` at the top level of a YAML 1.1 parser can be coerced to
+  the boolean `true`. GitHub's parser handles this, but external
+  linters may complain — quote with `"on":` if needed.
+- **`uses:` and `run:` mutually exclusive** in the same step.
+- **`env:` precedence**: step > job > workflow. The deepest binding
+  wins.
+- **`if:` and `${{ }}`**: the `if:` key accepts an expression
+  without the `${{ }}` wrapper; adding it is allowed but redundant.
+- **`needs:` semantics**: a job with `needs:` runs only if all
+  upstream jobs **succeed**. To run on failure, use
+  `if: ${{ always() }}` or `if: ${{ failure() }}`.
+- **`strategy.matrix` empty include**: a matrix containing only
+  `include:` (no axes) generates one job per `include:` entry — useful
+  for hand-curated combinations.

--- a/.gemini/skills/github-actions/scripts/check-pinned-actions.sh
+++ b/.gemini/skills/github-actions/scripts/check-pinned-actions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check-pinned-actions.sh — flag GitHub Actions references that are not pinned
+# to a 40-char commit SHA.
+#
+# Usage: check-pinned-actions.sh <workflow-file-or-directory>
+#
+# Rationale: pinning to a tag or branch lets an upstream maintainer push a
+# new commit that silently runs in your pipeline. Pinning to a full SHA
+# makes the reference immutable.
+#
+# Local actions (./path) are ignored — they are part of the repository.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no workflow files found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# Match: <indent>uses: <owner>/<repo>[/path]@<ref>
+# Capture group 1 = the value after "uses: ".
+uses_re='^[[:space:]]*uses:[[:space:]]*([^[:space:]#][^[:space:]#]*)'
+# A pinned reference ends with @<40 hex chars>.
+sha_re='@[0-9a-fA-F]{40}$'
+
+for f in "${files[@]}"; do
+    lineno=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+        if [[ "$line" =~ $uses_re ]]; then
+            value="${BASH_REMATCH[1]}"
+            # Strip surrounding quotes if any.
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            # Skip local actions.
+            case "$value" in
+                ./*|../*) continue ;;
+                docker://*) continue ;;
+            esac
+            # Must contain '@' and end with a 40-char hex SHA.
+            if [[ "$value" != *@* ]] || ! [[ "$value" =~ $sha_re ]]; then
+                echo "${C_RED}[UNPINNED]${C_RESET} ${f}:${lineno}: ${value}"
+                violations=$((violations + 1))
+            fi
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all action references are pinned to a SHA"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned action reference(s) found${C_RESET}" >&2
+exit 1

--- a/.gemini/skills/github-actions/scripts/check-pinned-actions.sh
+++ b/.gemini/skills/github-actions/scripts/check-pinned-actions.sh
@@ -9,6 +9,9 @@
 # makes the reference immutable.
 #
 # Local actions (./path) are ignored — they are part of the repository.
+#
+# Limitation: only inline `uses: owner/repo@ref` forms (value on the same
+# line) are matched. Multi-line YAML scalars for `uses:` are not detected.
 
 set -euo pipefail
 

--- a/.gemini/skills/github-actions/scripts/check-secrets-exposure.sh
+++ b/.gemini/skills/github-actions/scripts/check-secrets-exposure.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in GitHub Actions workflows that
+# may leak secrets into logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <workflow-file-or-directory>
+#
+# Patterns flagged:
+#   1. `echo ${{ secrets.* }}`           — secret echoed directly to stdout.
+#   2. workflow-level `env:`             — env values accessible to every job.
+#   3. `set -x` / `set +x` in `run:`     — shell trace expands env values.
+#   4. `toJSON(secrets)` anywhere        — serialises every secret as JSON.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no workflow files found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    saw_top_level_env=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # 1. echo of a secret expression.
+        if [[ "$line" =~ echo[[:space:]].*\$\{\{[[:space:]]*secrets\. ]]; then
+            report "$current_file" "$lineno" "echo \${{ secrets.* }}" \
+                "secret value is written to stdout and persisted in the run log"
+        fi
+
+        # 2. workflow-level env: — a line starting at column 0 that is "env:".
+        if [[ "$line" =~ ^env:[[:space:]]*$ ]] && [ "$saw_top_level_env" -eq 0 ]; then
+            report "$current_file" "$lineno" "top-level env:" \
+                "values defined here are inherited by every job and step (broad blast radius)"
+            saw_top_level_env=1
+        fi
+
+        # 3. set -x / set +x in a shell step.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret env values"
+        fi
+
+        # 4. toJSON(secrets) — full secret bag serialisation.
+        if [[ "$line" =~ toJSON\([[:space:]]*secrets[[:space:]]*\) ]]; then
+            report "$current_file" "$lineno" "toJSON(secrets)" \
+                "serialises the entire secrets context — any later echo, env, or file write leaks them all"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/.gemini/skills/github-actions/scripts/check-secrets-exposure.sh
+++ b/.gemini/skills/github-actions/scripts/check-secrets-exposure.sh
@@ -5,10 +5,10 @@
 # Usage: check-secrets-exposure.sh <workflow-file-or-directory>
 #
 # Patterns flagged:
-#   1. `echo ${{ secrets.* }}`           — secret echoed directly to stdout.
-#   2. workflow-level `env:`             — env values accessible to every job.
-#   3. `set -x` / `set +x` in `run:`     — shell trace expands env values.
-#   4. `toJSON(secrets)` anywhere        — serialises every secret as JSON.
+#   1. `echo ${{ secrets.* }}`                          — secret echoed directly to stdout.
+#   2. workflow-level `env:` referencing `secrets.*`    — broad blast radius across all jobs.
+#   3. `set -x` / `set +x` in `run:`                   — shell trace expands env values.
+#   4. `toJSON(secrets)` anywhere                       — serialises every secret as JSON.
 
 set -euo pipefail
 
@@ -67,6 +67,8 @@ report() {
 
 for current_file in "${files[@]}"; do
     lineno=0
+    in_top_level_env=0
+    top_level_env_lineno=0
     saw_top_level_env=0
     # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
     while IFS= read -r line || [ -n "$line" ]; do
@@ -78,11 +80,21 @@ for current_file in "${files[@]}"; do
                 "secret value is written to stdout and persisted in the run log"
         fi
 
-        # 2. workflow-level env: — a line starting at column 0 that is "env:".
+        # 2. workflow-level env: that contains ${{ secrets.* }} — broad blast radius.
+        # Only enter tracking on the first top-level (column-0) "env:" line.
         if [[ "$line" =~ ^env:[[:space:]]*$ ]] && [ "$saw_top_level_env" -eq 0 ]; then
-            report "$current_file" "$lineno" "top-level env:" \
-                "values defined here are inherited by every job and step (broad blast radius)"
+            in_top_level_env=1
+            top_level_env_lineno=$lineno
             saw_top_level_env=1
+        elif [ "$in_top_level_env" -eq 1 ] && [ "$lineno" -gt "$top_level_env_lineno" ]; then
+            # Exit the block on the first non-indented, non-blank, non-comment line.
+            if [[ "$line" =~ ^[^[:space:]#] ]] && [[ -n "$line" ]]; then
+                in_top_level_env=0
+            elif [[ "$line" =~ \$\{\{[[:space:]]*secrets\. ]]; then
+                report "$current_file" "$top_level_env_lineno" "top-level env: references \${{ secrets.* }}" \
+                    "secrets defined at workflow level are inherited by every job (broad blast radius)"
+                in_top_level_env=0
+            fi
         fi
 
         # 3. set -x / set +x in a shell step.

--- a/.gemini/skills/github-actions/scripts/lint-workflow.sh
+++ b/.gemini/skills/github-actions/scripts/lint-workflow.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# lint-workflow.sh — validate GitHub Actions workflow files via actionlint.
+#
+# Usage: lint-workflow.sh <workflow-file-or-directory>
+#
+# If a directory is passed, every .yml/.yaml under .github/workflows/ inside
+# that directory is linted. If actionlint is missing, the script exits 0 with
+# a friendly hint — it is not a hard blocker.
+
+set -euo pipefail
+
+# ANSI colours (disabled when stdout is not a TTY).
+if [ -t 1 ]; then
+    C_GREEN=$'\033[0;32m'
+    C_RED=$'\033[0;31m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_GREEN=""
+    C_RED=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+if ! command -v actionlint >/dev/null 2>&1; then
+    echo "${C_YELLOW}[SKIP] actionlint not found — install: brew install actionlint${C_RESET}"
+    exit 0
+fi
+
+# Build the list of files to lint.
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "${C_YELLOW}[SKIP] no workflow files found under: $TARGET${C_RESET}"
+    exit 0
+fi
+
+rc=0
+for f in "${files[@]}"; do
+    if actionlint -no-color "$f"; then
+        echo "${C_GREEN}[OK]${C_RESET} $f"
+    else
+        echo "${C_RED}[FAIL]${C_RESET} $f"
+        rc=1
+    fi
+done
+
+exit "$rc"

--- a/.gemini/skills/github-actions/scripts/simulate-job.sh
+++ b/.gemini/skills/github-actions/scripts/simulate-job.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# simulate-job.sh — dry-run a single workflow job locally via `act`.
+#
+# Usage: simulate-job.sh <workflow-file> <job-id> [event-type]
+#
+# Defaults: event-type = push.
+# Requires: `act` and a running Docker daemon. If either is missing the
+# script exits 0 with an explanatory message — it is not a hard blocker.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file> <job-id> [event-type]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+WORKFLOW="$1"
+JOB_ID="$2"
+EVENT="${3:-push}"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "[FAIL] workflow file not found: $WORKFLOW" >&2
+    exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "[SKIP] act not found — install: brew install act"
+    echo "       act runs GitHub Actions locally inside Docker containers."
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[SKIP] docker CLI not found — act needs Docker to run containers."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[SKIP] Docker daemon not reachable — start Docker Desktop or the docker service."
+    exit 0
+fi
+
+cmd=(act "$EVENT" --workflows "$WORKFLOW" --job "$JOB_ID" --dryrun)
+
+echo "+ ${cmd[*]}"
+"${cmd[@]}"

--- a/.gemini/skills/github-actions/scripts/simulate-workflow.sh
+++ b/.gemini/skills/github-actions/scripts/simulate-workflow.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# simulate-workflow.sh — dry-run a full workflow locally via `act`, with
+# optional event-payload injection.
+#
+# Usage: simulate-workflow.sh <workflow-file> [event-type] [event-payload-json-file]
+#
+# Defaults: event-type = push. When no payload file is given, a minimal
+# default payload matching the event-type is synthesised in a tempfile.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file> [event-type] [event-payload-json-file]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+WORKFLOW="$1"
+EVENT="${2:-push}"
+PAYLOAD="${3:-}"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "[FAIL] workflow file not found: $WORKFLOW" >&2
+    exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "[SKIP] act not found — install: brew install act"
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[SKIP] docker CLI not found — act needs Docker to run containers."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[SKIP] Docker daemon not reachable — start Docker Desktop or the docker service."
+    exit 0
+fi
+
+cleanup_payload=""
+cleanup() {
+    if [ -n "$cleanup_payload" ] && [ -f "$cleanup_payload" ]; then
+        rm -f "$cleanup_payload"
+    fi
+}
+trap cleanup EXIT
+
+default_payload_for() {
+    case "$1" in
+        push)               echo '{"ref":"refs/heads/main"}' ;;
+        pull_request)       echo '{"action":"opened","pull_request":{"number":1,"head":{"ref":"feature"},"base":{"ref":"main"}}}' ;;
+        workflow_dispatch)  echo '{"inputs":{}}' ;;
+        release)            echo '{"action":"published","release":{"tag_name":"v0.0.0"}}' ;;
+        schedule)           echo '{}' ;;
+        *)                  echo '{}' ;;
+    esac
+}
+
+if [ -z "$PAYLOAD" ]; then
+    cleanup_payload="$(mktemp -t act-payload.XXXXXX.json)"
+    default_payload_for "$EVENT" > "$cleanup_payload"
+    PAYLOAD="$cleanup_payload"
+elif [ ! -f "$PAYLOAD" ]; then
+    echo "[FAIL] event payload file not found: $PAYLOAD" >&2
+    exit 1
+fi
+
+cmd=(act "$EVENT" --workflows "$WORKFLOW" --eventpath "$PAYLOAD" --dryrun)
+
+echo "+ ${cmd[*]}"
+"${cmd[@]}"

--- a/community-config/agents/ci-configurator/AGENT.md
+++ b/community-config/agents/ci-configurator/AGENT.md
@@ -1,0 +1,279 @@
+---
+name: ci-configurator
+description: |
+  Specialist agent for configuring new GitHub Actions pipelines.
+  Interviews the project, generates a commit-ready workflow,
+  and validates its own output before delivery.
+type: agent
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.0.0"
+---
+
+# CI Configurator Agent
+
+You are a CI configuration agent. You operate under the **github-actions**
+skill (`community-config/skills/github-actions/SKILL.md`) — read it once
+at the start of any session and follow its conventions: action pinning,
+least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+
+Your persona is that of an experienced DevOps engineer: minimalist,
+security-oriented, allergic to copy-pasted workflows that "happen to
+work". You do not explore the repository looking for things to fix.
+You ask exactly what you need, generate exactly one workflow, validate
+your own output, and hand it over.
+
+Your default mode is **generate and validate**, not iterate. The user
+gets a workflow they can paste into `.github/workflows/` and commit. If
+you cannot produce a workflow that passes your own validation scripts,
+you say so plainly rather than shipping a draft that "should work".
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- The project has no `.github/workflows/` directory yet, or the
+  directory is empty.
+- The project is migrating from another CI platform (GitLab CI,
+  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
+  GitHub Actions pipeline.
+- An existing workflow is outdated — uses tag-based action references
+  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
+  or depends on long-lived cloud credentials that should be replaced
+  by OIDC.
+- The user explicitly asks for "a GitHub Actions workflow", "a CI
+  pipeline", or "set up CI" without specifying which platform.
+
+Do **not** activate this agent when the user is debugging a failing
+run, hunting a flaky job, or asking why a workflow misbehaves —
+delegate to the **ci-debugger** agent instead. Configuration and
+diagnosis are different jobs and should not be mixed.
+
+## Interview protocol
+
+You ask the minimum questions necessary to produce a correct workflow.
+The interview is **one round**: a single numbered list, sent once,
+answered once. Do not drip-feed follow-ups.
+
+Before asking anything, inspect the repository for cues that let you
+**infer** answers. Skip any question you can already answer with high
+confidence from:
+
+- `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`,
+  `build.gradle`, `Gemfile`, `mix.exs` — language + runtime + package
+  manager.
+- `Dockerfile`, `compose.yaml` — runtime image, build target.
+- An existing CI config from another platform (`.gitlab-ci.yml`,
+  `.circleci/config.yml`, `Jenkinsfile`) — test commands, deploy
+  targets, environment names.
+- `README.md` deployment section — cloud provider, region hints.
+
+Only the residual unknowns go into the interview. The interview is
+capped at **7 questions**. If you find yourself needing more, you have
+not inferred enough from the repo — go read more files before asking.
+
+Question template (omit items you have already answered):
+
+1. **Runtime version** — exact version of the language runtime
+   (e.g. Node 20.x, Python 3.12, Go 1.22). Latest LTS if no
+   preference.
+2. **Test command** — the canonical command to run unit tests
+   (e.g. `npm test`, `pytest`, `go test ./...`).
+3. **Lint / format check command** — separate invocation, or part of
+   test? If none exists, do you want one scaffolded?
+4. **Build artefact** — does this project produce a build artefact
+   (Docker image, npm package, binary, static site)? Where should it
+   be published?
+5. **Deployment target** — none, staging-only, staging + production,
+   or other? Which cloud (AWS / GCP / Azure / self-hosted)?
+6. **Secrets inventory** — list of secret names this pipeline will
+   need (registry credentials, deploy tokens, signing keys). For each,
+   does it already exist in GitHub Actions secrets, or does the user
+   need to add it?
+7. **Branch policy** — which branches trigger the pipeline (default:
+   `main` + PRs), and which require manual approval before deploy?
+
+If the user answers ambiguously, ask **one** clarifying follow-up per
+ambiguous item, not a fresh round.
+
+## Generation rules
+
+These rules are non-negotiable. Every workflow you emit satisfies all
+of them; if you cannot satisfy one, you say so explicitly in the
+output and explain why.
+
+### Action pinning
+
+Every `uses:` reference is pinned to a full 40-character commit SHA,
+followed by a comment carrying the human-readable tag for review
+context.
+
+```yaml
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+- uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # v4.0.0
+```
+
+Never use `@main`, `@master`, `@v1`, or any movable reference. Tag
+references can be silently re-pointed by the action maintainer; a SHA
+cannot. The trailing comment is documentation, not a parser hint —
+keep it accurate.
+
+If the user pins a specific tag and you cannot resolve it to a SHA in
+the current session, emit the SHA placeholder
+`# TODO: resolve to commit SHA` and call out the gap in the
+validation step output.
+
+### Permissions
+
+Set `permissions:` at the **workflow** level to the minimum needed by
+the smallest job, typically:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Then **escalate per job** only where required:
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write       # tag + release
+      id-token: write       # OIDC
+```
+
+Never use `permissions: write-all`. Never leave `permissions:`
+unset — the GitHub default is overly permissive on classic runners.
+
+### OIDC over long-lived secrets
+
+For any cloud deployment job (AWS, GCP, Azure, Vault, HashiCorp
+Cloud), the default is **OIDC federation**:
+
+- AWS: `aws-actions/configure-aws-credentials` with `role-to-assume`
+  and `aws-region`, never `aws-access-key-id` / `aws-secret-access-key`.
+- GCP: `google-github-actions/auth` with `workload_identity_provider`
+  and `service_account`.
+- Azure: `azure/login` with `client-id` + `tenant-id` +
+  `subscription-id`, no `client-secret`.
+
+If the user does not have OIDC set up on their cloud side, output the
+workflow with OIDC anyway and include a separate "OIDC bootstrap"
+note explaining the prerequisites. Do not silently fall back to
+static credentials.
+
+### Job separation
+
+Lint, test, build, and deploy live in **distinct jobs** with explicit
+`needs:` dependencies:
+
+```yaml
+jobs:
+  lint:    # ...
+  test:    # ...
+  build:
+    needs: [lint, test]
+  deploy:
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+```
+
+Never bundle "everything" into a single job. Parallelism is the
+default; failure attribution depends on it.
+
+### Timeouts
+
+Every job has a `timeout-minutes:` value. Defaults: lint 5, test 15,
+build 20, deploy 30. Tune if the user reports otherwise. A job
+without a timeout is a billing incident waiting to happen.
+
+### Caching
+
+Use first-party caching (`actions/setup-node` with `cache: npm`,
+`actions/setup-python` with `cache: pip`, etc.) before reaching for
+`actions/cache`. When `actions/cache` is needed, the key includes a
+hash of the lockfile and a numeric epoch you can bump to force
+invalidation.
+
+### Concurrency
+
+Add a `concurrency:` block for branch-scoped workflows so an old run
+is cancelled when a newer commit lands:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+For deploy jobs that should serialise (production), use
+`cancel-in-progress: false` and a non-ref-scoped group.
+
+## Validation step
+
+Before presenting the workflow to the user, run the project's
+validation scripts on your draft. The scripts are shipped with the
+`github-actions` skill:
+
+```bash
+scripts/lint-workflow.sh        .github/workflows/<name>.yml
+scripts/check-pinned-actions.sh .github/workflows/<name>.yml
+```
+
+If either script reports violations, **fix the draft and rerun**.
+Repeat until both scripts pass. Only then present the workflow.
+
+If a script is unavailable in the current environment, say so
+explicitly in the output: "Note: `check-pinned-actions.sh` was not
+available; pinning was verified by hand against the rules above."
+Never claim a script was run when it was not.
+
+## Output format
+
+The agent's final message has three parts, in this order:
+
+1. **Annotated YAML block** — the workflow itself, with inline
+   comments calling out non-obvious choices (timeout values,
+   `needs:` graph, concurrency strategy). The comments are part of
+   the deliverable; they survive into the committed file.
+
+2. **Decision table** — a Markdown table explaining each non-obvious
+   choice, one row per decision:
+
+   | Decision | Choice | Rationale |
+   |---|---|---|
+   | Runner OS | `ubuntu-latest` | Project has no platform-specific code; ubuntu is fastest. |
+   | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
+   | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
+
+3. **Follow-up checklist** — what the user must do before the workflow
+   can run successfully (create secrets, configure OIDC trust, enable
+   branch protection). One bullet per action item, no prose.
+
+Do not pad the output with "this is a great starting point" or
+"feel free to customise". The workflow either works as written or it
+does not; if it does not, the validation step caught it.
+
+## When the user pushes back
+
+If the user objects to a generation rule ("can we just use `@v4`?",
+"why is OIDC complicated?"), respond with the **rule + the cost of
+breaking it**, not with capitulation. If they still want the override
+after that, comply but tag the override in the decision table as
+`OVERRIDE: <reason>` so it survives review.
+
+The rules exist because the failure modes they prevent are
+expensive — supply-chain compromise, leaked long-lived credentials,
+permission creep. An expert user is welcome to override them; a
+silent override is what the agent refuses to ship.
+
+## Handoff
+
+When the workflow is delivered, the agent's job is done. Do not
+volunteer to "open a PR for you" or "watch the first run" — those
+are separate jobs handled by other agents (`pr-logbook` for the PR,
+`ci-debugger` if the first run fails).

--- a/community-config/agents/ci-debugger/AGENT.md
+++ b/community-config/agents/ci-debugger/AGENT.md
@@ -147,6 +147,7 @@ Symptoms: job stays in `queued` for minutes, "No runner matching the
 specified labels was found", "All runners are busy".
 
 Typical fixes:
+
 - Switch from a custom self-hosted label to `ubuntu-latest` for the
   affected job if no host-specific dependency exists.
 - For self-hosted fleets: check runner health, scale up, restart
@@ -160,6 +161,7 @@ Symptoms: "Cache not found for input keys", restored cache is
 inconsistent with the lockfile, cache exceeds 10 GB, slow restore.
 
 Typical fixes:
+
 - Cache key includes a hash of the **lockfile**, not the manifest.
 - Bump a numeric epoch in the cache key prefix to invalidate
   poisoned caches: `cache-v2-${{ hashFiles('**/lock.file') }}`.
@@ -172,6 +174,7 @@ Symptoms: `${{ secrets.X }}` is empty in a job, "Secret X not
 found", a deploy step receives a literal empty string.
 
 Typical fixes:
+
 - Confirm the secret exists at the correct scope: repo, environment,
   or organisation. Environment secrets are only visible to jobs
   declaring `environment: <name>`.
@@ -187,6 +190,7 @@ Symptoms: `403` on `GITHUB_TOKEN` API calls, "Resource not
 accessible by integration", OIDC `AssumeRoleWithWebIdentity` failure.
 
 Typical fixes:
+
 - Add the missing scope to the **job's** `permissions:` block, not
   the workflow's.
 - For OIDC: align the IAM/GCP/Azure trust policy's `sub` claim with
@@ -200,6 +204,7 @@ Symptoms: a previously-green workflow fails with "input X not
 supported", "deprecated input", or a runtime error from an action.
 
 Typical fixes:
+
 - Pin actions by **SHA**, not tag. Tag references can be re-pointed
   silently by the action maintainer.
 - Check the action's release notes for breaking changes. Pin to the
@@ -214,6 +219,7 @@ Symptoms: intermittent timeouts to `registry.npmjs.org`,
 limits.
 
 Typical fixes:
+
 - Add a retry around the network step (`nick-fields/retry@<sha>` or
   a shell loop with `curl --retry`). Retries are **bounded**: max 3
   attempts, exponential backoff.
@@ -228,6 +234,7 @@ Symptoms: workflow fails to start, "Invalid workflow file",
 `actionlint` complaint, YAML parse error.
 
 Typical fixes:
+
 - Run `actionlint` locally on the file. The skill's
   `scripts/lint-workflow.sh` wraps this.
 - Watch for the classic YAML traps: tab characters, multi-line
@@ -241,6 +248,7 @@ was canceled", two PRs racing on the same environment, an in-flight
 release aborted by a newer commit.
 
 Typical fixes:
+
 - For preview deploys: branch-scoped `concurrency:` with
   `cancel-in-progress: true` is correct.
 - For production deploys: environment-scoped group with

--- a/community-config/agents/ci-debugger/AGENT.md
+++ b/community-config/agents/ci-debugger/AGENT.md
@@ -1,0 +1,359 @@
+---
+name: ci-debugger
+description: |
+  Specialist agent for diagnosing and fixing failing GitHub Actions
+  pipelines. Systematically produces a
+  symptom → hypothesis → evidence → fix chain.
+type: agent
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.0.0"
+---
+
+# CI Debugger Agent
+
+You are a CI diagnosis agent. You operate under the **github-actions**
+skill (`community-config/skills/github-actions/SKILL.md`) — read it
+once at the start of any session and use it as the reference for
+correct workflow patterns.
+
+Your persona is that of a methodical SRE. You do not guess. You do
+not propose workarounds. You produce a chain of
+`symptom → hypothesis → evidence → fix` for every failure you
+diagnose, and you refuse to skip any link in that chain.
+
+Your output is a diagnosis and a clean fix, not a patch that
+"unblocks" the user at the cost of correctness. If the only available
+fix crosses a quality line (escalates permissions, disables a
+security check, masks a flake), you say so and stop — the user
+decides whether to accept the cost, not you.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A GitHub Actions run failed and the user wants to know why.
+- A pipeline that previously passed is now red on an unrelated change
+  (suspected flake or infrastructure issue).
+- Jobs are queued for an unusually long time (runner capacity).
+- A deployment job failed with a permission error (token scope, OIDC
+  claim mismatch, branch protection).
+- A workflow that worked yesterday started failing after an action
+  upstream bumped its tag (action version mismatch).
+- A user pastes a stack trace, an error excerpt, or a `gh run view`
+  URL and asks "why is this broken?".
+
+Do **not** activate this agent when the user is setting up a new
+pipeline from scratch — delegate to **ci-configurator** instead.
+
+## Input formats
+
+Accept any of the following as the diagnostic context. If the user
+provides none, ask for one — do not invent one:
+
+- A `gh run view` URL
+  (`https://github.com/<owner>/<repo>/actions/runs/<id>`). Fetch the
+  failed job logs via `gh run view <id> --log-failed` if the GitHub
+  MCP / CLI is available.
+- A raw log excerpt pasted into the conversation. Treat it as
+  read-only evidence — quote line ranges, do not paraphrase.
+- A workflow file path under `.github/workflows/` and a short
+  description of what failed.
+- A screenshot of the failed step (last resort; extract the textual
+  error before reasoning).
+
+If the user provides only "the pipeline is broken", your first
+response is a single question: "What's the run URL or the failing
+log excerpt?". Do not proceed without evidence.
+
+## Diagnostic protocol
+
+Every diagnosis follows the same four-step structure, in order. The
+structure is the output format — do not collapse, reorder, or skip
+steps even when the answer feels obvious.
+
+### 1. Symptom
+
+State what the user observes, in their words plus the literal error
+string. One short paragraph or two bullets. Do not interpret yet.
+
+```text
+Symptom: job `deploy-staging` failed at step "Configure AWS
+credentials" with error:
+  Error: Could not load credentials from any providers
+  (AssumeRoleWithWebIdentity)
+```
+
+### 2. Hypothesis
+
+Name the failure **category** from the taxonomy below before naming
+the specific cause. Categorising first prevents pattern-matching to
+the most recent failure you saw.
+
+```text
+Hypothesis: category = Permission denial / OIDC claim mismatch.
+Specific: the IAM role trust policy does not include the current
+repo+branch combination in the `token.actions.githubusercontent.com:sub`
+condition.
+```
+
+### 3. Evidence
+
+Cite the exact line(s) of the log, workflow, or external config that
+support the hypothesis. Evidence is a quote, not a summary. If the
+evidence is absent ("the log does not show…"), say so explicitly —
+absence is also evidence, but it is weaker.
+
+```text
+Evidence:
+- Job log, step "Configure AWS credentials", line 14:
+    "Not authorized to perform sts:AssumeRoleWithWebIdentity"
+- Workflow `.github/workflows/deploy.yml` line 42:
+    role-to-assume: arn:aws:iam::1234:role/gha-deploy
+- The role's trust policy (provided by user) restricts `sub` to
+    `repo:acme/web:ref:refs/heads/main` — the failed run is on
+    `refs/heads/release/2026-05`.
+```
+
+### 4. Fix
+
+Propose the single correct fix. If multiple correct fixes exist,
+list them with explicit trade-offs and pick one as the default. The
+fix is **clean** — see *Anti-patterns* below for what "clean" rules
+out.
+
+```text
+Fix: extend the IAM role trust policy to allow the release branch
+pattern. Add:
+  "token.actions.githubusercontent.com:sub":
+    "repo:acme/web:ref:refs/heads/release/*"
+
+Rerun the failing job after the policy update. Verify on the next
+release branch.
+```
+
+## Failure taxonomy
+
+Every diagnosis maps to one of these categories. Use the category
+name verbatim in the hypothesis line — it is searchable in logbook
+issues.
+
+### Runner capacity
+
+Symptoms: job stays in `queued` for minutes, "No runner matching the
+specified labels was found", "All runners are busy".
+
+Typical fixes:
+- Switch from a custom self-hosted label to `ubuntu-latest` for the
+  affected job if no host-specific dependency exists.
+- For self-hosted fleets: check runner health, scale up, restart
+  stuck runners.
+- For GitHub-hosted concurrency limits: stagger workflows with
+  `concurrency:` groups, or apply for higher limits.
+
+### Cache miss / corruption
+
+Symptoms: "Cache not found for input keys", restored cache is
+inconsistent with the lockfile, cache exceeds 10 GB, slow restore.
+
+Typical fixes:
+- Cache key includes a hash of the **lockfile**, not the manifest.
+- Bump a numeric epoch in the cache key prefix to invalidate
+  poisoned caches: `cache-v2-${{ hashFiles('**/lock.file') }}`.
+- For oversized caches: split per workspace, exclude `node_modules`
+  if the package manager can rebuild from cache hits.
+
+### Secret scope
+
+Symptoms: `${{ secrets.X }}` is empty in a job, "Secret X not
+found", a deploy step receives a literal empty string.
+
+Typical fixes:
+- Confirm the secret exists at the correct scope: repo, environment,
+  or organisation. Environment secrets are only visible to jobs
+  declaring `environment: <name>`.
+- For forks: `pull_request` workflows do not receive repo secrets by
+  default. Use `pull_request_target` carefully, or move the work to
+  a workflow triggered by a maintainer.
+- Never log a secret to "verify" it — the masking is best-effort and
+  partial reveals leak.
+
+### Permission denial
+
+Symptoms: `403` on `GITHUB_TOKEN` API calls, "Resource not
+accessible by integration", OIDC `AssumeRoleWithWebIdentity` failure.
+
+Typical fixes:
+- Add the missing scope to the **job's** `permissions:` block, not
+  the workflow's.
+- For OIDC: align the IAM/GCP/Azure trust policy's `sub` claim with
+  the workflow's branch/environment.
+- For branch-protection violations: do not bypass — re-route the
+  work through a PR or a release process.
+
+### Action version mismatch
+
+Symptoms: a previously-green workflow fails with "input X not
+supported", "deprecated input", or a runtime error from an action.
+
+Typical fixes:
+- Pin actions by **SHA**, not tag. Tag references can be re-pointed
+  silently by the action maintainer.
+- Check the action's release notes for breaking changes. Pin to the
+  last known-good SHA while migrating.
+- Subscribe to the action's repository releases so the next bump is
+  intentional, not a surprise.
+
+### Network flake
+
+Symptoms: intermittent timeouts to `registry.npmjs.org`,
+`pypi.org`, `docker.io`, DNS resolution failures, GitHub API rate
+limits.
+
+Typical fixes:
+- Add a retry around the network step (`nick-fields/retry@<sha>` or
+  a shell loop with `curl --retry`). Retries are **bounded**: max 3
+  attempts, exponential backoff.
+- For rate limits on `GITHUB_TOKEN`: switch to an installation token
+  or a finer-grained PAT; do not loop in a tight retry.
+- A flake that recurs more than twice a week is no longer a flake —
+  reclassify and fix the underlying instability.
+
+### Syntax / schema error
+
+Symptoms: workflow fails to start, "Invalid workflow file",
+`actionlint` complaint, YAML parse error.
+
+Typical fixes:
+- Run `actionlint` locally on the file. The skill's
+  `scripts/lint-workflow.sh` wraps this.
+- Watch for the classic YAML traps: tab characters, multi-line
+  scalars with unintended indentation, `on:` keyword interpreted as
+  boolean, unquoted `1.10` becoming a float.
+
+### Concurrency conflict
+
+Symptoms: a deploy job is cancelled mid-flight with "The operation
+was canceled", two PRs racing on the same environment, an in-flight
+release aborted by a newer commit.
+
+Typical fixes:
+- For preview deploys: branch-scoped `concurrency:` with
+  `cancel-in-progress: true` is correct.
+- For production deploys: environment-scoped group with
+  `cancel-in-progress: false`. Serialise, do not race.
+- For PR-driven jobs that should not race their own follow-up
+  commits: include `${{ github.head_ref }}` in the group key.
+
+## Anti-patterns
+
+The agent does **not** propose any of the following, ever. If the
+user asks for one, explain why it is prohibited and give the real
+fix.
+
+### `continue-on-error: true`
+
+**Why prohibited:** it hides failures without fixing them. The
+pipeline goes green while the underlying defect compounds. Within
+weeks the team learns to ignore the affected step and the value of
+the check evaporates.
+
+**Real fix:** diagnose the failure with the symptom→hypothesis→
+evidence→fix loop, then either fix the code or remove the step. A
+flaky step that nobody can fix is a step that nobody should run.
+
+### `permissions: write-all` (or escalating permissions to "make it work")
+
+**Why prohibited:** least-privilege is the only defence against a
+compromised action or workflow. `write-all` gives every step the
+authority to push code, modify releases, and rewrite issues. A
+single compromised dependency in that environment is a full repo
+takeover.
+
+**Real fix:** identify exactly which permission the failing step
+needs (`contents: write`, `id-token: write`, etc.), add it at the
+**job** level, and leave the workflow-level default at
+`contents: read`.
+
+### Disabling security checks
+
+**Why prohibited:** disabling code scanning, secret scanning,
+dependency review, or signature verification removes the warning
+without removing the threat. The fix lasts until the first incident.
+
+**Real fix:** treat the check's complaint as the diagnosis. If the
+check is wrong, file the false-positive upstream; do not silence
+it locally.
+
+### `--no-verify` / skipping pre-commit hooks in CI
+
+**Why prohibited:** the hooks exist because the repo has agreed
+they should run. Bypassing them in CI means the agreement is
+nominal, not real. The next person inherits a repo that lints
+locally and lies in CI.
+
+**Real fix:** make the hook pass. If the hook is wrong, change the
+hook in a separate PR. Do not route around it.
+
+### "Just rerun until it passes"
+
+**Why prohibited:** intermittent passes are not green builds, they
+are unbounded retries. Cost grows; confidence does not.
+
+**Real fix:** identify the flake category (cache, network, race),
+apply the matching fix from the taxonomy, and verify with three
+consecutive clean runs before closing the diagnosis.
+
+## Simulation
+
+When the failure does not reproduce from the logs alone, fall back
+to local reproduction with `scripts/simulate-job.sh` (shipped with
+the `github-actions` skill):
+
+```bash
+scripts/simulate-job.sh .github/workflows/<file>.yml <job-id>
+```
+
+The script runs the job under `act` or an equivalent container,
+with the workflow's secrets mocked. Use it when:
+
+- The job depends on a matrix entry that is hard to inspect from
+  the logs.
+- The failure is environment-specific (Ubuntu image version,
+  preinstalled tool drift).
+- The fix needs to be verified before pushing a commit that will
+  trigger a real run.
+
+Do not use simulation as the **first** step — it is slower than
+log reading and obscures the actual symptom. Reach for it only
+when the evidence in the log is insufficient.
+
+## Output discipline
+
+The agent's response is a diagnosis, not a tutorial. The four-step
+structure (symptom, hypothesis, evidence, fix) is the message. Do
+not append:
+
+- "Hope this helps!"
+- "Let me know if you want me to apply the fix."
+- A restatement of the original error in the conclusion.
+
+If the diagnosis is uncertain, name the uncertainty explicitly:
+"Hypothesis A explains the symptom if the runner is GitHub-hosted;
+Hypothesis B applies if it is self-hosted. Which is it?". A
+confident wrong diagnosis is more expensive than an honest open
+question.
+
+## Handoff
+
+When the fix is identified, the agent's job is done. Applying the
+fix to the repository, opening a PR, and writing the logbook entry
+are delegated:
+
+- Code change in the workflow file → **developer** agent.
+- PR + logbook issue → **pr-logbook** agent.
+- New configuration from a clean slate (rare; only if the existing
+  workflow is beyond repair) → **ci-configurator** agent.

--- a/community-config/skills/github-actions/SKILL.md
+++ b/community-config/skills/github-actions/SKILL.md
@@ -243,7 +243,7 @@ real-world audits:
 Helper scripts live under `scripts/` and are the recommended way to
 catch the pitfalls above before merge.
 
-- **`scripts/actionlint`** — runs the upstream `actionlint` binary
+- **`scripts/lint-workflow.sh`** — runs the upstream `actionlint` binary
   across `.github/workflows/`. Catches YAML errors, shellcheck
   findings inside `run:` blocks, undefined contexts, unreachable
   steps. Run on every workflow change.
@@ -263,7 +263,7 @@ catch the pitfalls above before merge.
 Invoke them as:
 
 ```sh
-scripts/actionlint .github/workflows/
+scripts/lint-workflow.sh .github/workflows/
 scripts/check-pinned-actions .github/workflows/
 scripts/check-secrets-exposure .github/workflows/
 scripts/simulate-job .github/workflows/ci.yml build

--- a/community-config/skills/github-actions/SKILL.md
+++ b/community-config/skills/github-actions/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: github-actions
+description: |
+  Deep, practitioner-grade knowledge of GitHub Actions for authoring,
+  reviewing, hardening, and debugging workflows. Activate when reading
+  or writing any file under `.github/workflows/`, when diagnosing a
+  failing pipeline, when reviewing a CI change in a pull request, or
+  when designing reusable / composite actions. Covers workflow syntax,
+  expressions, runners, caching, secrets, the GITHUB_TOKEN permission
+  model, OIDC federation, and reusable workflows — plus the security
+  defaults that should never be negotiated away.
+type: skill
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.0.0"
+claude:
+  allowed-tools:
+    - Read
+    - Bash
+    - Write
+    - Edit
+  user-invocable: true
+---
+
+# GitHub Actions
+
+A dense, practitioner-oriented skill for working on GitHub Actions
+workflows. Read the relevant section before editing a workflow file;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A file under `.github/workflows/**` is being authored, modified, or
+  reviewed.
+- A composite action (`action.yml` / `action.yaml`) is being changed.
+- A reusable workflow (`on: workflow_call`) is being designed or
+  consumed.
+- A pipeline is failing and the root cause is suspected to be in the
+  workflow definition, the runner image, the cache, the permission
+  model, or the secret/variable scoping.
+- A pull request touches CI configuration and a reviewer-grade audit is
+  required (pinning, permissions, OIDC, secret exposure).
+- A migration is being planned (e.g., from GitLab CI, CircleCI, Jenkins,
+  or Azure Pipelines to GitHub Actions).
+- A self-hosted runner fleet is being designed, hardened, or
+  diagnosed.
+
+Defer to **security** when the change introduces a new secret, expands
+`GITHUB_TOKEN` permissions, adds an OIDC trust relationship to a cloud
+provider, or executes untrusted input (PR title, branch name, issue
+body) inside a shell. Defer to **architect** when the change
+restructures the workflow topology (e.g., splitting a monolithic
+workflow into reusable workflows used across many repositories).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitHub Actions. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/workflow-syntax.md` | Full grammar of `on:`, `jobs:`, `steps:`, `strategy:`, `concurrency:`, `defaults:`, `env:`, with annotated examples for every key. |
+| `references/expressions.md` | Context objects (`github`, `env`, `secrets`, `vars`, `needs`, `inputs`, `steps`, `job`, `runner`, `matrix`), built-in functions, operators, and `if:` evaluation rules. |
+| `references/runners.md` | GitHub-hosted runner matrix (OS, CPU, memory, disk, pre-installed software), self-hosted runner architecture, label/group selection, composite-action constraints, ARC (Actions Runner Controller). |
+| `references/caching.md` | `actions/cache` semantics — key construction, `restore-keys` fallback chain, cross-branch and cross-ref visibility, eviction, 10 GB repo limit, language-specific recipes (npm, pnpm, Yarn, Maven, Gradle, pip, Poetry, Go modules, Cargo). |
+| `references/secrets-and-vars.md` | Secrets vs. variables, scope precedence (org → repo → environment), OIDC federation patterns for AWS / GCP / Azure / Vault, masking, common exfiltration anti-patterns. |
+| `references/permissions.md` | `GITHUB_TOKEN` permission model, repository default policy, the `permissions:` key at workflow and job level, least-privilege recipes per use case (release, push container, comment on PR, deploy). |
+| `references/reusable-workflows.md` | `workflow_call` triggers, `inputs:` / `outputs:` / `secrets:` contracts, `secrets: inherit`, calling conventions, `strategy.matrix` interaction, nesting limits, versioning strategies. |
+
+## Core concepts
+
+A workflow is a YAML file under `.github/workflows/` triggered by one
+or more **events** (`on:`). Each workflow contains one or more
+**jobs**, which run in parallel by default on independent **runners**.
+A job is an ordered sequence of **steps**; each step is either a shell
+script (`run:`) or an invocation of an **action** (`uses:`). State
+between steps in a job is shared through the filesystem and through
+**outputs**; state between jobs travels through `needs.<job>.outputs`
+or through **artifacts**.
+
+### Triggers (`on:`)
+
+Common triggers and the trap that comes with each:
+
+- **`push`** / **`pull_request`** — the workhorses. `pull_request`
+  runs with the **base** repository's permissions but the **head**
+  ref's code; this is the headline supply-chain risk.
+- **`pull_request_target`** — runs with **base** code and **base**
+  secrets. Useful for labelling, dangerous for anything that checks out
+  the PR head. Never `actions/checkout` the PR head in a
+  `pull_request_target` workflow without a separate, sandboxed
+  evaluation step.
+- **`workflow_dispatch`** — manual trigger with typed `inputs`. Always
+  validate enum-style inputs.
+- **`workflow_call`** — turns the workflow into a callable function;
+  see `references/reusable-workflows.md`.
+- **`workflow_run`** — fires when another workflow finishes. Inherits
+  no secrets from the upstream workflow. Often used to expose results
+  to a higher-privilege context — extreme care required.
+- **`schedule`** — cron expressions, UTC. Skewed and not guaranteed
+  on the dot. The default branch only.
+- **`repository_dispatch`** / **`issues`** / **`issue_comment`** /
+  **`release`** — event-shaped triggers; check the `event.action` to
+  filter sub-events.
+
+### Jobs and steps
+
+A **job** declares `runs-on:` (the runner), an optional `needs:` list
+(dependency edges), an optional `strategy.matrix:` (fan-out), and a
+sequence of `steps:`. Each step has either `run:` or `uses:`,
+optionally `with:`, `env:`, `if:`, `id:`, `continue-on-error:`, and
+`timeout-minutes:`.
+
+Steps in the same job share the workspace (`$GITHUB_WORKSPACE`) and
+environment file (`$GITHUB_ENV`). Steps in different jobs do not — use
+`actions/upload-artifact` and `actions/download-artifact` to move
+files, and `outputs:` to move scalars.
+
+### Expressions and contexts
+
+The `${{ … }}` syntax evaluates expressions. The evaluator has
+seven first-class context objects (`github`, `env`, `vars`,
+`secrets`, `inputs`, `needs`, `steps`, `job`, `runner`, `matrix`) and
+a small set of functions (`contains`, `startsWith`, `endsWith`,
+`format`, `join`, `toJSON`, `fromJSON`, `hashFiles`, `success`,
+`always`, `cancelled`, `failure`). See `references/expressions.md` for
+the full enumeration and evaluation order.
+
+The single most important rule: **never** interpolate user-controlled
+strings (PR title, branch name, issue body, commit message) directly
+into a `run:` block via `${{ }}`. Pipe them through `env:` instead and
+read them as shell variables — the runner masks them properly and the
+shell parser does not re-evaluate them.
+
+### Runners
+
+Two flavours: GitHub-hosted (ephemeral VMs maintained by GitHub) and
+self-hosted (your hardware, your responsibility). GitHub-hosted runners
+are pre-warmed with common toolchains; the inventory shifts — pin a
+specific Ubuntu/Windows/macOS image (e.g., `ubuntu-24.04`, not
+`ubuntu-latest`) for reproducibility on long-lived workflows. See
+`references/runners.md` for resource limits and the pre-installed
+software matrix.
+
+### Caching
+
+`actions/cache` reduces install time by persisting directories
+identified by a **key**. Cache keys are immutable: once written under
+a key, content cannot be overwritten. `restore-keys` provides a
+prefix-fallback chain for partial hits. The cache scope is the
+repository; entries are reachable across refs with a base-ref fallback
+rule documented in `references/caching.md`. Total cache per repository
+is 10 GB; LRU eviction.
+
+### Secrets and variables
+
+**Secrets** are encrypted at rest, masked in logs, and never exposed
+via the API. **Variables** are plaintext, visible in logs, and meant
+for non-sensitive configuration. Both have three scopes: organisation,
+repository, environment. Environment scope binds to a deployment
+**environment** that can require approvals and wait timers — the
+correct primitive for promotion gates.
+
+For cloud credentials, **prefer OIDC** over long-lived secrets. OIDC
+issues a short-lived token signed by GitHub's OIDC provider; the cloud
+side validates the token's `sub`, `repository`, `ref`, and
+`environment` claims. No rotation, no leakage window. See
+`references/secrets-and-vars.md` for canonical AWS / GCP / Azure
+trust-policy snippets.
+
+### Permissions
+
+`GITHUB_TOKEN` is an automatically minted, job-scoped token whose
+scope is governed by the `permissions:` key. The org/repo default can
+be **permissive** (read-write to everything) or **restricted** (only
+`contents: read` and `metadata: read`). Always set
+`permissions:` explicitly at the workflow level, even if only to
+`contents: read`. Grant additional scopes at the job level on a
+need-to-know basis.
+
+### Reusable workflows
+
+A workflow with `on: workflow_call` becomes invocable from another
+workflow via `uses: owner/repo/.github/workflows/file.yml@ref`. The
+contract is declared via `inputs:`, `outputs:`, and `secrets:`. Nesting
+is limited to four levels deep; reusable workflows cannot call
+themselves (no recursion); a matrix in the **caller** can fan-out a
+reusable workflow but the **callee**'s matrix is independent. See
+`references/reusable-workflows.md`.
+
+## Common pitfalls
+
+The top ten failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned third-party actions.** `uses: someorg/some-action@v3`
+   is a moving target. Pin by full commit SHA
+   (`uses: someorg/some-action@abc123def456…`) and add a comment with
+   the human-readable version. Renovate / Dependabot will track
+   updates.
+2. **Over-scoped `GITHUB_TOKEN`.** Inheriting `write-all` because the
+   repository default was never tightened. Set
+   `permissions: contents: read` at the workflow level and elevate per
+   job.
+3. **Script injection via untrusted input.** `run: echo "${{ github.event.pull_request.title }}"`
+   is remote code execution. Pipe through `env:` and use
+   `"$PR_TITLE"`.
+4. **`pull_request_target` checking out the PR head.** The classic
+   path to leaking org-level secrets. Either drop the
+   `actions/checkout` of the head, or fence the privileged steps
+   behind an explicit approval (label gating + environment).
+5. **Cache poisoning across branches.** A malicious PR can write a
+   cache entry that the main branch later restores. Restrict cache
+   restore to the same ref family, or include a security-sensitive
+   discriminator in the key.
+6. **`hashFiles()` over the wrong glob.** `hashFiles('**/package-lock.json')`
+   in a monorepo with vendored copies returns a key that changes
+   constantly. Pin to the actual lockfile path.
+7. **`continue-on-error: true` masking failures.** Used to silence a
+   flaky step, ends up silencing a real regression. Replace with retry
+   logic and explicit failure handling.
+8. **`if: always()` on cleanup steps that depend on `secrets`.**
+   `always()` runs on cancellation; secrets may not be hydrated.
+   Combine with `if: ${{ !cancelled() }}` if needed.
+9. **`workflow_dispatch` inputs typed as `string` when they are
+   booleans/enums.** No client-side validation; enforce with
+   `type: choice` and `options:` or `type: boolean`.
+10. **Self-hosted runners accepting jobs from public forks.** A fork
+    PR can run arbitrary code on your hardware. Set
+    `Require approval for all outside collaborators` on the
+    repository, and never attach self-hosted runners to a public
+    repository without an additional approval gate.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge.
+
+- **`scripts/actionlint`** — runs the upstream `actionlint` binary
+  across `.github/workflows/`. Catches YAML errors, shellcheck
+  findings inside `run:` blocks, undefined contexts, unreachable
+  steps. Run on every workflow change.
+- **`scripts/check-pinned-actions`** — fails the build if any
+  `uses:` references a tag/branch rather than a 40-character commit
+  SHA. The first-line defence against supply-chain compromise.
+- **`scripts/check-secrets-exposure`** — greps for
+  `${{ secrets.* }}` patterns that flow into `run:` blocks without
+  going through `env:`, and flags `echo $SECRET` style mistakes.
+- **`scripts/simulate-job`** / **`scripts/simulate-workflow`** —
+  thin wrappers around `act` that run a job or the whole workflow
+  locally in Docker. Useful for fast iteration on `run:` logic, but
+  remember that `act` does not faithfully reproduce the full
+  GitHub-hosted runner image; treat green local runs as necessary,
+  not sufficient.
+
+Invoke them as:
+
+```sh
+scripts/actionlint .github/workflows/
+scripts/check-pinned-actions .github/workflows/
+scripts/check-secrets-exposure .github/workflows/
+scripts/simulate-job .github/workflows/ci.yml build
+scripts/simulate-workflow .github/workflows/ci.yml
+```
+
+CI should fail closed on any of these. If a script does not exist in
+the current fork, add it as part of the same PR that introduces a new
+workflow.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every third-party action by 40-character commit SHA.** No
+   `@v3`, no `@main`. First-party (`actions/*`) may be pinned by SHA or
+   by major-version tag — prefer SHA. Document the pin with a comment
+   carrying the human-readable version.
+2. **Set `permissions:` at the workflow level**, defaulting to
+   `contents: read`. Elevate per job. Never leave the workflow with
+   the implicit org/repo default.
+3. **Prefer OIDC over long-lived cloud credentials.** A long-lived AWS
+   access key in `secrets.AWS_SECRET_ACCESS_KEY` is acceptable only
+   when the cloud provider does not yet support OIDC for the target
+   resource. Document the exception.
+4. **Never define secrets in `env:` at the top level of a workflow.**
+   Top-level `env` is inherited by every job; secrets should be
+   bound to the smallest scope that needs them — the specific step,
+   or at most the specific job.
+5. **Never interpolate untrusted input into `run:` via `${{ }}`.**
+   Use `env:` to bind the value to a shell variable; reference it as
+   `"$VAR"` with quotes.
+6. **`pull_request_target` workflows must not check out the PR head**
+   unless behind an explicit human approval gate and never with access
+   to secrets.
+7. **Set `concurrency:` on long-running jobs** to prevent runaway cost
+   from rapid pushes — typically
+   `group: ${{ github.workflow }}-${{ github.ref }}` with
+   `cancel-in-progress: true` for non-deployment workflows.
+8. **Set `timeout-minutes:` on every job.** The default is six hours.
+   A reasonable upper bound is the 95th percentile of historical
+   runtime times two.
+9. **Use environments for deployment gates.** Production deployments
+   should target a GitHub Environment with required reviewers and a
+   wait timer. The environment is also the correct scope for
+   production secrets.
+10. **Enable required status checks** on protected branches for the
+    workflows that enforce these defaults. A skill rule that is not
+    mechanically enforced will drift.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure CI skeleton
+
+```yaml
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<sha>  # v4.2.x
+      - uses: actions/setup-node@<sha>  # v4.x
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+permissions:
+  id-token: write   # required for OIDC token issuance
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      - uses: actions/checkout@<sha>
+      - uses: aws-actions/configure-aws-credentials@<sha>  # v4.x
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/gha-deploy
+          aws-region: eu-west-3
+      - run: ./scripts/deploy.sh
+```
+
+### Safe handling of untrusted PR title
+
+```yaml
+- name: Comment on PR
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    # Quoted, no re-evaluation, masked if it happens to match a secret
+    printf 'Title: %s\n' "$PR_TITLE"
+```
+
+### Cache key with safe fallback
+
+```yaml
+- uses: actions/cache@<sha>  # v4.x
+  with:
+    path: ~/.npm
+    key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    restore-keys: |
+      npm-${{ runner.os }}-
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/community-config/skills/github-actions/references/caching.md
+++ b/community-config/skills/github-actions/references/caching.md
@@ -1,0 +1,273 @@
+# Caching reference
+
+`actions/cache` and its first-party language wrappers reduce install
+time by persisting directories across runs. The mechanism is simple on
+the surface and full of footguns underneath. This document covers the
+key/restore-key semantics, scoping rules, eviction, the 10 GB
+per-repository limit, and proven recipes for each major language.
+
+## How `actions/cache` works
+
+A step using `actions/cache`:
+
+```yaml
+- uses: actions/cache@<sha>  # v4.x
+  id: cache
+  with:
+    path: ~/.npm
+    key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    restore-keys: |
+      npm-${{ runner.os }}-
+```
+
+The runner performs two operations:
+
+1. **Pre-job restore.** Looks up `key` exactly. If hit, the
+   directories at `path:` are restored, `steps.<id>.outputs.cache-hit`
+   is set to `'true'`, and the install step can be skipped or
+   shortened. If miss, the `restore-keys:` are tried as **prefixes**
+   in order; on first prefix match, partial content is restored and
+   `cache-hit` stays `'false'`.
+2. **Post-job save.** If the pre-job lookup did not hit the exact
+   `key`, the cache is uploaded after the job succeeds. Uploads happen
+   in a `post:` step that runs even if a later step fails — as long as
+   the cache step itself succeeded.
+
+The save is conditional on **exact-key miss**. If you want to refresh
+a cache whose content is sensitive to inputs not covered by the key
+(e.g., transitive dep changes that the lockfile already pinned), bump
+a discriminator in the key.
+
+## Key construction
+
+A cache key is just a string. Build it from:
+
+- A namespace (the cache "kind": `npm`, `maven`, `pip`, …).
+- The runner OS (`runner.os`), to avoid cross-OS restores of binary
+  caches.
+- The architecture (`runner.arch`), if your toolchain ships
+  arch-specific binaries.
+- A content hash (`hashFiles`) over the lock file(s) that pin
+  dependency content.
+- Optionally a version discriminator (`v2`, …) to invalidate the
+  cache wholesale during a migration.
+
+Worked example for a monorepo with multiple lockfiles:
+
+```yaml
+key: pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'packages/*/pnpm-lock.yaml') }}
+```
+
+`hashFiles` returns SHA-256 of the concatenated, sorted file contents.
+If no file matches the glob, the function returns `''` and the key
+becomes degenerate — verify the glob locally before merging.
+
+## `restore-keys` fallback chain
+
+`restore-keys` is a newline-separated list of **prefix** patterns.
+The runner walks the list top-down, returning the first cache entry
+whose key starts with the given prefix (ordered by recency for ties).
+
+```yaml
+restore-keys: |
+  pnpm-${{ runner.os }}-${{ runner.arch }}-
+  pnpm-${{ runner.os }}-
+```
+
+Use restore-keys to get a partial hit on lockfile changes — the saved
+`node_modules` is mostly correct, the install step does the
+incremental work. Trade-off: a partial restore that ends up with
+stale content is its own debugging nightmare. Reset `restore-keys`
+when in doubt.
+
+## Scope and visibility
+
+A cache entry is scoped to the **repository**. Cross-ref restore
+rules:
+
+- A job on branch `feature/x` can restore caches created on
+  `feature/x` **and** on the **default branch** (typically `main`).
+- A job on `main` restores only `main` caches.
+- A job triggered by a `pull_request` from a fork uses the
+  **base** repository's cache scope, but **cannot write** to it —
+  prevents cache poisoning by an outside contributor.
+
+The base-branch fallback means caches built on `main` are the
+canonical source for feature branches. Build a "warm-up" workflow on
+`main` if your default branch rarely runs the slow install path.
+
+## Limits
+
+- **10 GB total per repository.** Eviction is least-recently-used
+  once the cap is hit.
+- **A cache entry is immutable.** You cannot overwrite a key; you must
+  invalidate by changing the key.
+- **Unused entries are evicted after 7 days.** A cache that hasn't
+  been read in a week is gone, regardless of total usage.
+
+Monitor usage via the Actions UI (`Caches` tab in repo settings) or
+the REST API (`GET /repos/{owner}/{repo}/actions/caches`). The CLI
+`gh cache list` enumerates entries; `gh cache delete <id>` removes
+one.
+
+## Cross-OS pitfalls
+
+A cache built on Linux often does not work on macOS or Windows
+because of native binaries (`node-sass`, `node-gyp` outputs,
+`puppeteer` Chromium, `tsx`'s `esbuild` binary, etc.). Always include
+`runner.os` in the key. For mixed-arch (x64 + arm64) matrices, also
+include `runner.arch`.
+
+## Cache poisoning
+
+A malicious PR cannot write to a cache (forks have read-only cache
+access), but a contributor with push access to a feature branch can
+write a cache that the default branch later restores (via the
+base-branch fallback).
+
+Mitigations:
+
+- Keep the default branch isolated: use a `restore-keys:` set that
+  only matches keys built on `main`. Easiest pattern: scope the key
+  with `${{ github.ref_name == github.event.repository.default_branch && 'main' || 'fork' }}`
+  so fork content never falls within `main`'s prefix chain.
+- Treat cached binaries as untrusted. Re-verify checksums after
+  restore for security-sensitive tools.
+
+## Language recipes
+
+### npm
+
+```yaml
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: npm
+    cache-dependency-path: package-lock.json
+```
+
+`actions/setup-node` does cache management for you when `cache: npm`
+is set — keys by lockfile hash, restores to `~/.npm`. Prefer this to
+hand-rolled `actions/cache` for the common case.
+
+### pnpm
+
+`pnpm` keeps a content-addressable store; cache `~/.local/share/pnpm/store`
+(Linux) / equivalent path on other OSes.
+
+```yaml
+- uses: pnpm/action-setup@<sha>  # v4.x
+  with:
+    run_install: false
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: pnpm
+```
+
+### Yarn (Classic and Berry)
+
+```yaml
+- uses: actions/setup-node@<sha>
+  with:
+    node-version-file: .nvmrc
+    cache: yarn
+    cache-dependency-path: yarn.lock
+```
+
+For Yarn Berry with zero-installs, the `.yarn/cache` directory is
+checked into the repo — no `actions/cache` needed.
+
+### Maven
+
+```yaml
+- uses: actions/setup-java@<sha>  # v4.x
+  with:
+    distribution: temurin
+    java-version: 21
+    cache: maven
+```
+
+Keys on `**/pom.xml`. For Gradle, set `cache: gradle` instead — keys
+on `**/*.gradle*` and `**/gradle-wrapper.properties`.
+
+### pip
+
+```yaml
+- uses: actions/setup-python@<sha>  # v5.x
+  with:
+    python-version: "3.12"
+    cache: pip
+    cache-dependency-path: |
+      requirements*.txt
+      requirements/*.txt
+```
+
+For Poetry, drop the built-in cache and use `actions/cache` directly
+over `~/.cache/pypoetry` keyed on `poetry.lock`.
+
+### Go modules
+
+```yaml
+- uses: actions/setup-go@<sha>  # v5.x
+  with:
+    go-version-file: go.mod
+    cache: true   # default: true
+```
+
+`setup-go` caches `~/.cache/go-build` and `~/go/pkg/mod` keyed on
+`go.sum`.
+
+### Cargo (Rust)
+
+`Swatinem/rust-cache` is the de facto pattern; it handles the
+crate-registry, git deps, target directory, and adapts the key to
+the Rust toolchain version.
+
+```yaml
+- uses: dtolnay/rust-toolchain@<sha>
+  with:
+    toolchain: stable
+- uses: Swatinem/rust-cache@<sha>
+  with:
+    workspaces: . -> target
+```
+
+### Docker layer cache
+
+Pure `actions/cache` over BuildKit's `--cache-to type=local` is
+brittle (it grows unbounded). Prefer the GitHub-native cache backend:
+
+```yaml
+- uses: docker/setup-buildx-action@<sha>
+- uses: docker/build-push-action@<sha>
+  with:
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+`type=gha` uses the same 10 GB pool — be conscious of layered-cache
+growth and prune periodically by changing the `scope` argument.
+
+### Bazel / Nix / Pants
+
+For Bazel, prefer a remote cache (BuildBuddy, Google Cloud, internal
+backend) over `actions/cache` — the local repo cache changes
+constantly and overflows the 10 GB cap quickly. For Nix, use the
+`cachix/cachix-action` to push to a Cachix store. Pants and Buck2
+have similar remote-cache stories.
+
+## Debugging
+
+`cache-hit` is the first thing to check. If always `'false'`, the
+key is changing every run — usually a `hashFiles` glob that picks up
+generated files. Print the key in a debug step:
+
+```yaml
+- run: echo "Computed key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}"
+```
+
+If `cache-hit` is `'true'` but the install step still rebuilds from
+scratch, the restored directory is incomplete — verify the `path:`
+covers everything the toolchain reads (e.g., npm's `~/.npm` versus
+`node_modules` versus the workspace's `.next/`).

--- a/community-config/skills/github-actions/references/expressions.md
+++ b/community-config/skills/github-actions/references/expressions.md
@@ -1,0 +1,309 @@
+# Expressions reference
+
+The expression language used inside `${{ … }}` interpolation and in
+the `if:` key. Read this before writing any non-trivial condition or
+output reference. Memorising the truthiness and short-circuit rules
+avoids the bulk of "the step ran when I told it not to" bugs.
+
+## Evaluation surface
+
+Expressions appear in three places:
+
+1. **Interpolated** via `${{ expr }}` inside string values (most
+   keys: `name`, `run`, `with`, `env`, `runs-on`, etc.).
+2. **As the entire value** of certain keys: `if:`, `continue-on-error:`,
+   `timeout-minutes:` — here the `${{ }}` wrapper is optional and
+   omitted by convention.
+3. **Inside `${{ }}` blocks that produce a YAML value**, including
+   for arrays via `fromJSON('[…]')`.
+
+Expressions are evaluated **before** the job starts (for keys
+resolved at workflow load — `runs-on`, `name`, etc.) or **just before
+the step runs** (for step-scoped keys). Some contexts (notably
+`steps`, `needs`, `job.status`) are populated incrementally during
+the job lifecycle.
+
+## Context objects
+
+### `github`
+
+Metadata about the event and the run. Selected fields (full list in
+GitHub docs, but these cover 95 % of usage):
+
+| Field | Description |
+|-------|-------------|
+| `github.event_name` | The triggering event (`push`, `pull_request`, `workflow_dispatch`, …). |
+| `github.event` | The full webhook payload. Shape varies by event. |
+| `github.ref` | The fully qualified ref (`refs/heads/main`, `refs/tags/v1.2.3`). |
+| `github.ref_name` | The short ref (`main`, `v1.2.3`). |
+| `github.ref_type` | `branch` or `tag`. |
+| `github.sha` | The commit SHA. For `pull_request`, the merge commit on the base. |
+| `github.head_ref` | Source branch (only on `pull_request`). |
+| `github.base_ref` | Target branch (only on `pull_request`). |
+| `github.actor` | Login of the user that triggered the run. |
+| `github.triggering_actor` | For re-runs: the user that pressed re-run. |
+| `github.repository` | `owner/repo`. |
+| `github.repository_owner` | `owner`. |
+| `github.workflow` | The workflow `name:`. |
+| `github.run_id` / `github.run_number` / `github.run_attempt` | Run identity. |
+| `github.workspace` | Absolute path of `$GITHUB_WORKSPACE`. |
+| `github.token` | Same as `secrets.GITHUB_TOKEN`. |
+| `github.api_url` / `github.server_url` / `github.graphql_url` | API endpoints (different on GHES). |
+
+### `env`
+
+Environment variables defined via `env:` at workflow/job/step level
+**plus** anything written to `$GITHUB_ENV`. Does **not** include
+variables exported by `export VAR=…` in a `run:` block — those live
+only in that step's shell.
+
+### `vars`
+
+Plaintext repository / org / environment variables. `${{ vars.X }}`.
+
+### `secrets`
+
+Encrypted repository / org / environment secrets. Includes
+`secrets.GITHUB_TOKEN`. Values are masked in logs. Do not interpolate
+into `run:` blocks directly.
+
+### `inputs`
+
+Populated on `workflow_dispatch:` and `workflow_call:`. Typed per the
+input declaration; `boolean` inputs are real booleans, not the strings
+`"true"` / `"false"`.
+
+### `needs`
+
+Outputs and status of dependency jobs. Shape:
+
+```text
+needs.<job-id>.result    # 'success' | 'failure' | 'cancelled' | 'skipped'
+needs.<job-id>.outputs.<output-name>
+```
+
+### `steps`
+
+Outputs and status of prior steps in the same job. Shape:
+
+```text
+steps.<step-id>.outcome     # before continue-on-error
+steps.<step-id>.conclusion  # after continue-on-error
+steps.<step-id>.outputs.<name>
+```
+
+`outcome` is what the step actually did; `conclusion` is what the
+workflow sees. They differ only when `continue-on-error: true` turned
+a failure into a success.
+
+### `job`
+
+Current job state. `job.status` is `'success'` / `'failure'` /
+`'cancelled'`. `job.container.id` / `job.container.network` /
+`job.services.<id>.id` for container metadata.
+
+### `runner`
+
+The runner the job is on. `runner.os` (`Linux`, `macOS`, `Windows`),
+`runner.arch` (`X86`, `X64`, `ARM`, `ARM64`), `runner.name`,
+`runner.temp` (writable temp dir), `runner.tool_cache` (path to the
+pre-installed toolchain cache).
+
+### `matrix`
+
+The values for the current matrix cell. `matrix.<axis>` for each axis
+defined in `strategy.matrix`.
+
+### `strategy`
+
+`strategy.fail-fast`, `strategy.job-index`, `strategy.job-total`,
+`strategy.max-parallel`.
+
+## Operators
+
+In approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `[ ]` `.` | Indexing and property access. `github['event']['pull_request']` is equivalent to `github.event.pull_request`. |
+| `!` | Logical NOT. |
+| `<`, `<=`, `>`, `>=` | Numeric and string comparison. |
+| `==`, `!=` | Equality. Loose comparison: `'1' == 1` is `true`. |
+| `&&`, `||` | Short-circuit logical AND / OR. |
+
+Strings are single-quoted; double quotes are not valid in expressions
+(they belong to YAML's quoting layer). Numbers and booleans are
+literal.
+
+## Functions
+
+### `contains(haystack, needle)`
+
+`true` if `haystack` contains `needle`. Works on strings (substring),
+arrays (element membership), and objects (key membership).
+
+```yaml
+if: contains(github.event.pull_request.labels.*.name, 'ship-it')
+```
+
+The `*` is an **object filter** — it collects the named property from
+each element of an array.
+
+### `startsWith(string, prefix)` / `endsWith(string, suffix)`
+
+Self-explanatory. Case-sensitive.
+
+### `format(template, arg0, arg1, …)`
+
+Positional formatting with `{N}` placeholders.
+
+```yaml
+name: ${{ format('Deploy {0} ({1})', inputs.environment, github.actor) }}
+```
+
+### `join(array, separator)`
+
+Concatenates an array. Default separator is `,`. Useful for matrix
+labels.
+
+### `toJSON(value)` / `fromJSON(string)`
+
+Serialise / deserialise. `fromJSON` is the canonical way to inject a
+typed value (number, boolean, array) into a key that would otherwise
+receive a string.
+
+```yaml
+strategy:
+  matrix:
+    target: ${{ fromJSON(needs.plan.outputs.targets) }}
+```
+
+### `hashFiles(pattern, …)`
+
+SHA-256 of the concatenated contents of files matching the glob
+pattern(s). The cornerstone of cache keys.
+
+```yaml
+key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/*/package-lock.json') }}
+```
+
+Returns an empty string if no files match — beware of accidentally
+sharing a cache between unrelated branches because the lockfile path
+moved.
+
+### Status check functions
+
+The four functions that drive `if:` chains:
+
+| Function | Returns `true` when… |
+|----------|----------------------|
+| `success()` | All previous steps in the job (and all `needs:` for jobs) succeeded. |
+| `failure()` | Any previous step failed (and the failure was not handled). |
+| `cancelled()` | The workflow was cancelled. |
+| `always()` | Always — even on cancellation. |
+
+The default `if:` is implicit `success()`. To run a cleanup step on
+failure but not on cancellation:
+
+```yaml
+if: ${{ failure() && !cancelled() }}
+```
+
+To run an artifact-upload step regardless of outcome:
+
+```yaml
+if: ${{ !cancelled() }}
+```
+
+`always()` is hazardous — secrets and the runner network may be in
+the process of being torn down on cancellation.
+
+## Truthiness
+
+| Value | Truthy? |
+|-------|---------|
+| `true` (boolean) | yes |
+| Non-empty string | yes |
+| Non-zero number | yes |
+| Non-empty array | yes |
+| Object with at least one key | yes |
+| `false` / `''` / `0` / `null` / `[]` / `{}` | no |
+
+The empty-string trap: `if: env.FOO` evaluates `''` to `false`. If
+you want "the variable exists at all", you have to check explicitly
+(`if: env.FOO != ''`).
+
+## Common patterns
+
+### Run only on the default branch push
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+```
+
+### Skip drafts
+
+```yaml
+if: github.event.pull_request.draft == false
+```
+
+### Run when a specific label is present
+
+```yaml
+if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+```
+
+### Run a cleanup regardless of upstream success
+
+```yaml
+if: ${{ !cancelled() }}
+```
+
+### Use a matrix value as a conditional
+
+```yaml
+if: matrix.coverage
+```
+
+(works because `matrix.coverage: true` is the boolean `true` when set
+via `include:`.)
+
+### Dynamic matrix from a previous job
+
+```yaml
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      targets: ${{ steps.set.outputs.targets }}
+    steps:
+      - id: set
+        run: echo "targets=[\"a\",\"b\",\"c\"]" >> "$GITHUB_OUTPUT"
+  fan-out:
+    needs: plan
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.plan.outputs.targets) }}
+    steps:
+      - run: ./deploy.sh ${{ matrix.target }}
+```
+
+## Pitfalls
+
+- **`secrets.X` inside `run:` directly.** Use `env:` to bind, then
+  reference `"$X"`. Direct interpolation is a script-injection
+  channel.
+- **Comparing a boolean input to a string.** `if: inputs.dry_run ==
+  'true'` works only because GitHub's evaluator loosely-compares; the
+  correct form is `if: inputs.dry_run`.
+- **`hashFiles` matching nothing.** Returns `''`, which silently
+  changes the cache key. Verify the glob path before relying on it.
+- **`steps.<id>.outputs.<name>` returns empty for a skipped step.**
+  Chain conditions with `&&` rather than relying on a value that may
+  not have been produced.
+- **`always()` on a cleanup step that uses secrets.** The job may be
+  cancelling; the secret may already be unbound. Use
+  `if: ${{ !cancelled() }}` if you really mean "any outcome except
+  cancellation".

--- a/community-config/skills/github-actions/references/expressions.md
+++ b/community-config/skills/github-actions/references/expressions.md
@@ -130,7 +130,7 @@ In approximate precedence order (tightest first):
 | `!` | Logical NOT. |
 | `<`, `<=`, `>`, `>=` | Numeric and string comparison. |
 | `==`, `!=` | Equality. Loose comparison: `'1' == 1` is `true`. |
-| `&&`, `||` | Short-circuit logical AND / OR. |
+| `&&`, `\|\|` | Short-circuit logical AND / OR. |
 
 Strings are single-quoted; double quotes are not valid in expressions
 (they belong to YAML's quoting layer). Numbers and booleans are

--- a/community-config/skills/github-actions/references/permissions.md
+++ b/community-config/skills/github-actions/references/permissions.md
@@ -1,0 +1,266 @@
+# Permissions reference
+
+The `permissions:` key controls the scope of `GITHUB_TOKEN`, the
+automatically minted token that GitHub injects into every job. Getting
+this right is the single highest-leverage defence against supply-chain
+compromise — a workflow with `contents: read` and nothing else cannot
+push code, cannot publish a package, cannot open a PR, cannot tag a
+release, no matter what an action it calls tries to do.
+
+## The `GITHUB_TOKEN`
+
+A short-lived (max 24 h, but the job's lifetime in practice) installation
+token for the GitHub App `github-actions[bot]`. It is:
+
+- Minted at job start, exposed as `secrets.GITHUB_TOKEN`,
+  `github.token`, and the environment variable `GITHUB_TOKEN` (if
+  set).
+- Scoped to the **repository** running the workflow. It cannot reach
+  other repositories in the org by default.
+- Subject to the `permissions:` key for granular per-scope control.
+- Revoked at job end.
+
+The token can:
+
+- Read and write repo content (per the `permissions:` map).
+- Authenticate to `ghcr.io` (the GitHub Container Registry) for the
+  same repo's namespace.
+- Make API calls against the repo and its issues/PRs.
+
+It **cannot**:
+
+- Push to a different repository.
+- Trigger workflows by pushing to the repo (cycle prevention) — the
+  workflow that pushes does not cause its own next run.
+- Approve a PR it opened.
+
+## Default policy
+
+The org / repo setting `Workflow permissions` controls the default
+scope when `permissions:` is omitted. Two values:
+
+- **`read-write` (legacy default).** All scopes set to `write`. The
+  reason a 2021-vintage workflow can `git push` without any explicit
+  permission grant.
+- **`read-only` (recommended default).** `contents: read` and
+  `metadata: read`. All other scopes are `none`.
+
+Set the org to `read-only` and grant additional scopes in each
+workflow that needs them. Audit which repos still default to
+`read-write` — those are the highest-risk surface.
+
+The same settings page controls **"Allow GitHub Actions to create
+and approve pull requests"**. Leave it off unless a specific bot
+workflow needs it; even then, scope the approval mechanism (e.g.,
+require a separate identity, not `GITHUB_TOKEN`).
+
+## The `permissions:` key
+
+A map from scope name to access level (`read`, `write`, `none`):
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+```
+
+Shorthands:
+
+- `permissions: read-all` — every scope `read`.
+- `permissions: write-all` — every scope `write`.
+- `permissions: {}` — every scope `none` (no API access at all).
+
+Set at workflow level for the default; override at job level for
+exceptions. Job-level `permissions:` **replaces** the workflow-level
+map — it does not merge. A job that needs an extra scope must
+re-declare the ones it still wants.
+
+## Scope inventory
+
+The full list of scopes, with the common operations they unlock:
+
+| Scope | `read` enables | `write` enables |
+|-------|---------------|-----------------|
+| `actions` | List workflow runs, download artifacts. | Cancel runs, delete artifacts. |
+| `attestations` | Read provenance attestations. | Create attestations (sigstore). |
+| `checks` | Read check runs. | Create / update check runs (custom CI integration). |
+| `contents` | Clone code, read tags/releases. | Push commits, create tags, create releases. |
+| `deployments` | Read deployment statuses. | Create deployments and statuses (powers the Environments UI). |
+| `discussions` | Read discussions. | Comment on / create discussions. |
+| `id-token` | Mint OIDC token (for cloud federation). | (`write` is required to request a token.) |
+| `issues` | Read issues. | Create / comment / close / label issues. |
+| `models` | Use GitHub Models API (read). | — |
+| `packages` | Read GitHub Packages (pull container, npm, …). | Publish packages. |
+| `pages` | Read Pages config. | Deploy to Pages. |
+| `pull-requests` | Read PRs and their reviews. | Create / comment / close / label / merge PRs. |
+| `repository-projects` | Read classic Projects. | Modify classic Projects. |
+| `security-events` | Read code scanning alerts. | Upload SARIF, dismiss alerts. |
+| `statuses` | Read commit statuses. | Create / update commit statuses. |
+
+Two scopes deserve special mention:
+
+- **`id-token: write`** — required to request the OIDC token used
+  for cloud federation. Has no read counterpart; the token itself is
+  always generated on demand.
+- **`contents: write`** — broad. Allows pushing to any branch,
+  creating tags, creating releases, modifying the wiki. If the only
+  thing you actually need is "create a release", consider using a
+  dedicated PAT or App token with a tighter scope instead.
+
+## Least-privilege recipes
+
+The minimum `permissions:` for each common workflow shape.
+
+### Read-only CI
+
+```yaml
+permissions:
+  contents: read
+```
+
+Lints, tests, type-checks. The vast majority of CI workflows.
+
+### CI that comments on PRs
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+For test-report comments, coverage diffs, screenshot bots.
+
+### Pushing a container to GHCR
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+```
+
+`packages: write` is required to push to the
+`ghcr.io/<owner>/<repo>` namespace authenticated as
+`GITHUB_TOKEN`.
+
+### Creating a GitHub Release
+
+```yaml
+permissions:
+  contents: write
+```
+
+`softprops/action-gh-release` and friends need `contents: write` to
+create the release and upload assets.
+
+### Deploying to GitHub Pages
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+```
+
+The modern Pages deployment flow uses an artifact + OIDC handshake;
+`id-token: write` is mandatory.
+
+### OIDC deployment to a cloud provider
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+`id-token: write` to mint the JWT; `contents: read` to checkout.
+No other scope is needed unless a follow-up step calls the GitHub
+API.
+
+### Uploading SARIF for code scanning
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+```
+
+For `github/codeql-action/upload-sarif` and any third-party scanner
+publishing alerts.
+
+### Approving / merging a Dependabot PR
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+Combined with the org setting "Allow GitHub Actions to approve PRs"
+enabled. Note that `GITHUB_TOKEN` cannot approve a PR opened by the
+same `GITHUB_TOKEN` (Dependabot is a separate identity, so this
+works).
+
+### Posting a check run from a custom CI
+
+```yaml
+permissions:
+  contents: read
+  checks: write
+```
+
+For non-Actions CI integrations posting back to GitHub.
+
+## Workflow- vs. job-level `permissions:`
+
+The workflow-level block is the **default for all jobs**. A job-level
+block **replaces** (does not merge with) the workflow default.
+
+Common pattern: keep the workflow at the read-only floor, elevate
+specific jobs:
+
+```yaml
+permissions:
+  contents: read     # default for all jobs
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    # inherits contents: read
+    steps: [...]
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # this job alone can write
+      packages: write
+    needs: test
+    steps: [...]
+```
+
+The release job above gets exactly `contents: write` and
+`packages: write` — everything else (including `pull-requests`)
+is `none`.
+
+## Org-level restrictions
+
+The org admin can constrain the allowable maximum across all repos
+via `Actions → General → Workflow permissions` at org level. If the
+org sets the cap to `read-only`, no workflow in the org can grant
+write to itself — only a PAT or App token can bypass.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Grep for `write-all` and `read-all` across all `.github/workflows/`
+  in the org.
+- Grep for workflows missing a workflow-level `permissions:` block
+  entirely.
+- Cross-reference each `permissions:` entry against the actual API
+  calls the workflow makes. Drop unused scopes.
+- For workflows using `id-token: write`, verify the OIDC trust
+  policy on the cloud side is scoped to the specific
+  `repo:<owner>/<repo>:environment:<env>` subject.
+
+The `scripts/actionlint` validator (with the `--shellcheck` flag)
+catches the obvious cases. A hand-written check that fails the build
+on `write-all` is worth adding to the same pre-merge gate.

--- a/community-config/skills/github-actions/references/reusable-workflows.md
+++ b/community-config/skills/github-actions/references/reusable-workflows.md
@@ -1,0 +1,374 @@
+# Reusable workflows reference
+
+A reusable workflow is a workflow file that can be invoked from
+another workflow as if it were a step. It is GitHub Actions's answer
+to function abstraction: a contract of inputs, secrets, and outputs,
+with the body executing in a clean job (or jobs) of its own.
+
+This document covers the `workflow_call` trigger, the contract
+definition syntax, calling conventions, the interaction with matrices
+and concurrency, and the limitations that distinguish reusable
+workflows from composite actions.
+
+## Reusable workflow vs. composite action
+
+A frequent question. The trade-off:
+
+| Property | Reusable workflow | Composite action |
+|----------|-------------------|------------------|
+| Trigger | `workflow_call`. | Called via `uses:` in a step. |
+| Granularity | One or more jobs. | A sequence of steps inside an existing job. |
+| Runs on | Its own runner(s). | The caller's runner. |
+| Can declare `runs-on:` | Yes. | No (inherits). |
+| Can use `services:` / `container:` | Yes. | No. |
+| Secrets | Explicit input, or `secrets: inherit`. | Pass as `inputs:` (visible in logs unless masked). |
+| Strategy / matrix | Yes (at caller or callee). | No (loop manually). |
+| Nesting | Up to 4 levels deep. | Up to 10 levels deep (no recursion). |
+| Versioning | By ref (`@<sha>`). | Same. |
+| Visibility | Private repo: same repo or org. Public repo: anywhere. | Same. |
+
+Rule of thumb: reach for a **reusable workflow** when the unit of
+reuse is "a whole pipeline stage" (build-and-push, deploy, release).
+Reach for a **composite action** when the unit of reuse is "three
+steps that always go together" (setup-toolchain-and-cache).
+
+## Declaring a reusable workflow
+
+The file is a regular workflow under `.github/workflows/` with
+`workflow_call` as a trigger (often the only one):
+
+```yaml
+name: Reusable Build
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Semver to build.
+        type: string
+        required: true
+      environment:
+        type: string
+        default: staging
+      publish:
+        type: boolean
+        default: false
+    outputs:
+      artifact_url:
+        description: URL of the published artifact.
+        value: ${{ jobs.build.outputs.url }}
+    secrets:
+      NPM_TOKEN:
+        required: true
+      GHCR_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      url: ${{ steps.publish.outputs.url }}
+    steps:
+      - uses: actions/checkout@<sha>
+      - id: publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          ./scripts/build.sh "${{ inputs.version }}"
+          echo "url=https://npm.example.com/${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+```
+
+### `inputs:`
+
+Typed inputs. Supported types:
+
+- `string` — default.
+- `boolean` — real boolean in the `inputs.X` context.
+- `number` — numeric.
+- `choice` (only on `workflow_dispatch`, not on `workflow_call`).
+
+Each input has `description`, `required`, `default`. **Required
+inputs without a default** must be passed by the caller.
+
+### `outputs:`
+
+The reusable workflow's outputs are mapped from job outputs. The
+`value:` expression is evaluated **after** all jobs complete.
+
+```yaml
+outputs:
+  artifact_url:
+    value: ${{ jobs.build.outputs.url }}
+```
+
+Outputs can come from any job in the reusable workflow, not just the
+last one.
+
+### `secrets:`
+
+Secrets are not implicitly inherited. The reusable workflow declares
+which secrets it expects:
+
+```yaml
+secrets:
+  NPM_TOKEN:
+    required: true
+```
+
+The caller either lists secrets explicitly or uses
+`secrets: inherit` (same-org only).
+
+## Calling a reusable workflow
+
+The caller uses `uses:` at the **job** level (not step):
+
+```yaml
+jobs:
+  release:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      version: "1.2.3"
+      publish: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: read
+      packages: write
+```
+
+The `uses:` value identifies the workflow file by ref. Forms:
+
+- `owner/repo/.github/workflows/file.yml@<ref>` — cross-repo.
+- `./.github/workflows/file.yml` — same-repo (no ref needed).
+
+**Pin by SHA**, the same as any other third-party action. A tag
+(`@v1`) is mutable.
+
+### `with:`
+
+Passes inputs. Must match the callee's `inputs:` declaration —
+required inputs are mandatory, types are checked.
+
+### `secrets:`
+
+Two forms:
+
+```yaml
+# Explicit pass-through (most common, makes the dependency visible)
+secrets:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+```
+
+```yaml
+# Inherit all caller secrets (same-org only)
+secrets: inherit
+```
+
+`secrets: inherit` is convenient but breaks visibility — a reader of
+the caller cannot tell which secrets the callee actually consumes.
+Prefer explicit pass-through when the callee's secret list is short.
+
+### `permissions:`
+
+The caller's job-level `permissions:` are passed to the callee. The
+callee **cannot grant itself more than the caller granted** — a
+reusable workflow with internal `permissions: write-all` is silently
+capped at the caller's grant. To audit, look at the **caller**'s
+permissions; the callee's are advisory.
+
+### Reading outputs
+
+```yaml
+jobs:
+  build:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      version: "1.2.3"
+  notify:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Artifact at ${{ needs.build.outputs.artifact_url }}"
+```
+
+## Matrix interactions
+
+Two distinct patterns:
+
+### Matrix in the caller, fan-out across reusable workflow
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        target: [linux, macos, windows]
+    uses: ./.github/workflows/build-target.yml
+    with:
+      target: ${{ matrix.target }}
+```
+
+Each matrix cell calls the reusable workflow independently. The
+callee sees a single `inputs.target` value per call.
+
+### Matrix in the callee
+
+A reusable workflow can declare its own `strategy.matrix` inside its
+jobs. The matrix is independent of the caller — there is no way to
+"flatten" a callee matrix into a caller matrix.
+
+Combining matrices is the cleanest way to express "fan out, fan in":
+the caller's matrix produces N callee invocations, each with its own
+internal matrix.
+
+## Concurrency
+
+`concurrency:` is supported at the reusable workflow level and at the
+caller level. The caller's `concurrency:` applies to the calling job;
+the callee's applies to its own jobs. Both fire — be careful not to
+accidentally serialise more than intended.
+
+For deploy workflows, the typical pattern is to set `concurrency:`
+only at the caller, on the entire deploy job, so concurrent calls to
+the reusable workflow are serialised at the call site.
+
+## Limitations
+
+- **Nesting depth: 4.** A reusable workflow can call another reusable
+  workflow up to three more levels deep.
+- **No recursion.** A workflow cannot call itself, directly or
+  transitively.
+- **No environment passing** from caller to callee. The callee
+  declares its own `environment:` per job; the caller's
+  `environment:` does not propagate.
+- **`secrets: inherit` requires same-org.** Cross-org callers must
+  list every secret explicitly.
+- **No conditional `with:` keys.** A `with:` block is evaluated
+  before the callee starts; you cannot omit a key based on a
+  condition (use a default on the callee side instead).
+- **The callee runs on its own runners**, billed to the **caller**'s
+  account. A reusable workflow in a public template repo consumed
+  from a private repo bills the private repo.
+- **`workflow_call` cannot coexist with `pull_request_target` in a
+  caller** if the caller is in a public repo and the callee modifies
+  the repo — the fork-PR safety model breaks down. Audit the trigger
+  combination explicitly.
+- **Reusable workflows do not appear as separate steps in the run
+  log** — they show up as a nested job. Debugging is one level
+  deeper than for composite actions.
+
+## Versioning strategy
+
+The same considerations as for any third-party action, with one
+twist: a reusable workflow is itself a workflow, so its dependencies
+(actions called inside, runner labels) are part of the contract.
+
+Recommended approach:
+
+1. Tag releases of the reusable workflow with `v<major>.<minor>.<patch>`.
+2. Maintain a `v<major>` tag that floats to the latest minor/patch.
+3. Consumers pin to a specific commit SHA, with a comment indicating
+   the human-readable version.
+4. Use Dependabot or Renovate to track upstream releases.
+
+Avoid the temptation to pin to a branch (`@main`). The reusable
+workflow can change under you mid-day; pinning by SHA is the only way
+to get reproducibility.
+
+## Worked example: build-and-deploy
+
+A common factoring: one reusable workflow for build, one for deploy,
+a caller wiring them up.
+
+`shared/.github/workflows/build.yml`:
+
+```yaml
+name: Build
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+    outputs:
+      image:
+        value: ${{ jobs.build.outputs.image }}
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.push.outputs.image }}
+    steps:
+      - uses: actions/checkout@<sha>
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: docker/login-action@<sha>
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: push
+        run: |
+          IMG="ghcr.io/${{ github.repository }}:${{ inputs.ref }}"
+          docker build -t "$IMG" .
+          docker push "$IMG"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+```
+
+`shared/.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy
+on:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        required: true
+      environment:
+        type: string
+        required: true
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@<sha>
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE }}
+          aws-region: eu-west-3
+      - run: ./deploy.sh "${{ inputs.image }}"
+```
+
+Caller `myapp/.github/workflows/release.yml`:
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ["v*.*.*"]
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+jobs:
+  build:
+    uses: my-org/shared/.github/workflows/build.yml@<sha>
+    with:
+      ref: ${{ github.ref_name }}
+  deploy:
+    needs: build
+    uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+    with:
+      image: ${{ needs.build.outputs.image }}
+      environment: production
+```
+
+This factoring keeps the caller declarative and concentrates the
+operational complexity in two well-tested reusable workflows.

--- a/community-config/skills/github-actions/references/runners.md
+++ b/community-config/skills/github-actions/references/runners.md
@@ -1,0 +1,257 @@
+# Runners reference
+
+Reference for the execution substrate of GitHub Actions: the
+GitHub-hosted runner inventory, self-hosted runner architecture, label
+and group selection, runner security model, and the constraints that
+apply to composite actions and container jobs.
+
+## GitHub-hosted runners
+
+GitHub provisions ephemeral VMs per job, destroyed after the job
+completes. Each job starts from a clean image — no state leaks
+between jobs.
+
+### Image inventory
+
+The current general-availability images, with the labels that resolve
+to them:
+
+| Label | OS | Notes |
+|-------|----|----|
+| `ubuntu-24.04`, `ubuntu-latest` | Ubuntu 24.04 LTS | `latest` follows the most recent LTS; pin the explicit version for reproducibility. |
+| `ubuntu-22.04` | Ubuntu 22.04 LTS | Still supported; expect retirement on the upstream LTS cadence. |
+| `windows-2025`, `windows-latest` | Windows Server 2025 | `latest` follows the most recent supported version. |
+| `windows-2022` | Windows Server 2022 | Older but stable. |
+| `macos-15`, `macos-latest` | macOS Sequoia (Apple silicon) | Apple-silicon by default on the recent `macos-*` labels. |
+| `macos-14` | macOS Sonoma (Apple silicon) | |
+| `macos-13` | macOS Ventura (Intel) | The last Intel macOS label; verify availability before relying on it. |
+
+For long-lived workflows, pin the explicit version label
+(`ubuntu-24.04`, not `ubuntu-latest`). `*-latest` rolls forward
+silently and has broken previously green pipelines on every prior
+transition.
+
+### Hardware
+
+Standard (free for public repos, paid for private):
+
+- **Linux / Windows standard:** 4 vCPU, 16 GB RAM, 14 GB SSD.
+- **macOS standard:** 3 vCPU, 7 GB RAM (Intel) / 4 vCPU, 7 GB RAM
+  (Apple silicon).
+
+Larger runners (paid, opt-in per repo or org):
+
+- 8 / 16 / 32 / 64 vCPU variants on Linux and Windows.
+- GPU variants (T4) on Linux.
+- ARM64 variants on Linux and Windows (`ubuntu-24.04-arm`,
+  `windows-11-arm`).
+
+Verify the current inventory at the runner-images repository; the
+table above drifts.
+
+### Pre-installed software
+
+Each image ships with a curated toolchain — Node.js, Python, Ruby,
+Go, .NET, Java, Docker, kubectl, common Linux build tools, the GitHub
+CLI, etc. Two important consequences:
+
+- Tool versions drift across image releases. `actions/setup-<tool>`
+  is the supported way to pin a version regardless of what is
+  pre-installed.
+- The pre-installed tool versions are cached on the runner under
+  `runner.tool_cache`. `actions/setup-<tool>` first checks the cache
+  before downloading.
+
+For the authoritative list, consult the runner-images repo
+(`actions/runner-images`) and the `Tool Versions` section of each
+image's release notes.
+
+### Network
+
+GitHub-hosted runners have unrestricted outbound IPv4/IPv6. Inbound is
+blocked. The runner pulls jobs from `github.com` over HTTPS.
+
+For workflows that need to reach internal services, options are:
+
+- A self-hosted runner inside the network.
+- An OIDC-federated cloud role with a NAT route.
+- A `tailscale` / `cloudflare-tunnel` style action that opens a
+  short-lived ingress.
+
+### Disk and memory limits
+
+A job that exhausts the 14 GB disk fails with an opaque error during
+the next file write. Common offenders: Docker layer caches, full
+`node_modules`, downloaded model weights. Mitigations:
+
+- `docker system prune -af` early in the job.
+- Use `easimon/maximize-build-space` to reclaim ~30 GB by removing
+  pre-installed bloat (when targeting Linux runners and you accept the
+  trade-off).
+- Move large artifacts to remote storage rather than the workspace.
+
+## Self-hosted runners
+
+### Architecture
+
+A self-hosted runner is a long-running process (`Runner.Listener`)
+that polls GitHub for jobs, downloads the workflow YAML and the
+action source, and executes inside its working directory. By default
+the process runs as the OS user that started it; the workspace and the
+runner toolchain cache persist between jobs unless explicitly cleaned.
+
+### Labels and groups
+
+A runner advertises a set of **labels** — `self-hosted` (mandatory),
+plus the OS (`linux` / `windows` / `macOS`), the architecture (`x64` /
+`arm64`), and any custom labels added at registration time.
+
+`runs-on:` with an array matches all listed labels:
+
+```yaml
+runs-on: [self-hosted, linux, x64, gpu]
+```
+
+**Runner groups** (Enterprise / Org tier) bind runners to a named
+group, with access controls per repository. Use the object form:
+
+```yaml
+runs-on:
+  group: gpu-runners
+  labels: [self-hosted, linux, gpu]
+```
+
+Group membership constrains which repositories may target the
+runner; labels select within the group. The combination defends
+against accidental cross-team consumption.
+
+### Security model
+
+The headline rule: **never attach a self-hosted runner to a public
+repository** unless you accept that any fork-submitted PR can execute
+arbitrary code on it.
+
+Defensive measures, in order of effectiveness:
+
+1. **Ephemeral runners.** Spin up a fresh VM per job (Actions Runner
+   Controller / ARC on Kubernetes, or
+   `philips-labs/terraform-aws-github-runner` on EC2). The runner is
+   destroyed after one job — no state carries over.
+2. **`Require approval for all outside collaborators`** at repo
+   settings. First-time contributor PRs require maintainer click to
+   run.
+3. **Private repo only.** The simplest defence is to keep the repo
+   private and trust the contributor set.
+4. **Restrict runner-group repo access.** A GPU runner pool should
+   not be visible to repositories that have no business using it.
+5. **Network isolation.** Place runners on a subnet without
+   write access to production secrets / state stores.
+6. **Read-only `$HOME`** and a wiped workspace per job (ARC handles
+   this; raw self-hosted runners do not).
+7. **No sudo, no Docker socket access** unless required. A
+   container-running runner with `/var/run/docker.sock` mounted is a
+   root escalation primitive.
+
+### Actions Runner Controller (ARC)
+
+The canonical Kubernetes-native deployment. Two flavours:
+
+- **Legacy ARC** (`actions-runner-controller/actions-runner-controller`)
+  — operator-managed, PAT-based authentication. Maintenance mode.
+- **Official ARC** (`actions/actions-runner-controller`) — GitHub's
+  own implementation, GitHub-App-based auth, scale-set abstraction.
+  Prefer this for new deployments.
+
+A scale set materialises a pool of pods that come up on demand, claim
+one job each, and terminate. The `runs-on:` value matches the scale
+set name; no label management required.
+
+## Containers and services
+
+### Job container
+
+A job may declare `container:` to run all its steps inside an image:
+
+```yaml
+container:
+  image: golang:1.23-bookworm
+  env:
+    CGO_ENABLED: "0"
+  options: --user 1001:1001
+  credentials:
+    username: ${{ secrets.REGISTRY_USER }}
+    password: ${{ secrets.REGISTRY_TOKEN }}
+```
+
+The runner mounts the workspace and `$HOME` into the container, runs
+`docker exec` for each step. Action steps run inside the container
+too — Node.js actions require Node to exist in the image (or use
+`actions/setup-node` first).
+
+### Service containers
+
+Sidecars for the job duration, on a shared Docker network. Reach them
+by the service key as hostname:
+
+```yaml
+services:
+  redis:
+    image: redis:7
+    ports: ["6379:6379"]
+    options: --health-cmd "redis-cli ping" --health-interval 5s --health-retries 5
+```
+
+`options:` accepts any `docker run` flag. Health-check options gate
+the start of step execution: the runner waits until the container
+reports healthy.
+
+## Composite-action constraints
+
+Composite actions (`runs.using: composite`) run on whatever runner
+the calling workflow is on. Limitations:
+
+- Every `run:` step **must** declare `shell:` — no inheritance from
+  the workflow's `defaults.run.shell`.
+- `continue-on-error:` and `timeout-minutes:` are unsupported on
+  steps within the composite action.
+- The composite action cannot declare its own `container:` or
+  `services:` — those live at the calling job's level.
+- `secrets` are not directly accessible inside the composite; pass
+  them in as `inputs:` (with the caveat that input values are visible
+  in logs unless masked manually via `::add-mask::`).
+
+## Workflow commands
+
+The runner exposes a control channel through stdout. Selected
+commands:
+
+| Command | Effect |
+|---------|--------|
+| `echo "::add-mask::$VALUE"` | Masks the value in subsequent log output. |
+| `echo "key=value" >> "$GITHUB_OUTPUT"` | Step output. |
+| `echo "VAR=value" >> "$GITHUB_ENV"` | Persistent env var. |
+| `echo "$DIR" >> "$GITHUB_PATH"` | Prepend to `PATH`. |
+| `echo "::group::Title"` / `::endgroup::` | Collapse log section. |
+| `echo "::notice::msg"` / `::warning::` / `::error::` | Annotation surface. |
+| `echo "## Heading" >> "$GITHUB_STEP_SUMMARY"` | Markdown summary on the run page. |
+
+`::set-output` and `::set-env` (the old in-line forms) are deprecated
+and disabled by default since the 2022 CVE — use the file-based
+channels above.
+
+## Runner diagnostics
+
+When a self-hosted runner misbehaves:
+
+- `_diag/` directory under the runner install root has `Runner_*.log`
+  and `Worker_*.log` files per job. Worker log is where step-level
+  diagnostics live.
+- Enabling **step debug logging** requires repository secret
+  `ACTIONS_STEP_DEBUG=true`. Verbose, exposes context values — keep
+  it off by default.
+- Enabling **runner diagnostic logs** requires
+  `ACTIONS_RUNNER_DEBUG=true`. Useful for runner-side failures
+  (network, auth, image pull).
+
+For GitHub-hosted runners, the same two secrets unlock the verbose
+logging on the next run.

--- a/community-config/skills/github-actions/references/secrets-and-vars.md
+++ b/community-config/skills/github-actions/references/secrets-and-vars.md
@@ -1,0 +1,294 @@
+# Secrets and variables reference
+
+Secrets and variables are the two channels GitHub Actions offers for
+injecting configuration into a workflow run. The choice between them
+is the choice between confidentiality and observability. Use the
+wrong one and you either leak credentials to logs or accidentally
+encrypt a value you needed to debug.
+
+## Secrets vs. variables
+
+| Property | Secrets | Variables |
+|----------|---------|-----------|
+| Storage | Encrypted at rest (libsodium sealed box). | Plaintext. |
+| Reachable via API after creation | No (write-only). | Yes (read/write). |
+| Log masking | Yes — masked automatically. | No. |
+| Available to fork PRs | No. | Yes (read-only). |
+| Intended use | Credentials, tokens, signing keys. | URLs, flags, non-sensitive config. |
+| Expression | `${{ secrets.NAME }}` | `${{ vars.NAME }}` |
+
+Variables exist because misusing secrets for non-sensitive config is
+both inconvenient (you can't read them back) and dangerous (you train
+people to ignore the "masked" tag). Use variables for everything that
+is not a credential.
+
+## Scope and precedence
+
+Both secrets and variables have three scopes:
+
+1. **Organisation.** Visible to a configurable set of repositories.
+   Best for shared credentials (Docker registry, npm publish token).
+2. **Repository.** Repository-wide, visible to all environments.
+3. **Environment.** Scoped to a deployment environment (`staging`,
+   `production`). Combined with required reviewers and wait timers,
+   environments are the correct primitive for promotion gates.
+
+Precedence on name collision: **environment > repository > organisation**.
+A `secrets.AWS_ROLE` defined at all three levels resolves to the
+environment value.
+
+## Defining and consuming
+
+### Repository-level
+
+`Settings → Secrets and variables → Actions → New repository secret` (or
+`New variable`). From a workflow:
+
+```yaml
+- env:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    LOG_LEVEL: ${{ vars.LOG_LEVEL }}
+  run: npm publish
+```
+
+### Organisation-level
+
+`Org settings → Secrets and variables → Actions`. Specify the
+repository access policy: all, private only, or a selected list.
+
+### Environment-level
+
+The job declares `environment:`:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: production
+      url: https://app.example.com
+    steps:
+      - env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: ./scripts/deploy.sh
+```
+
+Environments support:
+
+- **Required reviewers.** Up to 6 users/teams whose approval is
+  needed before the job runs.
+- **Wait timer.** Delay between PR approval and job execution
+  (useful for canary rollouts).
+- **Deployment branches.** Restrict which refs may target the
+  environment.
+
+## Masking
+
+GitHub masks any **literal substring** of a secret in log output and
+in the run summary. Three caveats:
+
+- Masking is **substring-based**, not token-based. A 4-character
+  secret will mask every occurrence of that 4-character sequence,
+  including in unrelated output — and conversely, splitting a secret
+  with `echo "${SECRET:0:8}…${SECRET:8}"` bypasses masking.
+- Masking does **not** redact secrets from artifacts, from caches,
+  or from external systems your job writes to. A secret printed into
+  a file and uploaded as an artifact is leaked in plaintext.
+- The runner masks `secrets.*` values automatically. To mask a
+  derived value, use the workflow command
+  `echo "::add-mask::$VALUE"` before printing it.
+
+## OIDC federation
+
+For cloud credentials, **prefer OIDC over long-lived secrets**. The
+runner mints a short-lived JWT signed by GitHub's OIDC provider; the
+cloud side validates the token's claims (`sub`, `repository`, `ref`,
+`environment`, `job_workflow_ref`) and issues a temporary cloud
+credential.
+
+Benefits:
+
+- No long-lived secret to rotate or leak.
+- Per-job, per-environment scoping — a `production` deploy job gets
+  a token whose `sub` includes `environment:production`.
+- Audit trail in both GitHub and the cloud provider.
+
+### AWS
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+      },
+      "StringLike": {
+        "token.actions.githubusercontent.com:sub":
+          "repo:my-org/my-repo:environment:production"
+      }
+    }
+  }]
+}
+```
+
+In the workflow:
+
+```yaml
+permissions:
+  id-token: write   # required to request the OIDC token
+  contents: read
+steps:
+  - uses: aws-actions/configure-aws-credentials@<sha>  # v4.x
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/gha-deploy
+      aws-region: eu-west-3
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+steps:
+  - uses: google-github-actions/auth@<sha>  # v2.x
+    with:
+      workload_identity_provider: projects/123/locations/global/workloadIdentityPools/gha/providers/github
+      service_account: gha-deploy@my-project.iam.gserviceaccount.com
+```
+
+The WIF provider declares attribute mappings (e.g., `attribute.repository`)
+and an attribute condition pinning the allowed repos / environments.
+
+### Azure
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+steps:
+  - uses: azure/login@<sha>  # v2.x
+    with:
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+```
+
+The Azure side configures a **federated credential** on the app
+registration with the matching subject (`repo:my-org/my-repo:environment:production`).
+
+### HashiCorp Vault
+
+Use the JWT/OIDC auth method with a role whose
+`bound_subject` / `bound_claims` match the GitHub token.
+
+```yaml
+- uses: hashicorp/vault-action@<sha>  # v3.x
+  with:
+    url: https://vault.example.com
+    method: jwt
+    role: gha-deploy
+    secrets: |
+      kv/data/prod/db password | DB_PASSWORD
+```
+
+## Common pitfalls
+
+### Secrets in top-level `env:`
+
+```yaml
+# BAD: every job and every step in the workflow sees the secret
+env:
+  DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+```
+
+Bind secrets to the smallest scope that needs them — a specific
+step's `env:` is ideal.
+
+### Interpolating secrets into `run:`
+
+```yaml
+# BAD: the secret is evaluated by the YAML expression layer and
+# pasted into the shell verbatim. Quoting is brittle, and if the
+# secret contains shell metacharacters the script breaks (or worse).
+- run: echo "${{ secrets.API_TOKEN }}" | gh auth login --with-token
+
+# GOOD: bind via env, reference as a shell variable.
+- env:
+    API_TOKEN: ${{ secrets.API_TOKEN }}
+  run: printf '%s' "$API_TOKEN" | gh auth login --with-token
+```
+
+### Passing secrets to reusable workflows
+
+```yaml
+# BAD: re-listing every secret manually invites omissions.
+- uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+  secrets:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+
+# GOOD when the callee is trusted: inherit all caller secrets.
+- uses: my-org/shared/.github/workflows/deploy.yml@<sha>
+  secrets: inherit
+```
+
+`secrets: inherit` only works when both workflows are in the **same
+organisation**. For cross-org consumption, list explicitly.
+
+### Echoing a secret to debug
+
+```yaml
+# BAD: the runner masks the echoed value, but the secret is still
+# present in the artifact / cache / step summary you write next.
+- run: echo "DEBUG: token is $TOKEN"
+```
+
+Never debug a workflow by printing a secret. Print a checksum or a
+length instead:
+
+```yaml
+- run: echo "Token length: ${#TOKEN}"
+```
+
+### Storing structured data in a single secret
+
+A JSON blob in `secrets.CLOUD_CONFIG` is convenient for setup but
+defeats per-key rotation. Split into individual secrets, or use a
+secret-manager action (`hashicorp/vault-action`,
+`aws-actions/aws-secretsmanager-get-secrets`) to fetch a structured
+secret at runtime — the per-key value is then masked individually.
+
+### Variables that should be secrets
+
+A `vars.WEBHOOK_URL` whose URL embeds a token is a secret in
+disguise. If the value is sensitive on inspection, it is a secret.
+
+### Secrets visible to fork PRs
+
+By default, fork PRs receive **no secrets**. `pull_request_target`
+gives them the **base** repository's secrets, which is why it is
+dangerous to combine with `actions/checkout` of the PR head. If you
+must run privileged work against a fork PR, gate it behind an
+environment with required reviewers.
+
+## Auditing
+
+Periodic audit checklist:
+
+- List repository secrets: `gh secret list` — flag any that have not
+  been read in 90 days; rotate or delete.
+- List org-wide secrets and their repo access list. Tighten scope.
+- Inspect workflows for top-level `env:` referencing `secrets.*`.
+- Search for `${{ secrets.` patterns in `run:` blocks (the
+  `scripts/check-secrets-exposure` validator does this).
+- For each cloud provider, audit the OIDC trust conditions and ensure
+  every long-lived access key has a migration plan.

--- a/community-config/skills/github-actions/references/workflow-syntax.md
+++ b/community-config/skills/github-actions/references/workflow-syntax.md
@@ -1,0 +1,443 @@
+# Workflow syntax reference
+
+Canonical reference for the YAML grammar of a GitHub Actions workflow.
+Each top-level and nested key is enumerated with semantics, defaults,
+and a worked example. Read the section that matches the key you are
+editing — do not guess from memory.
+
+## File location and naming
+
+Workflow files live under `.github/workflows/` and end in `.yml` or
+`.yaml`. The basename has no semantic meaning beyond the workflow UI;
+the `name:` key is what appears in the Actions tab and the commit
+status.
+
+A repository may contain any number of workflow files. They are
+discovered on every push to the default branch (for `schedule:` and
+`workflow_dispatch:`) and on every event for the matching triggers.
+
+## Top-level keys
+
+### `name`
+
+Display name in the Actions UI and in commit statuses. Optional; if
+omitted, the file path is shown.
+
+```yaml
+name: CI
+```
+
+### `run-name`
+
+Dynamic display name for an individual run. Supports expression
+interpolation. Useful for surfacing the actor or the input that
+triggered the run.
+
+```yaml
+run-name: "Deploy ${{ inputs.environment }} by @${{ github.actor }}"
+```
+
+### `on`
+
+The trigger specification. Accepts:
+
+- A single event name: `on: push`.
+- A list of event names: `on: [push, pull_request]`.
+- A map of event names to filters:
+
+```yaml
+on:
+  push:
+    branches: [main, "release/**"]
+    paths-ignore: ["docs/**"]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: "17 3 * * 1-5"   # 03:17 UTC, Mon–Fri
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options: [staging, production]
+        default: staging
+        required: true
+      dry_run:
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+    outputs:
+      artifact_url:
+        value: ${{ jobs.build.outputs.url }}
+    secrets:
+      NPM_TOKEN:
+        required: true
+```
+
+Filter semantics:
+
+- `branches` / `branches-ignore` — glob list. Mutually exclusive.
+- `tags` / `tags-ignore` — same shape, applied to tag pushes.
+- `paths` / `paths-ignore` — path-glob filter on the changed files
+  in the push or PR. Combined with `branches`, both must match.
+- `types` — for `pull_request`, defaults to
+  `[opened, synchronize, reopened]`. Add `ready_for_review` if you
+  want the run to fire when a draft becomes a real PR; or skip
+  drafts explicitly with `if: github.event.pull_request.draft == false`.
+
+### `permissions`
+
+Sets the scope of `GITHUB_TOKEN`. Either a shorthand
+(`read-all` / `write-all` / `{}`) or an explicit map. See
+`permissions.md` for the per-scope semantics.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+```
+
+Applied at workflow level becomes the default for all jobs; can be
+overridden (further restricted or expanded within repo policy) at the
+job level.
+
+### `env`
+
+Workflow-wide environment variables. **Never** put secrets here; the
+value is inherited by every step in every job.
+
+```yaml
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+  CI: "true"
+```
+
+### `defaults`
+
+Default `run:` configuration for every step in every job. The only
+two keys are `run.shell` and `run.working-directory`.
+
+```yaml
+defaults:
+  run:
+    shell: bash
+    working-directory: ./app
+```
+
+The default shell on Linux/macOS is `bash -e -o pipefail {0}`; on
+Windows it is `pwsh -command ". '{0}'"`. Setting `shell: bash`
+explicitly on Windows runners pulls in Git Bash.
+
+### `concurrency`
+
+Concurrency control group. Runs sharing a group are serialised; the
+optional `cancel-in-progress` boolean cancels older runs in the same
+group when a new one queues.
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+Use cases: avoid wasting compute on rapid pushes; serialise
+deployments so only one ever runs to a given environment.
+
+### `jobs`
+
+A map of job-id → job definition. Job IDs are alphanumeric plus `_`
+and `-`; the first character must be a letter or `_`. They are
+referenced from `needs:` and from the `jobs.<id>.outputs` context.
+
+## Job-level keys
+
+### `runs-on`
+
+The runner selector. A string (`ubuntu-24.04`) or an array of labels
+(`[self-hosted, linux, x64, prod]`) — all labels must match. For
+runner groups (Enterprise/Org), the object form is required:
+
+```yaml
+runs-on:
+  group: ubuntu-runners
+  labels: [self-hosted, large]
+```
+
+Pin the OS version. `ubuntu-latest` drifts on a rolling schedule.
+
+### `needs`
+
+Dependency edges, single ID or array. The job runs after all listed
+jobs complete with a non-failure status (unless `if:` overrides). The
+outputs of `needs` jobs are exposed under
+`${{ needs.<id>.outputs.<name> }}`.
+
+```yaml
+needs: [build, lint]
+```
+
+### `if`
+
+Conditional execution. Evaluated against the same expression syntax
+as steps; see `expressions.md`. Pay attention to truthiness of empty
+strings.
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+```
+
+### `strategy`
+
+Fan-out specification. Three keys:
+
+- `matrix:` — Cartesian product of axes. Combined with `include:`
+  (additive) and `exclude:` (subtractive).
+- `fail-fast:` — default `true`. When `true`, a single failing
+  matrix cell cancels the others.
+- `max-parallel:` — concurrency cap across the matrix.
+
+```yaml
+strategy:
+  fail-fast: false
+  max-parallel: 4
+  matrix:
+    os: [ubuntu-24.04, macos-14, windows-2022]
+    node: ["20", "22"]
+    include:
+      - os: ubuntu-24.04
+        node: "22"
+        coverage: true
+    exclude:
+      - os: windows-2022
+        node: "20"
+```
+
+Each cell runs as an independent job; `matrix.<axis>` is available in
+expressions inside the job. The default job name is
+`<job-id> (<axis-values-joined>)`; override with `name:` on the job.
+
+### `outputs`
+
+Job-level outputs, surfaced to dependents via `needs.<id>.outputs`.
+Values come from step outputs.
+
+```yaml
+outputs:
+  version: ${{ steps.bump.outputs.version }}
+```
+
+### `env`, `defaults`, `permissions`, `concurrency`
+
+Same shape as the workflow-level equivalents, scoped to the job.
+
+### `timeout-minutes`
+
+Per-job timeout. Default 360 (six hours). **Always set this.** A
+reasonable upper bound is the 95th percentile of historical runtime
+times two.
+
+### `continue-on-error`
+
+When `true`, a failure in this job does not fail the workflow. Useful
+for opt-in matrix cells (experimental Node version, beta OS) — combine
+with `strategy.fail-fast: false`.
+
+### `container` and `services`
+
+Run the job inside a container image (`container:`) and/or alongside
+sidecar service containers (`services:`). Both reference Docker
+images.
+
+```yaml
+container:
+  image: node:22-bookworm
+  options: --user 1001
+services:
+  postgres:
+    image: postgres:16
+    env:
+      POSTGRES_PASSWORD: postgres
+    ports: ["5432:5432"]
+    options: >-
+      --health-cmd "pg_isready"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+```
+
+Service containers share a Docker network with the job container; the
+service hostname is the service key (`postgres` above).
+
+### `environment`
+
+Binds the job to a GitHub deployment **environment**. The environment
+can require manual approval, a wait timer, or restrict to specific
+branches. Secrets/variables scoped to the environment become available
+to the job.
+
+```yaml
+environment:
+  name: production
+  url: https://app.example.com
+```
+
+## Step-level keys
+
+A step has either `run:` or `uses:`, never both.
+
+### `id`
+
+Step identifier. Required to reference step outputs from later steps
+(`steps.<id>.outputs.<name>`).
+
+### `name`
+
+Display name. Optional; falls back to the `run:` first line or the
+`uses:` reference.
+
+### `if`
+
+Step-level conditional. Skipping a step does not skip the rest of the
+job. Combine with `steps.<earlier>.outcome` to chain.
+
+### `uses`
+
+Action reference. Forms:
+
+- `actions/checkout@v4` — versioned tag (mutable; **do not use** for
+  third-party actions).
+- `actions/checkout@<40-char-sha>` — pinned by commit SHA
+  (immutable; **always prefer** this).
+- `./.github/actions/my-local-action` — local action in the same
+  repo.
+- `docker://alpine:3.20` — Docker action (the image is the action).
+
+### `with`
+
+Action input map. Inputs are declared by the action's `action.yml`;
+the value is a string (numbers and booleans are coerced).
+
+```yaml
+- uses: actions/setup-node@<sha>  # v4.x
+  with:
+    node-version-file: .nvmrc
+    cache: npm
+    cache-dependency-path: package-lock.json
+```
+
+### `run`
+
+Shell script. Multiline via YAML block scalar (`|` or `>`). Shell is
+the workflow / job default unless overridden with `shell:` on the
+step.
+
+```yaml
+- name: Build
+  shell: bash
+  working-directory: app
+  run: |
+    set -euo pipefail
+    npm ci
+    npm run build
+```
+
+### `env`
+
+Per-step environment. The recommended channel for moving secrets and
+untrusted input into `run:`.
+
+```yaml
+- env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    gh pr comment "$PR_NUMBER" --body "Title: $PR_TITLE"
+```
+
+### `continue-on-error`
+
+Same semantics as the job-level key, applied to a single step.
+
+### `timeout-minutes`
+
+Step-level timeout. Default: no limit beyond the job timeout.
+
+### Step outputs
+
+A step writes to `$GITHUB_OUTPUT` to expose values to later steps and
+to job outputs.
+
+```yaml
+- id: bump
+  run: |
+    echo "version=1.2.3" >> "$GITHUB_OUTPUT"
+- run: echo "${{ steps.bump.outputs.version }}"
+```
+
+`$GITHUB_ENV` writes an environment variable visible to all
+subsequent steps in the job:
+
+```yaml
+- run: echo "BUILD_ID=$(date +%s)" >> "$GITHUB_ENV"
+```
+
+`$GITHUB_STEP_SUMMARY` writes Markdown to the run summary page; useful
+for surfacing test results without digging through logs.
+
+## Composite action syntax
+
+A composite action lives in its own repo (or under
+`.github/actions/<name>/`) with an `action.yml`:
+
+```yaml
+name: My composite action
+description: …
+inputs:
+  region:
+    description: AWS region
+    required: true
+    default: eu-west-3
+outputs:
+  cluster:
+    description: EKS cluster name
+    value: ${{ steps.lookup.outputs.cluster }}
+runs:
+  using: composite
+  steps:
+    - id: lookup
+      shell: bash
+      run: echo "cluster=prod" >> "$GITHUB_OUTPUT"
+```
+
+Composite actions have notable constraints:
+
+- `shell:` is mandatory on every `run:` step (no inheritance from
+  workflow defaults).
+- `continue-on-error:` is not supported on steps.
+- Conditional `if:` is supported.
+- No `services:` or `container:`.
+- Cannot use `secrets` directly; pass them as `inputs:`.
+
+## Edge cases and quirks
+
+- **YAML booleans.** `on: pull_request` parses cleanly, but a key
+  named `on` at the top level of a YAML 1.1 parser can be coerced to
+  the boolean `true`. GitHub's parser handles this, but external
+  linters may complain — quote with `"on":` if needed.
+- **`uses:` and `run:` mutually exclusive** in the same step.
+- **`env:` precedence**: step > job > workflow. The deepest binding
+  wins.
+- **`if:` and `${{ }}`**: the `if:` key accepts an expression
+  without the `${{ }}` wrapper; adding it is allowed but redundant.
+- **`needs:` semantics**: a job with `needs:` runs only if all
+  upstream jobs **succeed**. To run on failure, use
+  `if: ${{ always() }}` or `if: ${{ failure() }}`.
+- **`strategy.matrix` empty include**: a matrix containing only
+  `include:` (no axes) generates one job per `include:` entry — useful
+  for hand-curated combinations.

--- a/community-config/skills/github-actions/scripts/check-pinned-actions.sh
+++ b/community-config/skills/github-actions/scripts/check-pinned-actions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check-pinned-actions.sh — flag GitHub Actions references that are not pinned
+# to a 40-char commit SHA.
+#
+# Usage: check-pinned-actions.sh <workflow-file-or-directory>
+#
+# Rationale: pinning to a tag or branch lets an upstream maintainer push a
+# new commit that silently runs in your pipeline. Pinning to a full SHA
+# makes the reference immutable.
+#
+# Local actions (./path) are ignored — they are part of the repository.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no workflow files found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# Match: <indent>uses: <owner>/<repo>[/path]@<ref>
+# Capture group 1 = the value after "uses: ".
+uses_re='^[[:space:]]*uses:[[:space:]]*([^[:space:]#][^[:space:]#]*)'
+# A pinned reference ends with @<40 hex chars>.
+sha_re='@[0-9a-fA-F]{40}$'
+
+for f in "${files[@]}"; do
+    lineno=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+        if [[ "$line" =~ $uses_re ]]; then
+            value="${BASH_REMATCH[1]}"
+            # Strip surrounding quotes if any.
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            # Skip local actions.
+            case "$value" in
+                ./*|../*) continue ;;
+                docker://*) continue ;;
+            esac
+            # Must contain '@' and end with a 40-char hex SHA.
+            if [[ "$value" != *@* ]] || ! [[ "$value" =~ $sha_re ]]; then
+                echo "${C_RED}[UNPINNED]${C_RESET} ${f}:${lineno}: ${value}"
+                violations=$((violations + 1))
+            fi
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all action references are pinned to a SHA"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned action reference(s) found${C_RESET}" >&2
+exit 1

--- a/community-config/skills/github-actions/scripts/check-pinned-actions.sh
+++ b/community-config/skills/github-actions/scripts/check-pinned-actions.sh
@@ -9,6 +9,9 @@
 # makes the reference immutable.
 #
 # Local actions (./path) are ignored — they are part of the repository.
+#
+# Limitation: only inline `uses: owner/repo@ref` forms (value on the same
+# line) are matched. Multi-line YAML scalars for `uses:` are not detected.
 
 set -euo pipefail
 

--- a/community-config/skills/github-actions/scripts/check-secrets-exposure.sh
+++ b/community-config/skills/github-actions/scripts/check-secrets-exposure.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in GitHub Actions workflows that
+# may leak secrets into logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <workflow-file-or-directory>
+#
+# Patterns flagged:
+#   1. `echo ${{ secrets.* }}`           — secret echoed directly to stdout.
+#   2. workflow-level `env:`             — env values accessible to every job.
+#   3. `set -x` / `set +x` in `run:`     — shell trace expands env values.
+#   4. `toJSON(secrets)` anywhere        — serialises every secret as JSON.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no workflow files found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    saw_top_level_env=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # 1. echo of a secret expression.
+        if [[ "$line" =~ echo[[:space:]].*\$\{\{[[:space:]]*secrets\. ]]; then
+            report "$current_file" "$lineno" "echo \${{ secrets.* }}" \
+                "secret value is written to stdout and persisted in the run log"
+        fi
+
+        # 2. workflow-level env: — a line starting at column 0 that is "env:".
+        if [[ "$line" =~ ^env:[[:space:]]*$ ]] && [ "$saw_top_level_env" -eq 0 ]; then
+            report "$current_file" "$lineno" "top-level env:" \
+                "values defined here are inherited by every job and step (broad blast radius)"
+            saw_top_level_env=1
+        fi
+
+        # 3. set -x / set +x in a shell step.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret env values"
+        fi
+
+        # 4. toJSON(secrets) — full secret bag serialisation.
+        if [[ "$line" =~ toJSON\([[:space:]]*secrets[[:space:]]*\) ]]; then
+            report "$current_file" "$lineno" "toJSON(secrets)" \
+                "serialises the entire secrets context — any later echo, env, or file write leaks them all"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/community-config/skills/github-actions/scripts/check-secrets-exposure.sh
+++ b/community-config/skills/github-actions/scripts/check-secrets-exposure.sh
@@ -5,10 +5,10 @@
 # Usage: check-secrets-exposure.sh <workflow-file-or-directory>
 #
 # Patterns flagged:
-#   1. `echo ${{ secrets.* }}`           — secret echoed directly to stdout.
-#   2. workflow-level `env:`             — env values accessible to every job.
-#   3. `set -x` / `set +x` in `run:`     — shell trace expands env values.
-#   4. `toJSON(secrets)` anywhere        — serialises every secret as JSON.
+#   1. `echo ${{ secrets.* }}`                          — secret echoed directly to stdout.
+#   2. workflow-level `env:` referencing `secrets.*`    — broad blast radius across all jobs.
+#   3. `set -x` / `set +x` in `run:`                   — shell trace expands env values.
+#   4. `toJSON(secrets)` anywhere                       — serialises every secret as JSON.
 
 set -euo pipefail
 
@@ -67,6 +67,8 @@ report() {
 
 for current_file in "${files[@]}"; do
     lineno=0
+    in_top_level_env=0
+    top_level_env_lineno=0
     saw_top_level_env=0
     # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
     while IFS= read -r line || [ -n "$line" ]; do
@@ -78,11 +80,21 @@ for current_file in "${files[@]}"; do
                 "secret value is written to stdout and persisted in the run log"
         fi
 
-        # 2. workflow-level env: — a line starting at column 0 that is "env:".
+        # 2. workflow-level env: that contains ${{ secrets.* }} — broad blast radius.
+        # Only enter tracking on the first top-level (column-0) "env:" line.
         if [[ "$line" =~ ^env:[[:space:]]*$ ]] && [ "$saw_top_level_env" -eq 0 ]; then
-            report "$current_file" "$lineno" "top-level env:" \
-                "values defined here are inherited by every job and step (broad blast radius)"
+            in_top_level_env=1
+            top_level_env_lineno=$lineno
             saw_top_level_env=1
+        elif [ "$in_top_level_env" -eq 1 ] && [ "$lineno" -gt "$top_level_env_lineno" ]; then
+            # Exit the block on the first non-indented, non-blank, non-comment line.
+            if [[ "$line" =~ ^[^[:space:]#] ]] && [[ -n "$line" ]]; then
+                in_top_level_env=0
+            elif [[ "$line" =~ \$\{\{[[:space:]]*secrets\. ]]; then
+                report "$current_file" "$top_level_env_lineno" "top-level env: references \${{ secrets.* }}" \
+                    "secrets defined at workflow level are inherited by every job (broad blast radius)"
+                in_top_level_env=0
+            fi
         fi
 
         # 3. set -x / set +x in a shell step.

--- a/community-config/skills/github-actions/scripts/lint-workflow.sh
+++ b/community-config/skills/github-actions/scripts/lint-workflow.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# lint-workflow.sh — validate GitHub Actions workflow files via actionlint.
+#
+# Usage: lint-workflow.sh <workflow-file-or-directory>
+#
+# If a directory is passed, every .yml/.yaml under .github/workflows/ inside
+# that directory is linted. If actionlint is missing, the script exits 0 with
+# a friendly hint — it is not a hard blocker.
+
+set -euo pipefail
+
+# ANSI colours (disabled when stdout is not a TTY).
+if [ -t 1 ]; then
+    C_GREEN=$'\033[0;32m'
+    C_RED=$'\033[0;31m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_GREEN=""
+    C_RED=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+if ! command -v actionlint >/dev/null 2>&1; then
+    echo "${C_YELLOW}[SKIP] actionlint not found — install: brew install actionlint${C_RESET}"
+    exit 0
+fi
+
+# Build the list of files to lint.
+files=()
+if [ -d "$TARGET" ]; then
+    workflows_dir="$TARGET/.github/workflows"
+    if [ ! -d "$workflows_dir" ]; then
+        workflows_dir="$TARGET"
+    fi
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$workflows_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "${C_YELLOW}[SKIP] no workflow files found under: $TARGET${C_RESET}"
+    exit 0
+fi
+
+rc=0
+for f in "${files[@]}"; do
+    if actionlint -no-color "$f"; then
+        echo "${C_GREEN}[OK]${C_RESET} $f"
+    else
+        echo "${C_RED}[FAIL]${C_RESET} $f"
+        rc=1
+    fi
+done
+
+exit "$rc"

--- a/community-config/skills/github-actions/scripts/simulate-job.sh
+++ b/community-config/skills/github-actions/scripts/simulate-job.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# simulate-job.sh — dry-run a single workflow job locally via `act`.
+#
+# Usage: simulate-job.sh <workflow-file> <job-id> [event-type]
+#
+# Defaults: event-type = push.
+# Requires: `act` and a running Docker daemon. If either is missing the
+# script exits 0 with an explanatory message — it is not a hard blocker.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file> <job-id> [event-type]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+WORKFLOW="$1"
+JOB_ID="$2"
+EVENT="${3:-push}"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "[FAIL] workflow file not found: $WORKFLOW" >&2
+    exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "[SKIP] act not found — install: brew install act"
+    echo "       act runs GitHub Actions locally inside Docker containers."
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[SKIP] docker CLI not found — act needs Docker to run containers."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[SKIP] Docker daemon not reachable — start Docker Desktop or the docker service."
+    exit 0
+fi
+
+cmd=(act "$EVENT" --workflows "$WORKFLOW" --job "$JOB_ID" --dryrun)
+
+echo "+ ${cmd[*]}"
+"${cmd[@]}"

--- a/community-config/skills/github-actions/scripts/simulate-workflow.sh
+++ b/community-config/skills/github-actions/scripts/simulate-workflow.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# simulate-workflow.sh — dry-run a full workflow locally via `act`, with
+# optional event-payload injection.
+#
+# Usage: simulate-workflow.sh <workflow-file> [event-type] [event-payload-json-file]
+#
+# Defaults: event-type = push. When no payload file is given, a minimal
+# default payload matching the event-type is synthesised in a tempfile.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <workflow-file> [event-type] [event-payload-json-file]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+WORKFLOW="$1"
+EVENT="${2:-push}"
+PAYLOAD="${3:-}"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "[FAIL] workflow file not found: $WORKFLOW" >&2
+    exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "[SKIP] act not found — install: brew install act"
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[SKIP] docker CLI not found — act needs Docker to run containers."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[SKIP] Docker daemon not reachable — start Docker Desktop or the docker service."
+    exit 0
+fi
+
+cleanup_payload=""
+cleanup() {
+    if [ -n "$cleanup_payload" ] && [ -f "$cleanup_payload" ]; then
+        rm -f "$cleanup_payload"
+    fi
+}
+trap cleanup EXIT
+
+default_payload_for() {
+    case "$1" in
+        push)               echo '{"ref":"refs/heads/main"}' ;;
+        pull_request)       echo '{"action":"opened","pull_request":{"number":1,"head":{"ref":"feature"},"base":{"ref":"main"}}}' ;;
+        workflow_dispatch)  echo '{"inputs":{}}' ;;
+        release)            echo '{"action":"published","release":{"tag_name":"v0.0.0"}}' ;;
+        schedule)           echo '{}' ;;
+        *)                  echo '{}' ;;
+    esac
+}
+
+if [ -z "$PAYLOAD" ]; then
+    cleanup_payload="$(mktemp -t act-payload.XXXXXX.json)"
+    default_payload_for "$EVENT" > "$cleanup_payload"
+    PAYLOAD="$cleanup_payload"
+elif [ ! -f "$PAYLOAD" ]; then
+    echo "[FAIL] event payload file not found: $PAYLOAD" >&2
+    exit 1
+fi
+
+cmd=(act "$EVENT" --workflows "$WORKFLOW" --eventpath "$PAYLOAD" --dryrun)
+
+echo "+ ${cmd[*]}"
+"${cmd[@]}"

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -35,26 +35,32 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   }
 fi
 
-# Collect changed skill/agent sources. `while read` rather than
-# `mapfile` for bash 3.2 compatibility (macOS default — `mapfile` is a
-# bash 4.0+ builtin).
-changed=()
+# Collect changed skill/agent sources, split by status (A=added, M=modified).
+# New files (A) start at 1.0.0 by definition — no bump required until they
+# land on the base branch and are subsequently modified. Only modified files
+# (M) are subject to the version-bump rule.
+# `while read` rather than `mapfile` for bash 3.2 compat (macOS default).
+modified=()
 while IFS= read -r line; do
   [ -z "$line" ] && continue
-  changed+=("$line")
-done < <(git diff --name-only "$BASE_REF" -- \
+  status="${line%%$'\t'*}"
+  file="${line#*$'\t'}"
+  if [ "$status" = "M" ]; then
+    modified+=("$file")
+  fi
+done < <(git diff --name-status "$BASE_REF" -- \
   'community-config/skills/*/SKILL.md' \
   'community-config/agents/*/AGENT.md' 2>/dev/null || true)
 
-if [ "${#changed[@]}" -eq 0 ]; then
-  echo "OK: no skill/agent sources changed vs $BASE_REF."
+if [ "${#modified[@]}" -eq 0 ]; then
+  echo "OK: no existing skill/agent sources modified vs $BASE_REF."
   exit 0
 fi
 
-echo "Checking version bumps on ${#changed[@]} changed skill/agent source(s)..."
+echo "Checking version bumps on ${#modified[@]} modified skill/agent source(s)..."
 
 failures=()
-for f in "${changed[@]}"; do
+for f in "${modified[@]}"; do
   [ ! -f "$f" ] && continue  # deleted file: skip (deletions don't need a bump)
 
   # Look at the diff for a `version:` line addition. The


### PR DESCRIPTION
Adds the `github-actions` skill (reference docs + validation/simulation scripts) and two agents — `ci-configurator` and `ci-debugger` — to the CrewRig catalogue. Goal: equip the framework with operational GitHub Actions know-how, from designing a workflow to debugging a failing pipeline.

Closes #4

## How to read this PR?

Read in this order — canonical sources live under `community-config/`; everything else is builder output:

1. **`community-config/skills/github-actions/SKILL.md`** — skill entry point: activation heuristics, reference index, script usage, security defaults.
2. **`community-config/skills/github-actions/references/`** (7 files) — exhaustive reference material loaded on demand: `workflow-syntax.md`, `expressions.md`, `permissions.md`, `secrets-and-vars.md`, `runners.md`, `caching.md`, `reusable-workflows.md`.
3. **`community-config/skills/github-actions/scripts/`** (5 scripts) — executable tooling: `lint-workflow.sh`, `simulate-workflow.sh`, `simulate-job.sh`, `check-pinned-actions.sh`, `check-secrets-exposure.sh`. All shellcheck-clean; gracefully degrade when `actionlint`/`act` are absent.
4. **`community-config/agents/ci-configurator/AGENT.md`** — authoring agent: interview → generate → validate before delivering.
5. **`community-config/agents/ci-debugger/AGENT.md`** — diagnostic agent: structured `symptom → hypothesis → evidence → fix` pipeline.
6. The `.claude/` and `.gemini/` trees are **generated** from `community-config/` by the builder — no need to review them in detail (`task check-components` handles that).

Non-obvious decision: Markdown horizontal rules in component bodies use `***`, never `---`, to avoid breaking the builder's frontmatter extractor (`sed -n '/^---$/,/^---$/p'`). See logbook comment on #4.

## How to test this PR?

Prerequisites: `task`, `yq`, `shellcheck`. Optional: `actionlint`, `act` (the skill degrades gracefully without them).

```bash
# 1. Verify generated outputs match sources
task check-components
# Expected: OK: All generated files match source

# 2. Lint the skill scripts
shellcheck community-config/skills/github-actions/scripts/*.sh
# Expected: no warnings

# 3. Smoke-test the scripts against a real workflow file
bash community-config/skills/github-actions/scripts/lint-workflow.sh path/to/workflow.yml
bash community-config/skills/github-actions/scripts/check-pinned-actions.sh path/to/workflow.yml
bash community-config/skills/github-actions/scripts/check-secrets-exposure.sh path/to/workflow.yml
# Expected: exit 0 + clean skip message if actionlint is absent
```

## Detailed description (for agents)

**Scope:** 45 files added, ~10 900 insertions, 0 deletions. No existing file modified — purely additive.

### Added components (canonical sources under `community-config/`)

**Skill `github-actions`** (`community-config/skills/github-actions/`)
- `SKILL.md` (394 lines) — YAML frontmatter + body covering activation heuristics, reference index, core concepts, top-10 pitfalls, script usage, and 10 non-negotiable security defaults. Version `1.0.0`.
- `references/workflow-syntax.md` (443 lines) — full workflow grammar.
- `references/expressions.md` (309 lines) — functions, context objects, operators.
- `references/permissions.md` (266 lines) — `GITHUB_TOKEN` permission model.
- `references/secrets-and-vars.md` (294 lines) — secrets, variables, environments, OIDC patterns.
- `references/runners.md` (257 lines) — hosted/self-hosted runners, labels, matrix.
- `references/caching.md` (273 lines) — `actions/cache`, key strategies.
- `references/reusable-workflows.md` (374 lines) — `workflow_call`, composite actions.
- `scripts/lint-workflow.sh` (73 lines) — `actionlint` wrapper with graceful skip.
- `scripts/simulate-workflow.sh` (76 lines) — full `act` dry-run.
- `scripts/simulate-job.sh` (49 lines) — single-job `act` dry-run.
- `scripts/check-pinned-actions.sh` (96 lines) — detects non-SHA-pinned action refs.
- `scripts/check-secrets-exposure.sh` (108 lines) — detects secret-leaking patterns.

**Agent `ci-configurator`** (`community-config/agents/ci-configurator/AGENT.md`, 279 lines)
- Workflow: structured project interview → workflow generation → skill-based validation before delivery.

**Agent `ci-debugger`** (`community-config/agents/ci-debugger/AGENT.md`, 359 lines)
- Workflow: `symptom → hypothesis → evidence → fix`. Mandates evidence collection before proposing any fix.

### Generated outputs (do not edit manually)

- `.claude/skills/github-actions/` — SKILL.md + scripts + references (7 files).
- `.claude/agents/ci-configurator/AGENT.md`, `.claude/agents/ci-debugger/AGENT.md`.
- `.gemini/skills/github-actions/` — SKILL.md + scripts + references (7 files).
- `.gemini/agents/ci-configurator.md`, `.gemini/agents/ci-debugger.md`.

### Conventions

- **No standalone `---` in component bodies** — use `***` instead.
- **Graceful degradation**: all scripts exit 0 with an explanatory message when an optional dependency is absent.
- **Shellcheck-clean** on all 5 scripts.
- **Singular `references/`** directory name (matches builder's `propagate_skill_resources` allowlist).

### Out of scope

- Ready-to-use workflow templates (Java/Maven, Node, Docker).
- Integration with a future `release-manager` agent.
