### PR TITLE
📝 Encode CLI parity and symmetric-script rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,58 @@ CLI-prefixed entry in `Taskfile.yml` / `.gitignore`.
 cell, or refreshed `Parity gaps` entry. Drift is a parity bug.
 
 **Parity check.** When adding or modifying a feature for one CLI,
-verify the other. If the symmetric path is missing, either implement
-it in the same PR or record it under `Parity gaps` with a follow-up
-issue link. Silent asymmetry is prohibited.
+verify every other supported CLI. The default is **implement
+symmetrically in the same PR**. Recording a gap is an exception that
+requires written evidence (see *Gap-acceptance evidence rule* below);
+linking a follow-up issue is not, by itself, sufficient justification
+to defer. Silent asymmetry is prohibited.
+
+**Gap-acceptance evidence rule.** A `Parity gaps` entry MAY be added
+only when the agent has produced concrete evidence that no mechanism
+exists in the target CLI to support the feature. "Concrete evidence"
+means at least one of:
+
+- A citation from the CLI's public reference documentation explicitly
+  stating the absence (with URL and quoted sentence in the PR body
+  or the matrix entry itself).
+- An empirical reproduction (command + output) showing the CLI
+  rejecting or ignoring the symmetric artifact.
+- An upstream issue link where the CLI maintainers have declined or
+  deferred the capability.
+
+The following are **NOT** acceptable evidence and MUST NOT be used to
+justify a gap:
+
+- "The public reference does not mention it" (absence of mention is
+  not absence of mechanism — search for user-level, hook-level, and
+  alternative file-system paths first).
+- "A follow-up issue is filed."
+- "Out of scope for this PR."
+
+If the agent's own ADR, design note, or research surfaced a viable
+path — even an unconventional one (user-level config, hook directory,
+env var injection, wrapper script) — that path MUST be implemented in
+the current PR. Documenting a viable path and then declining to use
+it is a parity violation, not a deferral.
+
+**Symmetric-script rule.** When adding a new CLI target, every script
+under `scripts/` that already has a target for an existing CLI MUST
+gain a target for the new CLI in the **same PR** that introduces the
+CLI. This is a direct extension of working code, not new research,
+and is therefore in-scope by default. The list of trigger scripts is
+authoritative:
+
+- `scripts/setup-<cli>-interactive.sh`
+- `scripts/import-<cli>-history.sh`
+- `scripts/manage-<cli>-component.sh` (or a new `--target <cli>`
+  branch in `scripts/manage-workspace-component.sh` if that script
+  already serves multiple CLIs)
+- `scripts/build-components.sh` `--target <cli>` branch
+- Every `Taskfile.yml` entry whose name carries a CLI prefix
+
+Deferring any of the above to a follow-up ticket requires **explicit
+prior user authorization** captured in the PR or its linked logbook
+issue. Agent-initiated deferral of a symmetric script is prohibited.
 
 ## Agent Team Protocol
 

--- a/docs/cli-matrix.md
+++ b/docs/cli-matrix.md
@@ -62,6 +62,11 @@ candidate follow-up issue. **Do not fix them in this ticket.**
 
 ## Adding a new CLI
 
+Every checklist item below is governed by the **Symmetric-script rule**
+and **Gap-acceptance evidence rule** in `AGENTS.md` → *CLI Matrix
+Maintenance*. Unchecking an item requires the evidence the gap rule
+demands; it is not a free-form choice.
+
 Use this checklist when onboarding a new CLI. Each item maps to a row in
 the feature matrix above — leaving one unchecked produces a parity gap.
 


### PR DESCRIPTION
Closes #56. Hardens the CLI parity contract in `AGENTS.md` so that asymmetric CLI work — like the gap the Copilot CLI PR left behind — can no longer be deferred behind a "follow-up issue" link without concrete evidence that no symmetric path exists.

## How to read this PR?

Two files, ~60 lines of net change, no code or skill sources touched:

