### PR TITLE
📝 Require empirical probe before declaring a tool unavailable (#53)

### DIFF
--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -100,6 +100,41 @@ When the trigger is a bug fix:
 4. Run the rest of the suite to detect regressions in unrelated areas.
 
 A test that never failed before the fix proves nothing.
+
+### 6. Tool availability is empirical, not assumed
+
+Before declaring a test skipped because a tool, binary, subcommand, or
+service is "unavailable", you MUST run a concrete probe against it and
+cite the failure. Acceptable probes, in order of preference:
+
+1. The tool's own discovery flag: `<tool> --help`, `<tool> --version`,
+   `<tool> <subcommand> --help`.
+2. A minimal real invocation with throwaway input (e.g.
+   `<tool> -p "hello"`, a no-op call with `--dry-run`).
+3. A `which <tool>` / `command -v <tool>` check, but only as a
+   precursor — a binary on `$PATH` may still expose the subcommand you
+   need.
+
+A tool is unavailable only when the probe produces one of:
+
+- A non-zero exit code, with stderr captured in the report.
+- An explicit error message ("command not found", "unknown subcommand",
+  "permission denied", "connection refused").
+- A timeout exceeding a stated bound.
+
+Forbidden grounds for declaring unavailability:
+
+- "I don't recognise this subcommand." Recognition is not a probe —
+  CLIs evolve faster than training data.
+- "The documentation I've seen doesn't mention it." Documentation lags
+  releases.
+- "The previous attempt in this session failed." Re-probe; the
+  environment may have changed (PATH, login shell, credentials).
+
+When a probe fails, quote the exact command run and the exact output
+(exit code + first line of stderr) in the skip rationale. A skip
+without a quoted failure is a protocol violation and forces the test
+to be re-attempted.
 
 ## Output expectations
 

--- a/.gemini/skills/tester/SKILL.md
+++ b/.gemini/skills/tester/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -92,6 +92,41 @@ When the trigger is a bug fix:
 4. Run the rest of the suite to detect regressions in unrelated areas.
 
 A test that never failed before the fix proves nothing.
+
+### 6. Tool availability is empirical, not assumed
+
+Before declaring a test skipped because a tool, binary, subcommand, or
+service is "unavailable", you MUST run a concrete probe against it and
+cite the failure. Acceptable probes, in order of preference:
+
+1. The tool's own discovery flag: `<tool> --help`, `<tool> --version`,
+   `<tool> <subcommand> --help`.
+2. A minimal real invocation with throwaway input (e.g.
+   `<tool> -p "hello"`, a no-op call with `--dry-run`).
+3. A `which <tool>` / `command -v <tool>` check, but only as a
+   precursor — a binary on `$PATH` may still expose the subcommand you
+   need.
+
+A tool is unavailable only when the probe produces one of:
+
+- A non-zero exit code, with stderr captured in the report.
+- An explicit error message ("command not found", "unknown subcommand",
+  "permission denied", "connection refused").
+- A timeout exceeding a stated bound.
+
+Forbidden grounds for declaring unavailability:
+
+- "I don't recognise this subcommand." Recognition is not a probe —
+  CLIs evolve faster than training data.
+- "The documentation I've seen doesn't mention it." Documentation lags
+  releases.
+- "The previous attempt in this session failed." Re-probe; the
+  environment may have changed (PATH, login shell, credentials).
+
+When a probe fails, quote the exact command run and the exact output
+(exit code + first line of stderr) in the skip rationale. A skip
+without a quoted failure is a protocol violation and forces the test
+to be re-attempted.
 
 ## Output expectations
 

--- a/.github/skills/tester/SKILL.md
+++ b/.github/skills/tester/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -92,6 +92,41 @@ When the trigger is a bug fix:
 4. Run the rest of the suite to detect regressions in unrelated areas.
 
 A test that never failed before the fix proves nothing.
+
+### 6. Tool availability is empirical, not assumed
+
+Before declaring a test skipped because a tool, binary, subcommand, or
+service is "unavailable", you MUST run a concrete probe against it and
+cite the failure. Acceptable probes, in order of preference:
+
+1. The tool's own discovery flag: `<tool> --help`, `<tool> --version`,
+   `<tool> <subcommand> --help`.
+2. A minimal real invocation with throwaway input (e.g.
+   `<tool> -p "hello"`, a no-op call with `--dry-run`).
+3. A `which <tool>` / `command -v <tool>` check, but only as a
+   precursor — a binary on `$PATH` may still expose the subcommand you
+   need.
+
+A tool is unavailable only when the probe produces one of:
+
+- A non-zero exit code, with stderr captured in the report.
+- An explicit error message ("command not found", "unknown subcommand",
+  "permission denied", "connection refused").
+- A timeout exceeding a stated bound.
+
+Forbidden grounds for declaring unavailability:
+
+- "I don't recognise this subcommand." Recognition is not a probe —
+  CLIs evolve faster than training data.
+- "The documentation I've seen doesn't mention it." Documentation lags
+  releases.
+- "The previous attempt in this session failed." Re-probe; the
+  environment may have changed (PATH, login shell, credentials).
+
+When a probe fails, quote the exact command run and the exact output
+(exit code + first line of stderr) in the skip rationale. A skip
+without a quoted failure is a protocol violation and forces the test
+to be re-attempted.
 
 ## Output expectations
 

--- a/community-config/skills/tester/SKILL.md
+++ b/community-config/skills/tester/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read
@@ -104,6 +104,41 @@ When the trigger is a bug fix:
 4. Run the rest of the suite to detect regressions in unrelated areas.
 
 A test that never failed before the fix proves nothing.
+
+### 6. Tool availability is empirical, not assumed
+
+Before declaring a test skipped because a tool, binary, subcommand, or
+service is "unavailable", you MUST run a concrete probe against it and
+cite the failure. Acceptable probes, in order of preference:
+
+1. The tool's own discovery flag: `<tool> --help`, `<tool> --version`,
+   `<tool> <subcommand> --help`.
+2. A minimal real invocation with throwaway input (e.g.
+   `<tool> -p "hello"`, a no-op call with `--dry-run`).
+3. A `which <tool>` / `command -v <tool>` check, but only as a
+   precursor — a binary on `$PATH` may still expose the subcommand you
+   need.
+
+A tool is unavailable only when the probe produces one of:
+
+- A non-zero exit code, with stderr captured in the report.
+- An explicit error message ("command not found", "unknown subcommand",
+  "permission denied", "connection refused").
+- A timeout exceeding a stated bound.
+
+Forbidden grounds for declaring unavailability:
+
+- "I don't recognise this subcommand." Recognition is not a probe —
+  CLIs evolve faster than training data.
+- "The documentation I've seen doesn't mention it." Documentation lags
+  releases.
+- "The previous attempt in this session failed." Re-probe; the
+  environment may have changed (PATH, login shell, credentials).
+
+When a probe fails, quote the exact command run and the exact output
+(exit code + first line of stderr) in the skip rationale. A skip
+without a quoted failure is a protocol violation and forces the test
+to be re-attempted.
 
 ## Output expectations
 


### PR DESCRIPTION
Closes #53.

The tester skill previously allowed agents to skip tests by asserting a tool was "unavailable" on the strength of recognition alone — i.e. "I don't know this subcommand, therefore it doesn't exist." This PR adds an empirical-probe rule to the tester skill so that unavailability claims must be backed by a captured failure (exit code, error message, or timeout).

## How to read this PR?

1. `community-config/skills/tester/SKILL.md` — the source of truth. New section `### 6. Tool availability is empirical, not assumed` appended after rule 5; `metadata.provenance.version` bumped `1.1.0 → 1.2.0`.
2. `.claude/skills/tester/SKILL.md`, `.gemini/skills/tester/SKILL.md`, `.github/skills/tester/SKILL.md` — built outputs regenerated by `scripts/build-components.sh`. Identical content; same version bump. No drift.

No code paths, hooks, or harness wiring touched — this is a behavior-rule change in a skill document.

## How to test this PR?

Prerequisites: a working tree on this branch.

1. Confirm the built outputs match the source:
   ```sh
   bash scripts/build-components.sh
   git status --porcelain
   ```
   Expected: clean working tree (no drift).

2. Confirm the version-bump check passes:
   ```sh
   bash scripts/check-skill-versions.sh
   ```
   Expected: exit 0; the modified `tester/SKILL.md` files are detected as bumped.

3. Confirm the new section is present in all four locations:
   ```sh
   grep -l "Tool availability is empirical" community-config/skills/tester/SKILL.md .claude/skills/tester/SKILL.md .gemini/skills/tester/SKILL.md .github/skills/tester/SKILL.md
   ```
   Expected: four matching paths.

4. Behavioral acceptance (manual): a tester agent encountering an unavailable tool must run and quote a probe before skipping. A skip without a quoted failure is now a protocol violation.

## Detailed description (for agents)

**Source change** — `community-config/skills/tester/SKILL.md`:

- Inserted new section `### 6. Tool availability is empirical, not assumed` between rule 5 and `## Output expectations`.
- Mandates a probe before declaring unavailability. Three acceptable probe types, in preference order: discovery flags (`--help`, `--version`), minimal real invocation (`--dry-run`, throwaway input), and `which`/`command -v` as precursor only.
- Defines unavailability empirically: non-zero exit + captured stderr, explicit error message (`command not found`, `unknown subcommand`, `permission denied`, `connection refused`), or a timeout exceeding a stated bound.
- Enumerates forbidden grounds: recognition-based dismissal, documentation-lag assumption, prior-session-failure assumption.
- Requires the skip rationale to quote the exact command and the exact output (exit code + first line of stderr). Unquoted skip = protocol violation = re-attempt forced.
- Bumped `metadata.provenance.version` from `1.1.0` to `1.2.0` (MINOR — additive new section, no contract break).

**Built outputs** — `.claude/skills/tester/SKILL.md`, `.gemini/skills/tester/SKILL.md`, `.github/skills/tester/SKILL.md`:

- Regenerated by `scripts/build-components.sh`. Identical body content; same version bump. CI `check-components` job will pass.

**Single commit on branch**: `31b8b18 📝 Require empirical probe before declaring tool unavailable in tester skill (#53)`.