### PR TITLE
📝 Reinforce Rule B compliance for out-of-nominal events (#38)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ Once the PR is merged and the linked logbook issue closed (see *Logbook Issues �
 git worktree remove .worktrees/<ticket-id>
 ```
 
+Any obstacle encountered during the worktree lifecycle — merge conflicts, CI failures, friction declarations, scope changes, rebases that resolve conflicts — must be logged on the issue logbook before resuming work. See **Rule B** for the full trigger list.
+
 ### Built Components
 
 Source files under `community-config/` are compiled into `.gemini/` and `.claude/` by `scripts/build-components.sh`. The CI `check-components` job fails if the built outputs drift from sources.
@@ -304,6 +306,17 @@ batch the entire journey into a single end-of-work comment: batching
 loses the chronological structure, the failed attempts, and the reasoning
 behind course corrections, which is precisely the value the logbook is
 meant to preserve.
+
+Triggers that require an immediate logbook comment:
+
+- Merge conflicts encountered during rebase or merge
+- CI failures (any red check that prompts a code change)
+- Friction declarations (`harness-report` activations)
+- Scope changes or requirement pivots mid-ticket
+- Rebase operations that resolve conflicts (one comment per rebase, summarising the conflict and resolution)
+- Architectural course corrections (an ADR-worthy decision made inline)
+
+The comment must be posted **before** resuming work on the obstacle's resolution — not after the PR is opened.
 
 ### Rule C — Close immediately after merge
 


### PR DESCRIPTION
Reinforce AGENTS.md Rule B so agents post logbook comments the moment a significant obstacle occurs, rather than batching a summary at the end. Closes #38.

## How to read this PR?

1. `AGENTS.md` — two changes: (1) Rule B gets a concrete enumerated trigger list (merge conflicts, CI failures, friction declarations, scope changes, rebases, architectural course corrections) plus a "post before resuming" enforcement sentence; (2) the Worktree Isolation section gets a cross-reference sentence pointing to Rule B, placing the trigger near the lifecycle event most likely to spawn one.

No other files changed — AGENTS.md is the canonical source for logbook rules and is not a versioned component.

## How to test this PR?

1. `grep -n "Triggers that require" AGENTS.md` — expect a hit in the Rule B section.
2. `grep -n "See \*\*Rule B\*\*" AGENTS.md` — expect a hit in the Worktree Isolation section.
3. Manual: confirm Rule B's trigger list enumerates the six obstacle categories.
4. Manual: confirm the cross-reference sentence in Worktree Isolation points to Rule B.
5. `bash scripts/build-components.sh` + `git status --porcelain` — expect clean (AGENTS.md is not under `community-config/`, no regeneration needed).

## Detailed description (for agents)

**Why this PR exists.** Friction cluster `logbook-rule-b-incremental` (issue #38) recorded a violation: during PR #35 / logbook issue #26, a merge conflict, a friction declaration, and a rebase were performed but none logged at occurrence time. An end-of-work summary was posted instead, collapsing the chronological trail Rule B exists to preserve.

**Root cause.** Rule B's existing wording ("every time a significant obstacle, correction, or decision occurs") was too abstract — agents didn't recognise merge conflicts or friction declarations as qualifying events.

**Fix.** Two targeted changes to `AGENTS.md`, no other files:

1. **Rule B** — enumerated trigger list added after the existing paragraph, with an explicit enforcement sentence: "The comment must be posted before resuming work on the obstacle's resolution — not after the PR is opened."
2. **Worktree Isolation** — one cross-reference sentence added at the section end, surfacing the trigger near the lifecycle event (worktree conflicts/rebases) without duplicating the authoritative rule.

**What was deliberately not changed.** `community-config/agents/pr-logbook/AGENT.md` was not touched. The real-time logbook obligation falls on the orchestrating team-lead, not the pr-logbook specialist (which is invoked at PR-draft time). Placing obstacle triggers in pr-logbook AGENT.md would mislead future readers about responsibility ownership.