### PR TITLE
📊 Add e2e parity matrix reporting + full README (#81)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -342,3 +342,7 @@ tasks:
   e2e:test:cli:
     desc: "Run all scenarios against one CLI. Usage: task e2e:test:cli -- <claude|gemini|copilot>"
     cmd: bash {{.REPO_DIR}}/tests/e2e/run.sh --cli {{.CLI_ARGS}}
+
+  e2e:report:
+    desc: "Aggregate TAP results into a parity matrix (console + markdown)"
+    cmd: bash {{.REPO_DIR}}/tests/e2e/lib/report.sh

--- a/scripts/tests/test-e2e-report.sh
+++ b/scripts/tests/test-e2e-report.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test-e2e-report.sh — Regression for tests/e2e/lib/report.sh.
+#
+# Locks the v1 contract of the TAP aggregator:
+#   - executable + syntactically valid
+#   - empty TAP dir → exit 2 (not 0)
+#   - one `ok` line → exit 0, scenario name on stdout
+#   - one `not ok` line → exit 1
+#   - `# SKIP` directive → exit 0 with ⚠ glyph on stdout
+#   - --dry-run never writes a markdown file
+#   - non-dry-run writes parity-*.md to the output dir
+#   - Taskfile carries an e2e:report entry
+#   - tests/e2e/README.md mentions Prerequisites
+#
+# No docker, no network.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+note_pass() { echo "# PASS $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "# FAIL $1 — $2"; FAIL=$((FAIL + 1)); }
+note_skip() { echo "# SKIP $1: $2"; SKIP=$((SKIP + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPORT_SH="${REPO_DIR}/tests/e2e/lib/report.sh"
+TASKFILE="${REPO_DIR}/Taskfile.yml"
+README="${REPO_DIR}/tests/e2e/README.md"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Case 1: report.sh exists and is executable --------------------------
+if [[ -f "$REPORT_SH" && -x "$REPORT_SH" ]]; then
+  note_pass "report.sh exists and is executable"
+else
+  note_fail "report.sh exists/executable" "path=$REPORT_SH exists=$([[ -f $REPORT_SH ]] && echo y || echo n) exec=$([[ -x $REPORT_SH ]] && echo y || echo n)"
+fi
+
+# --- Case 2: bash -n passes ----------------------------------------------
+if bash -n "$REPORT_SH" 2>"$TMP/syntax.err"; then
+  note_pass "report.sh passes bash -n"
+else
+  note_fail "report.sh bash -n" "$(tr '\n' '|' < "$TMP/syntax.err")"
+fi
+
+# --- Case 3: empty TAP dir → exit 2 --------------------------------------
+empty_dir="$TMP/empty-tap"
+mkdir -p "$empty_dir"
+out3="$(bash "$REPORT_SH" --tap-dir "$empty_dir" --output-dir "$TMP/out3" --dry-run 2>"$TMP/c3.err")"
+rc3=$?
+if [[ $rc3 -eq 2 ]]; then
+  note_pass "empty TAP dir exits 2"
+else
+  note_fail "empty TAP dir exits 2" "rc=$rc3 stderr=$(tr '\n' '|' < "$TMP/c3.err") stdout=$(echo "$out3" | tr '\n' '|')"
+fi
+
+# --- Case 4: single ok line → exit 0, scenario name on stdout ------------
+tap4_dir="$TMP/c4-tap"
+out4_dir="$TMP/c4-out"
+mkdir -p "$tap4_dir/run-001" "$out4_dir"
+cat > "$tap4_dir/run-001/run.tap" <<'EOF'
+TAP version 13
+1..1
+ok 1 - claude/01-layered-context
+EOF
+out4="$(bash "$REPORT_SH" --tap-dir "$tap4_dir" --output-dir "$out4_dir" --dry-run 2>"$TMP/c4.err")"
+rc4=$?
+if [[ $rc4 -eq 0 ]]; then
+  note_pass "single ok line — exit 0"
+else
+  note_fail "single ok line — exit 0" "rc=$rc4 stderr=$(tr '\n' '|' < "$TMP/c4.err")"
+fi
+if grep -q '01-layered-context' <<< "$out4"; then
+  note_pass "single ok line — scenario name on stdout"
+else
+  note_fail "scenario name on stdout" "stdout=$(echo "$out4" | tr '\n' '|')"
+fi
+
+# --- Case 5: single not ok line → exit 1 ---------------------------------
+tap5_dir="$TMP/c5-tap"
+out5_dir="$TMP/c5-out"
+mkdir -p "$tap5_dir/run-001" "$out5_dir"
+cat > "$tap5_dir/run-001/run.tap" <<'EOF'
+TAP version 13
+1..1
+not ok 1 - claude/01-layered-context
+EOF
+bash "$REPORT_SH" --tap-dir "$tap5_dir" --output-dir "$out5_dir" --dry-run >/dev/null 2>"$TMP/c5.err"
+rc5=$?
+if [[ $rc5 -eq 1 ]]; then
+  note_pass "single not-ok line — exit 1"
+else
+  note_fail "single not-ok line — exit 1" "rc=$rc5 stderr=$(tr '\n' '|' < "$TMP/c5.err")"
+fi
+
+# --- Case 6: # SKIP directive → exit 0 with ⚠ glyph ----------------------
+tap6_dir="$TMP/c6-tap"
+out6_dir="$TMP/c6-out"
+mkdir -p "$tap6_dir/run-001" "$out6_dir"
+cat > "$tap6_dir/run-001/run.tap" <<'EOF'
+TAP version 13
+1..1
+ok 1 - copilot/01-layered-context # SKIP no auth
+EOF
+out6="$(bash "$REPORT_SH" --tap-dir "$tap6_dir" --output-dir "$out6_dir" --dry-run 2>"$TMP/c6.err")"
+rc6=$?
+if [[ $rc6 -eq 0 ]]; then
+  note_pass "# SKIP directive — exit 0 (not a failure)"
+else
+  note_fail "# SKIP directive — exit 0" "rc=$rc6 stderr=$(tr '\n' '|' < "$TMP/c6.err")"
+fi
+if grep -q '⚠' <<< "$out6"; then
+  note_pass "# SKIP directive — ⚠ glyph on stdout"
+else
+  note_fail "⚠ glyph on stdout" "stdout=$(echo "$out6" | tr '\n' '|')"
+fi
+
+# --- Case 7: --dry-run does NOT write a markdown file --------------------
+tap7_dir="$TMP/c7-tap"
+out7_dir="$TMP/c7-out"
+mkdir -p "$tap7_dir/run-001" "$out7_dir"
+cat > "$tap7_dir/run-001/run.tap" <<'EOF'
+TAP version 13
+1..1
+ok 1 - claude/01-layered-context
+EOF
+bash "$REPORT_SH" --tap-dir "$tap7_dir" --output-dir "$out7_dir" --dry-run >/dev/null 2>"$TMP/c7.err"
+mapfile -t md_files7 < <(find "$out7_dir" -maxdepth 1 -name '*.md' 2>/dev/null)
+if [[ ${#md_files7[@]} -eq 0 ]]; then
+  note_pass "--dry-run writes no markdown file"
+else
+  note_fail "--dry-run writes no markdown file" "found: ${md_files7[*]}"
+fi
+
+# --- Case 8: without --dry-run, parity-*.md is created -------------------
+tap8_dir="$TMP/c8-tap"
+out8_dir="$TMP/c8-out"
+mkdir -p "$tap8_dir/run-001" "$out8_dir"
+cat > "$tap8_dir/run-001/run.tap" <<'EOF'
+TAP version 13
+1..1
+ok 1 - claude/01-layered-context
+EOF
+bash "$REPORT_SH" --tap-dir "$tap8_dir" --output-dir "$out8_dir" >/dev/null 2>"$TMP/c8.err"
+rc8=$?
+mapfile -t md_files8 < <(find "$out8_dir" -maxdepth 1 -name 'parity-*.md' 2>/dev/null)
+if [[ $rc8 -eq 0 && ${#md_files8[@]} -ge 1 ]]; then
+  note_pass "non-dry-run creates parity-*.md"
+else
+  note_fail "non-dry-run creates parity-*.md" "rc=$rc8 files=${md_files8[*]:-(none)} stderr=$(tr '\n' '|' < "$TMP/c8.err")"
+fi
+
+# --- Case 9: Taskfile contains e2e:report task ---------------------------
+if [[ -f "$TASKFILE" ]] && grep -qE '^\s*e2e:report\s*:' "$TASKFILE"; then
+  note_pass "Taskfile.yml carries e2e:report task"
+else
+  note_fail "Taskfile.yml carries e2e:report task" "not found in $TASKFILE"
+fi
+
+# --- Case 10: tests/e2e/README.md mentions Prerequisites -----------------
+if [[ -s "$README" ]] && grep -q 'Prerequisites' "$README"; then
+  note_pass "tests/e2e/README.md is non-empty and mentions Prerequisites"
+else
+  note_fail "tests/e2e/README.md sanity check" "path=$README size=$(wc -c < "$README" 2>/dev/null || echo 0)"
+fi
+
+echo "# $PASS passed / $FAIL failed / $SKIP skipped"
+if [[ $FAIL -gt 0 ]]; then exit 1; fi
+exit 0

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,29 +1,36 @@
-# CrewRig end-to-end testing harness
+# CrewRig end-to-end testing framework
 
-This directory hosts the end-to-end (e2e) testing framework for CrewRig:
-real CLI agents (Claude Code, Gemini CLI, GitHub Copilot CLI) driven
-against scripted scenarios inside isolated Docker containers.
+## Overview
 
-The harness is being built incrementally across the epic
-[#75](https://github.com/Sfeir/crewrig/issues/75):
+This directory hosts CrewRig's end-to-end (e2e) testing harness: real CLI
+agents (Claude Code, Gemini CLI, GitHub Copilot CLI) driven against scripted
+pillar scenarios inside isolated Docker containers, with a shared MemPalace
+sidecar for cross-tool memory checks. The framework proves that the five
+CrewRig pillars — layered context, cross-tool memory, skill/agent build,
+harness loop, and multi-CLI parity — hold under real CLI execution, not just
+unit-tested in isolation. Output is TAP, one subtest per scenario × CLI.
 
-- **#76 — Foundation Docker images** (merged). Base + per-CLI images +
-  MemPalace sidecar. See [`docker/e2e/README.md`](../../docker/e2e/README.md).
-- **#77 — Dedicated-account auth flow** (this PR). One-off interactive
-  scripts that populate `~/.crewrig-e2e/<cli>/` with the test account's
-  credentials, mounted read-only at scenario time.
-- **#78 — Scenario runner**. Container orchestration, fixture mounts,
-  log capture.
-- **#79 / #80 / #81 — Scenario fixtures and assertions**. Per-CLI test
-  cases that exercise real agent behaviour.
+## Prerequisites
 
-The two design contracts that govern this directory are
-[ADR 0001](../../docs/adr/0001-e2e-docker-images.md) (images) and
-[ADR 0002](../../docs/adr/0002-e2e-auth-flow.md) (auth flow).
+- **Docker** with BuildKit support (Docker Desktop on macOS, Docker Engine
+  20.10+ on Linux). The harness pulls and builds five images locally.
+- **[Task](https://taskfile.dev/)** v3+ for the `task e2e:*` entry points.
+- **`jq`** for JSON probing in assertions and the runner's `effective.json`
+  resolution.
+- **`yq`** (Go version, mikefarah's) for TOML merging in
+  `tests/e2e/lib/toml_merge.sh`.
+- **`gh`** (GitHub CLI) for harness-loop scenarios and PAT minting.
+- **Bash 4+**. macOS ships Bash 3.2 by default — install via Homebrew
+  (`brew install bash`) or rely on the containerised execution path.
+
+**Host OS caveat — Gitmoji checks.** `assert_gitmoji_title` in
+`structural.sh` uses `grep -P` (PCRE). PCRE is present in the Debian-based
+e2e images (GNU grep 3.8) but **not** in BSD grep on macOS hosts. Run any
+Gitmoji-related smoke inside the e2e images, not on the host.
 
 ## One-off setup
 
-Two steps, both per developer and per workstation:
+Two steps, per developer and per workstation:
 
 ```sh
 # 1. Build (or rebuild) the e2e images.
@@ -35,108 +42,15 @@ task e2e:auth:gemini
 task e2e:auth:copilot
 ```
 
-Auth is interactive: you complete the OAuth browser flow (claude /
-gemini) or paste a PAT export line (copilot) on your host. Credentials
-are written to `~/.crewrig-e2e/<cli>/` and never leak into your personal
-`~/.claude`, `~/.gemini`, or `~/.copilot`.
+`task e2e:build` produces `crewrig/e2e-base`, `crewrig/e2e-claude`,
+`crewrig/e2e-gemini`, `crewrig/e2e-copilot`, and `crewrig/e2e-mempalace`
+(all `:latest`). Use the per-image targets (`task e2e:build:claude`, etc.)
+when iterating on a single Dockerfile.
 
-### Why a dedicated test account?
+### `~/.crewrig-e2e/` layout
 
-Scenarios send real prompts to real agents. Mixing them with your
-personal session would pollute your transcript history, count against
-your usage quota, and risk cross-contamination of state. The harness
-assumes you have provisioned a separate GitHub / Google / Anthropic
-account scoped to e2e use. You are responsible for creating and gating
-that account; the framework only persists what it authorises.
-
-## Per-CLI auth walkthrough
-
-All three flows are idempotent — re-running them on an
-already-authenticated dir is safe.
-
-### Claude Code
-
-```sh
-task e2e:auth:claude
-```
-
-What happens:
-
-1. `mkdir -p ~/.crewrig-e2e/claude`.
-2. One-shot `docker run --user root … chown -R 1000:1000` on the dir.
-   Required on macOS (VirtioFS bind mounts land root-owned); idempotent
-   on Linux — the chown itself is a filesystem no-op but the helper
-   still spawns a one-shot privileged container (~1–2 s spin-up).
-   Accepted trade-off vs OS-branching. See ADR 0002 Decision 6 for the
-   empirical trace.
-3. Interactive `docker run -it … crewrig/e2e-claude:latest claude /login`
-   with the dir bind-mounted RW at `/home/agent/.claude`. You complete
-   the OAuth flow in your browser on the host.
-4. Post-flight check: `.credentials.json` AND `.claude.json` must be
-   present in `~/.crewrig-e2e/claude/`. Both are required — persisting
-   only `.credentials.json` causes the CLI to treat the next session as
-   a fresh install (upstream
-   [tfvchow/field-notes-public#10](https://github.com/tfvchow/field-notes-public/issues/10)).
-
-Headless override (long scenarios): set
-`CLAUDE_CODE_OAUTH_TOKEN` (minted via `claude setup-token`) or
-`ANTHROPIC_API_KEY` in your host shell. The scenario runner will pass
-them through with `docker run -e …`; they MUST NOT be written under
-`~/.crewrig-e2e/`.
-
-### Gemini CLI
-
-```sh
-task e2e:auth:gemini
-```
-
-What happens:
-
-1. Same mkdir + chown bootstrap as claude.
-2. Interactive `docker run -it … crewrig/e2e-gemini:latest gemini`
-   with the dir bind-mounted RW at `/home/agent/.gemini`. In the menu,
-   pick **"Login with Google"** and complete the browser flow.
-   Type `/quit` (or Ctrl-D) when the welcome prompt appears.
-3. Post-flight check: `oauth_creds.json` AND `settings.json` must be
-   present in `~/.crewrig-e2e/gemini/`.
-
-Headless override: set `GEMINI_API_KEY` (or `GOOGLE_API_KEY` for Vertex)
-in your host shell.
-
-### GitHub Copilot CLI
-
-```sh
-task e2e:auth:copilot
-```
-
-This one is **not** an interactive container run. The v1 path uses an
-env-var token (PAT); no file is written under
-`~/.crewrig-e2e/copilot/`. See ADR 0002 Decision 4 for why we deferred
-the device-flow path.
-
-What happens:
-
-1. The script prints the PAT-creation URL, the recommended fine-grained
-   scopes (resource owner = test account; Copilot = Read & write), the
-   `export COPILOT_GITHUB_TOKEN=…` line to add to your shell rc, and a
-   90-day expiry reminder.
-2. If `COPILOT_GITHUB_TOKEN` is already set in the calling shell, the
-   script runs a 5-second sanity test: `docker run -e
-   COPILOT_GITHUB_TOKEN crewrig/e2e-copilot:latest copilot --version`.
-   A clean exit means the image launches and accepts the env var.
-
-#### PAT rotation cadence
-
-Fine-grained PATs default to **90 days**. Without a calendar reminder,
-CI will silently start failing. Rotate quarterly:
-
-1. Mint a new PAT at
-   <https://github.com/settings/personal-access-tokens/new> with the
-   same scopes.
-2. Update the export line in your shell rc.
-3. `source` it, then re-run `task e2e:auth:copilot` to confirm.
-
-## Directory layout
+The auth scripts write credentials into a dedicated host directory that the
+scenario runner mounts read-only at execution time:
 
 ```text
 ~/.crewrig-e2e/
@@ -149,51 +63,194 @@ CI will silently start failing. Rotate quarterly:
 └── copilot/                # empty by design — token lives in $COPILOT_GITHUB_TOKEN
 ```
 
-You can override the root with `CREWRIG_E2E_HOME=/path/to/parent` (the
-scripts will write to `${CREWRIG_E2E_HOME}/.crewrig-e2e/<cli>/`). This
-matters on shared CI runners where `$HOME` is multi-tenant.
+Override the root with `CREWRIG_E2E_HOME=/path/to/parent` (the auth
+scripts and the runner both honour it). This matters on shared CI runners
+where `$HOME` is multi-tenant.
 
-## Security posture
+### Per-CLI auth notes
 
-- **Read-only at scenario time.** Once authenticated, the scenario
-  runner (#78) bind-mounts each dir with `:ro`. A deliberate write
-  attempt from inside the container must fail with "Read-only file
-  system" — that is one of the assertions the runner ships with.
+- **Claude Code** — interactive `claude /login` inside the
+  `crewrig/e2e-claude` image. Both `.credentials.json` AND `.claude.json`
+  must end up under `~/.crewrig-e2e/claude/`; persisting only the former
+  causes the CLI to treat the next session as a fresh install.
+  Headless override: export `CLAUDE_CODE_OAUTH_TOKEN` or
+  `ANTHROPIC_API_KEY` in your host shell.
+- **Gemini CLI** — interactive `gemini` launch inside the
+  `crewrig/e2e-gemini` image. Pick **"Login with Google"** and `/quit`
+  once you reach the welcome prompt. Both `oauth_creds.json` and
+  `settings.json` must land under `~/.crewrig-e2e/gemini/`. Headless
+  override: `GEMINI_API_KEY` (or `GOOGLE_API_KEY` for Vertex).
+- **GitHub Copilot CLI** — env-var PAT path (no on-disk file). The
+  script prints the PAT-creation URL, the recommended fine-grained
+  scopes (resource owner = test account; Copilot = Read & write), the
+  `export COPILOT_GITHUB_TOKEN=…` line for your shell rc, and a
+  **90-day** expiry reminder. If the token is already exported, the
+  script runs a 5-second container sanity check.
+
+See [ADR 0002](../../docs/adr/0002-e2e-auth-flow.md) for the auth flow
+contract and `scripts/e2e/auth-{claude,gemini,copilot}.sh` for the
+scripts themselves.
+
+## Running tests
+
+```sh
+# Run every scenario × every configured CLI.
+task e2e:test
+
+# Run one scenario across all CLIs.
+task e2e:test:scenario -- 01-layered-context
+
+# Run all scenarios against a single CLI.
+task e2e:test:cli -- claude
+```
+
+Useful flags passed through `--` to the runner
+(`tests/e2e/run.sh`):
+
+| Flag | Meaning |
+|---|---|
+| `--dry-run` | Resolve config + write `effective.json`; do not spawn containers. |
+| `--keep <N>` | Keep at most N most-recent report dirs (default: 20). |
+| `--report-dir <path>` | Override the report directory. |
+| `--scenario <name>` | Limit to one scenario. |
+| `--cli <name>` | Limit to one CLI (`claude` \| `gemini` \| `copilot` \| `all`). |
+
+Exit code is `0` on success (or when no scenarios are defined) and
+non-zero when at least one scenario fails (TAP `not ok`). Per-run output
+lands in `tests/e2e/reports/<run-id>/`, with one subdirectory per
+`<cli>/<scenario>/` carrying `scenario.tap`, captured stdout/stderr,
+and (when invoked) `judge.count`.
+
+## Override file
+
+`tests/e2e/local.toml` is the gitignored override file deep-merged over
+`defaults.toml` at run time. The merge rules (see
+[ADR 0003](../../docs/adr/0003-e2e-runner-toml.md) Decision 2):
+
+- **Arrays APPEND.**
+- **Scalars REPLACE.**
+- **New tables graft in.**
+
+Copy `tests/e2e/local.toml.example` to `tests/e2e/local.toml` to start.
+The example routes Copilot through Ollama Cloud so local validation
+does not burn real Copilot quota:
+
+```toml
+[cli.copilot]
+command  = ["ollama", "launch", "copilot", "--model", "deepseek-v4-pro:cloud", "--"]
+env_keys = ["COPILOT_GITHUB_TOKEN", "OLLAMA_HOST"]
+```
+
+The runner writes the merged result to `effective.json` at the top of
+each run; inspect it under the run's report directory when debugging
+config resolution.
+
+## Adding a new scenario
+
+Each scenario is a host-side orchestrator that drives Docker itself.
+See [`scenarios/README.md`](scenarios/README.md) for the full contract;
+the short version:
+
+1. Create `tests/e2e/scenarios/<name>/` with an executable `run.sh`
+   (copy any existing scenario as a starting template) plus any
+   supporting fixtures.
+2. Source the assertion helpers via the runner-exported `E2E_LIB_DIR`:
+
+   ```bash
+   set -euo pipefail
+   : "${E2E_LIB_DIR:?runner must export E2E_LIB_DIR}"
+   source "${E2E_LIB_DIR}/assert.sh"
+   source "${E2E_LIB_DIR}/structural.sh"
+   source "${E2E_LIB_DIR}/llm_judge.sh"
+   ```
+
+3. Emit a TAP subtest plan to `${E2E_REPORT_DIR}/scenario.tap`. Exit
+   codes follow the runner convention: `0` → ok, `78` → skip (with a
+   diagnostic line on stdout), anything else → not ok.
+4. Add a `[scenarios.<name>]` table to `tests/e2e/defaults.toml` with
+   `description` and `applies_to`.
+5. Add one row per CLI × scenario to `docs/cli-matrix.md`.
+
+No runner change is needed — scenario discovery is by file presence
+plus the TOML table.
+
+The full env-var contract (`E2E_LIB_DIR`, `E2E_REPORT_DIR`, `E2E_CLI`,
+`E2E_IMAGE`, `E2E_EFFECTIVE_JSON`, `E2E_CREWRIG_E2E_HOME`,
+`E2E_SCENARIO_DIR`, `E2E_RUN_ID`) is documented in
+[`scenarios/README.md`](scenarios/README.md). The assertion API
+reference lives in [`lib/README.md`](lib/README.md).
+
+## Authentication strategy
+
+The harness is built around a **dedicated test account** per CLI provider
+(GitHub, Google, Anthropic). Three properties follow from that choice:
+
+- **Isolation from your personal CLI state.** Credentials are written
+  under `~/.crewrig-e2e/<cli>/`, never into `~/.claude`, `~/.gemini`, or
+  `~/.copilot`. Personal transcript history and quota stay clean.
+- **Read-only volume mounts at scenario time.** Once authenticated, the
+  scenario runner bind-mounts each per-CLI dir with `:ro`. A deliberate
+  write attempt from inside the container must fail with "Read-only
+  file system" — one of the assertions the runner ships with.
 - **No API keys on disk.** `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
-  `GH_TOKEN`, `COPILOT_GITHUB_TOKEN`, and the Ollama Cloud token are
-  read from your host shell at run time and passed via `docker run -e
-  <NAME>`. They MUST NEVER be written under `~/.crewrig-e2e/`. The
-  auth scripts refuse to proceed if they detect key material in a
-  credential file.
-- **Full reset.** Delete `~/.crewrig-e2e/<cli>/` and re-run
-  `task e2e:auth:<cli>`. PATs are rotated upstream on GitHub.
-- **OAuth refresh limitation.** Both Claude and Gemini refresh access
-  tokens by overwriting their credential file. Under `:ro` that write
-  fails silently; scenarios that outlive the access-token TTL
-  (~1 hour) will error mid-run. Workaround: keep scenarios short, or
-  use the env-var headless overrides for long ones. Tracked as
-  open risk #1 in ADR 0002.
+  `GH_TOKEN`, `COPILOT_GITHUB_TOKEN`, `ANTHROPIC_JUDGE_API_KEY`, and the
+  Ollama Cloud token are read from your host shell and passed via
+  `docker run -e <NAME>`. They MUST NEVER be written under
+  `~/.crewrig-e2e/`. The auth scripts refuse to proceed if they detect
+  key material in a credential file.
+
+**PAT rotation.** Fine-grained GitHub PATs default to **90 days**.
+Without a calendar reminder the Copilot leg silently starts failing.
+Rotate quarterly: mint a fresh PAT at
+<https://github.com/settings/personal-access-tokens/new> with the same
+scopes, update the export in your shell rc, then re-run
+`task e2e:auth:copilot` to confirm.
+
+**OAuth refresh under `:ro`.** Both Claude and Gemini refresh access
+tokens by overwriting their credential file. Under the read-only mount,
+that write fails silently; scenarios that outlive the access-token TTL
+(~1 hour) will error mid-run. Keep scenarios short, or use the headless
+env-var overrides for long ones. Tracked as open risk #1 in ADR 0002.
+
+Foundations: [ADR 0001 — Docker images](../../docs/adr/0001-e2e-docker-images.md)
+and [ADR 0002 — Auth flow](../../docs/adr/0002-e2e-auth-flow.md).
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `Permission denied` on first `/login` (macOS) | chown bootstrap was skipped — only happens if you ran a hand-rolled `docker run`, not via the script. | Re-run `task e2e:auth:<cli>`; the bootstrap is mandatory and always-on. |
+| `image 'crewrig/e2e-<cli>:latest' is not present locally` | You skipped `task e2e:build`. | Run `task e2e:build` (or the per-CLI target). |
 | Claude prompts for login on every run | `.claude.json` is missing alongside `.credentials.json`. | Re-run `task e2e:auth:claude` and complete the login fully. |
+| `Permission denied` on first `/login` (macOS) | One-shot chown bootstrap was skipped — only happens if you hand-rolled `docker run`. | Re-run `task e2e:auth:<cli>` — the bootstrap is always-on inside the script. |
 | `copilot` complains about a malformed token | PAT expired, was revoked, or was pasted with surrounding whitespace. | Mint a fresh PAT, re-export, re-run `task e2e:auth:copilot`. |
-| Scenario fails mid-run with auth error after ~1 h | OAuth access token expired and the RO mount blocked the refresh write. | For long scenarios, set `CLAUDE_CODE_OAUTH_TOKEN` / `GEMINI_API_KEY` in your shell instead. |
-| `image 'crewrig/e2e-<cli>:latest' is not present locally` | You skipped `task e2e:build`. | Run `task e2e:build` (or `task e2e:build:<cli>`). |
+| Scenario fails mid-run with auth error after ~1 h | OAuth access token expired and the RO mount blocked the refresh write. | Set `CLAUDE_CODE_OAUTH_TOKEN` / `GEMINI_API_KEY` in your shell for long scenarios. |
+| `llm_judge` returns `MISSING_KEY` | `ANTHROPIC_JUDGE_API_KEY` is unset on the host. | Export it (may share its value with `ANTHROPIC_API_KEY`; the split is for accounting, not secrecy). |
+| Ollama Cloud override hangs or 401s | `OLLAMA_HOST` or the Ollama Cloud token is not exported on the host. | Export both before invoking `task e2e:test`. |
+| `--dry-run` reports success but no containers ran | Expected behaviour. | `--dry-run` resolves config + writes `effective.json` only; drop the flag to execute. |
+| `assert_gitmoji_title` fails only on macOS | BSD grep lacks PCRE. | Run the assertion inside the e2e image, not on the host. |
 
-## Assertion libraries
+For deeper debugging, every run writes `effective.json`, per-case
+`scenario.tap`, and captured stdout/stderr under
+`tests/e2e/reports/<run-id>/<cli>/<scenario>/`.
 
-Scenarios assert via three sourceable bash libraries under
-`tests/e2e/lib/` — see [`lib/README.md`](lib/README.md) and
-[ADR 0004](../../docs/adr/0004-e2e-assertion-libs.md).
+## CI integration
 
-## Pointers
+Nightly CI execution is a deliberate follow-up. The current scope is
+**local developer runs**: the harness is wired for fast iteration on a
+workstation, not yet for unattended scheduled execution. The TAP output
+and the `--keep` retention flag are designed with a future CI runner in
+mind, but no GitHub Actions workflow ships in this round.
 
-- Design — [`docs/adr/0001-e2e-docker-images.md`](../../docs/adr/0001-e2e-docker-images.md),
-  [`docs/adr/0002-e2e-auth-flow.md`](../../docs/adr/0002-e2e-auth-flow.md)
-- Images — [`docker/e2e/README.md`](../../docker/e2e/README.md)
-- Auth scripts — [`scripts/e2e/`](../../scripts/e2e/)
+## References
+
+- Design ADRs:
+  [0001 — Docker images](../../docs/adr/0001-e2e-docker-images.md),
+  [0002 — Auth flow](../../docs/adr/0002-e2e-auth-flow.md),
+  [0003 — Runner & TOML](../../docs/adr/0003-e2e-runner-toml.md),
+  [0004 — Assertion libs](../../docs/adr/0004-e2e-assertion-libs.md),
+  [0005 — Pillar scenarios](../../docs/adr/0005-e2e-pillar-scenarios.md)
+- Assertion API reference — [`lib/README.md`](lib/README.md)
+- Scenario contract — [`scenarios/README.md`](scenarios/README.md)
+- Image definitions — [`../../docker/e2e/README.md`](../../docker/e2e/README.md)
+- Auth scripts — [`../../scripts/e2e/`](../../scripts/e2e/)
 - Epic and child issues — #75, #76, #77, #78, #79, #80, #81

--- a/tests/e2e/lib/report.sh
+++ b/tests/e2e/lib/report.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/report.sh — aggregate per-run TAP files into a parity matrix.
+#
+# Reads TAP 13 files produced by tests/e2e/run.sh (typically located at
+# <tap-dir>/<run-id>/run.tap, or any *.tap directly under <tap-dir>) and
+# emits:
+#
+#   1. A console table to stdout — rows are scenarios, columns are CLIs
+#      (claude, gemini, copilot), cells are one of:
+#        ✅  pass
+#        ❌  fail
+#        ⚠️   skip / uncertain / missing
+#
+#   2. A markdown report at <output-dir>/parity-YYYYMMDD-HHMMSS.md with
+#      the same matrix.
+#
+# Exit code: 1 if any cell is ❌, 0 otherwise.
+#
+# Usage:
+#   tests/e2e/lib/report.sh [--tap-dir <dir>] [--output-dir <dir>] [--dry-run]
+#
+# Defaults: --tap-dir tests/e2e/reports/  --output-dir tests/e2e/reports/
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# CLI parsing.
+# --------------------------------------------------------------------------
+TAP_DIR="tests/e2e/reports"
+OUTPUT_DIR="tests/e2e/reports"
+DRY_RUN=0
+
+usage() {
+  sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tap-dir)    TAP_DIR="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    -h|--help)    usage; exit 0 ;;
+    *) echo "report.sh: unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -d "$TAP_DIR" ]]; then
+  echo "report.sh: tap dir not found: $TAP_DIR" >&2
+  exit 2
+fi
+
+# --------------------------------------------------------------------------
+# Configuration.
+# --------------------------------------------------------------------------
+# Stable column order for both console and markdown outputs.
+CLIS=(claude gemini copilot)
+
+# --------------------------------------------------------------------------
+# Discover TAP files.
+# --------------------------------------------------------------------------
+# Accept any `*.tap` under TAP_DIR, recursively. Runner writes
+# `<run-id>/run.tap`, but historic / hand-placed files at the top level
+# work the same way.
+TAP_FILES=()
+while IFS= read -r -d '' f; do
+  TAP_FILES+=("$f")
+done < <(find "$TAP_DIR" -type f -name '*.tap' -print0 | sort -z)
+
+if [[ ${#TAP_FILES[@]} -eq 0 ]]; then
+  echo "report.sh: no .tap files found under $TAP_DIR" >&2
+  echo "Run \`task e2e:test\` first to produce TAP output." >&2
+  exit 2
+fi
+
+# --------------------------------------------------------------------------
+# Parse TAP into an associative result map keyed by "<cli>/<scenario>".
+# Values: pass | fail | skip
+#
+# When the same cell appears in multiple TAP files (e.g. successive runs),
+# the *most recent* file wins because `find ... | sort -z` orders by
+# pathname and runner dirs carry a timestamp prefix. We simply overwrite.
+# --------------------------------------------------------------------------
+declare -A RESULT=()
+declare -A SCENARIO_SEEN=()
+
+for tap in "${TAP_FILES[@]}"; do
+  # Strip CR; skip TAP header, plan, comments, diagnostics.
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    case "$line" in
+      ok\ *|'not ok'\ *) : ;;
+      *) continue ;;
+    esac
+
+    # Extract the description (everything after the first " - ") and
+    # the directive (text after " # ", if any).
+    desc="${line#* - }"
+    if [[ "$desc" == "$line" ]]; then
+      # Malformed — no " - " separator. Skip.
+      continue
+    fi
+    directive=""
+    if [[ "$desc" == *" # "* ]]; then
+      directive="${desc#* # }"
+      desc="${desc% # *}"
+    fi
+
+    # Description shape: "<cli>/<scenario>" — trim whitespace.
+    desc="${desc#"${desc%%[![:space:]]*}"}"
+    desc="${desc%"${desc##*[![:space:]]}"}"
+    cli="${desc%%/*}"
+    scen="${desc#*/}"
+    [[ -n "$cli" && -n "$scen" && "$cli" != "$scen" ]] || continue
+
+    # Classify.
+    if [[ "$line" == "not ok "* ]]; then
+      status="fail"
+    elif [[ -n "$directive" ]] && echo "$directive" | grep -qiE '^(skip|todo)'; then
+      status="skip"
+    else
+      status="pass"
+    fi
+
+    RESULT["${cli}/${scen}"]="$status"
+    SCENARIO_SEEN["$scen"]=1
+  done < "$tap"
+done
+
+# --------------------------------------------------------------------------
+# Sort scenarios deterministically.
+# --------------------------------------------------------------------------
+SCENARIOS=()
+while IFS= read -r s; do SCENARIOS+=("$s"); done < <(
+  printf '%s\n' "${!SCENARIO_SEEN[@]}" | sort
+)
+
+# --------------------------------------------------------------------------
+# Render console table.
+# --------------------------------------------------------------------------
+glyph_for() {
+  case "$1" in
+    pass) printf '✅' ;;
+    fail) printf '❌' ;;
+    skip|"") printf '⚠️' ;;
+  esac
+}
+
+# Compute column width for the scenario name column.
+name_w=8 # "Scenario"
+for s in "${SCENARIOS[@]}"; do
+  (( ${#s} > name_w )) && name_w=${#s}
+done
+
+print_row() {
+  local label="$1"; shift
+  printf '%-*s' "$name_w" "$label"
+  for cell in "$@"; do
+    printf '  %-8s' "$cell"
+  done
+  printf '\n'
+}
+
+# Header.
+print_row "Scenario" "${CLIS[@]}"
+# Separator.
+sep="$(printf '%*s' "$name_w" '' | tr ' ' '-')"
+seps=()
+for _ in "${CLIS[@]}"; do seps+=("--------"); done
+print_row "$sep" "${seps[@]}"
+
+EXIT_CODE=0
+for scen in "${SCENARIOS[@]}"; do
+  cells=()
+  for cli in "${CLIS[@]}"; do
+    s="${RESULT["${cli}/${scen}"]:-}"
+    g="$(glyph_for "$s")"
+    cells+=("$g")
+    [[ "$s" == "fail" ]] && EXIT_CODE=1
+  done
+  print_row "$scen" "${cells[@]}"
+done
+
+# --------------------------------------------------------------------------
+# Render markdown report (unless --dry-run).
+# --------------------------------------------------------------------------
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  mkdir -p "$OUTPUT_DIR"
+  ts="$(date +%Y%m%d-%H%M%S)"
+  out="${OUTPUT_DIR%/}/parity-${ts}.md"
+
+  {
+    printf '# e2e Parity Matrix — %s\n\n' "$ts"
+    printf '| Scenario |'
+    for cli in "${CLIS[@]}"; do printf ' %s |' "$cli"; done
+    printf '\n|%s|' '---'
+    for _ in "${CLIS[@]}"; do printf '%s|' '---'; done
+    printf '\n'
+
+    for scen in "${SCENARIOS[@]}"; do
+      printf '| %s |' "$scen"
+      for cli in "${CLIS[@]}"; do
+        s="${RESULT["${cli}/${scen}"]:-}"
+        printf ' %s |' "$(glyph_for "$s")"
+      done
+      printf '\n'
+    done
+
+    printf '\nGenerated by `task e2e:report` from `%s/*.tap`\n' "${TAP_DIR%/}"
+  } > "$out"
+
+  printf '\nMarkdown report: %s\n' "$out"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/e2e/lib/report.sh
+++ b/tests/e2e/lib/report.sh
@@ -31,7 +31,20 @@ OUTPUT_DIR="tests/e2e/reports"
 DRY_RUN=0
 
 usage() {
-  sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+report.sh — aggregate per-run TAP files into a parity matrix.
+
+Reads TAP 13 files produced by tests/e2e/run.sh and emits:
+  1. A console table to stdout (✅ pass / ❌ fail / ⚠️  skip)
+  2. A markdown report at <output-dir>/parity-YYYYMMDD-HHMMSS.md
+
+Exit code: 1 if any cell is ❌, 2 on empty TAP dir, 0 otherwise.
+
+Usage:
+  tests/e2e/lib/report.sh [--tap-dir <dir>] [--output-dir <dir>] [--dry-run]
+
+Defaults: --tap-dir tests/e2e/reports/  --output-dir tests/e2e/reports/
+EOF
 }
 
 while [[ $# -gt 0 ]]; do
@@ -115,7 +128,7 @@ for tap in "${TAP_FILES[@]}"; do
     # Classify.
     if [[ "$line" == "not ok "* ]]; then
       status="fail"
-    elif [[ -n "$directive" ]] && echo "$directive" | grep -qiE '^(skip|todo)'; then
+    elif [[ -n "$directive" && "${directive,,}" =~ ^(skip|todo) ]]; then
       status="skip"
     else
       status="pass"

--- a/tests/e2e/scenarios/README.md
+++ b/tests/e2e/scenarios/README.md
@@ -32,6 +32,13 @@ delegating:
 Exit codes follow the runner's convention: `0` → ok, `78` → skip
 (diagnostic line on stdout), anything else → not ok.
 
+> **Run-ID format invariant.** The parity matrix report (`tests/e2e/lib/report.sh`)
+> uses lexicographic ordering of TAP file paths to decide which run wins when
+> the same `<cli>/<scenario>` cell appears in multiple files — the last file
+> wins. This relies on `E2E_RUN_ID` carrying a `<timestamp>-<rand>` prefix so
+> that newer runs sort after older ones. Do not change this format without also
+> updating the report aggregator.
+
 Every scenario sources the assertion libs and writes a TAP subtest plan
 to `${E2E_REPORT_DIR}/scenario.tap` for drill-down. The runner captures
 the scenario's stdout/stderr alongside.


### PR DESCRIPTION
Completes epic #75 by adding the parity matrix report aggregator (`tests/e2e/lib/report.sh`) and the comprehensive end-to-end framework guide (`tests/e2e/README.md`). The report reads TAP output files and produces a per-CLI × per-scenario matrix with non-zero exit on any failure.

## How to read this PR?

Start with `tests/e2e/README.md` for the full framework overview. Then read `tests/e2e/lib/report.sh` for the aggregator logic. The `Taskfile.yml` diff shows the single new `e2e:report` entry. `scripts/tests/test-e2e-report.sh` validates the aggregator without requiring Docker.

## How to test this PR?

```sh
# Harness test (no Docker required) — 12 PASS expected
bash scripts/tests/test-e2e-report.sh

# Dry-run report with no TAP files yet
bash tests/e2e/lib/report.sh --dry-run --tap-dir /tmp/empty-dir || true

# Smoke test with synthetic fixture
mkdir -p /tmp/tap-test/run-001
echo "ok 1 - claude/01-layered-context" > /tmp/tap-test/run-001/run.tap
bash tests/e2e/lib/report.sh --tap-dir /tmp/tap-test --dry-run
```

## Detailed description (for agents)

**New files:**
- `tests/e2e/lib/report.sh` — TAP aggregator: recursive `find *.tap`, console table (✅/❌/⚠️), markdown report at `tests/e2e/reports/parity-<timestamp>.md`, exit 1 on any ❌, exit 2 on empty TAP dir, `--dry-run` flag
- `tests/e2e/README.md` — 256-line comprehensive guide: Overview, Prerequisites, One-off setup, Running tests, Override file, Adding a new scenario, Authentication strategy, Troubleshooting, CI integration; cross-links to all 5 ADRs + lib/README + scenarios/README
- `scripts/tests/test-e2e-report.sh` — 172-line harness test, 12 PASS / 0 FAIL / 0 SKIP

**Modified files:**
- `Taskfile.yml` — added `e2e:report` task

Closes #81