### PR TITLE
📝 Document version bump convention and fix stale base ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Test extract_frontmatter regression
         run: bash scripts/tests/test-extract-frontmatter.sh
 
+      - name: Test check-skill-versions regression
+        run: bash scripts/tests/test-check-skill-versions.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Refer to [gitmoji.dev](https://gitmoji.dev/) for the full list of valid emojis a
 ## Version Bump Convention
 
 Skill and agent sources carry a `metadata.provenance.version` field that
-tracks shipped revisions. Two rules govern when it must change.
+tracks shipped revisions. One rule and one exemption govern when it must change.
 
 **Rule — bump on modification of shipped sources.** Any diff that modifies
 a skill or agent source already present on `main` MUST bump

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,35 @@ Examples:
 
 Refer to [gitmoji.dev](https://gitmoji.dev/) for the full list of valid emojis and their meanings.
 
+## Version Bump Convention
+
+Skill and agent sources carry a `metadata.provenance.version` field that
+tracks shipped revisions. Two rules govern when it must change.
+
+**Rule — bump on modification of shipped sources.** Any diff that modifies
+a skill or agent source already present on `main` MUST bump
+`metadata.provenance.version` in the same diff. Affected paths:
+
+- `community-config/skills/*/SKILL.md`
+- `community-config/agents/*/AGENT.md`
+
+**Exemption — new components do not bump in-branch.** Components
+introduced on a feature branch start at `1.0.0` and stay there until the
+branch is merged. In-branch fixes to a brand-new component MUST NOT bump
+its version — the version is only meaningful once the component ships on
+`main`. CI enforces this: only files with `git diff --name-status` status
+`M` (modified) trigger the check; newly added files (`A`) are skipped.
+
+**SemVer guidance for bumps:**
+
+- `PATCH` (1.0.x) — friction fix, wording change
+- `MINOR` (1.x.0) — additive change (new section, new field)
+- `MAJOR` (x.0.0) — breaking contract change
+
+**Enforcement.** `scripts/check-skill-versions.sh` runs in CI, diffs the
+PR against its target branch, and fails the build when a modified source
+ships without a version bump.
+
 ## Agent Team Protocol
 
 Project tickets are multi-step work. They must be treated by a **team of specialist agents**, not by a single agent working solo inline.

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -10,7 +10,7 @@
 # Usage:
 #   bash scripts/check-skill-versions.sh [<base-ref>]
 #
-# Default base ref: origin/release/crew-v0. CI passes BASE_REF env var
+# Default base ref: origin/main. CI passes BASE_REF env var
 # pointing at the PR's *target* branch (`base.ref` in GitHub Actions
 # context) — NOT the PR's source/head branch. The guard diffs the PR
 # against what it's about to merge into, so changes that haven't yet
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-BASE_REF="${1:-${BASE_REF:-origin/release/crew-v0}}"
+BASE_REF="${1:-${BASE_REF:-origin/main}}"
 
 # Make sure the base is fetched. CI runners do shallow clones by default.
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then

--- a/scripts/tests/test-check-skill-versions.sh
+++ b/scripts/tests/test-check-skill-versions.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# test-check-skill-versions.sh — Regression test for check-skill-versions.sh.
+#
+# Pins the contract from issue #26: the version-bump rule applies only to
+# MODIFIED skill/agent sources (git status `M`), never to newly ADDED ones
+# (status `A`). New components start at 1.0.0 by definition and are not
+# subject to the bump rule until they are subsequently modified.
+#
+# Cases:
+#   1. Status A (new component, no bump)      → exit 0
+#   2. Status M (modified, no bump)           → exit 1
+#   3. Status M (modified, with version bump) → exit 0
+#
+# Usage:
+#   bash scripts/tests/test-check-skill-versions.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-skill-versions.sh"
+
+if [ ! -x "$SCRIPT_UNDER_TEST" ] && [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# Render a minimal SKILL.md with the given version string.
+render_skill() {
+  local version="$1"
+  cat <<EOF
+---
+name: example
+description: Example skill used as a test fixture.
+metadata:
+  provenance:
+    version: "$version"
+---
+
+# Example
+
+Body.
+EOF
+}
+
+# Set up a fresh temp git repo and return its path on stdout.
+new_repo() {
+  local dir
+  dir="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  (
+    cd "$dir"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false
+  )
+  echo "$dir"
+}
+
+run_case() {
+  local name="$1"
+  local repo="$2"
+  local expected_exit="$3"
+
+  local actual_exit=0
+  ( cd "$repo" && bash "$SCRIPT_UNDER_TEST" HEAD~1 >/dev/null 2>&1 ) || actual_exit=$?
+
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "PASS  $name (exit $actual_exit)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $name (expected exit $expected_exit, got $actual_exit)"
+    fail=$((fail + 1))
+  fi
+}
+
+# -------------------------------------------------------------------------
+# Case 1 — Status A: new SKILL.md, no bump required → exit 0
+# -------------------------------------------------------------------------
+repo1="$(new_repo)"
+(
+  cd "$repo1"
+  # Base commit: unrelated file, no skill yet.
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "seed"
+
+  # Head commit: ADD a brand-new skill source.
+  mkdir -p community-config/skills/new-skill
+  render_skill "1.0.0" > community-config/skills/new-skill/SKILL.md
+  git add community-config/skills/new-skill/SKILL.md
+  git commit -q -m "add new skill"
+)
+run_case "Case 1 — new component (status A) requires no bump" "$repo1" 0
+
+# -------------------------------------------------------------------------
+# Case 2 — Status M: existing SKILL.md modified, no bump → exit 1
+# -------------------------------------------------------------------------
+repo2="$(new_repo)"
+(
+  cd "$repo2"
+  mkdir -p community-config/skills/old-skill
+  render_skill "1.0.0" > community-config/skills/old-skill/SKILL.md
+  git add community-config/skills/old-skill/SKILL.md
+  git commit -q -m "seed old-skill at 1.0.0"
+
+  # Head commit: modify body, but leave version untouched.
+  printf '\nExtra line.\n' >> community-config/skills/old-skill/SKILL.md
+  git add community-config/skills/old-skill/SKILL.md
+  git commit -q -m "tweak body, forget version bump"
+)
+run_case "Case 2 — modified component without bump fails" "$repo2" 1
+
+# -------------------------------------------------------------------------
+# Case 3 — Status M: existing SKILL.md modified, with bump → exit 0
+# -------------------------------------------------------------------------
+repo3="$(new_repo)"
+(
+  cd "$repo3"
+  mkdir -p community-config/skills/old-skill
+  render_skill "1.0.0" > community-config/skills/old-skill/SKILL.md
+  git add community-config/skills/old-skill/SKILL.md
+  git commit -q -m "seed old-skill at 1.0.0"
+
+  # Head commit: bump version (and tweak body for realism).
+  render_skill "1.0.1" > community-config/skills/old-skill/SKILL.md
+  printf '\nExtra line.\n' >> community-config/skills/old-skill/SKILL.md
+  git add community-config/skills/old-skill/SKILL.md
+  git commit -q -m "patch bump"
+)
+run_case "Case 3 — modified component with bump passes" "$repo3" 0
+
+# -------------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------------
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test-check-skill-versions.sh
+++ b/scripts/tests/test-check-skill-versions.sh
@@ -14,6 +14,9 @@
 # Usage:
 #   bash scripts/tests/test-check-skill-versions.sh
 
+# -e is intentionally omitted: exit behaviour is controlled through explicit
+# pass/fail counters and a final assertion; adding -e would cause the harness
+# to abort on the expected non-zero exit codes from the script under test.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
Closes #26. Codifies the version-bump rule in `AGENTS.md` so agents stop bumping new components in-branch, and repairs `check-skill-versions.sh`'s stale default base ref so local runs compare against `origin/main` instead of the long-gone `origin/release/crew-v0`.

## How to read this PR?

1. **`AGENTS.md`** — read the new `## Version Bump Convention` section first. It is the contract: only `M` (modified) files trigger the check; newly added (`A`) files are exempt. Inserted between `## Naming Convention` and `## Agent Team Protocol`.
2. **`scripts/check-skill-versions.sh`** — two-line change: `BASE_REF` default fallback and adjacent comment updated from `origin/release/crew-v0` to `origin/main`. No control-flow changes.
3. **`scripts/tests/test-check-skill-versions.sh`** — new regression harness: status `A` no-bump → exit 0, status `M` no-bump → exit 1, status `M` with bump → exit 0.
4. **`.github/workflows/build.yml`** — one step added to `check-components` to run the regression test in CI.

## How to test this PR?

Prerequisites: `bash`, `git`.

```sh
# Run the regression harness
bash scripts/tests/test-check-skill-versions.sh
# Expected: all 3 cases PASS, exit 0

# Confirm default base ref is now origin/main
grep 'BASE_REF' scripts/check-skill-versions.sh
```

## Detailed description (for agents)

**Root cause.** Two independent causes compounded:
1. `AGENTS.md` had no version-bump documentation — agents over-applied the rule, bumping brand-new components on their own feature branches.
2. `check-skill-versions.sh` defaulted `BASE_REF` to `origin/release/crew-v0` (a retired branch), so local enforcement was muted.

**`AGENTS.md` (+29 lines).** New `## Version Bump Convention` section. Key points: bump rule applies to `M`-status files only (not `A`); new components stay at `1.0.0` until merged to `main`; SemVer ladder (PATCH/MINOR/MAJOR); pointer to the enforcement script. Wording uses "only `M` triggers the check" to precisely match the script's inclusion-only logic (avoids overpromising on `R`/`C` handling).

**`scripts/check-skill-versions.sh` (2 lines).** Default `BASE_REF` changed from `origin/release/crew-v0` to `origin/main`. CI is unaffected (it passes `BASE_REF` explicitly via `github.event.pull_request.base.ref`); this only affects local runs.

**`scripts/tests/test-check-skill-versions.sh` (new, 177 lines).** Self-contained bash harness using throwaway git repos to simulate the three scenarios the contract cares about. Cleanup via `trap`. Wired into `build.yml` under the `check-components` job.

**`.github/workflows/build.yml` (+3 lines).** Step `Test check-skill-versions regression` added after `Test build-components validator` in `check-components`.