### PR TITLE
🐛 Fix frontmatter extraction leaking fenced code block content

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Test build-components validator
         run: bash scripts/test-build-components.sh
 
+      - name: Test extract_frontmatter regression
+        run: bash scripts/tests/test-extract-frontmatter.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -172,7 +172,7 @@ inject_provenance() {
 
 # Extract YAML frontmatter from a Markdown file (between first two ---)
 extract_frontmatter() {
-  sed -n '/^---$/,/^---$/p' "$1" | sed '1d;$d'
+  awk 'NR==1 && /^---$/{inblk=1; next} inblk && /^---$/{exit} inblk{print}' "$1"
 }
 
 # Extract body from a Markdown file (everything after second ---)

--- a/scripts/tests/test-extract-frontmatter.sh
+++ b/scripts/tests/test-extract-frontmatter.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression test for issue #24 — extract_frontmatter() leaks body content
+# when bare `---` lines appear inside fenced code blocks in the Markdown body.
+#
+# The current implementation in scripts/build-components.sh uses:
+#   sed -n '/^---$/,/^---$/p' "$1" | sed '1d;$d'
+# `sed` range mode restarts after each closing match, so any subsequent pair
+# of `---` lines (including ones inside ```yaml fenced blocks) is re-emitted
+# and merged with the real frontmatter.
+#
+# Expected behavior: only the YAML between the FIRST two `---` lines is
+# returned. The test fails (exit 1) against the buggy implementation and
+# passes (exit 0) once the bug is fixed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET_SCRIPT="$REPO_DIR/scripts/build-components.sh"
+
+if [[ ! -f "$TARGET_SCRIPT" ]]; then
+  echo "FAIL: cannot locate build-components.sh at $TARGET_SCRIPT" >&2
+  exit 1
+fi
+
+# Extract the current extract_frontmatter() function body from the real
+# script, then eval it into this shell. We do NOT source the whole script
+# because it has `set -euo pipefail` and runs a CLI parser at load time.
+fn_src="$(awk '
+  /^extract_frontmatter\(\) \{/ { capture = 1 }
+  capture { print }
+  capture && /^\}/ { exit }
+' "$TARGET_SCRIPT")"
+
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: could not extract extract_frontmatter() from $TARGET_SCRIPT" >&2
+  exit 1
+fi
+
+eval "$fn_src"
+
+# Build a fixture: real frontmatter + a body containing a fenced code block
+# with bare `---` separators inside.
+fixture="$(mktemp -t extract-frontmatter-fixture.XXXXXX)"
+trap 'rm -f "$fixture"' EXIT
+
+cat > "$fixture" <<'EOF'
+---
+name: test-skill
+description: A test skill
+---
+
+Some body text.
+
+```yaml
+---
+nested: value
+---
+```
+
+More body text.
+EOF
+
+actual="$(extract_frontmatter "$fixture")"
+
+# The bug surfaces as `nested: value` (or the embedded `---` separators)
+# bleeding into the output.
+if printf '%s\n' "$actual" | grep -q 'nested: value'; then
+  printf 'FAIL: extracted frontmatter leaked body content. Expected only {name, description}; got: %s\n' \
+    "$(printf '%s' "$actual" | tr '\n' '|')" >&2
+  exit 1
+fi
+
+# Positive assertions — the real frontmatter must still be present.
+if ! printf '%s\n' "$actual" | grep -qx 'name: test-skill'; then
+  printf 'FAIL: expected "name: test-skill" in output; got: %s\n' \
+    "$(printf '%s' "$actual" | tr '\n' '|')" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$actual" | grep -qx 'description: A test skill'; then
+  printf 'FAIL: expected "description: A test skill" in output; got: %s\n' \
+    "$(printf '%s' "$actual" | tr '\n' '|')" >&2
+  exit 1
+fi
+
+echo "PASS: extract_frontmatter ignores ---  lines inside fenced code blocks"
+exit 0


### PR DESCRIPTION
Closes #24.

`extract_frontmatter()` in `scripts/build-components.sh` leaked SKILL.md body content into the YAML frontmatter when bare `---` lines appeared inside fenced code blocks, breaking downstream `yq` parsing. This PR replaces the `sed` range expression with an `awk` state machine that stops at the first closing `---`, adds a regression test, and wires that test into CI.

## How to read this PR?

1. **`scripts/build-components.sh`** — single-line change at line 175. The `sed -n '/^---$/,/^---$/p'` range was restartable: after the closing `---` of the real frontmatter, any subsequent `---` pair (typical inside fenced code samples) opened a new range, so its content was concatenated into the extracted frontmatter. The `awk` replacement uses an `inblk` flag that flips on at the first `---` (only when it is line 1) and exits on the next `---`, guaranteeing a single extraction window. (`inblk` is used instead of `in` because `in` is a reserved keyword in awk.)
2. **`scripts/tests/test-extract-frontmatter.sh`** — new regression test. Pulls the live `extract_frontmatter()` function out of `build-components.sh` via `awk` + `eval` rather than sourcing the whole script (which runs under `set -euo pipefail` and would execute top-level side effects). Fixture mirrors the real-world trigger: a bare `---` inside a fenced code block in SKILL.md.
3. **`.github/workflows/build.yml`** — one step added to the `check-components` job, immediately after the existing `Test build-components validator` step, to run the new regression test in CI.

## How to test this PR?

Prerequisites: `bash`, `awk` (POSIX). `yq` not required for the regression test.

```sh
# Run the new regression test
bash scripts/tests/test-extract-frontmatter.sh
# Expected: exit 0, "PASS: extract_frontmatter ignores --- lines inside fenced code blocks"

# Smoke-test against the file that triggered the bug
bash -c 'source scripts/build-components.sh 2>/dev/null; extract_frontmatter community-config/skills/astro/SKILL.md' \
  | yq '.'
# Expected: clean YAML output, no body content leaking in
```

To confirm the test guards the regression, temporarily revert line 175 to the old `sed` version and re-run — it must exit 1 with a diagnostic showing leaked body content.

## Detailed description (for agents)

**Bug.** `extract_frontmatter()` previously used:

```sh
sed -n '/^---$/,/^---$/p' "$1" | sed '1d;$d'
```

`sed`'s range operator is **restartable**: once the closing address matches, the next occurrence of the opening address reopens the range. In SKILL.md files containing fenced code blocks whose contents include bare `---` lines (e.g. `community-config/skills/astro/SKILL.md`), every subsequent `---` pair after the real frontmatter reopened the range and leaked body content into the extracted YAML. Downstream `yq` parsing then failed on the malformed input.

**Fix.** `scripts/build-components.sh` line 175:

```diff
-  sed -n '/^---$/,/^---$/p' "$1" | sed '1d;$d'
+  awk 'NR==1 && /^---$/{inblk=1; next} inblk && /^---$/{exit} inblk{print}' "$1"
```

Semantics: `NR==1` anchors the opening fence to line 1 (files with no leading `---` produce empty output); `exit` on the closing `---` is final — no restart possible.

Gotcha: initial draft used `in` as the awk variable, which is a reserved keyword. Renamed to `inblk`.

**Regression test.** `scripts/tests/test-extract-frontmatter.sh` extracts the live `extract_frontmatter()` definition via `awk` + `eval`, creates a fixture with a fenced code block containing bare `---`, and asserts only the YAML frontmatter is returned. Verified: exits 1 against the original `sed` implementation, exits 0 against the `awk` replacement.

**CI wiring.** Added `bash scripts/tests/test-extract-frontmatter.sh` as a step in the `check-components` job of `.github/workflows/build.yml`, immediately after the existing `Test build-components validator` step. The job already has `yq` and standard POSIX tools available; no new dependencies required.