### PR TITLE
📝 Add Agent Team Protocol section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,50 @@ Examples:
 
 Refer to [gitmoji.dev](https://gitmoji.dev/) for the full list of valid emojis and their meanings.
 
+## Agent Team Protocol
+
+Project tickets are multi-step work. They must be treated by a **team of specialist agents**, not by a single agent working solo inline.
+
+### When this applies
+
+Any time the agent is asked to treat a project ticket (a GitHub issue, a PR
+task, a feature request, or any equivalent unit of tracked work), the
+**first action** is to assemble a team of relevant specialist agents sized
+to the ticket's scope. This applies even for tickets that look small at
+first glance — the cost of assembling a team is low, the cost of solo
+rework is high.
+
+### On Claude Code CLI (team support available)
+
+When running on a harness that exposes team-management tools (Claude Code
+CLI and equivalent), the following three tools are **mandatory**:
+
+1. **`TeamCreate`** — instantiate a dedicated team for the ticket. Name
+   the team after the ticket identifier (e.g. `issue-42-auth-refactor`).
+2. **`TaskCreate`** — assign **one task per agent role**. Each task
+   targets a specific specialist (`architect`, `developer`, `tester`,
+   `security`, `doc-writer`, `pr-reviewer`, `pr-logbook`, etc.) with a
+   self-contained brief.
+3. **`SendMessage`** — coordinate progress, hand off intermediate
+   artifacts, and unblock teammates. All cross-agent communication flows
+   through this tool — never through plain text replies.
+
+### On CLIs without team support (e.g. Gemini CLI)
+
+When the harness does not expose `TeamCreate` / `TaskCreate` /
+`SendMessage`, fall back to **sequential `Agent` spawns** with an
+explicit `subagent_type` matching the specialist role. Each spawn must
+carry a self-contained brief — the spawned agent inherits no
+conversation context. Aggregate results in the orchestrating session
+before moving to the next role.
+
+### Solo work prohibition
+
+**Never** treat a multi-step ticket with inline solo work when specialist
+agents are available. Inline solo work on a ticket is reserved for trivial
+single-file edits explicitly scoped that way by the user. If in doubt,
+assemble the team.
+
 ## Pull Request Format
 
 Every PR must follow this structure:


### PR DESCRIPTION
Adds an `Agent Team Protocol` section to `AGENTS.md` mandating team-based handling of project tickets. Closes the harness-friction cluster `agent-team-activation` reported in issue #9.

## How to read this PR?

Single-file change. Read `AGENTS.md` between the existing `## Naming Convention` and `## Pull Request Format` sections — the new `## Agent Team Protocol` section is inserted there. The four sub-sections are ordered for the reader's decision flow: when the rule applies → behavior on Claude Code CLI → fallback for CLIs without team support → solo-work prohibition. The Claude Code branch names the three mandatory tools (`TeamCreate`, `TaskCreate`, `SendMessage`); the fallback branch names the substitute (`Agent` spawn with `subagent_type`).

## How to test this PR?

1. Pull the branch: `git fetch crewrig fix/agent-team-protocol && git checkout fix/agent-team-protocol`.
2. Open `AGENTS.md` and confirm the new `## Agent Team Protocol` section sits between `## Naming Convention` and `## Pull Request Format`.
3. Verify the four sub-sections render: *When this applies*, *On Claude Code CLI (team support available)*, *On CLIs without team support (e.g. Gemini CLI)*, *Solo work prohibition*.
4. Behavioral check (next agent session): on starting a project ticket, the agent should assemble a team via `TeamCreate` rather than attempt inline solo work — exactly what this PR is being shipped through.

## Detailed description (for agents)

- **File modified**: `AGENTS.md` (single file, additive change — no removals).
- **Insertion point**: after the `## Naming Convention` section (ends at line 38 of the pre-change file), before `## Pull Request Format`.
- **New section**: `## Agent Team Protocol`, with four sub-sections:
  - *When this applies* — defines the trigger (any project ticket: GitHub issue, PR task, feature request, or equivalent unit of tracked work) and mandates team assembly as the first action, even for tickets that look small.
  - *On Claude Code CLI (team support available)* — declares three mandatory tools: `TeamCreate` (instantiate the team, name after the ticket id), `TaskCreate` (one task per agent role, self-contained brief per specialist), `SendMessage` (all cross-agent communication; never plain text replies).
  - *On CLIs without team support (e.g. Gemini CLI)* — fallback to sequential `Agent` spawns with explicit `subagent_type`, self-contained briefs, and orchestrator-side aggregation.
  - *Solo work prohibition* — inline solo work is reserved for trivial single-file edits explicitly scoped that way by the user; in doubt, assemble the team.
- **Rationale**: closes the friction cluster `agent-team-activation` (issue #9, two reports tagged 2026-05-15) where the agent silently fell back to single-agent spawns when the user expected a team, and treated tickets inline without team activation. The new section makes both behaviors contract violations rather than judgment calls.
- **No code, config, or CI touched** — documentation-only change. No version-bump rule applies (no `community-config/skills/*/SKILL.md` or `community-config/agents/*/AGENT.md` source modified).

Closes #9