### PR TITLE
🐛 Add post-merge flow rule for downstream PR propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,18 @@ rule takes over.
 - **NEVER merge a Pull Request (PR/MR)** without asking for the user's formal permission JUST BEFORE executing the merge.
 - The `import/gitlab` branch tracks the legacy GitLab project (`gitlab` remote) and serves as inspiration only.
 
+## Post-Merge Flow
+
+After any `gh pr merge`, the agent MUST verify the merge target before closing the task:
+
+1. **Check the target branch.** If the PR was merged into `main` (or `master`), no further action is needed — the change is already on the primary branch.
+2. **If the target was NOT `main`/`master`:** verify whether a downstream PR toward `main` is needed. This is required when:
+   - A sibling repository or workflow is gated on `main` (e.g. deploy pipelines that only trigger from `main`).
+   - The merge target is an intermediate integration branch that must eventually reach `main`.
+3. **Open or propose the downstream PR** before considering the task complete. If the downstream PR can be created automatically (fast-forward or trivial rebase), open it. Otherwise, surface the need to the user with a clear explanation of what remains.
+
+This rule applies regardless of whether the merge was initiated by a human or an agent — the obligation to verify downstream propagation is the same.
+
 ## Naming Convention
 
 The [Gitmoji](https://gitmoji.dev/) convention applies to **all named project artifacts** — not only git commit messages:


### PR DESCRIPTION
After merging into a non-main branch, the agent must verify whether a downstream PR toward main is needed before considering the task complete.

## How to read this PR?

Single file: `AGENTS.md` — new `## Post-Merge Flow` section inserted between `## Branching Strategy` and `## Naming Convention`.

## How to test this PR?

Review the rule text for clarity and completeness. No code changes — documentation only.

## Detailed description (for agents)

- **AGENTS.md**: Added `## Post-Merge Flow` section (12 lines) with a 3-step rule: (1) check target branch after `gh pr merge`, (2) if not main/master, verify downstream PR need, (3) open or propose the downstream PR before closing the task. Includes two trigger conditions (sibling repo CI gated on main, intermediate integration branch) and the human-or-agent applicability clause.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)