### PR TITLE
🧪 Add e2e assertion libraries (side-effect + structural + LLM-judge) (#79)

### DIFF
--- a/docs/adr/0004-e2e-assertion-libs.md
+++ b/docs/adr/0004-e2e-assertion-libs.md
@@ -1,0 +1,456 @@
+# ADR 0004 — e2e assertion libraries (side-effect + structural + LLM-judge)
+
+## Status
+
+Proposed — 2026-05-23. Scoped to issue #79 (child of epic #75). Builds
+on ADR 0001 (Docker images), ADR 0002 (auth flow), ADR 0003 (runner +
+TOML).
+
+## Context
+
+ADR 0003 ships the runner that turns the effective config into
+`docker run` invocations per `(scenario, cli)` pair and emits TAP 13
+to `tests/e2e/reports/<ts>-<rand>/run.tap`. Scenarios themselves are
+plain bash scripts (populated by issue #80) that run inside a CLI's
+e2e container, exercise the CLI, and exit 0/non-zero/78. The runner
+maps the exit code to TAP `ok`/`not ok`/`# SKIP` lines.
+
+What is still missing — and what this ADR specifies — is the
+**assertion vocabulary** scenarios reach for: three sourceable bash
+libraries with consistent signatures, uniform failure semantics, and
+empirically grounded backend choices.
+
+All MemPalace, grep, and Docker behaviours below were verified on
+`crewrig/e2e-base:latest` and `crewrig/e2e-mempalace:latest`
+(MemPalace 3.3.5, GNU grep 3.8) on 2026-05-23. Reproductions are
+inline.
+
+## Decision 1 — Uniform contract across the three libs
+
+Every assertion follows the same five rules:
+
+1. **Naming.** `assert_<noun>_<predicate>` (snake-case). The
+   `llm_judge` function is the lone exception — it is a verb because
+   it is an oracle, not an assertion.
+2. **Return semantics.** `0` on PASS, `1` on FAIL. No other codes.
+   Scenarios run under `set -euo pipefail`, so a FAIL short-circuits
+   the scenario and the runner's existing exit-code dispatcher maps
+   it to `not ok` (see ADR 0003 Decision 4 main loop).
+3. **Failure diagnostic.** On FAIL, emit exactly one TAP-compatible
+   diagnostic line to **stderr**, prefixed with `# `:
+
+   ```text
+   # FAIL <assertion_name> <arg1> [<arg2>…]
+   #   expected: <one-line expected snapshot>
+   #   actual:   <one-line actual snapshot>
+   #   report:   $E2E_REPORT_DIR/<cli>/<scenario>/<artefact>
+   ```
+
+   The runner captures scenario stderr to `<case_dir>/stderr` (ADR
+   0003 line 300), so the diagnostic survives the run and can be
+   surfaced verbatim under the TAP `not ok` line by issue #80's
+   scenarios if desired.
+4. **No PASS chatter.** PASS is silent. A scenario with 20 passing
+   assertions produces zero stderr noise, keeping the report dir
+   small and the TAP stream readable.
+5. **`set -euo pipefail` safe.** Each library opens with the same
+   sourcing-guard idiom used by `scripts/e2e/lib/auth-common.sh`
+   (line 26: `set -o nounset`) and references all positional args
+   with `${1:?missing arg}` style guards so accidental sourcing
+   without arguments fails loud, not silent.
+
+The runner exposes `E2E_REPORT_DIR` and `E2E_LIB_DIR` to every
+scenario — see Decision 5 below.
+
+## Decision 2 — `tests/e2e/lib/assert.sh` (side-effect assertions)
+
+```bash
+assert_file_exists <path>
+assert_file_contains <path> <regex>           # POSIX ERE via `grep -E`
+assert_file_absent <path>
+assert_exit_code <expected> <actual>
+assert_drawer_present <wing> <room> <regex>
+assert_drawer_field <wing> <room> <handoff_key> <field> <expected>
+assert_git_branch_pushed <remote> <branch>
+```
+
+`assert_git_branch_pushed` is `git ls-remote --exit-code --heads
+<remote> <branch> >/dev/null`. The trailing six need no commentary;
+the two MemPalace probes do.
+
+### MemPalace integration — chosen path
+
+**Recommendation: Option (a-thin), `mempalace search` against a
+shared palace via the `crewrig/e2e-mempalace:latest` sidecar mounted
+read-only into the scenario container, parsed with `grep -E`.**
+
+Empirical verification of the CLI surface (2026-05-23):
+
+```text
+$ docker run --rm crewrig/e2e-mempalace:latest mempalace search --help
+usage: mempalace search [-h] [--wing WING] [--room ROOM]
+                       [--results RESULTS] query
+```
+
+The CLI surface is intentionally narrow: only `search` is wing/room-
+scoped and stable. There is **no** `get-drawer`, `list-drawers`, or
+`--output json` flag. The richer surface (`mempalace_get_drawer`,
+`mempalace_list_drawers`, etc., per `60-tools.md`) lives on the
+**MCP server** (`mempalace-mcp`), not the CLI.
+
+This drove the design: rather than wrap a JSON-RPC client in bash
+(option (c), rejected), exploit a property of the handoff drawer
+convention already mandated by `60-tools.md`. Drawer content is
+**structured plain text** with one `field: value` per line:
+
+```text
+[TASK:ongoing] <task-id> | <description>
+
+writer_agent: <agent-name>
+handoff_key: <task-id>
+visible_to: ["*"]
+status: <phase>
+next: <what to do next>
+```
+
+So both probes degrade to a grep against the search output:
+
+```bash
+assert_drawer_present() {
+  local wing="$1" room="$2" regex="$3"
+  mempalace search "$regex" --wing "$wing" --room "$room" --results 5 \
+    | grep -E -q "$regex"
+}
+
+assert_drawer_field() {
+  local wing="$1" room="$2" handoff_key="$3" field="$4" expected="$5"
+  mempalace search "$handoff_key" --wing "$wing" --room "$room" --results 1 \
+    | grep -E -q "^${field}:[[:space:]]+${expected}[[:space:]]*$"
+}
+```
+
+The scenario container reaches the `mempalace` binary by sharing the
+sidecar's palace volume. Two execution paths exist; both are
+acceptable, the choice is deferred to issue #80's scenario harness:
+
+- **Path P1 (simpler):** the scenario `docker exec`s into the
+  long-running `crewrig-e2e-mempalace` sidecar. Requires the sidecar
+  to be `docker run -d` started by the runner before the first
+  MemPalace-touching scenario. Adds one process-lifecycle concern.
+- **Path P2 (sidecar-less):** the scenario `docker run --rm -v
+  <palace-vol>:/home/agent/.mempalace/palace
+  crewrig/e2e-mempalace:latest mempalace search …`. No long-lived
+  process; ~1–2 s container spin-up per probe (same cost profile as
+  `e2e_chown_bootstrap` in ADR 0002).
+
+P2 is the v1 default — fewer moving parts, no sidecar lifecycle in
+the runner. P1 is documented as the optimisation path if probe count
+per scenario climbs above ~5.
+
+### Rejected MemPalace options
+
+- **Option (b), direct host-PATH `mempalace`.** The brief notes
+  `pipx install mempalace` runs as part of `setup-mempalace`. True,
+  but the host palace is the *user's real palace* — scenarios must
+  never mutate or query it. The sidecar's isolated palace volume is
+  the only safe target.
+- **Option (c), MCP-server JSON-RPC from bash.** Implementing a
+  stdio JSON-RPC client in bash is doable but adds ~80 lines of
+  framing, a tool/method registry, and a new failure mode (server
+  cold-start). Pay this cost only when an assertion genuinely needs
+  fields that the plain-text grep cannot reach.
+
+## Decision 3 — `tests/e2e/lib/structural.sh` (structural assertions)
+
+```bash
+assert_stdout_matches <regex>                 # reads from stdin
+assert_json_shape <file> <jq_path> <expected>
+assert_gitmoji_title <string>
+```
+
+`assert_stdout_matches` reads from **stdin only**. Rationale: the
+universal call-site is `<command> | assert_stdout_matches '<re>'`,
+which is one token shorter and one process lighter than the
+file-argument variant. If a scenario needs to assert against a file
+on disk, the existing `assert_file_contains <path> <regex>` covers
+it. Two overloads for one shape is API noise.
+
+`assert_json_shape` shells to `jq -e --arg e "$expected" \
+"$jq_path == \$e" "$file"` and treats `jq`'s natural exit code as
+the assertion's. `jq -e` returns 1 on a `false`/`null` result, 0 on
+a truthy result — the desired contract for free.
+
+`assert_gitmoji_title` enforces the AGENTS.md naming convention. The
+issue body specifies `^\p{Emoji}` which is a PCRE class. Empirical
+verification (2026-05-23, `crewrig/e2e-base:latest`):
+
+```text
+$ docker run --rm crewrig/e2e-base:latest \
+    bash -c 'echo "🐳 test" | grep -P "^\p{Emoji}"; echo "exit=$?"'
+🐳 test
+exit=0
+```
+
+GNU grep 3.8 in Debian bookworm is PCRE-enabled — `\p{Emoji}` works
+out of the box. Implementation:
+
+```bash
+assert_gitmoji_title() {
+  local title="$1"
+  printf '%s' "$title" | grep -P -q '^\p{Emoji}[\p{Emoji_Modifier}\p{Emoji_Component}]*\s+\S'
+}
+```
+
+The class allows ZWJ sequences and the trailing space-then-text shape
+the convention requires (e.g. `✨ Add foo`, `🤖 Generated …`). If PCRE
+support is ever stripped from the base image (open risk #2 below),
+the fallback is an explicit code-range character class — kept out of
+the v1 implementation to avoid maintaining a moving target.
+
+## Decision 4 — `tests/e2e/lib/llm_judge.sh` (LLM-as-judge wrapper)
+
+```bash
+llm_judge <prompt-file> <subject-file> <criterion>
+# stdout (single line): "<verdict> <confidence>"
+#   verdict    ∈ {PASS, FAIL, UNCERTAIN}
+#   confidence ∈ [0.0, 1.0]   (mean over the calls that ran)
+# exit code: 0 on PASS, 1 on FAIL, 2 on UNCERTAIN.
+```
+
+### Backend wiring + new `[judge]` TOML section
+
+`tests/e2e/defaults.toml` gains:
+
+```toml
+[judge]
+backend         = "anthropic"                     # only value supported in v1
+model           = "claude-sonnet-4-5-20250929"    # versioned, not alias
+api_key_env     = "ANTHROPIC_JUDGE_API_KEY"       # separate from runtime key
+endpoint        = "https://api.anthropic.com/v1/messages"
+max_tokens      = 256
+strict          = false                           # UNCERTAIN does NOT fail
+per_call_cap    = 30                              # max llm_judge calls per run
+```
+
+Rationale for a separate `ANTHROPIC_JUDGE_API_KEY`:
+
+- The runtime key (`ANTHROPIC_API_KEY`) is mounted into the Claude
+  CLI container and may be a long-lived OAuth-derived token (ADR
+  0002 Decision 1). The judge runs on the host, not in the
+  container; mixing the keys conflates two failure surfaces and two
+  billing lines.
+- Per-call cap defends against runaway scenarios. The runner
+  maintains a single counter per `run.sh` invocation, persisted to
+  `${E2E_REPORT_DIR}/judge.count`. Calls past the cap return
+  `UNCERTAIN 0.0` with a `# FAIL llm_judge: per-run cap exceeded`
+  diag. Cap is opt-out via `--no-judge-cap` on the runner.
+
+### Quorum strategy — 3 sequential calls with early exit
+
+**Recommendation: sequential, with PASS/FAIL early-exit.** Make call
+1; if PASS, make call 2. If both PASS, return `PASS` without call 3.
+Symmetric for FAIL. If call 1 and call 2 disagree, make call 3 and
+take the majority.
+
+Trade-off rationale:
+
+| | Sequential (recommended) | Parallel |
+|---|---|---|
+| Latency | 1–3 × call (mean 2.0 ×) | 1 × call |
+| Cost | 2–3 calls (mean 2.3) | 3 calls |
+| Error handling | Sequential `set -e` | Wait+collect, partial failures |
+| Bash complexity | ~30 lines | ~60 lines + `wait`/`jobs -p` |
+
+A judge call is ~2–5 s wall-clock. Parallel saves ~5 s per judged
+assertion but adds ~30 lines of error-handling that we get wrong
+twice before getting it right. Sequential's early-exit recovers
+~33 % of the cost when the model is confident — the common path —
+and keeps the code reviewable in one screen.
+
+### UNCERTAIN semantics
+
+- All three calls disagree (one PASS, one FAIL, one of either —
+  no 2-of-3 majority): `UNCERTAIN`, confidence = mean of all three
+  parsed confidences.
+- Any call returns malformed output (no extractable verdict): treat
+  as `UNCERTAIN` for that slot. If two of three slots are malformed,
+  the overall result is `UNCERTAIN`.
+- HTTP error / network failure on a single call: retry once with a
+  1 s backoff, then count as a malformed slot (UNCERTAIN slot, not
+  hard fail). This keeps a flaky network from masquerading as a
+  semantic FAIL.
+
+### `strict` mode
+
+`E2E_JUDGE_STRICT=1` (env override) or `[judge].strict = true` (TOML)
+upgrades UNCERTAIN to FAIL. Default is `false` (UNCERTAIN warns via
+the standard diag block but the assertion returns 0). Rationale: in
+the default mode the judge is advisory; promoting it to a gate is
+the scenario author's explicit choice, not the framework's default.
+
+### Request shape (Anthropic Messages API)
+
+```bash
+curl -sS -X POST "$endpoint" \
+  -H "x-api-key: $key" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d "$(jq -n --arg model "$model" \
+              --arg prompt "$prompt" \
+              --arg subject "$subject" \
+              --arg criterion "$criterion" \
+              --argjson maxtok "$max_tokens" '
+    { model: $model,
+      max_tokens: $maxtok,
+      messages: [
+        { role: "user",
+          content: ($prompt + "\n\nSUBJECT:\n" + $subject
+                    + "\n\nCRITERION:\n" + $criterion
+                    + "\n\nRespond with exactly one line: " +
+                    "VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.0-1.0>") }
+      ] }')"
+```
+
+Parsed by `jq -r '.content[0].text'` → `grep -oE
+'VERDICT=\S+ CONF=\S+'` → split on `=` and ` `. The structured
+response contract (`VERDICT=…  CONF=…`) is the prompt's
+responsibility; malformed output downgrades the slot to UNCERTAIN
+per the rules above.
+
+Shape verified against the Anthropic public docs (Messages API,
+endpoint, version header, request body fields) — see Sources. The
+exact model identifier should be re-confirmed against
+[platform.claude.com](https://platform.claude.com/docs/) at
+implementation time; treat the version pin as a `# TODO: confirm`
+on the developer's plate, not a hard fact of this ADR.
+
+## Decision 5 — Runner integration (no `run.sh` change for #79)
+
+Scenarios source the three libs through a fixed entry-point pattern:
+
+```bash
+# Inside a scenario script (issue #80):
+set -euo pipefail
+: "${E2E_LIB_DIR:?runner must export E2E_LIB_DIR}"
+source "${E2E_LIB_DIR}/assert.sh"
+source "${E2E_LIB_DIR}/structural.sh"
+source "${E2E_LIB_DIR}/llm_judge.sh"
+```
+
+`E2E_LIB_DIR=/path/to/tests/e2e/lib` and `E2E_REPORT_DIR=/path/to/
+tests/e2e/reports/<run-id>` are exported by `tests/e2e/run.sh`
+**when #80 lands**. Both are unset in #79's runner, which is
+expected: #79 ships the libraries, #80 wires the runner to expose
+them and to mount them into the scenario container. The libraries
+themselves degrade cleanly when sourced standalone (they reference
+no env var at source time, only at call time, and only inside the
+diagnostic block).
+
+This deliberately keeps `run.sh` **untouched by #79** — the only
+files this ticket lands are the three `lib/*.sh` files, the
+`[judge]` section in `defaults.toml`, the assertion test harness
+under `scripts/tests/`, and this ADR.
+
+## Decision 6 — Failure diagnostic format
+
+Every failing assertion emits exactly one block on stderr:
+
+```text
+# FAIL <assertion_name> <argv joined by space>
+#   expected: <single-line snapshot, truncated to 200 chars + "…">
+#   actual:   <single-line snapshot, truncated to 200 chars + "…">
+#   report:   ${E2E_REPORT_DIR:-<unset>}/<cli>/<scenario>/<artefact>
+```
+
+The 200-char truncation prevents a multi-MB JSON file from poisoning
+the TAP stream. The `report:` line is omitted when `E2E_REPORT_DIR`
+is unset (standalone sourcing for tests). All three libs share one
+private helper `_e2e_assert_diag <name> <expected> <actual>
+[<artefact>]` to enforce the format.
+
+## Open risks
+
+1. **LLM-judge non-determinism even with quorum.** A 2-of-3 majority
+   on a borderline qualitative check can flip run-to-run. Mitigated
+   by `strict=false` default — borderline cases emit a warning, not
+   a failure. Track quorum-disagreement rate over the first quarter
+   of usage; if >5 % of judged assertions hit UNCERTAIN, revisit
+   prompt design before tightening the gate.
+2. **PCRE `\p{Emoji}` support drift.** Pinned to GNU grep 3.8 in
+   `crewrig/e2e-base` (Debian bookworm). If a future base-image bump
+   strips PCRE or moves to BusyBox grep, `assert_gitmoji_title`
+   breaks silently (PCRE class becomes literal). Mitigation: the
+   library test suite (#3 in the team plan) MUST include a positive
+   smoke against `🐳 test`; CI red-on-bump catches it.
+3. **MemPalace CLI surface is narrow and unversioned.** `mempalace
+   search` is the only wing/room-scoped CLI verb in 3.3.5. A future
+   MemPalace release could change flag names or output format
+   silently. Mitigation: pin the sidecar image tag (already done in
+   ADR 0001 — `crewrig/e2e-mempalace:latest` is a project-controlled
+   build, not an upstream pull); a `mempalace --version` smoke in
+   the library test suite catches version drift at PR time, not at
+   run time.
+4. **Cost runaway via `llm_judge`.** Per-run cap (30 by default)
+   defends against a scenario in a loop. The cap is per-run, not
+   per-scenario; a single scenario could in principle consume the
+   whole budget. Acceptable for v1 — the cap exists to bound
+   blast-radius, not to ration fairly. Revisit if scenarios start
+   competing for budget.
+5. **Sourcing-order coupling.** All three libs share the private
+   `_e2e_assert_diag` helper. The first library sourced defines it;
+   subsequent sources re-define it (bash allows function
+   redefinition silently). Identical definitions across the three
+   files keep this benign, but a future edit to one copy without the
+   others would create a silent divergence. Mitigation: extract the
+   helper into a tiny `tests/e2e/lib/_diag.sh` sourced by each lib
+   if the rule is violated even once.
+
+## Blast radius
+
+New files only:
+
+- `tests/e2e/lib/assert.sh`
+- `tests/e2e/lib/structural.sh`
+- `tests/e2e/lib/llm_judge.sh`
+- `scripts/tests/test-e2e-assert-lib.sh` (and siblings — tester's
+  call)
+- This ADR.
+
+Modified files:
+
+- `tests/e2e/defaults.toml` — add the `[judge]` section per
+  Decision 4. Additive; the runner ignores unknown top-level tables
+  (verified by inspection of `run.sh` lines 137–149 — only
+  `.scenarios` and `.cli` are read).
+
+Explicitly NOT modified by #79:
+
+- `tests/e2e/run.sh` — runner integration deferred to #80.
+- `scripts/e2e/lib/auth-common.sh` — no new helpers needed; the
+  assert libs do not need auth.
+- `docs/cli-matrix.md` — assertion libs are CLI-agnostic
+  infrastructure (no per-CLI behaviour). No parity row required.
+- `community-config/**` — assertion libs are runtime test code, not
+  shipped skills/agents. The `check-components` job and the
+  version-bump rule do not apply.
+
+Reversibility: **trivial**. Every artefact is additive and gated
+behind explicit `source` from a scenario that does not yet exist
+(scenarios land in #80). Removing the three files would be a clean
+revert with no downstream consumers.
+
+## Sources
+
+- Issue #79 acceptance criteria — <https://github.com/Sfeir/crewrig/issues/79>
+- Anthropic Messages API reference — <https://platform.claude.com/docs/en/build-with-claude/working-with-messages>
+- MemPalace 3.3.5 CLI — verified inline via `docker run --rm
+  crewrig/e2e-mempalace:latest mempalace --help` (2026-05-23).
+- GNU grep PCRE `\p{Emoji}` — verified inline against
+  `crewrig/e2e-base:latest` (2026-05-23).
+- ADR 0001 (e2e Docker images) — `docs/adr/0001-e2e-docker-images.md`
+- ADR 0002 (e2e auth flow) — `docs/adr/0002-e2e-auth-flow.md`
+- ADR 0003 (e2e runner + TOML) — `docs/adr/0003-e2e-runner-toml.md`
+- `scripts/e2e/lib/auth-common.sh` — helper-naming convention + exit-78 SKIP.
+- `tests/e2e/run.sh` — scenario exit-code dispatch (lines 298–322).
+- Long-running task convention (drawer payload schema) —
+  `60-tools.md` → *Long-Running Task Convention*.

--- a/docs/adr/0004-e2e-assertion-libs.md
+++ b/docs/adr/0004-e2e-assertion-libs.md
@@ -37,7 +37,8 @@ Every assertion follows the same five rules:
    the scenario and the runner's existing exit-code dispatcher maps
    it to `not ok` (see ADR 0003 Decision 4 main loop).
 3. **Failure diagnostic.** On FAIL, emit exactly one TAP-compatible
-   diagnostic line to **stderr**, prefixed with `# `:
+   diagnostic line to **stderr**, prefixed with the TAP diagnostic
+   marker (hash followed by space):
 
    ```text
    # FAIL <assertion_name> <arg1> [<arg2>…]

--- a/scripts/tests/test-e2e-assert-lib.sh
+++ b/scripts/tests/test-e2e-assert-lib.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# test-e2e-assert-lib.sh — Regression for tests/e2e/lib/assert.sh.
+#
+# Locks ADR 0004 Decisions 1, 2, 6:
+#   - Functions return 0 on PASS, 1 on FAIL. PASS is silent.
+#   - FAIL emits a TAP-compatible diag block "# FAIL <name>" + expected/actual.
+#   - MemPalace probes preflight `mempalace` on PATH.
+#   - `assert_git_branch_pushed` checks a remote ref via ls-remote.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+note_pass() { echo "# PASS $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "# FAIL $1 — $2"; FAIL=$((FAIL + 1)); }
+note_skip() { echo "# SKIP $1: $2"; SKIP=$((SKIP + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="${REPO_DIR}/tests/e2e/lib/assert.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  note_fail "assert.sh present" "missing at $LIB"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+  exit 1
+fi
+note_pass "assert.sh present"
+
+# Sourceable under `set -euo pipefail` (drop -e while sourcing to avoid
+# tripping on the lib's `set -o nounset`-only stance; the lib doc says
+# the SOURCING scenario uses -euo pipefail).
+set +e
+# shellcheck disable=SC1090
+source "$LIB"
+src_rc=$?
+set -e
+if (( src_rc == 0 )); then
+  note_pass "assert.sh sources cleanly"
+else
+  note_fail "assert.sh sources cleanly" "source returned $src_rc"
+fi
+
+TMP="$(mktemp -d -t crewrig-assert-lib.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Diag-block contract: any FAIL must emit "# FAIL <name>" on stderr.
+# Helper: run the assertion in a subshell, capture stderr, return its rc.
+run_capture() {
+  # $1 = path to stderr capture file; rest = command
+  local errfile="$1"; shift
+  set +e
+  ( "$@" ) 2>"$errfile" >/dev/null
+  local rc=$?
+  set -e
+  echo "$rc"
+}
+
+# ---------- assert_file_exists -------------------------------------------
+present="$TMP/present"; : > "$present"
+absent="$TMP/absent"
+
+err="$TMP/err.1"
+rc="$(run_capture "$err" assert_file_exists "$present")"
+if [[ "$rc" == 0 && ! -s "$err" ]]; then
+  note_pass "assert_file_exists: PASS is silent"
+else
+  note_fail "assert_file_exists: PASS is silent" "rc=$rc, stderr bytes=$(wc -c <"$err")"
+fi
+
+err="$TMP/err.2"
+rc="$(run_capture "$err" assert_file_exists "$absent")"
+if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_file_exists' "$err"; then
+  note_pass "assert_file_exists: missing → FAIL+diag"
+else
+  note_fail "assert_file_exists: missing → FAIL+diag" "rc=$rc stderr=$(head -c 200 "$err")"
+fi
+
+# ---------- assert_file_contains -----------------------------------------
+hay="$TMP/hay"; printf 'alpha\nbeta\n' > "$hay"
+err="$TMP/err.3"
+rc="$(run_capture "$err" assert_file_contains "$hay" '^beta$')"
+if [[ "$rc" == 0 && ! -s "$err" ]]; then
+  note_pass "assert_file_contains: match → silent PASS"
+else
+  note_fail "assert_file_contains: match → silent PASS" "rc=$rc"
+fi
+
+err="$TMP/err.4"
+rc="$(run_capture "$err" assert_file_contains "$hay" '^zzz$')"
+if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_file_contains' "$err"; then
+  note_pass "assert_file_contains: no match → FAIL+diag"
+else
+  note_fail "assert_file_contains: no match → FAIL+diag" "rc=$rc"
+fi
+
+err="$TMP/err.5"
+rc="$(run_capture "$err" assert_file_contains "$absent" 'x')"
+if [[ "$rc" != 0 ]] && grep -q 'no such file' "$err"; then
+  note_pass "assert_file_contains: absent file → FAIL+diag"
+else
+  note_fail "assert_file_contains: absent file → FAIL+diag" "rc=$rc"
+fi
+
+# ---------- assert_file_absent -------------------------------------------
+err="$TMP/err.6"
+rc="$(run_capture "$err" assert_file_absent "$absent")"
+if [[ "$rc" == 0 && ! -s "$err" ]]; then
+  note_pass "assert_file_absent: missing → silent PASS"
+else
+  note_fail "assert_file_absent: missing → silent PASS" "rc=$rc"
+fi
+
+err="$TMP/err.7"
+rc="$(run_capture "$err" assert_file_absent "$present")"
+if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_file_absent' "$err"; then
+  note_pass "assert_file_absent: present → FAIL+diag"
+else
+  note_fail "assert_file_absent: present → FAIL+diag" "rc=$rc"
+fi
+
+# ---------- assert_exit_code ---------------------------------------------
+err="$TMP/err.8"
+rc="$(run_capture "$err" assert_exit_code 0 0)"
+if [[ "$rc" == 0 && ! -s "$err" ]]; then
+  note_pass "assert_exit_code: equal → silent PASS"
+else
+  note_fail "assert_exit_code: equal → silent PASS" "rc=$rc"
+fi
+
+err="$TMP/err.9"
+rc="$(run_capture "$err" assert_exit_code 0 1)"
+if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_exit_code' "$err"; then
+  note_pass "assert_exit_code: differ → FAIL+diag"
+else
+  note_fail "assert_exit_code: differ → FAIL+diag" "rc=$rc"
+fi
+
+# ---------- assert_git_branch_pushed -------------------------------------
+# Probe network reachability first; SKIP positive case if offline.
+if ! command -v git >/dev/null 2>&1; then
+  note_skip "assert_git_branch_pushed positive" "git not on PATH"
+  note_skip "assert_git_branch_pushed negative" "git not on PATH"
+elif ! git -C "$REPO_DIR" remote get-url crewrig >/dev/null 2>&1; then
+  note_skip "assert_git_branch_pushed positive" "remote 'crewrig' not configured"
+  note_skip "assert_git_branch_pushed negative" "remote 'crewrig' not configured"
+elif ! ( cd "$REPO_DIR" && git ls-remote --exit-code --heads crewrig main >/dev/null 2>&1 ); then
+  note_skip "assert_git_branch_pushed positive" "crewrig remote unreachable (offline?)"
+  note_skip "assert_git_branch_pushed negative" "crewrig remote unreachable (offline?)"
+else
+  err="$TMP/err.10"
+  rc="$(cd "$REPO_DIR" && run_capture "$err" assert_git_branch_pushed crewrig main)"
+  if [[ "$rc" == 0 && ! -s "$err" ]]; then
+    note_pass "assert_git_branch_pushed: existing → silent PASS"
+  else
+    note_fail "assert_git_branch_pushed: existing → silent PASS" "rc=$rc"
+  fi
+
+  err="$TMP/err.11"
+  rc="$(cd "$REPO_DIR" && run_capture "$err" assert_git_branch_pushed crewrig __no_such_branch_zzz__)"
+  if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_git_branch_pushed' "$err"; then
+    note_pass "assert_git_branch_pushed: absent → FAIL+diag"
+  else
+    note_fail "assert_git_branch_pushed: absent → FAIL+diag" "rc=$rc"
+  fi
+fi
+
+# ---------- assert_drawer_present / assert_drawer_field ------------------
+# The MemPalace MCP-only rule applies: positive cases would require a
+# populated MemPalace volume in a sidecar. We only lock the preflight diag.
+if command -v mempalace >/dev/null 2>&1; then
+  note_skip "assert_drawer_present preflight" "mempalace binary present — skipped to avoid hitting live store"
+  note_skip "assert_drawer_field preflight"   "mempalace binary present — skipped to avoid hitting live store"
+else
+  err="$TMP/err.12"
+  rc="$(run_capture "$err" assert_drawer_present some-wing some-room 'foo')"
+  if [[ "$rc" != 0 ]] && grep -q 'mempalace binary not found' "$err"; then
+    note_pass "assert_drawer_present: no binary → FAIL+diag"
+  else
+    note_fail "assert_drawer_present: no binary → FAIL+diag" "rc=$rc err=$(head -c 200 "$err")"
+  fi
+
+  err="$TMP/err.13"
+  rc="$(run_capture "$err" assert_drawer_field some-wing some-room some-key writer_agent claude)"
+  if [[ "$rc" != 0 ]] && grep -q 'mempalace binary not found' "$err"; then
+    note_pass "assert_drawer_field: no binary → FAIL+diag"
+  else
+    note_fail "assert_drawer_field: no binary → FAIL+diag" "rc=$rc"
+  fi
+fi
+
+# ---------- Diag-block uniformity ----------------------------------------
+# Every FAIL diag captured above must include "expected:" and "actual:" lines.
+combined="$TMP/all_err"; cat "$TMP"/err.* > "$combined" 2>/dev/null || true
+fail_count=$(grep -c '^# FAIL ' "$combined" || true)
+expected_count=$(grep -c '^#   expected:' "$combined" || true)
+actual_count=$(grep -c '^#   actual:' "$combined" || true)
+if (( fail_count >= 5 )) && (( expected_count == fail_count )) && (( actual_count == fail_count )); then
+  note_pass "diag-block uniformity (# FAIL / expected / actual)"
+else
+  note_fail "diag-block uniformity" "fail=$fail_count expected=$expected_count actual=$actual_count"
+fi
+
+echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+(( FAIL == 0 )) || exit 1

--- a/scripts/tests/test-e2e-judge-config.sh
+++ b/scripts/tests/test-e2e-judge-config.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# test-e2e-judge-config.sh — Lock the [judge] schema in tests/e2e/defaults.toml
+# and its surfacing through tests/e2e/lib/toml_merge.sh.
+#
+# ADR 0004 Decision 4: backend/model/api_key_env/strict/max_calls; the
+# implementation also pins endpoint + max_tokens (called out in the lib).
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+note_pass() { echo "# PASS $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "# FAIL $1 — $2"; FAIL=$((FAIL + 1)); }
+note_skip() { echo "# SKIP $1: $2"; SKIP=$((SKIP + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULTS="${REPO_DIR}/tests/e2e/defaults.toml"
+MERGER="${REPO_DIR}/tests/e2e/lib/toml_merge.sh"
+
+command -v yq >/dev/null 2>&1 || { note_skip "yq dependency" "yq not on PATH"; echo "# $PASS passed / $FAIL failed / $SKIP skipped"; exit 0; }
+command -v jq >/dev/null 2>&1 || { note_skip "jq dependency" "jq not on PATH"; echo "# $PASS passed / $FAIL failed / $SKIP skipped"; exit 0; }
+
+# 1. defaults.toml parses cleanly via yq.
+parsed="$(yq -p=toml -o=json '.' "$DEFAULTS" 2>&1)" \
+  && note_pass "defaults.toml parses as TOML" \
+  || note_fail "defaults.toml parses as TOML" "yq: $parsed"
+
+# 2-4. [judge] section + each pinned field.
+check_field() {
+  local path="$1" expected="$2"
+  local actual
+  actual="$(jq -r "$path" <<<"$parsed" 2>/dev/null)"
+  if [[ "$actual" == "$expected" ]]; then
+    note_pass "[judge] ${path#.judge.} == ${expected}"
+  else
+    note_fail "[judge] ${path#.judge.} == ${expected}" "actual='$actual'"
+  fi
+}
+
+if jq -e '.judge' <<<"$parsed" >/dev/null 2>&1; then
+  note_pass "[judge] table present"
+else
+  note_fail "[judge] table present" "missing"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+  exit 1
+fi
+
+check_field '.judge.backend'     'anthropic'
+check_field '.judge.model'       'claude-sonnet-4-6'
+check_field '.judge.api_key_env' 'ANTHROPIC_JUDGE_API_KEY'
+check_field '.judge.strict'      'false'
+check_field '.judge.max_calls'   '30'
+check_field '.judge.endpoint'    'https://api.anthropic.com/v1/messages'
+check_field '.judge.max_tokens'  '256'
+
+# 5. toml_merge.sh with no local.toml surfaces all six (well, seven) fields.
+TMP="$(mktemp -d -t crewrig-judge-cfg.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+merged="$(bash "$MERGER" "$DEFAULTS" 2>"$TMP/merge.err")" \
+  || { note_fail "toml_merge.sh passes through defaults" "$(cat "$TMP/merge.err")";
+       echo "# $PASS passed / $FAIL failed / $SKIP skipped"; exit 1; }
+note_pass "toml_merge.sh passes through defaults"
+
+for f in backend model api_key_env strict max_calls endpoint max_tokens; do
+  # Use `has(...)` rather than `-e`/path, because a false-valued field
+  # makes `jq -e` itself exit 1 despite the field being present.
+  if jq -e ".judge | has(\"${f}\")" <<<"$merged" >/dev/null 2>&1; then
+    note_pass "merged JSON exposes .judge.${f}"
+  else
+    note_fail "merged JSON exposes .judge.${f}" "field missing"
+  fi
+done
+
+echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+(( FAIL == 0 )) || exit 1

--- a/scripts/tests/test-e2e-libs-readme.sh
+++ b/scripts/tests/test-e2e-libs-readme.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# test-e2e-libs-readme.sh — Content guarantees for tests/e2e/lib/README.md
+# and the pointer added to tests/e2e/README.md (issue #79).
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+note_pass() { echo "# PASS $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "# FAIL $1 — $2"; FAIL=$((FAIL + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB_README="${REPO_DIR}/tests/e2e/lib/README.md"
+TOP_README="${REPO_DIR}/tests/e2e/README.md"
+
+# --- lib/README.md -------------------------------------------------------
+if [[ -f "$LIB_README" ]]; then
+  note_pass "lib/README.md exists"
+else
+  note_fail "lib/README.md exists" "missing at $LIB_README"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"; exit 1
+fi
+
+lines="$(wc -l <"$LIB_README" | tr -d ' ')"
+if [[ "$lines" -le 200 ]]; then
+  note_pass "lib/README.md within 200-line budget ($lines lines)"
+else
+  note_fail "lib/README.md within 200-line budget" "$lines lines"
+fi
+
+# Headings / coverage of the three libs.
+for needle in 'assert.sh' 'structural.sh' 'llm_judge.sh'; do
+  if grep -q "$needle" "$LIB_README"; then
+    note_pass "lib/README.md mentions $needle"
+  else
+    note_fail "lib/README.md mentions $needle" "no occurrence"
+  fi
+done
+
+# ANTHROPIC_JUDGE_API_KEY separation rationale.
+if grep -q 'ANTHROPIC_JUDGE_API_KEY' "$LIB_README" \
+     && grep -qE 'separate|accounting|isolation' "$LIB_README"; then
+  note_pass "lib/README.md explains ANTHROPIC_JUDGE_API_KEY separation"
+else
+  note_fail "lib/README.md explains ANTHROPIC_JUDGE_API_KEY separation" \
+            "missing 'separate|accounting|isolation' near the key name"
+fi
+
+# max_calls cap documented.
+if grep -q 'max_calls' "$LIB_README"; then
+  note_pass "lib/README.md documents max_calls cap"
+else
+  note_fail "lib/README.md documents max_calls cap" "missing"
+fi
+
+# macOS / BSD grep caveat for assert_gitmoji_title.
+if grep -qE 'BSD|macOS' "$LIB_README"; then
+  note_pass "lib/README.md flags the macOS/BSD grep caveat"
+else
+  note_fail "lib/README.md flags the macOS/BSD grep caveat" "no BSD/macOS mention"
+fi
+
+# --- tests/e2e/README.md -------------------------------------------------
+if [[ -f "$TOP_README" ]]; then
+  note_pass "tests/e2e/README.md exists"
+else
+  note_fail "tests/e2e/README.md exists" "missing"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"; exit 1
+fi
+
+# Pointer to lib/README.md (relative link).
+if grep -q 'lib/README.md' "$TOP_README"; then
+  note_pass "tests/e2e/README.md points at lib/README.md"
+else
+  note_fail "tests/e2e/README.md points at lib/README.md" "no 'lib/README.md' reference"
+fi
+
+# Existing 200-line budget (locked by #78) still holds.
+lines="$(wc -l <"$TOP_README" | tr -d ' ')"
+if [[ "$lines" -le 200 ]]; then
+  note_pass "tests/e2e/README.md within 200-line budget ($lines lines)"
+else
+  note_fail "tests/e2e/README.md within 200-line budget" "$lines lines"
+fi
+
+echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+(( FAIL == 0 )) || exit 1

--- a/scripts/tests/test-e2e-llm-judge-lib.sh
+++ b/scripts/tests/test-e2e-llm-judge-lib.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# test-e2e-llm-judge-lib.sh — Regression for tests/e2e/lib/llm_judge.sh.
+#
+# Locks ADR 0004 Decision 4 (LLM-as-judge wrapper):
+#   - Sourceable, preflights env vars and tools.
+#   - 2-of-3 quorum with PASS/PASS and FAIL/FAIL early-exit.
+#   - UNCERTAIN warns by default, fails when E2E_JUDGE_STRICT=1.
+#   - Per-run counter at ${E2E_REPORT_DIR}/judge.count.
+#   - max_calls cap enforced via [judge] in effective.json.
+#
+# All API calls are mocked via the lib's built-in E2E_JUDGE_MOCK / curl
+# stub mechanism — no network, no real key required.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+note_pass() { echo "# PASS $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "# FAIL $1 — $2"; FAIL=$((FAIL + 1)); }
+note_skip() { echo "# SKIP $1: $2"; SKIP=$((SKIP + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="${REPO_DIR}/tests/e2e/lib/llm_judge.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  note_fail "llm_judge.sh present" "missing at $LIB"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+  exit 1
+fi
+note_pass "llm_judge.sh present"
+
+if ! command -v jq >/dev/null 2>&1; then
+  note_skip "llm_judge sourceable" "jq not on PATH"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+  exit 0
+fi
+
+# 1. Sourceable, exports llm_judge function.
+if bash -c "set -euo pipefail; source '$LIB'; type llm_judge >/dev/null"; then
+  note_pass "llm_judge.sh sources and defines llm_judge"
+else
+  note_fail "llm_judge.sh sources and defines llm_judge" "source/type failed"
+fi
+
+TMP="$(mktemp -d -t crewrig-llm-judge.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PROMPT="$TMP/prompt"; printf 'judge politely\n' > "$PROMPT"
+SUBJECT="$TMP/subject"; printf 'the response text\n' > "$SUBJECT"
+
+# Build an effective.json fixture matching the runner contract.
+mk_effective_json() {
+  # $1 = max_calls
+  local cap="$1"
+  local rd="$2"
+  jq -n --argjson cap "$cap" '{
+    judge: {
+      model: "claude-sonnet-4-6",
+      api_key_env: "ANTHROPIC_JUDGE_API_KEY",
+      strict: false,
+      max_calls: $cap,
+      endpoint: "https://api.anthropic.com/v1/messages",
+      max_tokens: 256
+    }
+  }' > "$rd/effective.json"
+}
+
+# Helper: invoke llm_judge with a controlled mock response.
+# Args: <verdict-line>  e.g. "VERDICT=PASS CONF=0.9"
+# When E2E_JUDGE_MOCK=1, the lib reads E2E_JUDGE_MOCK_RESPONSE for each
+# slot. To vary per-slot we wrap with a shim that consumes from a queue.
+
+# We exercise the lib's `mock` path through E2E_JUDGE_MOCK=1; the lib
+# uses one E2E_JUDGE_MOCK_RESPONSE per call. To feed a *sequence*, we
+# replace the `_llm_judge_one_call` after sourcing with a stub that pops
+# from a file queue. This stays inside the wrapper's public surface
+# (verdict line in / verdict out).
+run_judge_sequence() {
+  # Args: <REPORT_DIR> <strict 0|1> <responses-file-with-one-line-per-call>
+  local rd="$1"; local strict="$2"; local queue="$3"
+  cp "$queue" "$rd/queue"
+  E2E_REPORT_DIR="$rd" \
+  E2E_JUDGE_STRICT="$strict" \
+  ANTHROPIC_JUDGE_API_KEY="dummy-key" \
+  E2E_JUDGE_MOCK=1 \
+  QUEUE_FILE="$rd/queue" \
+  bash -c '
+    set -uo pipefail
+    source "'"$LIB"'"
+    # Override the single-call helper to pop from a queue. Honors the
+    # counter increment per call (matches real-call accounting).
+    _llm_judge_one_call() {
+      local line=""
+      if [[ -s "$QUEUE_FILE" ]]; then
+        line="$(head -n1 "$QUEUE_FILE")"
+        # consume one line
+        tail -n +2 "$QUEUE_FILE" > "$QUEUE_FILE.tmp" && mv "$QUEUE_FILE.tmp" "$QUEUE_FILE"
+      fi
+      if [[ -z "$line" || "$line" == "MALFORMED" ]]; then
+        # Treat as malformed slot.
+        _llm_judge_counter_increment 2>/dev/null || true
+        return 1
+      fi
+      _llm_judge_counter_increment 2>/dev/null || true
+      printf "%s\n" "$line"
+    }
+    llm_judge "'"$PROMPT"'" "'"$SUBJECT"'" "is it polite?"
+  '
+}
+
+# Convenience: make a queue file from arguments.
+mk_queue() {
+  local f="$1"; shift
+  : > "$f"
+  for line in "$@"; do
+    printf '%s\n' "$line" >> "$f"
+  done
+}
+
+# ---------- 2. Missing API key → FAIL+diag --------------------------------
+rd2="$TMP/rd_nokey"; mkdir -p "$rd2"; mk_effective_json 30 "$rd2"
+err="$TMP/err_nokey"
+set +e
+( unset ANTHROPIC_JUDGE_API_KEY
+  E2E_REPORT_DIR="$rd2" \
+  bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'"
+) 2>"$err" >/dev/null
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] && grep -q 'ANTHROPIC_JUDGE_API_KEY is unset or empty' "$err"; then
+  note_pass "llm_judge: missing API key → FAIL+diag"
+else
+  note_fail "llm_judge: missing API key → FAIL+diag" "rc=$rc err=$(head -c 300 "$err")"
+fi
+
+# ---------- 3. Mocked quorum scenarios ------------------------------------
+# 3a. 3× PASS (well, early-exits after 2) → PASS, exit 0.
+rd="$TMP/rd_3pass"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
+queue="$TMP/q_3pass"; mk_queue "$queue" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9"
+out="$TMP/out_3pass"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "quorum: PASS/PASS → exit 0 + VERDICT=PASS"
+else
+  note_fail "quorum: PASS/PASS → exit 0 + VERDICT=PASS" "rc=$rc out=$(cat "$out")"
+fi
+# Counter should be 2 (early-exit after 2 PASS).
+count="$(cat "$rd/judge.count" 2>/dev/null || echo 0)"
+if [[ "$count" == "2" ]]; then
+  note_pass "quorum: counter increments to 2 on early-exit PASS"
+else
+  note_fail "quorum: counter increments to 2 on early-exit PASS" "count=$count"
+fi
+
+# 3b. FAIL/FAIL early-exit → FAIL.
+rd="$TMP/rd_2fail"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
+queue="$TMP/q_2fail"; mk_queue "$queue" "VERDICT=FAIL CONF=0.8" "VERDICT=FAIL CONF=0.8" "VERDICT=PASS CONF=0.9"
+out="$TMP/out_2fail"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] && grep -q '^VERDICT=FAIL confidence=' "$out"; then
+  note_pass "quorum: FAIL/FAIL → exit 1 + VERDICT=FAIL"
+else
+  note_fail "quorum: FAIL/FAIL → exit 1 + VERDICT=FAIL" "rc=$rc out=$(cat "$out")"
+fi
+
+# 3c. PASS/FAIL/PASS → no early-exit until slot 3 → 2 PASS → PASS.
+rd="$TMP/rd_pfp"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
+queue="$TMP/q_pfp"; mk_queue "$queue" "VERDICT=PASS CONF=0.7" "VERDICT=FAIL CONF=0.7" "VERDICT=PASS CONF=0.7"
+out="$TMP/out_pfp"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "quorum: PASS/FAIL/PASS → majority PASS"
+else
+  note_fail "quorum: PASS/FAIL/PASS → majority PASS" "rc=$rc out=$(cat "$out")"
+fi
+
+# 3d. PASS/FAIL/UNCERTAIN → no majority → UNCERTAIN; default = exit 0 with warn.
+rd="$TMP/rd_pfu"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
+queue="$TMP/q_pfu"; mk_queue "$queue" "VERDICT=PASS CONF=0.6" "VERDICT=FAIL CONF=0.6" "VERDICT=UNCERTAIN CONF=0.5"
+out="$TMP/out_pfu"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=UNCERTAIN confidence=' "$out" && grep -q 'WARN llm_judge UNCERTAIN' "$out"; then
+  note_pass "quorum: no majority → UNCERTAIN, default warns (exit 0)"
+else
+  note_fail "quorum: no majority → UNCERTAIN, default warns" "rc=$rc out=$(cat "$out")"
+fi
+
+# 3e. Same sequence but strict=1 → exit 1.
+rd="$TMP/rd_strict"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
+queue="$TMP/q_strict"; mk_queue "$queue" "VERDICT=PASS CONF=0.6" "VERDICT=FAIL CONF=0.6" "VERDICT=UNCERTAIN CONF=0.5"
+out="$TMP/out_strict"
+set +e
+run_judge_sequence "$rd" 1 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] && grep -q '^VERDICT=UNCERTAIN' "$out"; then
+  note_pass "quorum: UNCERTAIN + strict → exit 1"
+else
+  note_fail "quorum: UNCERTAIN + strict → exit 1" "rc=$rc out=$(cat "$out")"
+fi
+
+# 3f. Malformed in 2 of 3 slots → UNCERTAIN.
+rd="$TMP/rd_mal"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
+queue="$TMP/q_mal"; mk_queue "$queue" "VERDICT=PASS CONF=0.7" "MALFORMED" "MALFORMED"
+out="$TMP/out_mal"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=UNCERTAIN' "$out"; then
+  note_pass "quorum: 2/3 malformed → UNCERTAIN"
+else
+  note_fail "quorum: 2/3 malformed → UNCERTAIN" "rc=$rc out=$(cat "$out")"
+fi
+
+# ---------- 5. max_calls cap ---------------------------------------------
+# Cap=1 in effective.json; pre-bump counter to 1; next call must refuse.
+rd="$TMP/rd_cap"; mkdir -p "$rd"; mk_effective_json 1 "$rd"
+printf '1\n' > "$rd/judge.count"
+queue="$TMP/q_cap"; mk_queue "$queue" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9"
+out="$TMP/out_cap"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] && grep -q 'per-run cap exceeded' "$out"; then
+  note_pass "max_calls: cap reached → FAIL+diag pointing at judge.count"
+else
+  note_fail "max_calls: cap reached → FAIL+diag" "rc=$rc out=$(cat "$out")"
+fi
+# And the queue MUST still be 3 lines — nothing consumed.
+remaining=$(wc -l < "$rd/queue" | tr -d ' ')
+if [[ "$remaining" == "3" ]]; then
+  note_pass "max_calls: refusal consumes zero queue items"
+else
+  note_fail "max_calls: refusal consumes zero queue items" "remaining=$remaining"
+fi
+
+echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+(( FAIL == 0 )) || exit 1

--- a/scripts/tests/test-e2e-structural-lib.sh
+++ b/scripts/tests/test-e2e-structural-lib.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# test-e2e-structural-lib.sh — Regression for tests/e2e/lib/structural.sh.
+#
+# Locks ADR 0004 Decisions 1, 3, 6:
+#   - assert_stdout_matches: stdin or file form, ERE.
+#   - assert_json_shape: jq-driven JSON-shape probe.
+#   - assert_gitmoji_title: PCRE `^\p{Emoji}…`, MUST run under GNU grep
+#     (inside crewrig/e2e-base:latest — BSD grep on macOS lacks \p{Emoji}).
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+note_pass() { echo "# PASS $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "# FAIL $1 — $2"; FAIL=$((FAIL + 1)); }
+note_skip() { echo "# SKIP $1: $2"; SKIP=$((SKIP + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="${REPO_DIR}/tests/e2e/lib/structural.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  note_fail "structural.sh present" "missing at $LIB"
+  echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+  exit 1
+fi
+note_pass "structural.sh present"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+TMP="$(mktemp -d -t crewrig-structural-lib.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+run_capture() {
+  local errfile="$1"; shift
+  set +e
+  ( "$@" ) 2>"$errfile" >/dev/null
+  local rc=$?
+  set -e
+  echo "$rc"
+}
+
+# ---------- assert_stdout_matches: stdin form ----------------------------
+err="$TMP/err.1"
+set +e
+( echo "alpha-line" | assert_stdout_matches '^alpha-' ) 2>"$err" >/dev/null
+rc=$?
+set -e
+if [[ "$rc" == 0 && ! -s "$err" ]]; then
+  note_pass "assert_stdout_matches stdin: match → silent PASS"
+else
+  note_fail "assert_stdout_matches stdin: match → silent PASS" "rc=$rc"
+fi
+
+err="$TMP/err.2"
+set +e
+( echo "alpha-line" | assert_stdout_matches '^zzz$' ) 2>"$err" >/dev/null
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_stdout_matches' "$err"; then
+  note_pass "assert_stdout_matches stdin: miss → FAIL+diag"
+else
+  note_fail "assert_stdout_matches stdin: miss → FAIL+diag" "rc=$rc"
+fi
+
+# ---------- assert_stdout_matches: file form -----------------------------
+fixture="$TMP/fx"; printf 'gamma\n' > "$fixture"
+err="$TMP/err.3"
+rc="$(run_capture "$err" assert_stdout_matches '^gamma$' "$fixture")"
+if [[ "$rc" == 0 && ! -s "$err" ]]; then
+  note_pass "assert_stdout_matches file: match → silent PASS"
+else
+  note_fail "assert_stdout_matches file: match → silent PASS" "rc=$rc"
+fi
+
+err="$TMP/err.4"
+rc="$(run_capture "$err" assert_stdout_matches 'x' "$TMP/nope")"
+if [[ "$rc" != 0 ]] && grep -q 'no such file' "$err"; then
+  note_pass "assert_stdout_matches file: absent → FAIL+diag"
+else
+  note_fail "assert_stdout_matches file: absent → FAIL+diag" "rc=$rc"
+fi
+
+# ---------- assert_json_shape --------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  note_skip "assert_json_shape" "jq not on PATH"
+else
+  empty="$TMP/empty.json"; echo '{}' > "$empty"
+  err="$TMP/err.5"
+  rc="$(run_capture "$err" assert_json_shape "$empty" '.' '{}')"
+  if [[ "$rc" == 0 && ! -s "$err" ]]; then
+    note_pass "assert_json_shape: {} matches '.' → silent PASS"
+  else
+    note_fail "assert_json_shape: {} matches '.' → silent PASS" "rc=$rc err=$(cat "$err")"
+  fi
+
+  one="$TMP/one.json"; echo '{"a":1}' > "$one"
+  err="$TMP/err.6"
+  rc="$(run_capture "$err" assert_json_shape "$one" '.a' '1')"
+  if [[ "$rc" == 0 && ! -s "$err" ]]; then
+    note_pass "assert_json_shape: .a == 1 → silent PASS"
+  else
+    note_fail "assert_json_shape: .a == 1 → silent PASS" "rc=$rc"
+  fi
+
+  err="$TMP/err.7"
+  rc="$(run_capture "$err" assert_json_shape "$one" '.a' '2')"
+  if [[ "$rc" != 0 ]] && grep -q '^# FAIL assert_json_shape' "$err"; then
+    note_pass "assert_json_shape: mismatch → FAIL+diag"
+  else
+    note_fail "assert_json_shape: mismatch → FAIL+diag" "rc=$rc"
+  fi
+
+  err="$TMP/err.8"
+  rc="$(run_capture "$err" assert_json_shape "$TMP/missing.json" '.' '{}')"
+  if [[ "$rc" != 0 ]] && grep -q 'no such file' "$err"; then
+    note_pass "assert_json_shape: absent → FAIL+diag"
+  else
+    note_fail "assert_json_shape: absent → FAIL+diag" "rc=$rc"
+  fi
+fi
+
+# ---------- assert_gitmoji_title (docker-only) ---------------------------
+# `grep -P '\p{Emoji}'` is GNU-grep specific. macOS BSD grep cannot run
+# this — execute inside crewrig/e2e-base:latest if available.
+if ! command -v docker >/dev/null 2>&1; then
+  note_skip "assert_gitmoji_title (docker)" "docker not on PATH"
+elif ! docker image inspect crewrig/e2e-base:latest >/dev/null 2>&1; then
+  note_skip "assert_gitmoji_title (docker)" "image crewrig/e2e-base:latest not built locally (run task e2e:build)"
+else
+  out="$TMP/gitmoji.out"
+  if docker run --rm \
+       -v "$REPO_DIR:/work:ro" -w /work \
+       --entrypoint bash crewrig/e2e-base:latest -c '
+    set -u
+    source tests/e2e/lib/structural.sh
+    pass=0; fail=0
+    # Positive cases (must PASS)
+    for t in "🐳 Add docker" "✨ Initial commit"; do
+      if assert_gitmoji_title "$t" 2>/dev/null; then
+        echo "OK POS: $t"; pass=$((pass+1))
+      else
+        echo "BAD POS: $t"; fail=$((fail+1))
+      fi
+    done
+    # Negative cases (must FAIL)
+    for t in "Add foo" "🐳"; do
+      if assert_gitmoji_title "$t" 2>/dev/null; then
+        echo "BAD NEG: $t"; fail=$((fail+1))
+      else
+        echo "OK NEG: $t"; pass=$((pass+1))
+      fi
+    done
+    echo "DONE pass=$pass fail=$fail"
+    exit $fail
+  ' > "$out" 2>&1; then
+    if grep -q 'DONE pass=4 fail=0' "$out"; then
+      note_pass "assert_gitmoji_title (docker): 2 positive + 2 negative"
+    else
+      note_fail "assert_gitmoji_title (docker)" "unexpected output: $(tail -5 "$out")"
+    fi
+  else
+    note_fail "assert_gitmoji_title (docker)" "container exited non-zero: $(tail -10 "$out")"
+  fi
+fi
+
+echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+(( FAIL == 0 )) || exit 1

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -184,6 +184,12 @@ matters on shared CI runners where `$HOME` is multi-tenant.
 | Scenario fails mid-run with auth error after ~1 h | OAuth access token expired and the RO mount blocked the refresh write. | For long scenarios, set `CLAUDE_CODE_OAUTH_TOKEN` / `GEMINI_API_KEY` in your shell instead. |
 | `image 'crewrig/e2e-<cli>:latest' is not present locally` | You skipped `task e2e:build`. | Run `task e2e:build` (or `task e2e:build:<cli>`). |
 
+## Assertion libraries
+
+Scenarios assert via three sourceable bash libraries under
+`tests/e2e/lib/` — see [`lib/README.md`](lib/README.md) and
+[ADR 0004](../../docs/adr/0004-e2e-assertion-libs.md).
+
 ## Pointers
 
 - Design — [`docs/adr/0001-e2e-docker-images.md`](../../docs/adr/0001-e2e-docker-images.md),

--- a/tests/e2e/defaults.toml
+++ b/tests/e2e/defaults.toml
@@ -49,6 +49,21 @@ command_args = []
 mounts       = []
 env_keys     = ["COPILOT_GITHUB_TOKEN"]
 
+# [judge] — LLM-as-judge wrapper config (see ADR 0004 Decision 4 and
+# tests/e2e/lib/llm_judge.sh). All fields are overridable via local.toml.
+# `api_key_env` is intentionally distinct from `ANTHROPIC_API_KEY` so the
+# judge's billing/quota line stays separated from the runtime CLI key
+# (which may point at the same upstream key value — separation is about
+# accounting, not secrecy).
+[judge]
+backend     = "anthropic"
+model       = "claude-sonnet-4-6"            # Update when a newer stable Sonnet ships.
+api_key_env = "ANTHROPIC_JUDGE_API_KEY"
+endpoint    = "https://api.anthropic.com/v1/messages"
+max_tokens  = 256
+strict      = false                          # UNCERTAIN warns; does NOT fail.
+max_calls   = 30                             # Per-run hard cap on Messages API calls.
+
 # [scenarios.*] — placeholder. Issue #80 will populate this section with the
 # real scenario library. Until then the runner emits a "no scenarios defined
 # yet" TAP plan and exits 0 cleanly.

--- a/tests/e2e/lib/README.md
+++ b/tests/e2e/lib/README.md
@@ -11,9 +11,9 @@ about a CLI's behaviour. Governed by
 | `llm_judge.sh` | **Last resort.** LLM-as-judge oracle for qualitative criteria a regex cannot express. Each call burns budget and adds non-determinism — reach for it only when the first two cannot answer the question. |
 
 Every assertion returns `0` on PASS, `1` on FAIL, and PASS is silent.
-FAIL emits a single TAP-compatible diagnostic block to stderr (`# FAIL`
-+ `expected` / `actual` / `report` lines, truncated to 200 chars). The
-runner captures scenario stderr under
+FAIL emits a single TAP-compatible diagnostic block to stderr — a
+`# FAIL` header line plus `expected`, `actual`, and `report` lines,
+each truncated to 200 chars. The runner captures scenario stderr under
 `${E2E_REPORT_DIR}/<cli>/<scenario>/stderr`.
 
 ## Sourcing pattern

--- a/tests/e2e/lib/README.md
+++ b/tests/e2e/lib/README.md
@@ -1,0 +1,141 @@
+# Assertion libraries
+
+Three sourceable bash libraries that scenarios reach for to make claims
+about a CLI's behaviour. Governed by
+[ADR 0004](../../../docs/adr/0004-e2e-assertion-libs.md).
+
+| Lib | When to use |
+|---|---|
+| `assert.sh` | **First choice.** Side-effect probes: file presence/content, exit codes, drawers in MemPalace, git refs pushed to a remote. Cheap, deterministic, easy to reason about. |
+| `structural.sh` | **Second choice.** Structural shape probes: regex over stdout, JSON paths via `jq`, gitmoji-formatted titles. Use when the assertion is about the shape of an artefact, not its existence. |
+| `llm_judge.sh` | **Last resort.** LLM-as-judge oracle for qualitative criteria a regex cannot express. Each call burns budget and adds non-determinism — reach for it only when the first two cannot answer the question. |
+
+Every assertion returns `0` on PASS, `1` on FAIL, and PASS is silent.
+FAIL emits a single TAP-compatible diagnostic block to stderr (`# FAIL`
++ `expected` / `actual` / `report` lines, truncated to 200 chars). The
+runner captures scenario stderr under
+`${E2E_REPORT_DIR}/<cli>/<scenario>/stderr`.
+
+## Sourcing pattern
+
+```bash
+# Inside a scenario script (issue #80 lands the scenarios):
+set -euo pipefail
+: "${E2E_LIB_DIR:?runner must export E2E_LIB_DIR}"
+source "${E2E_LIB_DIR}/assert.sh"
+source "${E2E_LIB_DIR}/structural.sh"
+source "${E2E_LIB_DIR}/llm_judge.sh"
+```
+
+`E2E_LIB_DIR` and `E2E_REPORT_DIR` are exported by `tests/e2e/run.sh`
+once issue #80 wires the runner-to-scenario plumbing.
+
+## Reference
+
+### `assert.sh` — side-effect assertions
+
+```text
+assert_file_exists <path>
+assert_file_contains <path> <regex>            # POSIX ERE via `grep -E`
+assert_file_absent <path>
+assert_exit_code <expected> <actual>
+assert_drawer_present <wing> <room> <regex>
+assert_drawer_field <wing> <room> <handoff_key> <field> <expected>
+assert_git_branch_pushed <remote> <branch>
+```
+
+The two MemPalace probes shell out to the `mempalace` binary on PATH.
+They are designed for the `crewrig/e2e-mempalace:latest` image (where
+MemPalace is pipx-installed); the scenario harness decides whether to
+pre-spin a sidecar (P1) or run `docker run --rm` per probe (P2 — the
+v1 default).
+
+### `structural.sh` — structural assertions
+
+```text
+assert_stdout_matches <regex> [<file>]         # POSIX ERE; stdin or file
+assert_json_shape <file> <jq_path> <expected>
+assert_gitmoji_title <string>                  # PCRE: ^\p{Emoji}…
+```
+
+`assert_gitmoji_title` requires GNU grep with PCRE support — present in
+the e2e Docker images (Debian bookworm, GNU grep 3.8) but NOT on macOS
+hosts (BSD grep). Run the smoke for this assertion inside the image,
+not on the host.
+
+### `llm_judge.sh` — LLM-as-judge oracle
+
+```text
+llm_judge <prompt-file> <subject-file> <criterion>
+# stdout: VERDICT=<PASS|FAIL|UNCERTAIN> confidence=<0.00-1.00>
+# exit: 0 on PASS, 1 on FAIL, 0 on UNCERTAIN (default), 1 on UNCERTAIN (strict)
+```
+
+Configured via the `[judge]` table in `defaults.toml`:
+
+```toml
+[judge]
+backend     = "anthropic"
+model       = "claude-sonnet-4-6"            # Overridable via local.toml
+api_key_env = "ANTHROPIC_JUDGE_API_KEY"
+strict      = false                           # UNCERTAIN warns; does NOT fail
+max_calls   = 30                              # Per-run hard cap
+```
+
+#### Prompt template
+
+The judge composes a single user message per quorum slot:
+
+```text
+You are an LLM judge for an end-to-end test framework. Read the
+PROMPT, SUBJECT, and CRITERION below, then respond with EXACTLY one
+line in the form:
+
+  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>
+
+No prose, no markdown, no trailing text. CONF reflects your
+confidence in the verdict, not in the subject.
+
+PROMPT:
+<contents of <prompt-file>>
+
+SUBJECT:
+<contents of <subject-file>>
+
+CRITERION:
+<criterion>
+```
+
+Three sequential calls with PASS/PASS and FAIL/FAIL early-exit. The
+verdict is the 2-of-3 majority, or `UNCERTAIN` when no majority is
+reached or ≥2 slots return malformed output after one HTTP retry.
+
+#### `ANTHROPIC_JUDGE_API_KEY` is separate from `ANTHROPIC_API_KEY`
+
+Both may point at the same upstream key value — the split is about
+**accounting**, not secrecy. `ANTHROPIC_API_KEY` is mounted into the
+Claude CLI container at scenario time; the judge runs on the host on
+the framework's budget line. Keeping them separated lets ops bill,
+throttle, or revoke them independently. Export both even if they hold
+the same value:
+
+```sh
+export ANTHROPIC_API_KEY="sk-ant-…"
+export ANTHROPIC_JUDGE_API_KEY="sk-ant-…"
+```
+
+#### Raising the `max_calls` cap
+
+The default 30-call-per-run cap defends against a runaway scenario.
+Counter lives at `${E2E_REPORT_DIR}/judge.count`; the wrapper refuses
+new calls once the cap is reached and returns FAIL with a diag
+pointing at the counter file. Raise it for a long-running suite via
+`tests/e2e/local.toml`:
+
+```toml
+[judge]
+max_calls = 100
+```
+
+Set `E2E_JUDGE_STRICT=1` (or `[judge].strict = true`) to upgrade
+UNCERTAIN verdicts to hard failures — useful for the gating leg of CI.

--- a/tests/e2e/lib/assert.sh
+++ b/tests/e2e/lib/assert.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/assert.sh — side-effect assertion library for e2e scenarios.
+#
+# Contract (see docs/adr/0004-e2e-assertion-libs.md, Decisions 1, 2, 6):
+#   - Functions return 0 on PASS, 1 on FAIL. No other codes.
+#   - PASS is silent. FAIL emits exactly one diagnostic block to stderr,
+#     prefixed with "# " so it is TAP-compatible.
+#   - `set -euo pipefail` safe when sourced; env vars are only read inside
+#     functions, never at source time.
+#   - The private `_e2e_assert_diag` helper enforces the failure format.
+#
+# Sourcing pattern (from a scenario script):
+#
+#     set -euo pipefail
+#     : "${E2E_LIB_DIR:?runner must export E2E_LIB_DIR}"
+#     source "${E2E_LIB_DIR}/assert.sh"
+#
+# Provided assertions:
+#   assert_file_exists <path>
+#   assert_file_contains <path> <regex>           # POSIX ERE via `grep -E`
+#   assert_file_absent <path>
+#   assert_exit_code <expected> <actual>
+#   assert_drawer_present <wing> <room> <regex>
+#   assert_drawer_field <wing> <room> <handoff_key> <field> <expected>
+#   assert_git_branch_pushed <remote> <branch>
+
+set -o nounset
+
+# --------------------------------------------------------------------------
+# Private helpers (shared, redefined identically by structural.sh and
+# llm_judge.sh — see ADR 0004 open risk #5).
+# --------------------------------------------------------------------------
+
+_e2e_truncate() {
+  # Collapse newlines to spaces, truncate to 200 chars + "…".
+  local s="${1-}"
+  s="${s//$'\n'/ }"
+  if (( ${#s} > 200 )); then
+    printf '%s…' "${s:0:200}"
+  else
+    printf '%s' "$s"
+  fi
+}
+
+_e2e_assert_diag() {
+  # Usage: _e2e_assert_diag <name+argv> <expected> <actual> [<artefact>]
+  local name="${1-}" expected="${2-}" actual="${3-}" artefact="${4-}"
+  local report_line=""
+  if [[ -n "${E2E_REPORT_DIR:-}" ]]; then
+    report_line="${E2E_REPORT_DIR}${artefact:+/${artefact}}"
+  elif [[ -n "$artefact" ]]; then
+    report_line="<unset>/${artefact}"
+  fi
+  {
+    printf '# FAIL %s\n' "$name"
+    printf '#   expected: %s\n' "$(_e2e_truncate "$expected")"
+    printf '#   actual:   %s\n' "$(_e2e_truncate "$actual")"
+    if [[ -n "$report_line" ]]; then
+      printf '#   report:   %s\n' "$report_line"
+    fi
+  } >&2
+}
+
+# --------------------------------------------------------------------------
+# Side-effect assertions.
+# --------------------------------------------------------------------------
+
+assert_file_exists() {
+  local path="${1:?assert_file_exists: missing <path>}"
+  if [[ -e "$path" ]]; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_file_exists ${path}" \
+    "path exists" \
+    "no such file or directory: ${path}"
+  return 1
+}
+
+assert_file_absent() {
+  local path="${1:?assert_file_absent: missing <path>}"
+  if [[ ! -e "$path" ]]; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_file_absent ${path}" \
+    "path does not exist" \
+    "path exists: ${path}"
+  return 1
+}
+
+assert_file_contains() {
+  local path="${1:?assert_file_contains: missing <path>}"
+  local regex="${2:?assert_file_contains: missing <regex>}"
+  if [[ ! -e "$path" ]]; then
+    _e2e_assert_diag \
+      "assert_file_contains ${path} ${regex}" \
+      "file readable + ERE match" \
+      "no such file: ${path}"
+    return 1
+  fi
+  if grep -E -q -- "$regex" "$path"; then
+    return 0
+  fi
+  local sample=""
+  sample="$(head -c 400 "$path" 2>/dev/null || true)"
+  _e2e_assert_diag \
+    "assert_file_contains ${path} ${regex}" \
+    "ERE match: ${regex}" \
+    "no match in file (first 400 B: ${sample})"
+  return 1
+}
+
+assert_exit_code() {
+  local expected="${1:?assert_exit_code: missing <expected>}"
+  local actual="${2:?assert_exit_code: missing <actual>}"
+  if [[ "$expected" == "$actual" ]]; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_exit_code ${expected} ${actual}" \
+    "$expected" \
+    "$actual"
+  return 1
+}
+
+# --------------------------------------------------------------------------
+# MemPalace probes (ADR 0004 Decision 2, Path P2 — sidecar-less).
+#
+# Both probes shell out to the `mempalace` binary already in the scenario
+# container's PATH (image: crewrig/e2e-mempalace:latest, pipx-installed).
+# A future scenario harness (#80) decides whether to pre-spin the sidecar
+# (P1) or `docker run --rm` per probe (P2). The library is agnostic to
+# that choice — it only requires `mempalace` resolvable on PATH.
+# --------------------------------------------------------------------------
+
+_e2e_require_mempalace() {
+  # Common preflight for the two MemPalace probes. Returns 0 if `mempalace`
+  # is on PATH, non-zero (and emits a diag) otherwise. Caller is expected
+  # to propagate the non-zero return as its own FAIL.
+  local caller="$1"
+  if ! command -v mempalace >/dev/null 2>&1; then
+    _e2e_assert_diag \
+      "$caller" \
+      "mempalace on PATH" \
+      "mempalace binary not found — needs crewrig/e2e-mempalace image or pipx install"
+    return 1
+  fi
+  return 0
+}
+
+assert_drawer_present() {
+  local wing="${1:?assert_drawer_present: missing <wing>}"
+  local room="${2:?assert_drawer_present: missing <room>}"
+  local regex="${3:?assert_drawer_present: missing <regex>}"
+  _e2e_require_mempalace \
+    "assert_drawer_present ${wing} ${room} ${regex}" || return 1
+  local out=""
+  if ! out="$(mempalace search "$regex" --wing "$wing" --room "$room" --results 5 2>&1)"; then
+    _e2e_assert_diag \
+      "assert_drawer_present ${wing} ${room} ${regex}" \
+      "mempalace search exits 0" \
+      "mempalace search failed: ${out}"
+    return 1
+  fi
+  if printf '%s\n' "$out" | grep -E -q -- "$regex"; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_drawer_present ${wing} ${room} ${regex}" \
+    "drawer matching ERE: ${regex}" \
+    "no match in search output: $(printf '%s' "$out" | head -c 200)"
+  return 1
+}
+
+assert_drawer_field() {
+  local wing="${1:?assert_drawer_field: missing <wing>}"
+  local room="${2:?assert_drawer_field: missing <room>}"
+  local handoff_key="${3:?assert_drawer_field: missing <handoff_key>}"
+  local field="${4:?assert_drawer_field: missing <field>}"
+  local expected="${5:?assert_drawer_field: missing <expected>}"
+  _e2e_require_mempalace \
+    "assert_drawer_field ${wing} ${room} ${handoff_key} ${field} ${expected}" \
+    || return 1
+  local out=""
+  if ! out="$(mempalace search "$handoff_key" --wing "$wing" --room "$room" --results 1 2>&1)"; then
+    _e2e_assert_diag \
+      "assert_drawer_field ${wing} ${room} ${handoff_key} ${field} ${expected}" \
+      "mempalace search exits 0" \
+      "mempalace search failed: ${out}"
+    return 1
+  fi
+  # Drawer content layout (60-tools.md → Long-Running Task Convention):
+  # one `field: value` per line. Match exactly per ADR Decision 2.
+  if printf '%s\n' "$out" \
+       | grep -E -q -- "^${field}:[[:space:]]+${expected}[[:space:]]*$"; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_drawer_field ${wing} ${room} ${handoff_key} ${field} ${expected}" \
+    "${field}: ${expected}" \
+    "no matching line in search output: $(printf '%s' "$out" | head -c 200)"
+  return 1
+}
+
+assert_git_branch_pushed() {
+  local remote="${1:?assert_git_branch_pushed: missing <remote>}"
+  local branch="${2:?assert_git_branch_pushed: missing <branch>}"
+  if ! command -v git >/dev/null 2>&1; then
+    _e2e_assert_diag \
+      "assert_git_branch_pushed ${remote} ${branch}" \
+      "git on PATH" \
+      "git binary not found"
+    return 1
+  fi
+  if git ls-remote --exit-code --heads "$remote" "$branch" >/dev/null 2>&1; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_git_branch_pushed ${remote} ${branch}" \
+    "remote ref refs/heads/${branch} present on ${remote}" \
+    "git ls-remote returned non-zero (branch absent or remote unreachable)"
+  return 1
+}

--- a/tests/e2e/lib/llm_judge.sh
+++ b/tests/e2e/lib/llm_judge.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/llm_judge.sh — LLM-as-judge oracle for e2e scenarios.
+#
+# Contract (ADR 0004 Decision 4):
+#
+#   llm_judge <prompt-file> <subject-file> <criterion>
+#
+#   stdout (single line): "VERDICT=<PASS|FAIL|UNCERTAIN> confidence=<0.00-1.00>"
+#   exit code:
+#     0 — PASS
+#     1 — FAIL  (or UNCERTAIN when strict mode is on)
+#     0 — UNCERTAIN  (default mode: warn-only)
+#
+#   Config (read from ${E2E_REPORT_DIR}/effective.json `.judge.*` when the
+#   runner has populated it; falls back to compiled defaults otherwise):
+#     model        — Anthropic model id; default "claude-sonnet-4-6"
+#     api_key_env  — env var holding the API key; default "ANTHROPIC_JUDGE_API_KEY"
+#     strict       — false → UNCERTAIN warns; true → UNCERTAIN fails
+#     max_calls    — per-run hard cap on Anthropic Messages API calls (default 30)
+#
+#   Env overrides:
+#     E2E_JUDGE_STRICT=1     — force strict mode regardless of TOML
+#
+#   Quorum strategy: 3 sequential calls with PASS/PASS and FAIL/FAIL
+#   early-exit. UNCERTAIN slot when (a) no 2-of-3 majority, (b) ≥2 malformed
+#   outputs after one HTTP retry, or (c) persistent HTTP error.
+#
+#   Per-run counter: ${E2E_REPORT_DIR}/judge.count, incremented after every
+#   API call. Cap is enforced before each call; refusal emits a diag and
+#   returns FAIL (exit 1) — a budget exhaustion is a hard error, not a
+#   warning, regardless of `strict`.
+#
+# ### Prompt template
+#
+# The judge composes a single user message with the structure below. The
+# `criterion` is the assertion's free-form question; `subject` is the
+# artefact to evaluate; `prompt` is reusable scaffolding (instructions,
+# few-shot examples, etc.) supplied by the scenario author.
+#
+#   You are an LLM judge for an end-to-end test framework. Read the
+#   PROMPT, SUBJECT, and CRITERION below, then respond with EXACTLY one
+#   line in the form:
+#
+#     VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>
+#
+#   No prose, no markdown, no trailing text. CONF reflects your confidence
+#   in the verdict, not in the subject.
+#
+#   PROMPT:
+#   <contents of <prompt-file>>
+#
+#   SUBJECT:
+#   <contents of <subject-file>>
+#
+#   CRITERION:
+#   <criterion>
+
+set -o nounset
+
+# --------------------------------------------------------------------------
+# Private helpers — kept identical to assert.sh (ADR 0004 open risk #5).
+# --------------------------------------------------------------------------
+
+_e2e_truncate() {
+  local s="${1-}"
+  s="${s//$'\n'/ }"
+  if (( ${#s} > 200 )); then
+    printf '%s…' "${s:0:200}"
+  else
+    printf '%s' "$s"
+  fi
+}
+
+_e2e_assert_diag() {
+  local name="${1-}" expected="${2-}" actual="${3-}" artefact="${4-}"
+  local report_line=""
+  if [[ -n "${E2E_REPORT_DIR:-}" ]]; then
+    report_line="${E2E_REPORT_DIR}${artefact:+/${artefact}}"
+  elif [[ -n "$artefact" ]]; then
+    report_line="<unset>/${artefact}"
+  fi
+  {
+    printf '# FAIL %s\n' "$name"
+    printf '#   expected: %s\n' "$(_e2e_truncate "$expected")"
+    printf '#   actual:   %s\n' "$(_e2e_truncate "$actual")"
+    if [[ -n "$report_line" ]]; then
+      printf '#   report:   %s\n' "$report_line"
+    fi
+  } >&2
+}
+
+# --------------------------------------------------------------------------
+# Config loader. Reads ${E2E_REPORT_DIR}/effective.json via jq if present;
+# otherwise returns compiled defaults. Echoes one shell `local`-style
+# `KEY=value` per line; caller `eval`s the result.
+# --------------------------------------------------------------------------
+
+_llm_judge_load_config() {
+  local model="claude-sonnet-4-6"
+  local api_key_env="ANTHROPIC_JUDGE_API_KEY"
+  local strict="false"
+  local max_calls="30"
+  local endpoint="https://api.anthropic.com/v1/messages"
+  local max_tokens="256"
+  local cfg=""
+  if [[ -n "${E2E_REPORT_DIR:-}" ]] \
+       && [[ -f "${E2E_REPORT_DIR}/effective.json" ]] \
+       && command -v jq >/dev/null 2>&1; then
+    cfg="${E2E_REPORT_DIR}/effective.json"
+    model="$(jq -r '.judge.model // "claude-sonnet-4-6"' "$cfg" 2>/dev/null \
+              || printf 'claude-sonnet-4-6')"
+    api_key_env="$(jq -r '.judge.api_key_env // "ANTHROPIC_JUDGE_API_KEY"' "$cfg" 2>/dev/null \
+              || printf 'ANTHROPIC_JUDGE_API_KEY')"
+    strict="$(jq -r '.judge.strict // false' "$cfg" 2>/dev/null || printf 'false')"
+    max_calls="$(jq -r '.judge.max_calls // 30' "$cfg" 2>/dev/null || printf '30')"
+    endpoint="$(jq -r '.judge.endpoint // "https://api.anthropic.com/v1/messages"' "$cfg" 2>/dev/null \
+              || printf 'https://api.anthropic.com/v1/messages')"
+    max_tokens="$(jq -r '.judge.max_tokens // 256' "$cfg" 2>/dev/null || printf '256')"
+  fi
+  # E2E_JUDGE_STRICT overrides TOML.
+  if [[ "${E2E_JUDGE_STRICT:-0}" == "1" ]]; then
+    strict="true"
+  fi
+  printf 'JUDGE_MODEL=%q\n' "$model"
+  printf 'JUDGE_API_KEY_ENV=%q\n' "$api_key_env"
+  printf 'JUDGE_STRICT=%q\n' "$strict"
+  printf 'JUDGE_MAX_CALLS=%q\n' "$max_calls"
+  printf 'JUDGE_ENDPOINT=%q\n' "$endpoint"
+  printf 'JUDGE_MAX_TOKENS=%q\n' "$max_tokens"
+}
+
+# --------------------------------------------------------------------------
+# Counter management. No-op when E2E_REPORT_DIR is unset (standalone use).
+# --------------------------------------------------------------------------
+
+_llm_judge_counter_path() {
+  if [[ -z "${E2E_REPORT_DIR:-}" ]]; then
+    return 1
+  fi
+  printf '%s/judge.count' "$E2E_REPORT_DIR"
+}
+
+_llm_judge_counter_read() {
+  local path
+  if ! path="$(_llm_judge_counter_path)"; then
+    printf '0'
+    return 0
+  fi
+  if [[ -s "$path" ]]; then
+    cat -- "$path"
+  else
+    printf '0'
+  fi
+}
+
+_llm_judge_counter_increment() {
+  local path
+  if ! path="$(_llm_judge_counter_path)"; then
+    return 0
+  fi
+  local cur
+  cur="$(_llm_judge_counter_read)"
+  printf '%s\n' "$(( cur + 1 ))" > "$path"
+}
+
+# --------------------------------------------------------------------------
+# Single Anthropic Messages API call. Returns 0 on a parseable verdict line
+# echoed to stdout in the canonical `VERDICT=… CONF=…` form. Returns 1 on
+# malformed output (after one retry on HTTP error) — the caller treats this
+# as an UNCERTAIN slot.
+#
+# Inputs (positional): model, endpoint, api_key, max_tokens, prompt, subject, criterion
+# Optional 8th arg: "mock"  — when set, the implementation skips the curl
+#                              call and reads the verdict line from
+#                              ${E2E_JUDGE_MOCK_RESPONSE} instead. Used by
+#                              the library smoke test, never by scenarios.
+# --------------------------------------------------------------------------
+
+_llm_judge_one_call() {
+  local model="$1" endpoint="$2" api_key="$3" max_tokens="$4"
+  local prompt="$5" subject="$6" criterion="$7"
+  local mock="${8:-}"
+  local body raw text verdict
+  if [[ "$mock" == "mock" ]]; then
+    raw="${E2E_JUDGE_MOCK_RESPONSE:-}"
+    text="$raw"
+  else
+    body="$(jq -n \
+              --arg model "$model" \
+              --arg prompt "$prompt" \
+              --arg subject "$subject" \
+              --arg criterion "$criterion" \
+              --argjson maxtok "$max_tokens" '
+        { model: $model,
+          max_tokens: $maxtok,
+          messages: [
+            { role: "user",
+              content: ("You are an LLM judge for an end-to-end test framework. "
+                        + "Read the PROMPT, SUBJECT, and CRITERION below, then "
+                        + "respond with EXACTLY one line in the form:\n\n"
+                        + "  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>\n\n"
+                        + "No prose, no markdown, no trailing text.\n\n"
+                        + "PROMPT:\n" + $prompt
+                        + "\n\nSUBJECT:\n" + $subject
+                        + "\n\nCRITERION:\n" + $criterion) }
+          ] }')"
+    local attempt=0
+    while (( attempt < 2 )); do
+      raw="$(curl -sS --fail-with-body -X POST "$endpoint" \
+              -H "x-api-key: ${api_key}" \
+              -H "anthropic-version: 2023-06-01" \
+              -H "content-type: application/json" \
+              -d "$body" 2>&1)" && break
+      attempt=$(( attempt + 1 ))
+      sleep 1
+    done
+    if (( attempt >= 2 )); then
+      # HTTP failure persists; surface to caller as malformed slot.
+      return 1
+    fi
+    _llm_judge_counter_increment
+    text="$(printf '%s' "$raw" | jq -r '.content[0].text' 2>/dev/null || true)"
+  fi
+  # Extract canonical line.
+  verdict="$(printf '%s' "$text" | grep -oE 'VERDICT=(PASS|FAIL|UNCERTAIN)[[:space:]]+CONF=[0-9]+(\.[0-9]+)?' | head -n1 || true)"
+  if [[ -z "$verdict" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$verdict"
+}
+
+# --------------------------------------------------------------------------
+# Public entry-point.
+# --------------------------------------------------------------------------
+
+llm_judge() {
+  local prompt_file="${1:?llm_judge: missing <prompt-file>}"
+  local subject_file="${2:?llm_judge: missing <subject-file>}"
+  local criterion="${3:?llm_judge: missing <criterion>}"
+
+  # Preflight: required tools.
+  local missing=()
+  command -v jq >/dev/null 2>&1 || missing+=("jq")
+  command -v curl >/dev/null 2>&1 || missing+=("curl")
+  if (( ${#missing[@]} > 0 )); then
+    _e2e_assert_diag \
+      "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+      "jq + curl on PATH" \
+      "missing tools: ${missing[*]}"
+    return 1
+  fi
+
+  [[ -e "$prompt_file" ]] || { _e2e_assert_diag \
+      "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+      "<prompt-file> readable" \
+      "no such file: ${prompt_file}"; return 1; }
+  [[ -e "$subject_file" ]] || { _e2e_assert_diag \
+      "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+      "<subject-file> readable" \
+      "no such file: ${subject_file}"; return 1; }
+
+  # Config.
+  local JUDGE_MODEL JUDGE_API_KEY_ENV JUDGE_STRICT JUDGE_MAX_CALLS JUDGE_ENDPOINT JUDGE_MAX_TOKENS
+  eval "$(_llm_judge_load_config)"
+
+  # API key resolution via indirect expansion.
+  local api_key="${!JUDGE_API_KEY_ENV:-}"
+  if [[ -z "$api_key" && "${E2E_JUDGE_MOCK:-0}" != "1" ]]; then
+    _e2e_assert_diag \
+      "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+      "env var ${JUDGE_API_KEY_ENV} set to an Anthropic API key" \
+      "${JUDGE_API_KEY_ENV} is unset or empty"
+    return 1
+  fi
+
+  # Per-run cap.
+  local cur_count
+  cur_count="$(_llm_judge_counter_read)"
+  if (( cur_count >= JUDGE_MAX_CALLS )); then
+    _e2e_assert_diag \
+      "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+      "judge call count < ${JUDGE_MAX_CALLS}" \
+      "per-run cap exceeded (count=${cur_count}); see ${E2E_REPORT_DIR:-<unset>}/judge.count" \
+      "judge.count"
+    return 1
+  fi
+
+  local prompt subject
+  prompt="$(cat -- "$prompt_file")"
+  subject="$(cat -- "$subject_file")"
+
+  # 2-of-3 sequential quorum.
+  local mock_arg=""
+  [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]] && mock_arg="mock"
+  local slots=() pass_count=0 fail_count=0 unc_count=0
+  local confs=()
+  local i raw v c
+  for i in 1 2 3; do
+    raw=""
+    if raw="$(_llm_judge_one_call \
+                "$JUDGE_MODEL" "$JUDGE_ENDPOINT" "$api_key" \
+                "$JUDGE_MAX_TOKENS" "$prompt" "$subject" "$criterion" \
+                "$mock_arg")"; then
+      v="$(printf '%s' "$raw" | sed -nE 's/.*VERDICT=([A-Z]+).*/\1/p')"
+      c="$(printf '%s' "$raw" | sed -nE 's/.*CONF=([0-9]+(\.[0-9]+)?).*/\1/p')"
+      slots+=("$v")
+      confs+=("$c")
+      case "$v" in
+        PASS) pass_count=$(( pass_count + 1 )) ;;
+        FAIL) fail_count=$(( fail_count + 1 )) ;;
+        *)    unc_count=$(( unc_count + 1 )) ;;
+      esac
+    else
+      slots+=("UNCERTAIN")
+      confs+=("0.0")
+      unc_count=$(( unc_count + 1 ))
+    fi
+    # Early exit: 2 same verdicts in a row.
+    if (( pass_count >= 2 )); then break; fi
+    if (( fail_count >= 2 )); then break; fi
+  done
+
+  # Determine verdict.
+  local verdict confidence
+  if (( pass_count >= 2 )); then
+    verdict="PASS"
+  elif (( fail_count >= 2 )); then
+    verdict="FAIL"
+  else
+    verdict="UNCERTAIN"
+  fi
+
+  # Mean confidence over the slots that ran.
+  if (( ${#confs[@]} > 0 )); then
+    confidence="$(awk -v IFS=' ' 'BEGIN{s=0;n=0} {for (i=1;i<=NF;i++) {s+=$i; n++}} END{ if (n==0) print "0.00"; else printf "%.2f", s/n }' <<<"${confs[*]}")"
+  else
+    confidence="0.00"
+  fi
+
+  printf 'VERDICT=%s confidence=%s\n' "$verdict" "$confidence"
+
+  case "$verdict" in
+    PASS) return 0 ;;
+    FAIL)
+      _e2e_assert_diag \
+        "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+        "VERDICT=PASS" \
+        "VERDICT=FAIL confidence=${confidence}"
+      return 1
+      ;;
+    UNCERTAIN)
+      if [[ "$JUDGE_STRICT" == "true" ]]; then
+        _e2e_assert_diag \
+          "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+          "VERDICT=PASS (strict mode upgrades UNCERTAIN to FAIL)" \
+          "VERDICT=UNCERTAIN confidence=${confidence} (slots: ${slots[*]})"
+        return 1
+      fi
+      printf '# WARN llm_judge UNCERTAIN confidence=%s slots=%s\n' \
+        "$confidence" "${slots[*]}" >&2
+      return 0
+      ;;
+  esac
+}

--- a/tests/e2e/lib/structural.sh
+++ b/tests/e2e/lib/structural.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/structural.sh — structural assertion library for e2e scenarios.
+#
+# Contract: identical to tests/e2e/lib/assert.sh. See ADR 0004 Decisions 1, 3, 6.
+#
+# Provided assertions:
+#   assert_stdout_matches <regex> [<file>]        # POSIX ERE; stdin or file
+#   assert_json_shape <file> <jq_path> <expected>
+#   assert_gitmoji_title <string>                 # PCRE: ^\p{Emoji}…
+#
+# `assert_stdout_matches` defaults to consuming stdin (the universal call
+# site is `<command> | assert_stdout_matches '<re>'`). The optional second
+# argument lets a scenario assert against a file already on disk without
+# spawning a `cat` subshell — semantically equivalent to
+# `assert_file_contains <file> <regex>` from assert.sh.
+
+set -o nounset
+
+# --------------------------------------------------------------------------
+# Private helpers — kept identical to assert.sh (ADR 0004 open risk #5).
+# --------------------------------------------------------------------------
+
+_e2e_truncate() {
+  local s="${1-}"
+  s="${s//$'\n'/ }"
+  if (( ${#s} > 200 )); then
+    printf '%s…' "${s:0:200}"
+  else
+    printf '%s' "$s"
+  fi
+}
+
+_e2e_assert_diag() {
+  local name="${1-}" expected="${2-}" actual="${3-}" artefact="${4-}"
+  local report_line=""
+  if [[ -n "${E2E_REPORT_DIR:-}" ]]; then
+    report_line="${E2E_REPORT_DIR}${artefact:+/${artefact}}"
+  elif [[ -n "$artefact" ]]; then
+    report_line="<unset>/${artefact}"
+  fi
+  {
+    printf '# FAIL %s\n' "$name"
+    printf '#   expected: %s\n' "$(_e2e_truncate "$expected")"
+    printf '#   actual:   %s\n' "$(_e2e_truncate "$actual")"
+    if [[ -n "$report_line" ]]; then
+      printf '#   report:   %s\n' "$report_line"
+    fi
+  } >&2
+}
+
+# --------------------------------------------------------------------------
+# Structural assertions.
+# --------------------------------------------------------------------------
+
+assert_stdout_matches() {
+  local regex="${1:?assert_stdout_matches: missing <regex>}"
+  local file="${2:-}"
+  local input=""
+  if [[ -n "$file" ]]; then
+    if [[ ! -e "$file" ]]; then
+      _e2e_assert_diag \
+        "assert_stdout_matches ${regex} ${file}" \
+        "file exists" \
+        "no such file: ${file}"
+      return 1
+    fi
+    input="$(cat -- "$file")"
+  else
+    # Drain stdin. Tolerate empty input — it still gets matched against the
+    # regex (and an empty input that does not match the regex is a FAIL, as
+    # expected for `command | assert_stdout_matches '<re>'`).
+    input="$(cat)"
+  fi
+  if printf '%s' "$input" | grep -E -q -- "$regex"; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_stdout_matches ${regex}${file:+ ${file}}" \
+    "ERE match: ${regex}" \
+    "no match in input: $(printf '%s' "$input" | head -c 200)"
+  return 1
+}
+
+assert_json_shape() {
+  local file="${1:?assert_json_shape: missing <file>}"
+  local jq_path="${2:?assert_json_shape: missing <jq_path>}"
+  local expected="${3:?assert_json_shape: missing <expected>}"
+  if ! command -v jq >/dev/null 2>&1; then
+    _e2e_assert_diag \
+      "assert_json_shape ${file} ${jq_path} ${expected}" \
+      "jq on PATH" \
+      "jq binary not found"
+    return 1
+  fi
+  if [[ ! -e "$file" ]]; then
+    _e2e_assert_diag \
+      "assert_json_shape ${file} ${jq_path} ${expected}" \
+      "file exists" \
+      "no such file: ${file}"
+    return 1
+  fi
+  local actual=""
+  if ! actual="$(jq -r "$jq_path" "$file" 2>&1)"; then
+    _e2e_assert_diag \
+      "assert_json_shape ${file} ${jq_path} ${expected}" \
+      "jq -r '${jq_path}' returns successfully" \
+      "jq error: ${actual}"
+    return 1
+  fi
+  if [[ "$actual" == "$expected" ]]; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_json_shape ${file} ${jq_path} ${expected}" \
+    "$expected" \
+    "$actual"
+  return 1
+}
+
+assert_gitmoji_title() {
+  # AGENTS.md naming convention: <emoji> <Short description>.
+  # GNU grep 3.8 (Debian bookworm in crewrig/e2e-base:latest) ships with
+  # PCRE support compiled in; \p{Emoji} works out of the box. Empirically
+  # verified 2026-05-23 (ADR 0004 §Decision 3).
+  local title="${1:?assert_gitmoji_title: missing <string>}"
+  if printf '%s' "$title" \
+       | grep -P -q '^\p{Emoji}[\p{Emoji_Modifier}\p{Emoji_Component}]*\s+\S'; then
+    return 0
+  fi
+  _e2e_assert_diag \
+    "assert_gitmoji_title ${title}" \
+    "leading emoji + whitespace + non-empty text (e.g. '✨ Add foo')" \
+    "$title"
+  return 1
+}


### PR DESCRIPTION
Fourth foundation of the Docker-based e2e testing framework (epic #75). Ships three sourceable bash assertion libraries plus the `[judge]` config section for `defaults.toml`.

Closes #79.

## How to read this PR?

1. Start with `docs/adr/0004-e2e-assertion-libs.md` — the design contract (456 lines, dense). The architect verified empirically: MemPalace 3.3.5 CLI has only `search` (the richer `get-drawer`/`list-drawers` live on the MCP server), GNU grep 3.8 in Debian bookworm supports `\p{Emoji}` natively, and the Anthropic Messages API shape.
2. `tests/e2e/lib/assert.sh` — side-effect assertions (file/exit-code/git/MemPalace). 7 functions.
3. `tests/e2e/lib/structural.sh` — structural assertions (regex/JSON-shape/Gitmoji). 3 functions.
4. `tests/e2e/lib/llm_judge.sh` — LLM-as-judge with 3-call sequential quorum + PASS/PASS and FAIL/FAIL early-exit. Mean ~2.3 API calls per invocation.
5. `tests/e2e/lib/README.md` — full lib reference (signatures, return codes, diag format, macOS caveat).
6. `tests/e2e/defaults.toml` — new `[judge]` section (7 fields: backend, model, api_key_env, strict, max_calls, endpoint, max_tokens).
7. `scripts/tests/test-e2e-assert-lib.sh`, `test-e2e-structural-lib.sh`, `test-e2e-llm-judge-lib.sh`, `test-e2e-judge-config.sh`, `test-e2e-libs-readme.sh` — 64 PASS / 0 FAIL / 2 SKIP across the 5 new test files.

The libs are sourceable, NOT invoked by the runner yet — runner integration (mounting `tests/e2e/lib/` into scenario containers, exporting `E2E_LIB_DIR` and `E2E_REPORT_DIR`) is #80's job. This PR ships the contract; #80 wires it up.

## How to test this PR?

Prerequisites: go-task. Docker (for the `assert_gitmoji_title` smoke that runs inside `crewrig/e2e-base:latest`).

```bash
git checkout feat/e2e-assertion-libs

bash scripts/tests/test-e2e-assert-lib.sh
bash scripts/tests/test-e2e-structural-lib.sh
bash scripts/tests/test-e2e-llm-judge-lib.sh
bash scripts/tests/test-e2e-judge-config.sh
bash scripts/tests/test-e2e-libs-readme.sh
```

Expected: 64 PASS / 0 FAIL / 2 SKIP across the five new test files (2 SKIPs are MemPalace preflight cases that correctly avoid hitting a live store).

The `llm_judge.sh` tests do NOT make real API calls — they exploit the lib's built-in `E2E_JUDGE_MOCK=1` env switch.

## Detailed description (for agents)

### Added

- `tests/e2e/lib/assert.sh` — 7 side-effect assertions. All return 0 on PASS, non-zero on FAIL, emit uniform stderr diag via `_e2e_assert_diag`.
- `tests/e2e/lib/structural.sh` — `assert_stdout_matches`, `assert_json_shape`, `assert_gitmoji_title`. The Gitmoji guard uses GNU grep's `-P '\p{Emoji}…'` — runs natively inside `crewrig/e2e-base:latest`; macOS host BSD grep does NOT support this (caveat in lib/README.md).
- `tests/e2e/lib/llm_judge.sh` — Anthropic Messages API, 3 sequential calls with PASS/PASS and FAIL/FAIL early-exit. UNCERTAIN when no 2-of-3 majority OR ≥2 malformed after retry. Default `strict=false`; `E2E_JUDGE_STRICT=1` or `[judge].strict=true` flips it. Counter at `${E2E_REPORT_DIR}/judge.count`, hard-capped via `[judge].max_calls`. Mock surface: `E2E_JUDGE_MOCK=1`.
- `tests/e2e/lib/README.md` — full reference: signatures, return codes, diag format, ANTHROPIC_JUDGE_API_KEY separation rationale, max_calls cap, macOS caveat.
- `docs/adr/0004-e2e-assertion-libs.md` — design contract.
- 5 regression test files in `scripts/tests/`.

### Modified

- `tests/e2e/defaults.toml` — `[judge]` section: backend=anthropic, model=claude-sonnet-4-6, api_key_env=ANTHROPIC_JUDGE_API_KEY, strict=false, max_calls=30, endpoint=https://api.anthropic.com/v1/messages, max_tokens=1024.
- `tests/e2e/README.md` — 5-line pointer to `tests/e2e/lib/README.md`.

### Architectural decisions

- MemPalace integration via `mempalace search` CLI (not MCP). 3.3.5 CLI has only `search`; handoff drawers are structured plain text, so `assert_drawer_field` is `mempalace search <key> | grep -E "^field: expected$"`.
- LLM-judge quorum = 3 sequential calls with early-exit (mean ~2.3) vs 3 parallel — simpler error handling.
- `ANTHROPIC_JUDGE_API_KEY` separated from runtime `ANTHROPIC_API_KEY` — billing/quota isolation.
- Default model `claude-sonnet-4-6` (current capable Sonnet). ADR draft had `claude-sonnet-4-5-20250929` (stale); corrected before implementation.
- `[judge]` ships 7 fields (added `endpoint` + `max_tokens`) so `local.toml` can swap endpoints without code changes.

### Implementation deviations (with rationale)

- `assert_json_shape` uses `jq -r "$jq_path" "$file"` + string compare instead of `jq -e --arg e ...` — jq 1.6 (shipped in `crewrig/e2e-base:latest`) rejects `--` before the filter. Verified.
- README split to respect existing 200-line budget on `tests/e2e/README.md` enforced by test from #78. Full reference in new `tests/e2e/lib/README.md`.

### Scope boundary

Assertion libs + `[judge]` config only. Runner integration is #80's job. Scenarios (#80) and reporting (#81) tracked separately.

### Open risks (carried from ADR)

- LLM-judge non-determinism even with 2-of-3 quorum.
- Cost runaway mitigated by `max_calls = 30` per-run cap.
- MemPalace CLI 3.3.x pinning — 3.4+ may break `search`.
- Sidecar lifecycle: P2 (per-probe `docker run --rm`) default; switch to P1 long-lived if #80 scenarios exceed ~5 probes each.