### PR TITLE
✅ Add mandatory CI check step to pr-reviewer skill

### DIFF
--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -34,9 +34,37 @@ why.
 
 ## Protocol
 
-Five ordered steps. Do not skip ahead.
+Six ordered steps. Do not skip ahead.
 
-### 1. Read the project conventions
+### 1. Preflight — check CI status
+
+Before reading the diff, query the CI state for the PR:
+
+```bash
+gh pr checks <number> --repo <owner/repo>
+```
+
+Classify each required check as **pass**, **fail**, or **pending**.
+
+- A **failing** required check is a hard blocker. Do not post `APPROVE`
+  or any "LGTM" framing while any required check is failing — the
+  editorial diff review is moot until CI is green. The verdict in this
+  case is `REQUEST_CHANGES` (or `COMMENT` if the failure is clearly
+  unrelated infrastructure flake, in which case say so explicitly and
+  cite the failing job).
+- A **pending** required check means the review is premature. Either
+  wait for completion, or post `COMMENT` and state plainly that the
+  verdict is deferred until CI resolves.
+- All required checks **passing** clears the preflight; proceed to
+  step 2.
+
+The CI status MUST be surfaced explicitly in the final verdict body
+(pass / fail / pending, with the failing job name when applicable).
+A silent skip of this section is a protocol violation: a failing
+required job overrides any editorial LGTM, and the reader of the
+review needs to see that signal in writing.
+
+### 2. Read the project conventions
 
 Open `AGENTS.md` at the repo root (or the project's equivalent) and
 note:
@@ -49,7 +77,7 @@ note:
 
 Different projects have different rules. Do not assume.
 
-### 2. Fetch the PR diff and metadata
+### 3. Fetch the PR diff and metadata
 
 ```bash
 gh pr diff <number>
@@ -59,7 +87,7 @@ gh pr view <number> --json title,body,files,headRefName,baseRefName,labels
 Identify linked issues by parsing the body (`Fixes #N`, `Closes #N`,
 `Refs #N`) and fetch each: `gh issue view <N>`.
 
-### 3. Run the bundled linter scripts
+### 4. Run the bundled linter scripts
 
 Select scripts based on file extensions in the changed-files list, then
 invoke each with the matching subset of paths. Capture stdout and exit
@@ -67,10 +95,13 @@ code; treat exit 0 as no findings, exit 1 as findings present.
 
 See *Scripts* below for the full table.
 
-### 4. Compose the structured review
+### 5. Compose the structured review
 
-Four sections, in this order:
+Five sections, in this order:
 
+- **CI status** — pass / fail / pending for each required check
+  (from step 1). When any required check is failing or pending, this
+  section drives the verdict; do not bury it.
 - **Correctness** — does the code do what the PR claims? Cite the file
   path and line range for each claim.
 - **Convention compliance** — does the change follow the rules
@@ -85,7 +116,7 @@ optional line number, or a specific assertion from the diff). If you
 cannot cite, write "see diff" or omit the claim. See *Grounding
 discipline* below.
 
-### 5. Post the review
+### 6. Post the review
 
 Use the GitHub MCP `pull_request_review_write` tool with the
 appropriate event:

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -29,9 +29,37 @@ why.
 
 ## Protocol
 
-Five ordered steps. Do not skip ahead.
+Six ordered steps. Do not skip ahead.
 
