### PR TITLE
📝 Add single-source brief rule to Agent Team Protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,13 @@ CLI and equivalent), the following three tools are **mandatory**:
    artifacts, and unblock teammates. All cross-agent communication flows
    through this tool — never through plain text replies.
 
+**Single-source brief rule**: The `Agent` spawn prompt is the
+authoritative brief — it must be self-contained because spawned agents
+inherit no conversation context. Use `TaskCreate` for tracking only:
+its `description` should be a one-liner (what the task is and where to
+find it), not a duplicate of the Agent prompt. Never write the same
+brief in both places.
+
 ### On CLIs without team support (e.g. Gemini CLI)
 
 When the harness does not expose `TeamCreate` / `TaskCreate` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,7 @@ CLI and equivalent), the following three tools are **mandatory**:
 **Single-source brief rule**: The `Agent` spawn prompt is the
 authoritative brief — it must be self-contained because spawned agents
 inherit no conversation context. Use `TaskCreate` for tracking only:
-its `description` should be a one-liner (what the task is and where to
-find it), not a duplicate of the Agent prompt. Never write the same
+its `description` should be a one-liner (e.g. `"Implement feature X — full brief in Agent prompt"`), not a duplicate of the Agent prompt. Never write the same
 brief in both places.
 
 ### On CLIs without team support (e.g. Gemini CLI)


### PR DESCRIPTION
Codify the resolution to issue #29 (`duplicate-task-briefing` friction) by adding a single paragraph to `AGENTS.md` that names the `Agent` spawn prompt as the authoritative task brief. Closes the loop where team-leads were duplicating briefs across `TaskCreate.description` and the `Agent` spawn prompt, producing redundant and potentially contradictory instructions.

Closes #29

## How to read this PR?

One file, one commit, +7 lines. Read `AGENTS.md` around the inserted paragraph (immediately after the three-tool numbered list in `### On Claude Code CLI (team support available)`, before `### On CLIs without team support`). The placement is deliberate: the rule sits next to the three tools it constrains (`TeamCreate`, `TaskCreate`, `SendMessage`) so an agent reading the protocol top-to-bottom encounters the rule in the same scroll as the tools.

## How to test this PR?

- Render `AGENTS.md` on GitHub and confirm the new paragraph is well-formed Markdown (bold lead-in, inline `code` for tool names, no broken list nesting).
- Confirm `Closes #29` triggers auto-close on merge.
- Failure mode to check: the new paragraph sits between the numbered list and the next `###` heading — verify no stray blank line breaks the visual grouping.

## Detailed description (for agents)

**File modified**: `AGENTS.md` — single insertion, no deletions, no other files touched (see diff).

**Inserted block** (after the three-tool numbered list, before `### On CLIs without team support`):

> **Single-source brief rule**: The `Agent` spawn prompt is the authoritative brief — it must be self-contained because spawned agents inherit no conversation context. Use `TaskCreate` for tracking only: its `description` should be a one-liner (what the task is and where to find it), not a duplicate of the Agent prompt. Never write the same brief in both places.

**Rationale**: Issue #29 collected one friction report (severity `med`, room `behavior`) converging on a single resolution: the task brief should live in exactly one place. Option (a) from the reporter — minimal `Agent` prompt referring to the `TaskList` entry — was rejected in favour of option (b)-adjacent wording, because spawned `Agent` subprocesses do not inherit the orchestrator's conversation and cannot reliably resolve a "see your task list" pointer. Making the `Agent` prompt the single source of truth removes that dependency.

**Scope boundaries**: The rule applies only to the Claude-Code-CLI path (where both `TaskCreate` and `Agent` exist). The fallback path in `### On CLIs without team support` already uses `Agent` spawns exclusively and is unaffected.