### PR TITLE
🐛 Fix pr-reviewer CI check obligation in templates and agent protocol

### DIFF
--- a/.claude/agents/pr-reviewer/AGENT.md
+++ b/.claude/agents/pr-reviewer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -27,9 +27,9 @@ On activation:
    `gh pr view <number> --json title,body,files,headRefName,baseRefName,labels`.
 3. Identify the changed file types and select the matching linter
    scripts from the `pr-reviewer` skill bundle.
-4. Activate the `pr-reviewer` skill and follow its five-step protocol
-   (read conventions → fetch diff → run linters → compose review →
-   post).
+4. Activate the `pr-reviewer` skill and follow its six-step protocol
+   (check CI status → read conventions → fetch diff → run linters →
+   compose review → post).
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).

--- a/.gemini/agents/pr-reviewer.md
+++ b/.gemini/agents/pr-reviewer.md
@@ -2,7 +2,7 @@
 name: pr-reviewer
 description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the GitHub MCP."
 ---
-<!-- crewrig-provenance: version="1.1.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # PR Reviewer Agent
 
@@ -22,9 +22,9 @@ On activation:
    `gh pr view <number> --json title,body,files,headRefName,baseRefName,labels`.
 3. Identify the changed file types and select the matching linter
    scripts from the `pr-reviewer` skill bundle.
-4. Activate the `pr-reviewer` skill and follow its five-step protocol
-   (read conventions → fetch diff → run linters → compose review →
-   post).
+4. Activate the `pr-reviewer` skill and follow its six-step protocol
+   (check CI status → read conventions → fetch diff → run linters →
+   compose review → post).
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -27,9 +27,9 @@ On activation:
    `gh pr view <number> --json title,body,files,headRefName,baseRefName,labels`.
 3. Identify the changed file types and select the matching linter
    scripts from the `pr-reviewer` skill bundle.
-4. Activate the `pr-reviewer` skill and follow its five-step protocol
-   (read conventions → fetch diff → run linters → compose review →
-   post).
+4. Activate the `pr-reviewer` skill and follow its six-step protocol
+   (check CI status → read conventions → fetch diff → run linters →
+   compose review → post).
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ user.
 | 2 | `developer` (×N) | Implementation in the worktree |
 | 3 | `tester` | Write / update tests |
 | 4 | `pr-logbook` | Draft PR title, body, and logbook entry |
-| 5 | `pr-reviewer` | Independent cold review of the diff |
+| 5 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
 
 Use multiple `developer` agents in parallel when the work decomposes into
 independent files or modules; a single developer suffices otherwise.
@@ -317,7 +317,7 @@ Lighter pipeline — no code, no tests.
 |---|---|---|
 | 1 | `doc-writer` | Write / update the documentation |
 | 2 | `pr-logbook` | Draft PR title, body, and logbook entry |
-| 3 | `pr-reviewer` | Independent cold review of the diff |
+| 3 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
 
 If the documentation change modifies an established protocol, convention, or
 contract (e.g. AGENTS.md itself), insert `architect` as step 0.
@@ -332,7 +332,7 @@ to lock in reproduction.
 | 1 | `tester` | Write a failing regression test that reproduces the bug |
 | 2 | `developer` | Implement the fix until the regression test passes |
 | 3 | `pr-logbook` | Draft PR title, body, and logbook entry |
-| 4 | `pr-reviewer` | Independent cold review of the diff |
+| 4 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
 
 `architect` is optional: include it only when the root cause exposes a
 design flaw rather than a localized defect.

--- a/community-config/agents/pr-reviewer/AGENT.md
+++ b/community-config/agents/pr-reviewer/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 # PR Reviewer Agent
@@ -30,9 +30,9 @@ On activation:
    `gh pr view <number> --json title,body,files,headRefName,baseRefName,labels`.
 3. Identify the changed file types and select the matching linter
    scripts from the `pr-reviewer` skill bundle.
-4. Activate the `pr-reviewer` skill and follow its five-step protocol
-   (read conventions → fetch diff → run linters → compose review →
-   post).
+4. Activate the `pr-reviewer` skill and follow its six-step protocol
+   (check CI status → read conventions → fetch diff → run linters →
+   compose review → post).
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).


### PR DESCRIPTION
The pr-reviewer SKILL.md already had CI preflight as step 1, but AGENTS.md templates and AGENT.md were not aligned with this requirement.

## How to read this PR?

1. `AGENTS.md` — three template tables, pr-reviewer role description updated
2. `community-config/agents/pr-reviewer/AGENT.md` — source: step count + version bump
3. `.claude/`, `.gemini/`, `.github/` — regenerated outputs

## How to test this PR?

```bash
# Verify no drift between sources and built outputs
bash scripts/build-components.sh
git diff --stat --exit-code
```

Expected: clean exit, no uncommitted changes.

## Detailed description (for agents)

- **AGENTS.md**: Added "verifies CI checks pass before posting verdict" to the `pr-reviewer` role in Template 1 (line 307), Template 2 (line 319), and Template 3 (line 335)
- **community-config/agents/pr-reviewer/AGENT.md**: Fixed stale "five-step protocol" reference → "six-step protocol" with correct step list (check CI status → read conventions → fetch diff → run linters → compose review → post). Bumped PATCH 1.1.0 → 1.1.1
- **Built outputs** (`.claude/agents/pr-reviewer/AGENT.md`, `.gemini/agents/pr-reviewer.md`, `.github/agents/pr-reviewer.md`): regenerated via `build-components.sh`

The `--watch` flag suggested in the friction report was intentionally omitted — the current SKILL.md approach (query state, handle pending/fail/pass explicitly) is better suited for agent workflows where blocking wait could exceed session timeouts.

Closes #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)