-### 1. Read the project conventions
+### 1. Preflight — check CI status
+
+Before reading the diff, query the CI state for the PR:
+
+```bash
+gh pr checks <number> --repo <owner/repo>
+```
+
+Classify each required check as **pass**, **fail**, or **pending**.
+
+- A **failing** required check is a hard blocker. Do not post `APPROVE`
+  or any "LGTM" framing while any required check is failing — the
+  editorial diff review is moot until CI is green. The verdict in this
+  case is `REQUEST_CHANGES` (or `COMMENT` if the failure is clearly
+  unrelated infrastructure flake, in which case say so explicitly and
+  cite the failing job).
+- A **pending** required check means the review is premature. Either
+  wait for completion, or post `COMMENT` and state plainly that the
+  verdict is deferred until CI resolves.
+- All required checks **passing** clears the preflight; proceed to
+  step 2.
+
+The CI status MUST be surfaced explicitly in the final verdict body
+(pass / fail / pending, with the failing job name when applicable).
+A silent skip of this section is a protocol violation: a failing
+required job overrides any editorial LGTM, and the reader of the
+review needs to see that signal in writing.
+
+### 2. Read the project conventions
 
 Open `AGENTS.md` at the repo root (or the project's equivalent) and
 note:
@@ -44,7 +72,7 @@ note:
 
 Different projects have different rules. Do not assume.
 
-### 2. Fetch the PR diff and metadata
+### 3. Fetch the PR diff and metadata
 
 ```bash
 gh pr diff <number>
@@ -54,7 +82,7 @@ gh pr view <number> --json title,body,files,headRefName,baseRefName,labels
 Identify linked issues by parsing the body (`Fixes #N`, `Closes #N`,
 `Refs #N`) and fetch each: `gh issue view <N>`.
 
-### 3. Run the bundled linter scripts
+### 4. Run the bundled linter scripts
 
 Select scripts based on file extensions in the changed-files list, then
 invoke each with the matching subset of paths. Capture stdout and exit
@@ -62,10 +90,13 @@ code; treat exit 0 as no findings, exit 1 as findings present.
 
 See *Scripts* below for the full table.
 
-### 4. Compose the structured review
+### 5. Compose the structured review
 
-Four sections, in this order:
+Five sections, in this order:
 
+- **CI status** — pass / fail / pending for each required check
+  (from step 1). When any required check is failing or pending, this
+  section drives the verdict; do not bury it.
 - **Correctness** — does the code do what the PR claims? Cite the file
   path and line range for each claim.
 - **Convention compliance** — does the change follow the rules
@@ -80,7 +111,7 @@ optional line number, or a specific assertion from the diff). If you
 cannot cite, write "see diff" or omit the claim. See *Grounding
 discipline* below.
 
-### 5. Post the review
+### 6. Post the review
 
 Use the GitHub MCP `pull_request_review_write` tool with the
 appropriate event:

--- a/community-config/skills/pr-reviewer/SKILL.md
+++ b/community-config/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.0.0"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/pr-reviewer/SKILL.md
+++ b/community-config/skills/pr-reviewer/SKILL.md
@@ -40,9 +40,37 @@ why.
 
 ## Protocol
 
-Five ordered steps. Do not skip ahead.
+Six ordered steps. Do not skip ahead.
 
-### 1. Read the project conventions
+### 1. Preflight — check CI status
+
+Before reading the diff, query the CI state for the PR:
+
+```bash
+gh pr checks <number> --repo <owner/repo>
+```
+
+Classify each required check as **pass**, **fail**, or **pending**.
+
+- A **failing** required check is a hard blocker. Do not post `APPROVE`
+  or any "LGTM" framing while any required check is failing — the
+  editorial diff review is moot until CI is green. The verdict in this
+  case is `REQUEST_CHANGES` (or `COMMENT` if the failure is clearly
+  unrelated infrastructure flake, in which case say so explicitly and
+  cite the failing job).
+- A **pending** required check means the review is premature. Either
+  wait for completion, or post `COMMENT` and state plainly that the
+  verdict is deferred until CI resolves.
+- All required checks **passing** clears the preflight; proceed to
+  step 2.
+
+The CI status MUST be surfaced explicitly in the final verdict body
+(pass / fail / pending, with the failing job name when applicable).
+A silent skip of this section is a protocol violation: a failing
+required job overrides any editorial LGTM, and the reader of the
+review needs to see that signal in writing.
+
+### 2. Read the project conventions
 
 Open `AGENTS.md` at the repo root (or the project's equivalent) and
 note:
@@ -55,7 +83,7 @@ note:
 
 Different projects have different rules. Do not assume.
 
-### 2. Fetch the PR diff and metadata
+### 3. Fetch the PR diff and metadata
 
 ```bash
 gh pr diff <number>
@@ -65,7 +93,7 @@ gh pr view <number> --json title,body,files,headRefName,baseRefName,labels
 Identify linked issues by parsing the body (`Fixes #N`, `Closes #N`,
 `Refs #N`) and fetch each: `gh issue view <N>`.
 
