### PR TITLE
📝 Add What is CrewRig overview section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,31 @@
 
 This document defines the rules and conventions that all agents (human or AI) must follow when contributing to this project.
 
+## What is CrewRig?
+
+CrewRig is a centralized configuration framework for Gemini CLI, Claude Code,
+and GitHub Copilot CLI. Any agent loading this file should understand these
+five pillars without needing to read README.md or ADRs:
+
+1. **Layered context system engineering** — 00–60 priority files deployed to
+   CLI user directories (`~/.gemini/`, `~/.claude/rules/`,
+   `~/.copilot/instructions/`) that shape how AI assistants behave for a
+   specific user's role, team, and seniority.
+2. **Shared cross-tool memory** — MemPalace provides persistent agent memory
+   accessible across tools and sessions, enabling continuity between Gemini
+   CLI, Claude Code, and Copilot CLI.
+3. **Skill/agent/command creation and sharing** — `community-config/` is a
+   single-source sandbox where skills, agents, and commands are authored once;
+   `scripts/build-components.sh` compiles them into outputs for all three CLIs.
+4. **Harness engineering** — a built-in feedback loop where agents invoke the
+   `harness-report` skill to tag frictions during real work, and the
+   `harness-curator` skill clusters those frictions into actionable GitHub
+   issues.
+5. **Multi-CLI parity** — features are implemented symmetrically across Claude
+   Code, Gemini CLI, and GitHub Copilot CLI. Silent asymmetry is prohibited;
+   every parity gap requires concrete evidence that the missing mechanism does
+   not exist in the target CLI.
+
 ## Language
 
 All **project content must be written in English**. "Project content" covers


### PR DESCRIPTION
## Summary

Adds a concise "What is CrewRig?" section to AGENTS.md so agents loading the file immediately understand the project's five pillars without needing to read README.md or ADRs. Resolves the onboarding-context friction cluster reported in #57.

## How to read this PR?

Single file, single addition: `AGENTS.md` — read the new section at lines 4-28. The section is inserted between the title/description paragraph and the "Language" section.

## How to test this PR?

1. Open `AGENTS.md` and verify the new "What is CrewRig?" section appears after the introductory paragraph and before "## Language".
2. Confirm the five pillars are listed: (1) layered context system, (2) shared cross-tool memory, (3) skill/agent/command sharing, (4) harness engineering, (5) multi-CLI parity.

## Detailed description (for agents)

- **Added**: New `## What is CrewRig?` section (25 lines) at AGENTS.md:4-28.
- **Content**: Five numbered pillars extracted from README.md and ticket #57 suggestion — layered context (00-60 priority files → CLI user dirs), MemPalace cross-tool memory, community-config/ single-source build pipeline, harness-report + harness-curator feedback loop, and multi-CLI parity requirement.
- **Insertion point**: Between the introductory paragraph (line 3) and the existing `## Language` section.
- **Rationale**: Harness curator clustered 1 friction (severity: high) under `onboarding-context` — agents loading AGENTS.md waste time discovering what CrewRig is on every session. This section eliminates that redundant discovery by providing immediate ambient knowledge.
- **Scope**: Documentation-only, no code or community-config/ changes, no version bumps needed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)