### PR TITLE
�� Add pr-logbook-before-pr-reviewer ordering constraint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,13 @@ user.
 | 4 | `pr-logbook` | Draft PR title, body, and logbook entry |
 | 5 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
 
+**Ordering constraint:** `pr-logbook` MUST open the PR (or hand the complete
+draft to `team-lead` for opening) before `pr-reviewer` is spawned. The
+orchestrator MUST NOT parallelise these two roles — `pr-reviewer` cannot
+fulfil its cold-start contract without a valid PR number. `pr-reviewer`
+receives the PR number from `pr-logbook`'s result message (see *Team
+Communication → Rule 1*).
+
 Use multiple `developer` agents in parallel when the work decomposes into
 independent files or modules; a single developer suffices otherwise.
 
@@ -330,6 +337,13 @@ Lighter pipeline — no code, no tests.
 | 1 | `doc-writer` | Write / update the documentation |
 | 2 | `pr-logbook` | Draft PR title, body, and logbook entry |
 | 3 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
+
+**Ordering constraint:** `pr-logbook` MUST open the PR (or hand the complete
+draft to `team-lead` for opening) before `pr-reviewer` is spawned. The
+orchestrator MUST NOT parallelise these two roles — `pr-reviewer` cannot
+fulfil its cold-start contract without a valid PR number. `pr-reviewer`
+receives the PR number from `pr-logbook`'s result message (see *Team
+Communication → Rule 1*).
 
 If the documentation change modifies an established protocol, convention, or
 contract (e.g. AGENTS.md itself), insert `architect` as step 0.
@@ -345,6 +359,13 @@ to lock in reproduction.
 | 2 | `developer` | Implement the fix until the regression test passes |
 | 3 | `pr-logbook` | Draft PR title, body, and logbook entry |
 | 4 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
+
+**Ordering constraint:** `pr-logbook` MUST open the PR (or hand the complete
+draft to `team-lead` for opening) before `pr-reviewer` is spawned. The
+orchestrator MUST NOT parallelise these two roles — `pr-reviewer` cannot
+fulfil its cold-start contract without a valid PR number. `pr-reviewer`
+receives the PR number from `pr-logbook`'s result message (see *Team
+Communication → Rule 1*).
 
 `architect` is optional: include it only when the root cause exposes a
 design flaw rather than a localized defect.


### PR DESCRIPTION
Fixes the friction cluster from #68 where the orchestrator parallelised
`pr-logbook` and `pr-reviewer`, breaking `pr-reviewer`'s cold-start
contract because no PR number existed yet.

## How to read this PR?

Single-file change — `AGENTS.md` only. The three added blocks are
structurally identical, one per pipeline template. Start with the
first block (Template 1, after line ~320), then verify the other two
match.

## How to test this PR?

1. Open `AGENTS.md` in the worktree and locate the three pipeline
   templates (Templates 1, 2, and 3).
2. Confirm each template's step table is immediately followed by a
   bold **Ordering constraint:** paragraph.
3. Verify each paragraph states: `pr-logbook` MUST open the PR (or
   hand the draft to `team-lead`) before `pr-reviewer` is spawned,
   and the orchestrator MUST NOT parallelise them.
4. Confirm `pr-reviewer`'s column-5 entry in each table still
   references the "cold review" / "independent cold review" contract,
   consistent with the ordering rationale.

## Detailed description (for agents)

**File:** `AGENTS.md` (+21 lines, 0 deletions across 3 blocks)

**Template 1 — Feature pipeline** (lines 321–327): Added ordering
constraint paragraph between the step table and the "Use multiple
`developer` agents" note. The `pr-logbook` row (step 4) and
`pr-reviewer` row (step 5) remain unchanged; the new paragraph
sits between them conceptually.

**Template 2 — Documentation pipeline** (lines 341–347): Same
constraint block inserted after the 3-step table. The
`pr-logbook` row (step 2) and `pr-reviewer` row (step 3) are
unchanged.

**Template 3 — Bug-fix pipeline** (lines 363–369): Same constraint
block inserted after the 4-step table. `pr-logbook` (step 3) and
`pr-reviewer` (step 4) unchanged.

**Why these 3 templates and not others:** These are the only
templates that pair `pr-logbook` immediately before `pr-reviewer`
in the step sequence. Templates without `pr-reviewer` (e.g. the
refactor pipeline) or without `pr-logbook` do not exhibit the
parallelisation hazard.

**Root cause:** Pipeline templates that list steps in a numbered
table invite parallelisation — the table format is itself the
affordance that caused the orchestrator to spawn both agents
simultaneously. The ordering constraint paragraph acts as an
explicit serialisation barrier that the table alone failed to
provide.

**No version bump required:** The diff touches only `AGENTS.md`,
not any `community-config/skills/*/SKILL.md` or
`community-config/agents/*/AGENT.md` path, so the version-bump
rule (AGENTS.md line ~100) is not triggered.