-### 3. Run the bundled linter scripts
+### 4. Run the bundled linter scripts
 
 Select scripts based on file extensions in the changed-files list, then
 invoke each with the matching subset of paths. Capture stdout and exit
@@ -73,10 +101,13 @@ code; treat exit 0 as no findings, exit 1 as findings present.
 
 See *Scripts* below for the full table.
 
-### 4. Compose the structured review
+### 5. Compose the structured review
 
-Four sections, in this order:
+Five sections, in this order:
 
+- **CI status** — pass / fail / pending for each required check
+  (from step 1). When any required check is failing or pending, this
+  section drives the verdict; do not bury it.
 - **Correctness** — does the code do what the PR claims? Cite the file
   path and line range for each claim.
 - **Convention compliance** — does the change follow the rules
@@ -91,7 +122,7 @@ optional line number, or a specific assertion from the diff). If you
 cannot cite, write "see diff" or omit the claim. See *Grounding
 discipline* below.
 
-### 5. Post the review
+### 6. Post the review
 
 Use the GitHub MCP `pull_request_review_write` tool with the
 appropriate event:


### PR DESCRIPTION
Wires a mandatory CI preflight into the pr-reviewer skill so a failing pipeline can no longer be silently overridden by an editorial LGTM. Closes #30.

## How to read this PR?

Start with the canonical source: `community-config/skills/pr-reviewer/SKILL.md`. The two built copies under `.claude/skills/pr-reviewer/SKILL.md` and `.gemini/skills/pr-reviewer/SKILL.md` are identical propagations — read them only to confirm the lockstep. Focus areas:

1. The new **Step 1: Preflight — check CI status** at the top of the review procedure.
2. The renumbering of the following steps (2–6).
3. The **CI status** line newly inserted as the first item of the structured verdict composition (step 5).

## How to test this PR?

1. Check out the branch: `git checkout pr-issue-30-reviewer-ci`.
2. Open `community-config/skills/pr-reviewer/SKILL.md` and confirm Step 1 runs `gh pr checks <number> --repo <owner/repo>` and defines the three outcomes (`pass` / `fail` / `pending`).
3. Confirm `.claude/skills/pr-reviewer/SKILL.md` and `.gemini/skills/pr-reviewer/SKILL.md` carry the same changes.
4. Dry-run mentally: activate the pr-reviewer skill against a PR with a red check — the verdict must be REQUEST CHANGES regardless of the diff quality.
5. Dry-run a pending-checks PR — the verdict must be COMMENT with review deferred, not APPROVE.

## Detailed description (for agents)

- **Files changed:** 3 (`community-config/skills/pr-reviewer/SKILL.md`, `.claude/skills/pr-reviewer/SKILL.md`, `.gemini/skills/pr-reviewer/SKILL.md`).
- **Line delta:** +114 / −21.
- **New Step 1 — Preflight: check CI status.** Inserted at the start of the review procedure. Runs `gh pr checks <number> --repo <owner/repo>` and branches:
  - `fail` → hard blocker. Verdict MUST be REQUEST CHANGES. Overrides any editorial LGTM.
  - `pending` → premature. Verdict MUST be COMMENT with review deferred until checks complete; APPROVE is disallowed.
  - `pass` → proceed to the editorial review.
- **Renumbering.** The pre-existing steps shift from 1–5 to 2–6 to make room for the preflight.
- **Verdict schema.** Step 5 (structured verdict composition) now lists **CI status** as its first item, so every emitted review surfaces the CI signal explicitly alongside the editorial verdict.
- **Lockstep.** The canonical file is `community-config/skills/pr-reviewer/SKILL.md`; the two built copies are byte-for-byte propagations.

Closes #30