### PR TITLE
📝 Enforce build-components.sh regeneration after community-config/ modifications (#37)

### DIFF
--- a/.claude/agents/developer/AGENT.md
+++ b/.claude/agents/developer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -32,6 +32,8 @@ verification you did not perform.
 
 When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
+
+When modifying any file under `community-config/`, follow the **Built Components** rule in `AGENTS.md`.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -32,6 +32,8 @@ verification you did not perform.
 
 When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
+
+When modifying any file under `community-config/`, follow the **Built Components** rule in `AGENTS.md`.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,16 @@ Once the PR is merged and the linked logbook issue closed (see *Logbook Issues �
 git worktree remove .worktrees/<ticket-id>
 ```
 
+### Built Components
+
+Source files under `community-config/` are compiled into `.gemini/` and `.claude/` by `scripts/build-components.sh`. The CI `check-components` job fails if the built outputs drift from sources.
+
+**Rule:** any commit that modifies a file under `community-config/` MUST also run `bash scripts/build-components.sh` and stage the regenerated outputs in the same commit or an immediately following one — never deferred to a separate PR.
+
+**Verify before push:** run `bash scripts/build-components.sh` after staging. A clean `git status --porcelain` means no drift.
+
+This rule applies to every role — doc-writer edits to `SKILL.md`, architect edits to `AGENT.md`, and pr-reviewer self-edits all count. The CI job is a backstop; this rule closes the loop before push.
+
 ### Standard Team Templates
 
 Every role in the templates below operates inside the ticket worktree as

--- a/community-config/agents/developer/AGENT.md
+++ b/community-config/agents/developer/AGENT.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 # Developer Agent
@@ -33,6 +33,8 @@ verification you did not perform.
 
 When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
+
+When modifying any file under `community-config/`, follow the **Built Components** rule in `AGENTS.md`.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in


### PR DESCRIPTION
Closes #37.

Adds a mandatory rule that any agent modifying a source under `community-config/` must run `bash scripts/build-components.sh` and commit the regenerated outputs before pushing. Closes the documented gap where CI's `check-components` job was the only safety net against source/built drift.

## How to read this PR?

1. Start with `AGENTS.md` — the new `### Built Components` rule lives there so it binds every role (developer, doc-writer, pr-logbook, architect, etc.), not just the developer agent.
2. Then check the rebuilt outputs under `.gemini/` and `.claude/` — these are the result of running `bash scripts/build-components.sh` after the edits, demonstrating the rule applied to its own PR.
3. Skim `community-config/agents/developer/AGENT.md` — the developer role gets a reinforcing pointer back to the AGENTS.md rule (no duplicate spec, single source of truth).

## How to test this PR?

Prerequisites: clean working tree on this branch, `bash` available.

1. Verify the rule is discoverable: `grep -n "build-components.sh" AGENTS.md` — expect a hit in the new section.
2. Confirm built outputs match sources:
   ```sh
   bash scripts/build-components.sh
   git status --porcelain
   ```
   Expected: no output (clean tree — built files already up to date with sources).
3. Simulate the failure mode the rule prevents:
   ```sh
   echo "# scratch" >> community-config/skills/pr-logbook/SKILL.md
   bash scripts/build-components.sh
   git diff --stat .gemini/ .claude/
   git checkout -- community-config/ .gemini/ .claude/
   ```
   Expected: the diff covers built outputs under both `.gemini/` and `.claude/`, proving regeneration produces visible drift when sources change.
4. Run the CI check locally: `bash scripts/build-components.sh --check` (or the equivalent task) — expect exit code 0.

## Detailed description (for agents)

**Problem.** `scripts/build-components.sh` regenerates `.gemini/` and `.claude/` from `community-config/` sources. Until now, the obligation to run it before pushing was implicit — only the CI `check-components` job enforced it, after push. Agents working under time pressure routinely skipped the regeneration and let CI fail, costing a round-trip per oversight.

**Change.** A new `### Built Components` section in `AGENTS.md` (immediately after `### Worktree Isolation`) requires every agent that modifies any file under `community-config/` to:

1. Run `bash scripts/build-components.sh` in the worktree.
2. Stage and commit the regenerated outputs (`.gemini/**`, `.claude/**`) in the same commit or an immediately following one — never in a separate PR.
3. Verify a clean tree (`git status --porcelain` empty) before pushing.

The rule is scoped at AGENTS.md level rather than the developer AGENT.md because any role can land a `community-config/` edit: doc-writer (skill prose), architect (AGENT.md design refresh), pr-reviewer (self-edit). A role-scoped rule would leave gaps.

`community-config/agents/developer/AGENT.md` receives a one-liner pointer back to the AGENTS.md rule (no duplicate spec). Version bumped 1.1.0 → 1.2.0 (MINOR — additive pointer).

**Built outputs in this PR.** The `.gemini/` and `.claude/` diffs are the mechanical regeneration after the edits. Re-running `scripts/build-components.sh` on this branch produces a clean tree.

**Out of scope.** The reporter's alternative suggestion (pre-commit hook) is deferred to a follow-up issue — the documented rule is the cheapest first move; CI remains the backstop.