### PR TITLE
📝 Add Rule 3 — review findings are not auto-deferrals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,15 @@ can resume rather than restart from scratch. Direct `Agent` spawns (without team
 reliably complete and return results; `SendMessage` to a stuck idle
 agent does not.
 
+**Rule 3 — Review findings are not auto-deferrals.** When a reviewer
+lists findings marked "non-blocking", that label means the PR can merge
+without them — it does NOT mean the findings should be deferred to a
+follow-up ticket without asking the user. The agent MUST present every
+finding to the user and implement each one in the same session unless
+the user explicitly decides to skip or defer it. The user sets the
+scope, not the reviewer's severity labels. Auto-deferring findings to
+follow-up tickets without user authorization is prohibited.
+
 ## Pull Request Format
 
 Every PR must follow this structure:


### PR DESCRIPTION
## Summary

Adds Rule 3 to the Team Communication section: non-blocking reviewer findings must be presented to the user for explicit decision, not auto-deferred to follow-up tickets. Resolves #58.

## How to read this PR?

Single file, single addition: `AGENTS.md` — read the new Rule 3 paragraph inserted after Rule 2 (Idle fallback) and before the Pull Request Format section. 9 lines.

## How to test this PR?

1. Open `AGENTS.md` and verify Rule 3 appears in the Team Communication section after Rule 2.
2. Confirm it states: non-blocking means "can merge without" not "defer to follow-up", findings must be presented to the user, user sets scope.

## Detailed description (for agents)

- **Added**: `**Rule 3 — Review findings are not auto-deferrals.**` paragraph (+9 lines) in AGENTS.md §Agent Team Protocol → Team Communication.
- **Content**: Non-blocking label = PR can merge without, NOT auto-defer to follow-up. Agent must present every finding and implement unless user explicitly defers. User sets scope, not reviewer's severity labels.
- **Rationale**: Issue #58 friction cluster. Evidence from crewrig-website PR #11 (aria-controls, role=tabpanel, Playwright tests deferred) and crewrig PR #51 (manage-copilot-component.sh and cross-project hooks deferred as [GAP]). Pattern: agent treats reviewer severity labels as scope decisions, bypassing user authority.
🤖 Generated with [Claude Code](https://claude.com/claude-code)