### PR TITLE
📝 Mandate rebase against main before push in Worktree Isolation protocol (#39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,14 @@ git worktree add -b <branch-name> .worktrees/<ticket-id> crewrig/main
 
 All file edits performed by the team — by every specialist, without exception — **MUST** happen inside `.worktrees/<ticket-id>/`. The main working directory is off-limits for the duration of the ticket; treat it as read-only.
 
+Before pushing, always rebase the worktree branch against the upstream main to avoid merge conflicts on shared files:
+
+```sh
+git fetch crewrig && git rebase crewrig/main
+```
+
+If the rebase raises conflicts, resolve them, then `git rebase --continue`. Log the conflict on the issue logbook before resuming (Rule B).
+
 Once the PR is merged and the linked logbook issue closed (see *Logbook Issues → Rule C*), remove the worktree to keep the repository clean:
 
 ```sh


### PR DESCRIPTION
Closes #39.

Parallel worktrees on tickets #24 and #26 both modified `.github/workflows/build.yml` and collided at push time because the Worktree Isolation protocol does not require refreshing the branch against `main` before publishing. This PR adds a mandatory `git fetch crewrig && git rebase crewrig/main` step to the protocol so the collision window closes by construction.

## How to read this PR?

Single-file change: `AGENTS.md`, *Agent Team Protocol → Worktree Isolation* section. Read the new "Rebase before publish" paragraph that lands between the existing worktree-creation block and the worktree-removal block. Nothing else in the protocol moves; the surrounding sentences are unchanged.

## How to test this PR?

1. Open `AGENTS.md` and locate *Agent Team Protocol → Worktree Isolation*.
2. Confirm the new rebase paragraph appears between the `git worktree add` block and the `git worktree remove` block.
3. Confirm the rebase command targets `crewrig/main` (matching the remote already referenced by `git worktree add … crewrig/main`).
4. Confirm the rule applies before both `git push` and `gh pr create`, and before the `pr-reviewer` cold review.
5. `AGENTS.md` is not a skill/agent source — no version-bump check should trigger.

## Detailed description (for agents)

**Change:** `AGENTS.md` only, +8 lines. One new paragraph added to *Agent Team Protocol → Worktree Isolation*.

**New rule:** Immediately before any `git push` or `gh pr create` (and before handing the diff to `pr-reviewer`), the orchestrating agent MUST run:

```sh
git fetch crewrig && git rebase crewrig/main
```

If the rebase produces conflicts, they MUST be resolved inside the worktree before the push proceeds, and the conflict must be logged on the issue logbook (Rule B). The rebase is mandatory even when the agent believes the branch is up to date — a no-op rebase is negligible overhead; a collision at push time is a manual recovery.

**Rationale:** Tickets #24 and #26 both modified `.github/workflows/build.yml` from worktrees cut against the same `main` snapshot. #24 merged first; #26's push then failed on the shared file. The Worktree Isolation protocol prevented index-level collisions between concurrent agents but said nothing about staleness against `main` at publish time — cross-ticket collisions on shared files were guaranteed to recur.

**Scope:** No code changes. No skill/agent source modified. The rule lives in *Worktree Isolation* (not *Pull Request Format*) because the trigger is the worktree publish step, keeping the worktree lifecycle in one place. No automated enforcement; convention-based, consistent with the rest of *Agent Team Protocol*.