### PR TITLE
📝 Mandate git worktree isolation in Agent Team Protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ assemble the team.
 Parallel agent teams operating on the same git working directory collide on branch checkout and the staging index, corrupting each other's work. To prevent this, the orchestrating agent **MUST** create a dedicated git worktree **before** issuing any `TaskCreate` call or `Agent` spawn for the ticket:
 
 ```sh
-git worktree add .worktrees/<ticket-id> -b <branch-name> crewrig/main
+git worktree add -b <branch-name> .worktrees/<ticket-id> crewrig/main
 ```
 
 All file edits performed by the team — by every specialist, without exception — **MUST** happen inside `.worktrees/<ticket-id>/`. The main working directory is off-limits for the duration of the ticket; treat it as read-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,22 @@ agents are available. Inline solo work on a ticket is reserved for trivial
 single-file edits explicitly scoped that way by the user. If in doubt,
 assemble the team.
 
+### Worktree Isolation
+
+Parallel agent teams operating on the same git working directory collide on branch checkout and the staging index, corrupting each other's work. To prevent this, the orchestrating agent **MUST** create a dedicated git worktree **before** issuing any `TaskCreate` call or `Agent` spawn for the ticket:
+
+```sh
+git worktree add .worktrees/<ticket-id> -b <branch-name> crewrig/main
+```
+
+All file edits performed by the team — by every specialist, without exception — **MUST** happen inside `.worktrees/<ticket-id>/`. The main working directory is off-limits for the duration of the ticket; treat it as read-only.
+
+Once the PR is merged and the linked logbook issue closed (see *Logbook Issues → Rule C*), remove the worktree to keep the repository clean:
+
+```sh
+git worktree remove .worktrees/<ticket-id>
+```
+
 ## Pull Request Format
 
 Every PR must follow this structure:


### PR DESCRIPTION
Parallel agent teams sharing a single working directory collide on branch checkout and the staging index, corrupting each other's work. This PR amends `AGENTS.md` to mandate that every ticket runs inside its own `git worktree`, isolating each team's filesystem from the others.

## How to read this PR?

Single-file change to `AGENTS.md`. Read the new `### Worktree Isolation` subsection (inserted between `### Solo work prohibition` and `## Pull Request Format` inside `## Agent Team Protocol`). The placement is deliberate: the rule belongs to the team-assembly protocol, not the PR-format section, because it constrains the orchestrator's *first* action when assembling a team.

## How to test this PR?

This is a documentation-only change; no executable test plan applies. Validation steps:

1. Check out the branch: `git checkout pr-issue-19-worktree-isolation`.
2. Open `AGENTS.md` and confirm the `### Worktree Isolation` subsection appears between `### Solo work prohibition` and `## Pull Request Format`.
3. Confirm both fenced `sh` blocks render correctly (the `git worktree add` and `git worktree remove` snippets).
4. Confirm the section is in English and uses no conventional-commit prefixes.

## Detailed description (for agents)

- **File touched:** `AGENTS.md` (only).
- **Section added:** `### Worktree Isolation`, nested under `## Agent Team Protocol`.
- **Placement:** between the existing `### Solo work prohibition` subsection and the `## Pull Request Format` top-level section.
- **Normative content:**
  - The orchestrating agent **MUST** run `git worktree add .worktrees/<ticket-id> -b <branch-name> crewrig/main` **before** issuing any `TaskCreate` call or `Agent` spawn for the ticket.
  - All file edits by every specialist on the team **MUST** happen inside `.worktrees/<ticket-id>/`.
  - The main working directory is treated as read-only for the duration of the ticket.
  - After the PR merges and the logbook issue closes (cross-referenced to `Logbook Issues → Rule C`), the worktree **MUST** be removed via `git worktree remove .worktrees/<ticket-id>`.
- **Rationale embedded in the doc:** parallel teams colliding on branch checkout and the staging index corrupt each other's work; per-ticket worktrees eliminate that class of collision.
- **No other files changed**; no code, configuration, or tooling impacted.

Closes #19