### PR TITLE
🐛 Fix unbound variable crash in e2e auth scripts (#88)

### DIFF
--- a/scripts/e2e/auth-claude.sh
+++ b/scripts/e2e/auth-claude.sh
@@ -25,7 +25,7 @@ DIR="$(e2e_cli_dir "$CLI")"
 e2e_require_docker
 e2e_require_image "$IMAGE" "task e2e:build:claude"
 
-e2e_info "[$CLI] Preparing $DIR…"
+e2e_info "[$CLI] Preparing ${DIR}…"
 mkdir -p "$DIR"
 
 # Decision 6: chown bootstrap is mandatory (macOS) and harmless (Linux).

--- a/scripts/e2e/auth-gemini.sh
+++ b/scripts/e2e/auth-gemini.sh
@@ -23,7 +23,7 @@ DIR="$(e2e_cli_dir "$CLI")"
 e2e_require_docker
 e2e_require_image "$IMAGE" "task e2e:build:gemini"
 
-e2e_info "[$CLI] Preparing $DIR…"
+e2e_info "[$CLI] Preparing ${DIR}…"
 mkdir -p "$DIR"
 
 # Decision 6: chown bootstrap is mandatory (macOS) and harmless (Linux).


### PR DESCRIPTION
Fixes a crash in \`task e2e:auth:claude\` and \`task e2e:auth:gemini\` caused by an unbound variable error when bash's \`set -u\` is active.

## How to read this PR?

Two one-line changes in \`scripts/e2e/auth-claude.sh\` and \`scripts/e2e/auth-gemini.sh\`: \`\$DIR…\` → \`\${DIR}…\`. The ellipsis character U+2026 (\`…\`) was glued directly to \`\$DIR\`, causing bash to interpret \`DIR…\` as the variable name.

## How to test this PR?

```sh
# Should reach the docker/image check instead of crashing immediately
bash scripts/e2e/auth-claude.sh 2>&1 | head -3
bash scripts/e2e/auth-gemini.sh 2>&1 | head -3
```

Expected: output starts with \`[claude] Preparing …\` or fails at the docker/image check — not \`DIR…: variable sans liaison\`.

## Detailed description (for agents)

**Root cause:** \`e2e_info "[\$CLI] Preparing \$DIR…"\` — U+2026 (\`…\`, UTF-8: \`\xe2\x80\xa6\`) immediately follows \`\$DIR\` without braces. With \`set -euo pipefail\`, bash treats \`\$DIR…\` as variable \`DIR…\` (unbound) and aborts with exit 201.

**Fix:** replace bare \`\$DIR\` with \`\${DIR}\` in the two affected lines.

**Files changed:**
- \`scripts/e2e/auth-claude.sh:28\`
- \`scripts/e2e/auth-gemini.sh:26\`

Closes #88