### PR TITLE
📝 Tighten Language scope and rewrite Logbook Issues rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,28 @@ This document defines the rules and conventions that all agents (human or AI) mu
 
 ## Language
 
-All project content (code, comments, documentation, commits, issues, PRs) **must be written in English**.
+All **project content must be written in English**. "Project content" covers
+every artifact that lands in the repository or on GitHub — there are no
+exceptions for "internal" notes, draft documents, or AI-authored prose.
 
-**Exception:** Interpersonal interactions between the user and the agent (chat sessions) MUST be conducted in the **User Preferred Language**.
+This includes, but is not limited to:
+
+- **File content in the repository** — source code, inline comments,
+  documentation prose, READMEs, ADRs, RFCs, configuration files, shell
+  scripts, and every framework artifact (`SKILL.md`, `AGENT.md`,
+  `AGENTS.md`, `CLAUDE.md`, etc.).
+- **GitHub artifacts** — commit messages, PR titles, PR bodies, PR review
+  comments, issue titles, issue bodies, and every comment posted on an
+  issue or PR (including incremental logbook updates).
+
+**Decision rule:** *Is this landing in the project or on GitHub?* → English
+only.
+
+**Exception:** Interpersonal interactions between the user and the agent
+(chat sessions, transient terminal output) MUST be conducted in the **User
+Preferred Language**. This exception covers only ephemeral dialogue — the
+moment content is committed, pushed, or posted to GitHub, the English-only
+rule takes over.
 
 ## Branching Strategy
 
@@ -112,20 +131,42 @@ Be explicit about what was added, modified, or removed and why.>
 
 ## Logbook Issues
 
-Every PR **must** be linked to a **logbook issue** on GitHub.
+Every PR **must** be anchored to a **logbook** on GitHub — a journal that
+traces every obstacle encountered (with its resolution or avoidance
+strategy), every challenge faced during implementation, and every success
+or breakthrough. This ensures that the full experience of agents working
+on the project — failures and successes alike — is recorded for future
+reference.
 
-A logbook issue is a detailed journal entry that traces:
+Three rules govern how logbooks are kept:
 
-- Every obstacle encountered and the resolution or avoidance strategy applied
-- Every challenge faced during implementation
-- Every success and breakthrough
+### Rule A — A feature issue IS its own logbook
 
-This strategy ensures that all experience (failures and successes) from agents working on the project is recorded and available for future reference.
+When a feature issue (or any pre-existing tracked issue) already exists
+for the work, **that issue IS the logbook**. Post all logbook content —
+obstacles, decisions, breakthroughs — as **incremental comments directly
+on that issue**. Never open a separate logbook issue in this case;
+duplicating the journal across two issues fragments the trail.
 
-Logbook issues must be written in English and use the label `logbook`.
+Only create a dedicated logbook issue when there is **no pre-existing
+issue** to anchor the work to (e.g., spontaneous refactor, exploratory
+fix). A dedicated logbook issue uses the `logbook` label.
 
-Once the PR is merged and any linked feature issue is closed, the logbook
-issue must also be closed (`state_reason: completed`).
+### Rule B — Update incrementally, not at the end
+
+Post a logbook comment **every time a significant obstacle, correction,
+or decision occurs** — as it happens, while context is fresh. Do **not**
+batch the entire journey into a single end-of-work comment: batching
+loses the chronological structure, the failed attempts, and the reasoning
+behind course corrections, which is precisely the value the logbook is
+meant to preserve.
+
+### Rule C — Close immediately after merge
+
+Once the PR is merged and the changes verified, **close the linked issue
+immediately** (`state_reason: completed`). Do not defer closing to a
+later cleanup pass — stale open issues accumulate and obscure the actual
+state of work in flight.
 
 ## GitHub Access
 


