### PR TITLE
📝 Clarify Gitmoji applies to all named artifacts (commits, issues, PRs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,15 @@ All project content (code, comments, documentation, commits, issues, PRs) **must
 - **NEVER merge a Pull Request (PR/MR)** without asking for the user's formal permission JUST BEFORE executing the merge.
 - The `import/gitlab` branch tracks the legacy GitLab project (`gitlab` remote) and serves as inspiration only.
 
-## Commit Convention
+## Naming Convention
 
-All commits must follow the [Gitmoji](https://gitmoji.dev/) convention.
+The [Gitmoji](https://gitmoji.dev/) convention applies to **all named project artifacts** — not only git commit messages:
 
-Format: `<emoji> <Short description>`
+- **Git commits** — `<emoji> <Short description>`
+- **Issue titles** — `<emoji> <Short description>`
+- **Pull request titles** — `<emoji> <Short description>`
+
+Never use conventional-commit prefixes (`feat:`, `fix:`, `chore:`, etc.) in any of the above. Gitmoji is the sole convention.
 
 Examples:
 


### PR DESCRIPTION
Fixes a process gap surfaced by harness friction #2: agents were defaulting to conventional-commit prefixes (`feat:`, `fix:`) when naming issues and PRs because `AGENTS.md` only mentioned Gitmoji in the context of git commits.

Closes #2

## How to read this PR?

Single file changed: `AGENTS.md`. The "Commit Convention" section is renamed "Naming Convention" and extended with an explicit scope table covering commits, issue titles, and PR titles. The prohibition on conventional-commit prefixes is stated directly.

## How to test this PR?

Read `AGENTS.md` § Naming Convention and verify:
- Gitmoji is listed for commits, issue titles, and PR titles.
- `feat:` / `fix:` / `chore:` prefixes are explicitly prohibited.

## Detailed description (for agents)

**File changed:** `AGENTS.md`

- Renamed section `## Commit Convention` → `## Naming Convention`.
- Added an explicit scope table: git commits / issue titles / PR titles all require `<emoji> <Short description>`.
- Added a negative rule: never use conventional-commit prefixes (`feat:`, `fix:`, `chore:`, etc.) in any of the above.
- Existing examples and gitmoji.dev reference link are unchanged.

**Logbook:** issue #2 (harness-feedback, labelled `logbook`).