### PR TITLE
📝 Add model compatibility rule to Agent Team Protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,16 @@ inherit no conversation context. Use `TaskCreate` for tracking only:
 its `description` should be a one-liner (e.g. `"Implement feature X — full brief in Agent prompt"`), not a duplicate of the Agent prompt. Never write the same
 brief in both places.
 
+**Model compatibility rule**: When the orchestrating Claude Code session
+runs on a non-Anthropic backend (Ollama, Ollama Cloud, or any
+non-default model provider), every spawned `Agent` MUST use the same
+model as the parent orchestrator. This is achieved either by passing an
+explicit `model` parameter matching the parent model identifier, or by
+omitting the `model` parameter to let the harness inherit from the
+parent session. A model mismatch causes spawned agents to fail silently
+— no output, no file edits, no error — which makes
+`TeamCreate`/`TaskCreate`/`Agent` effectively non-functional.
+
 ### On CLIs without team support (e.g. Gemini CLI)
 
 When the harness does not expose `TeamCreate` / `TaskCreate` /


### PR DESCRIPTION
## Summary

Adds a model compatibility rule to the Agent Team Protocol section: spawned agents on non-Anthropic backends (Ollama, Ollama Cloud) must use the same model as the parent orchestrator, or they fail silently. Resolves #62.

## How to read this PR?

Single file, single addition: `AGENTS.md` — read the new paragraph at lines 217-226, inserted after "Single-source brief rule" and before "On CLIs without team support".

## How to test this PR?

1. Open `AGENTS.md` and verify the "Model compatibility rule" paragraph appears in the "On Claude Code CLI" section.
2. Confirm it covers: non-Anthropic backends, explicit model parameter, omission for auto-inheritance, and silent-failure consequence.

## Detailed description (for agents)

- **Added**: `**Model compatibility rule**` paragraph (+10 lines) in AGENTS.md §Agent Team Protocol → On Claude Code CLI.
- **Content**: When orchestrator runs on Ollama/Ollama Cloud/non-default provider, every spawned Agent MUST use the same model — via explicit `model` param or omission (auto-inherit). Model mismatch = silent failure, making TeamCreate/TaskCreate/Agent non-functional.
- **Rationale**: Issue #62 friction cluster. During #57 crew run, all 3 spawned agents (doc-writer, pr-logbook, pr-reviewer) silently failed on Ollama Cloud. Team-lead had to apply edit, write PR body, and review inline — solo work instead of team pipeline. This rule prevents the same class of failure by making the model constraint explicit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)