### PR TITLE
🐛 Probe git remotes instead of hardcoding origin/main in check-skill-versions

### DIFF
--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -10,7 +10,8 @@
 # Usage:
 #   bash scripts/check-skill-versions.sh [<base-ref>]
 #
-# Default base ref: origin/main. CI passes BASE_REF env var
+# Default base ref: probes remotes for crewrig or origin, falls back to the
+# first available remote, and appends /main. CI passes BASE_REF env var
 # pointing at the PR's *target* branch (`base.ref` in GitHub Actions
 # context) — NOT the PR's source/head branch. The guard diffs the PR
 # against what it's about to merge into, so changes that haven't yet

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-BASE_REF="${1:-${BASE_REF:-origin/main}}"
+BASE_REF="${1:-${BASE_REF:-$(git remote | grep -E -m1 'crewrig|origin' || git remote | head -1)/main}}"
 
 # Make sure the base is fetched. CI runners do shallow clones by default.
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then

--- a/scripts/tests/test-check-skill-versions.sh
+++ b/scripts/tests/test-check-skill-versions.sh
@@ -139,6 +139,41 @@ repo3="$(new_repo)"
 run_case "Case 3 — modified component with bump passes" "$repo3" 0
 
 # -------------------------------------------------------------------------
+# Case 4 — Remote probing: repo with crewrig remote (no origin) and no
+# explicit argument exercises the default BASE_REF resolution on line 24.
+# -------------------------------------------------------------------------
+repo4="$(new_repo)"
+(
+  cd "$repo4"
+  git branch -m main  # ensure the branch is named main for crewrig/main
+  mkdir -p community-config/skills/old-skill
+  render_skill "1.0.0" > community-config/skills/old-skill/SKILL.md
+  git add community-config/skills/old-skill/SKILL.md
+  git commit -q -m "seed old-skill at 1.0.0"
+
+  # Head commit: bump version.
+  render_skill "1.0.1" > community-config/skills/old-skill/SKILL.md
+  printf '\nExtra line.\n' >> community-config/skills/old-skill/SKILL.md
+  git add community-config/skills/old-skill/SKILL.md
+  git commit -q -m "patch bump"
+
+  # Add a remote named crewrig (no origin) pointing at the repo itself.
+  git remote add crewrig "$repo4"
+  git fetch crewrig >/dev/null 2>&1
+)
+
+# Run without explicit base ref — exercises the remote-probe fallback.
+actual_exit=0
+( cd "$repo4" && bash "$SCRIPT_UNDER_TEST" >/dev/null 2>&1 ) || actual_exit=$?
+if [ "$actual_exit" -eq 0 ]; then
+  echo "PASS  Case 4 — remote probing (crewrig, no origin) (exit $actual_exit)"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 4 — remote probing (crewrig, no origin) (expected exit 0, got $actual_exit)"
+  fail=$((fail + 1))
+fi
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Replaces the hardcoded `origin/main` fallback in `scripts/check-skill-versions.sh` with a remote probe so the script works when the upstream remote is named `crewrig` (or any name other than `origin`).

## How to read this PR?

1. `scripts/check-skill-versions.sh` L24 — the one-line fix: `origin/main` → remote probe
2. `scripts/tests/test-check-skill-versions.sh` — new Case 4 regression test

## How to test this PR?

```bash
bash scripts/tests/test-check-skill-versions.sh
# Expected: 4 passed, 0 failed
```

Also test manually in a repo with a non-origin remote:

```bash
# In any git repo where the primary remote is 'crewrig':
bash scripts/check-skill-versions.sh
# Should resolve crewrig/main without error
```

## Detailed description (for agents)

**Problem:** `scripts/check-skill-versions.sh` L24 hardcoded `origin/main` as the default BASE_REF fallback. In repos where the upstream remote is named `crewrig` (this repo), the script fails because `origin/main` doesn't exist.

**Fix:** Replaced the hardcoded fallback with a pipeline probe:
```bash
BASE_REF="${1:-${BASE_REF:-$(git remote | grep -E -m1 'crewrig|origin' || git remote | head -1)/main}}"
```

Resolution order: explicit `$1` → `$BASE_REF` env var → first remote matching `crewrig` or `origin` → first available remote.

**Test:** Case 4 creates a temp git repo with only a `crewrig` remote (no `origin`), renames the default branch to `main`, adds a version-bumped skill source, and calls the script with no arguments. This exercises the default BASE_REF resolution path that was previously untested. 4/4 PASS.

**Scope check:**
- `scripts/check-skill-versions.sh` is not in the CLI matrix trigger surface (not a `{build,install,setup,import,manage}-*.sh` script) → no `docs/cli-matrix.md` update needed
- No `community-config/` files touched → no `build-components.sh` needed
- No SemVer bump needed (not a skill/agent source)

Fixes #65.