### PR TITLE
📝 Add Standard Team Templates to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,67 @@ Once the PR is merged and the linked logbook issue closed (see *Logbook Issues �
 git worktree remove .worktrees/<ticket-id>
 ```
 
+### Standard Team Templates
+
+Every role in the templates below operates inside the ticket worktree as
+required by the rule above.
+
+Agents **MUST** use the closest matching template below as the starting team
+composition. Adjust by dropping a role only when the ticket's scope explicitly
+excludes it, or by adding a role when the change crosses a specialist's
+trigger surface (e.g. `security`, `architect`). Either adjustment requires a
+one-line rationale in the task handoff comment. Ad-hoc partial crews —
+omitting roles without justification — are prohibited.
+
+**Security rule (applies to all templates):** When a change touches the
+security skill's trigger surface (authentication, authorization, secrets,
+cryptography, input parsing, deserialization, network calls, or dependency
+upgrades), insert `security` after `developer` in the applicable template.
+
+#### Template 1 — Feature implementation (results in a PR)
+
+Full pipeline. Every role is mandatory unless explicitly scoped out by the
+user.
+
+| Order | Role | Responsibility |
+|---|---|---|
+| 1 | `architect` | Design review, ADR if needed, blast-radius check |
+| 2 | `developer` (×N) | Implementation in the worktree |
+| 3 | `tester` | Write / update tests |
+| 4 | `pr-logbook` | Draft PR title, body, and logbook entry |
+| 5 | `pr-reviewer` | Independent cold review of the diff |
+
+Use multiple `developer` agents in parallel when the work decomposes into
+independent files or modules; a single developer suffices otherwise.
+
+#### Template 2 — Documentation-only change
+
+Lighter pipeline — no code, no tests.
+
+| Order | Role | Responsibility |
+|---|---|---|
+| 1 | `doc-writer` | Write / update the documentation |
+| 2 | `pr-logbook` | Draft PR title, body, and logbook entry |
+| 3 | `pr-reviewer` | Independent cold review of the diff |
+
+If the documentation change modifies an established protocol, convention, or
+contract (e.g. AGENTS.md itself), insert `architect` as step 0.
+
+#### Template 3 — Bug fix
+
+Test-first pipeline: the failing regression test is written before the fix
+to lock in reproduction.
+
+| Order | Role | Responsibility |
+|---|---|---|
+| 1 | `tester` | Write a failing regression test that reproduces the bug |
+| 2 | `developer` | Implement the fix until the regression test passes |
+| 3 | `pr-logbook` | Draft PR title, body, and logbook entry |
+| 4 | `pr-reviewer` | Independent cold review of the diff |
+
+`architect` is optional: include it only when the root cause exposes a
+design flaw rather than a localized defect.
+
 ## Pull Request Format
 
 Every PR must follow this structure:


### PR DESCRIPTION
Codify the mandatory starting team composition for project tickets so agents stop assembling partial crews. Adds a "Standard Team Templates" subsection to the Agent Team Protocol with three templates (feature PR, docs-only, bug fix) and a rationale requirement when a role is dropped.

## How to read this PR?

Single-file documentation change in `AGENTS.md`. The new `### Standard Team Templates` subsection sits inside the existing *Agent Team Protocol* section, between the *Worktree Isolation* subsection and `## Pull Request Format`. Read top-to-bottom: the opening paragraph defines the worktree anchor and the adjustment rule, the security cross-cutting rule follows, then three tables enumerate the templates in execution order. No code, no configuration, no other files touched.

## How to test this PR?

1. Open `AGENTS.md` and confirm the new `### Standard Team Templates` subsection renders correctly (three markdown tables, ordered role columns).
2. Verify the subsection is nested under `## Agent Team Protocol` and ordered after `### Worktree Isolation`.
3. Run a markdown linter if configured locally; otherwise no automated tests apply (documentation-only change).
4. Sanity-check the templates against a recent ticket: every role listed (`architect`, `developer`, `tester`, `pr-logbook`, `pr-reviewer`, `doc-writer`, `security`) maps to an existing agent type available in the harness.

## Detailed description (for agents)

**Friction addressed.** The friction cluster `agent-team-composition` (issue #23) observed orchestrating agents assembling ad-hoc partial teams for feature tickets — typically `architect` plus one or more `developer`s — and skipping `tester`, `pr-logbook`, and `pr-reviewer`. The protocol said "assemble a team of relevant specialist agents sized to the ticket's scope" but offered no concrete baseline.

**Change.** Added `### Standard Team Templates` to `AGENTS.md` inside `## Agent Team Protocol`. The subsection establishes:

- **Worktree anchor.** First sentence ties the templates to the worktree rule above.
- **Bidirectional adjustment rule.** Agents may drop a role (scope exclusion) or add a role (specialist trigger surface crossed); either requires a one-line rationale in the task handoff comment.
- **Security cross-cutting rule.** When a change touches auth, secrets, crypto, input parsing, deserialization, network calls, or dependency upgrades, `security` is inserted after `developer` in the applicable template.
- **Template 1 — Feature implementation (5 roles):** `architect` → `developer` (×N) → `tester` → `pr-logbook` → `pr-reviewer`. Fan-out guidance for multiple developers included.
- **Template 2 — Documentation-only (3 roles):** `doc-writer` → `pr-logbook` → `pr-reviewer`. Optional `architect` as step 0 when the change modifies an established protocol or contract.
- **Template 3 — Bug fix (4 roles, test-first):** `tester` (writes failing regression test) → `developer` → `pr-logbook` → `pr-reviewer`. Optional `architect` when root cause exposes a design flaw.

**Out of scope.** No changes to worktree-isolation rules, logbook rules, PR-format rules, or any other section. No new agent types introduced.