1. **`AGENTS.md`** — read `## CLI Matrix Maintenance` end-to-end. The existing `**Parity check.**` paragraph was rewritten, then two new rules appended immediately after it: `**Gap-acceptance evidence rule.**` (what counts as evidence of an unsupported feature) and `**Symmetric-script rule.**` (which `scripts/` targets must ship together).
2. **`docs/cli-matrix.md`** — a four-line cross-reference paragraph inserted at the top of `## Adding a new CLI`, pointing readers back to the two new rules.

Key design decisions:

- Evidence is named as an explicit allow-list (public-reference citation with URL, empirical reproduction, upstream issue), and the three most-common bad justifications are banned by name inline. This makes drift cheaper to catch in review than to litigate.
- The symmetric-script list is authoritative, not illustrative — adding a new CLI without one of those targets is a contract violation, not an open question.
- Agent-initiated deferral is prohibited; only explicit prior user authorization allows it. This is a deliberate shift of the default.

## How to test this PR?

```sh
git fetch crewrig
git checkout fix/issue-56-cli-parity-coverage
# Read the new section
sed -n '/## CLI Matrix Maintenance/,/## Agent Team Protocol/p' AGENTS.md
# Verify cross-reference
grep -A4 "## Adding a new CLI" docs/cli-matrix.md | head -10
```

Expected: two new bolded rules under `## CLI Matrix Maintenance`, cross-reference paragraph present at the head of `docs/cli-matrix.md → ## Adding a new CLI`. CI: `check-components` and `check-skill-versions` should pass — no community-config sources changed.

## Detailed description (for agents)

**Files changed:** 2 (`AGENTS.md`, `docs/cli-matrix.md`). **Lines:** +57 / -3.

**`AGENTS.md` — `## CLI Matrix Maintenance`:**

- Replaced the prior `**Parity check.**` paragraph. Old text accepted "record it under Parity gaps with a follow-up issue link" as a sufficient deferral. New text: default is *implement symmetrically in the same PR*; recording a gap is an exception that requires written evidence; a follow-up issue link is explicitly insufficient on its own.
- Appended `**Gap-acceptance evidence rule.**`. Concrete evidence is defined as one of: (a) a public-reference citation with URL and quoted sentence, (b) an empirical reproduction (command + output) showing the CLI rejecting or ignoring the symmetric artifact, (c) an upstream issue link where maintainers declined or deferred. The rule names three justifications that MUST NOT be used: "the public reference does not mention it" (absence of mention ≠ absence of mechanism), "a follow-up issue is filed", and "out of scope for this PR". Adds a forcing clause: if the agent's own ADR/design/research surfaced a viable path — even unconventional (user-level config, hook directory, env var injection, wrapper script) — that path MUST be implemented in the current PR.
- Appended `**Symmetric-script rule.**`. When adding a new CLI target, every script under `scripts/` that already has a target for an existing CLI MUST gain a target for the new CLI in the same PR. Authoritative list: `scripts/setup-<cli>-interactive.sh`, `scripts/import-<cli>-history.sh`, `scripts/manage-<cli>-component.sh` (or a `--target <cli>` branch in `scripts/manage-workspace-component.sh`), `scripts/build-components.sh --target <cli>`, and every `Taskfile.yml` entry with a CLI prefix. Agent-initiated deferral prohibited; explicit prior user authorization is the only deferral path.

**`docs/cli-matrix.md` — `## Adding a new CLI`:** Four-line paragraph inserted before the existing checklist intro, pointing readers to the two new rules in `AGENTS.md` and stating that unchecking a checklist item requires the evidence the gap rule demands.

**Non-changes:** No skill or agent sources modified → no `metadata.provenance.version` bumps. No `community-config/` edits → no rebuild of `.claude/` or `.gemini/` outputs. CI `check-components` and `check-skill-versions` operate against unchanged inputs.

**Root cause closure:** Issue #56 traces the asymmetry to the previous parity-check paragraph treating the follow-up-issue escape hatch as a soft default. This PR moves the default the other way and adds an explicit evidence bar; the loophole is closed at the contract layer rather than via new CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)