### PR DESCRIPTION
This PR strengthens two sections of `AGENTS.md` that were producing repeat frictions in agent runs: the Language rule now scopes English-only to every file-content and every GitHub artifact via an explicit decision rule, and the Logbook Issues section is rewritten as three named rules (A/B/C) that close the lifecycle loopholes around feature issues, incremental updates, and post-merge closure. Closes #8 and closes #10.

## How to read this PR?

Single-file change: `AGENTS.md`. Read in this order:

1. **§ Language** (top of file) — note the new enumerated scope (file content incl. `SKILL.md` / `AGENT.md` / scripts, plus all GitHub artifacts) and the **decision rule**: *"Is this landing in the project or on GitHub? → English only."* The exception for chat now explicitly carves out only ephemeral dialogue.
2. **§ Logbook Issues** (lower in the file) — the previous prose is replaced by three labelled rules:
   - **Rule A** — A feature issue IS its own logbook (no separate logbook issue when an issue already exists).
   - **Rule B** — Update incrementally, not at the end.
   - **Rule C** — Close immediately after merge (`state_reason: completed`).

No other files are touched. No code or workflow changes.

## How to test this PR?

This is a documentation contract. Verification is by reading:

1. Check out the branch: `git checkout fix/agents-md-logbook-and-language`.
2. Open `AGENTS.md` and confirm § Language enumerates both bullet groups (file content / GitHub artifacts) and contains the decision rule line.
3. Confirm § Logbook Issues contains three `### Rule A/B/C` subheadings with the semantics summarized above.
4. Confirm both linked issues (#8, #10) are referenced by `Closes` in this PR body so they close automatically on merge.

Expected outcome: no behavioural change in CI; the next agent that reads `AGENTS.md` has unambiguous guidance on language scope and logbook lifecycle.

## Detailed description (for agents)

**File modified:** `AGENTS.md` (only).

**§ Language — changes:**

- Replaced the single-sentence rule with an explicit scope block.
- Added two enumerated bullet groups:
  - *File content in the repository* — source, comments, docs, READMEs, ADRs, RFCs, configs, shell scripts, and framework artifacts (`SKILL.md`, `AGENT.md`, `AGENTS.md`, `CLAUDE.md`).
  - *GitHub artifacts* — commit messages, PR titles/bodies/review comments, issue titles/bodies, and all issue/PR comments (including incremental logbook updates).
- Added the **decision rule**: *"Is this landing in the project or on GitHub? → English only."*
- Reworded the chat exception to explicitly cover only ephemeral dialogue and to state that "the moment content is committed, pushed, or posted to GitHub, the English-only rule takes over."

**Rationale (fixes #10):** prior wording was a single sentence and did not name `SKILL.md` / `AGENT.md` / shell scripts. Frictions observed agents writing French inside component bodies and on GitHub artifacts. The enumerated scope + decision rule eliminates the ambiguity.

**§ Logbook Issues — changes:**

- Replaced the previous "every PR linked to a logbook issue" prose with a journal-oriented preamble describing what a logbook traces (obstacles, challenges, breakthroughs).
- Introduced three named rules:
  - **Rule A — A feature issue IS its own logbook.** When a pre-existing issue exists, post logbook content as comments on it; do not open a parallel logbook issue. Dedicated logbook issues are reserved for spontaneous work and use the `logbook` label.
  - **Rule B — Update incrementally, not at the end.** Logbook comments are posted as obstacles/decisions/corrections occur, not batched at the end of the work.
  - **Rule C — Close immediately after merge.** Once the PR is merged and the changes verified, close the linked issue with `state_reason: completed` — no deferred cleanup.

**Rationale (fixes #8):** the Harness Curator clustered three frictions under `issue-lifecycle-management`: agents created parallel logbook issues, batched journal content at the end, and forgot to close issues after merge. The three-rule structure addresses each failure mode by name.

**Out of scope:** no changes to other sections of `AGENTS.md`, no code, no CI. A separate follow-up may add a linter step to enforce the language scope at file-content level (suggested in #10) — not in this PR.