### PR TITLE
👽 Mandate report-before-idle for team agents

### DIFF
--- a/.claude/agents/pr-reviewer/AGENT.md
+++ b/.claude/agents/pr-reviewer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.1.0"
 ---
 
 
@@ -33,6 +33,12 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
+6. After completing the review, you MUST send your verdict to
+   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
+   without having sent the verdict message — idle without reporting is
+   a protocol violation. The message must include the PR number, the
+   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+   summary of the key findings.
 
 ## Activation
 

--- a/.gemini/agents/pr-reviewer.md
+++ b/.gemini/agents/pr-reviewer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.1.0"
 ---
 
 
@@ -33,6 +33,12 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
+6. After completing the review, you MUST send your verdict to
+   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
+   without having sent the verdict message — idle without reporting is
+   a protocol violation. The message must include the PR number, the
+   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+   summary of the key findings.
 
 ## Activation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,28 @@ to lock in reproduction.
 `architect` is optional: include it only when the root cause exposes a
 design flaw rather than a localized defect.
 
+### Team Communication
+
+Two rules govern how teammates report back inside a team.
+
+**Rule 1 — Report before idle.** Every agent operating inside a team
+(spawned via `TeamCreate` / `TaskCreate`) MUST send a message to
+`team-lead` via `SendMessage` with a result summary before its turn ends.
+Going idle without sending a result message is a protocol violation. The
+result message must include: the task identifier, the outcome, and any
+artifact (file path, diff summary, verdict, etc.) the team lead needs to
+proceed.
+
+**Rule 2 — Idle fallback.** If a teammate goes idle twice in a row
+without reporting back on its assigned task, the team lead MUST NOT send
+a third `SendMessage`. Instead, spawn a fresh direct `Agent` with a
+self-contained brief — the same brief as the original task, plus context
+about what was attempted. Include any state already produced — PR
+number, branch name, worktree path, logbook issue — so the fresh spawn
+can resume rather than restart from scratch. Direct `Agent` spawns (without team context)
+reliably complete and return results; `SendMessage` to a stuck idle
+agent does not.
+
 ## Pull Request Format
 
 Every PR must follow this structure:

--- a/community-config/agents/pr-reviewer/AGENT.md
+++ b/community-config/agents/pr-reviewer/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.0.1"
+    version: "1.1.0"
 ---
 
 # PR Reviewer Agent
@@ -36,6 +36,12 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
+6. After completing the review, you MUST send your verdict to
+   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
+   without having sent the verdict message — idle without reporting is
+   a protocol violation. The message must include the PR number, the
+   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+   summary of the key findings.
 
 ## Activation
 


### PR DESCRIPTION
Closes #25. Team agents (notably `pr-reviewer` in tickets #14 and #15) were going idle after receiving a `SendMessage` without sending their verdict back to `team-lead`, leaving the orchestrator blocked. This PR adds an explicit protocol rule to `AGENTS.md` and patches `pr-reviewer/AGENT.md` so the contract is visible at the agent level.

## How to read this PR?

1. **`AGENTS.md`** — new `### Team Communication` subsection under `## Agent Team Protocol` (after `### Standard Team Templates`). Two rules: (1) every team agent MUST `SendMessage` a result to `team-lead` before its turn ends; (2) after two unreported idles, `team-lead` MUST spawn a fresh `Agent` rather than a third `SendMessage`, passing all state already produced.
2. **`community-config/agents/pr-reviewer/AGENT.md`** — the documented offender. New step 6 in the cold-start contract mandates sending the verdict before going idle, with required fields (PR number, event, key findings). Version bumped 1.0.1 → 1.1.0 (MINOR — additive new step).

## How to test this PR?

Documentation contract change — no executable test. Verify by reading:

1. `AGENTS.md` → `## Agent Team Protocol` → confirm `### Team Communication` exists with both rules, and Rule 2 includes the resume-context list (PR number, branch, worktree path, logbook issue).
2. `community-config/agents/pr-reviewer/AGENT.md` → confirm step 6 is present and version is `1.1.0`.

End-to-end verification lands on the next team-mode ticket: every spawned specialist should send a closing `SendMessage` before going idle.

## Detailed description (for agents)

**Root cause.** No protocol mandated a closing report from team agents. The silence after `SendMessage` delivery was technically conformant — and operationally broken: `team-lead` had no signal that work was done and no payload to act on. Evidence: `pr-reviewer` went idle 4 times on ticket #15 and repeatedly on #14 without sending its verdict.

**Design choice — single-source, not per-agent duplication.** The general mandate lives only in `AGENTS.md §Team Communication`. Only `pr-reviewer/AGENT.md` gets a per-agent addition because it carries pr-reviewer-specific payload requirements (PR number, review event). Generic agents (architect, developer, tester, doc-writer, pr-logbook) are covered by the global rule — adding verbatim copies would drift across 16 agents.

**Changes (2 files, +29/-1):**

- `AGENTS.md` (+22): new `### Team Communication` subsection. Rule 1: MUST `SendMessage` result before idle. Rule 2: after 2 silent idles, MUST spawn fresh `Agent` with state (PR number, branch, worktree path, logbook issue).
- `community-config/agents/pr-reviewer/AGENT.md` (+7/-1): step 6 added to cold-start contract; version 1.0.1 → 1.1.0.