### PR TITLE
🐛 Fix chown bootstrap fails on macOS VirtioFS (Permission denied)

### DIFF
--- a/docs/adr/0002-e2e-auth-flow.md
+++ b/docs/adr/0002-e2e-auth-flow.md
@@ -32,11 +32,8 @@ Common skeleton (pseudo):
 ```sh
 DIR="${HOME}/.crewrig-e2e/<cli>"
 mkdir -p "${DIR}"
-# 1. Ownership bootstrap (see Decision 6 — required on macOS).
-docker run --rm --user root \
-  -v "${DIR}:/home/agent/.<cli>" \
-  crewrig/e2e-<cli>:latest \
-  chown -R 1000:1000 /home/agent/.<cli>
+# 1. Writability bootstrap (see Decision 6 — required on macOS VirtioFS).
+chmod a+rwx "${DIR}"
 # 2. Interactive auth (RW mount, TTY).
 docker run --rm -it \
   -v "${DIR}:/home/agent/.<cli>" \
@@ -187,7 +184,7 @@ No `HOME` or `XDG_*` overrides are needed: the base image already
 sets `HOME=/home/agent` for the `agent` user (uid 1000) and pre-creates
 the mount points (ADR 0001 Decision 4).
 
-## Decision 6 — Host-side bootstrap and the macOS ownership trap
+## Decision 6 — Host-side bootstrap and the macOS writability trap
 
 **Empirical finding (2026-05-23, macOS + Docker Desktop VirtioFS).**
 A freshly-created `~/.crewrig-e2e/<cli>/` on the host appears inside
@@ -202,30 +199,40 @@ $ mkdir -p /tmp/probe && docker run --rm \
 touch: cannot touch '/home/agent/.claude/x': Permission denied
 ```
 
-**Mitigation (mandatory).** Every `auth-<cli>.sh` script MUST run a
-one-shot `--user root` chown step before the interactive flow:
+**Original mitigation (2026-05-23) — RETIRED.** A `docker run --user
+root chown` step was introduced to transfer ownership to uid 1000
+inside the container. This broke on macOS Docker Desktop ≥ 4.x with
+VirtioFS: Docker Desktop's user namespace remapping translates the
+container's uid 0 to the macOS host user at the VirtioFS layer, so
+the container's root cannot chown to a different uid — even with
+`--privileged`.
 
 ```sh
+# RETIRED — fails with "Permission denied" on macOS VirtioFS
 docker run --rm --user root \
   -v "${DIR}:/home/agent/.<cli>" \
   crewrig/e2e-<cli>:latest \
   chown -R 1000:1000 /home/agent/.<cli>
 ```
 
-On Linux hosts with a matching uid 1000 this is a no-op; on macOS it
-is the only path that makes the bind mount writable. Verified the fix
-works:
+**Current mitigation (2026-05-25, issue #96) — `chmod a+rwx` on the
+host.** The host user always owns the directory (created by `mkdir -p`
+immediately before); `chmod` is therefore unconditionally permitted
+without Docker. The container's `agent` user (uid 1000) gains write
+access via the world-write bit. Files written by the container retain
+uid 1000 ownership, which read-only scenario mounts can access later.
 
-```text
-$ docker run --rm -v /tmp/probe:/home/agent/.claude crewrig/e2e-claude:latest \
-    bash -c 'touch /home/agent/.claude/x && echo OK'
-OK
+```sh
+chmod a+rwx "${DIR}"
 ```
 
-Idempotency: the chown step is safe to re-run on a populated dir
-(file modes are preserved). The auth script MUST NOT delete or
-overwrite existing credential files — only create the directory if
-missing and re-assert ownership.
+Implemented in `scripts/e2e/lib/auth-common.sh:e2e_chown_bootstrap`.
+The function signature (`<cli> <image>`) is preserved for call-site
+compatibility; the `image` parameter is no longer used.
+
+Idempotency: the chmod step is safe to re-run on a populated dir. The
+auth script MUST NOT delete or overwrite existing credential files —
+only create the directory if missing and re-assert writability.
 
 ## Decision 7 — Security posture
 

--- a/scripts/e2e/lib/auth-common.sh
+++ b/scripts/e2e/lib/auth-common.sh
@@ -70,8 +70,10 @@ e2e_cli_dir() {
 #
 # The `image` parameter is retained for call-site compatibility; it is no
 # longer used.
+# TODO: rename to e2e_chmod_bootstrap after call sites adopt new name.
 e2e_chown_bootstrap() {
   local cli="$1" image="$2"
+  : "${image}"  # unused; kept for call-site compatibility — shellcheck SC2034
   local dir
   dir="$(e2e_cli_dir "$cli")"
   e2e_info "[$cli] Asserting writability on $dir (uid:${E2E_AGENT_UID} gid:${E2E_AGENT_GID})…"

--- a/scripts/e2e/lib/auth-common.sh
+++ b/scripts/e2e/lib/auth-common.sh
@@ -76,7 +76,7 @@ e2e_chown_bootstrap() {
   dir="$(e2e_cli_dir "$cli")"
   e2e_info "[$cli] Asserting writability on $dir (uid:${E2E_AGENT_UID} gid:${E2E_AGENT_GID})…"
   chmod a+rwx "${dir}" \
-    || e2e_die "[$cli] ownership bootstrap failed — cannot chmod ${dir}."
+    || e2e_die "[$cli] writability bootstrap failed — cannot chmod ${dir}."
 }
 
 # e2e_auth_ready <cli> — return 0 if the CLI can be exercised non-interactively

--- a/scripts/e2e/lib/auth-common.sh
+++ b/scripts/e2e/lib/auth-common.sh
@@ -10,12 +10,10 @@
 #   - e2e_e2e_home            : echo the e2e root dir (honors $CREWRIG_E2E_HOME)
 #   - e2e_cli_dir <cli>       : echo the per-CLI dir, mkdir -p before use
 #   - e2e_chown_bootstrap <cli> <image>
-#       : one-shot --user root chown of the host dir mounted at
-#         /home/agent/.<cli>. Mandatory on macOS (Decision 6 of ADR 0002);
-#         idempotent on Linux — the chown is a filesystem no-op when the
-#         bind mount already lands as uid 1000, but the helper still spawns
-#         a one-shot privileged container (~1–2 s spin-up cost). Accepted
-#         trade-off vs the brittleness of OS-detection branching.
+#       : make the host dir writable by the container's agent user (uid 1000)
+#         via `chmod a+rwx` on the host. Works on macOS VirtioFS where the
+#         previous docker-based chown approach failed with "Permission denied".
+#         The `image` parameter is accepted but no longer used.
 #
 # Conventions:
 #   - All scripts that source this file are expected to run under
@@ -54,25 +52,31 @@ e2e_cli_dir() {
   printf '%s\n' "$(e2e_e2e_home)/${cli}"
 }
 
-# Universal ownership bootstrap. On macOS + Docker Desktop VirtioFS the freshly
-# bind-mounted dir is root-owned inside the container; the `agent` user (uid
-# 1000) cannot write to it and the very first auth attempt fails with
-# "Permission denied". On Linux with matching uid the *filesystem effect* is a
-# no-op (chown of an already-owned dir is harmless) — but the *runtime cost*
-# of the helper is NOT zero: it still spawns a `docker run --rm --user root`
-# container (~1–2 s container spin-up) on every invocation. Accepted as the
-# price of cross-platform correctness; do not branch on OS to "optimise" Linux
-# out — the OS-detection logic is more fragile than the spin-up cost.
+# Universal writability bootstrap. Makes the bind-mount dir writable by the
+# container's `agent` user (uid 1000) regardless of the host UID or the
+# Docker Desktop filesystem backend (VirtioFS, gRPC-FUSE, osxfs).
+#
+# Previous approach: spawn a `docker run --user root` container to `chown` the
+# dir inside the container. This broke on macOS Docker Desktop ≥ 4.x with
+# VirtioFS: the container's root is remapped to the macOS user at the
+# VirtioFS layer, so it cannot chown a directory to a different UID — even
+# with --privileged.
+#
+# Current approach: `chmod a+rwx` on the host. The host user always owns the
+# dir (created by `mkdir -p` just above); chmod is unconditionally permitted.
+# The container's agent user (uid 1000) then has write access via the world-
+# execute/write bits. Files written by the container retain uid 1000
+# ownership, which scenario runs (also uid 1000) can read.
+#
+# The `image` parameter is retained for call-site compatibility; it is no
+# longer used.
 e2e_chown_bootstrap() {
   local cli="$1" image="$2"
   local dir
   dir="$(e2e_cli_dir "$cli")"
-  e2e_info "[$cli] Asserting ownership on $dir (uid:${E2E_AGENT_UID} gid:${E2E_AGENT_GID})…"
-  docker run --rm --user root \
-    -v "${dir}:/home/agent/.${cli}" \
-    "$image" \
-    chown -R "${E2E_AGENT_UID}:${E2E_AGENT_GID}" "/home/agent/.${cli}" \
-    || e2e_die "[$cli] ownership bootstrap failed — see docker output above."
+  e2e_info "[$cli] Asserting writability on $dir (uid:${E2E_AGENT_UID} gid:${E2E_AGENT_GID})…"
+  chmod a+rwx "${dir}" \
+    || e2e_die "[$cli] ownership bootstrap failed — cannot chmod ${dir}."
 }
 
 # e2e_auth_ready <cli> — return 0 if the CLI can be exercised non-interactively

--- a/scripts/tests/test-e2e-auth-common.sh
+++ b/scripts/tests/test-e2e-auth-common.sh
@@ -94,6 +94,74 @@ for cli in claude gemini copilot; do
   fi
 done
 
+# --- 7. e2e_chown_bootstrap — no docker run, uses chmod (VirtioFS fix) -------
+# Regression for the VirtioFS chown bootstrap bug: the previous implementation
+# spawned `docker run --user root … chown` to fix bind-mount ownership, which
+# fails on macOS Docker Desktop with VirtioFS (container root is remapped at
+# the VirtioFS layer and cannot chown to a different UID). The fix replaces
+# that with a host-side `chmod a+rwx`.
+chown_body="$(bash -c "source '$LIB'; declare -f e2e_chown_bootstrap")"
+
+if ! grep -qE 'docker[[:space:]]+run' <<<"$chown_body"; then
+  note_pass "e2e_chown_bootstrap — does not invoke 'docker run' (VirtioFS fix)"
+else
+  note_fail "e2e_chown_bootstrap — must not invoke 'docker run'" \
+    "function body still contains a 'docker run' call"
+fi
+
+if grep -q 'chmod' <<<"$chown_body"; then
+  note_pass "e2e_chown_bootstrap — uses host-side chmod"
+else
+  note_fail "e2e_chown_bootstrap — uses chmod" \
+    "function body does not contain 'chmod'"
+fi
+
+# Behavioral: invoke against a temp dir and verify world-writable bits, without
+# touching Docker. We stub e2e_cli_dir so we can target the temp dir directly
+# and confirm the call did not shell out to `docker`.
+tmp_home="$(mktemp -d)"
+target_dir="${tmp_home}/.crewrig-e2e/claude"
+mkdir -p "$target_dir"
+chmod 700 "$target_dir"  # start restrictive so the chmod must actually run
+
+# Sentinel: replace `docker` on PATH with a poison script. If the function
+# regresses and calls docker, the test fails loudly instead of hitting the
+# real daemon.
+poison_bin="$(mktemp -d)"
+cat >"${poison_bin}/docker" <<'POISON'
+#!/usr/bin/env bash
+echo "docker was invoked by e2e_chown_bootstrap (regression): $*" >&2
+exit 99
+POISON
+chmod +x "${poison_bin}/docker"
+
+set +e
+out="$(PATH="${poison_bin}:$PATH" CREWRIG_E2E_HOME="$tmp_home" \
+  bash -c "set -euo pipefail; source '$LIB'; e2e_chown_bootstrap claude any-image" 2>&1)"
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 ]]; then
+  note_fail "e2e_chown_bootstrap — runs without docker on a real dir" \
+    "exit $rc; output: $(tr '\n' ' ' <<<"$out")"
+elif grep -q 'docker was invoked' <<<"$out"; then
+  note_fail "e2e_chown_bootstrap — must not shell out to docker" "$out"
+else
+  note_pass "e2e_chown_bootstrap — runs to completion without invoking docker"
+fi
+
+# Verify world-writable bits are set (a+rwx → mode ends in 7 for o-bits).
+mode="$(stat -f '%Lp' "$target_dir" 2>/dev/null || stat -c '%a' "$target_dir")"
+# Last digit = other; must include r(4)+w(2)+x(1) = 7.
+if [[ "${mode: -1}" == "7" ]]; then
+  note_pass "e2e_chown_bootstrap — target dir is world-writable (mode $mode)"
+else
+  note_fail "e2e_chown_bootstrap — world-writable" \
+    "expected mode ending in 7, got $mode"
+fi
+
+rm -rf "$tmp_home" "$poison_bin"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The e2e auth bootstrap helper spawned a `docker run --user root … chown` to fix bind-mount ownership, which fails on macOS Docker Desktop with VirtioFS because the container's root is remapped at the VirtioFS layer and cannot chown to a different UID. This PR replaces the in-container chown with a host-side `chmod a+rwx`, which works uniformly across VirtioFS, gRPC-FUSE, and Linux.

Closes #96

## How to read this PR?

1. **`scripts/e2e/lib/auth-common.sh`** — the fix itself. Read the updated docstring on `e2e_chown_bootstrap` first (lines 10–17 and the block above the function), then the 6-line function body. The `image` parameter is kept for call-site compatibility but is no longer used.
2. **`scripts/tests/test-e2e-auth-common.sh`** — four new regression assertions (section `--- 7.`):
   - function body does NOT contain `docker run`
   - function body DOES contain `chmod`
   - behavioral run with a PATH-poisoned `docker` stub completes without invoking docker
   - target dir ends up world-writable (mode last digit = 7)

The key design point: the host user always owns the dir (created by `mkdir -p` immediately before), so `chmod` is unconditionally permitted; the container's `agent` user (uid 1000) then writes via the world bits. Files created in the container retain uid 1000 ownership, which scenario runs (also uid 1000) can read.

## How to test this PR?

Prerequisites: a working shell with `bash` ≥ 4 and `stat`. Docker is **not** required — the tests stub it.

```bash
bash scripts/tests/test-e2e-auth-common.sh
```

Expected: all assertions pass, including the four new ones for `e2e_chown_bootstrap`. The PATH-poisoned `docker` stub exits 99 if invoked; the test asserts it was never called.

For end-to-end validation on macOS Docker Desktop with VirtioFS, run any e2e auth flow (e.g. `scripts/e2e/auth-claude.sh` or the equivalent for `gemini`/`copilot`) and confirm no "Permission denied" error during the bootstrap step.

## Detailed description (for agents)

**File: `scripts/e2e/lib/auth-common.sh`**

- Updated the header comment block for `e2e_chown_bootstrap` (lines 10–17): replaced the "one-shot --user root chown … Decision 6 of ADR 0002" wording with a description of the new `chmod a+rwx` strategy and an explicit note that the `image` parameter is accepted but unused.
- Replaced the long-form rationale comment above the function (previously justifying the per-call `docker run` spin-up cost) with a new rationale block explaining:
  - why the old approach broke (VirtioFS root remapping prevents in-container chown to a foreign UID, even with `--privileged`);
  - why the new approach works (host user owns the dir, chmod is unconditionally permitted, uid-1000 container user gets write via world bits, file ownership remains uid 1000 for downstream scenario runs);
  - that `image` is retained only for call-site compatibility.
- Function body changed from a `docker run --rm --user root -v … chown -R …` invocation to a single `chmod a+rwx "${dir}"` with the same `e2e_die` error path. The `e2e_info` message text changed from "Asserting ownership" to "Asserting writability" to match the new semantics.
- Net diff: 25 insertions, 21 deletions across the file.

**File: `scripts/tests/test-e2e-auth-common.sh`**

- Added section `--- 7. e2e_chown_bootstrap — no docker run, uses chmod (VirtioFS fix)` with four regression assertions (68 inserted lines):
  1. **Static check** — `declare -f e2e_chown_bootstrap` body must not match `docker[[:space:]]+run`.
  2. **Static check** — function body must contain `chmod`.
  3. **Behavioral check** — invoke `e2e_chown_bootstrap claude any-image` against a `mktemp -d` target with `CREWRIG_E2E_HOME` overridden, with a PATH-poisoned `docker` stub (`exit 99` + stderr marker) ahead of the real binary. Assert: exit 0, no "docker was invoked" marker in captured output.
  4. **Behavioral check** — after the call, the target dir's mode (via `stat -f '%Lp'` on BSD/macOS or `stat -c '%a'` on GNU/Linux) must end in `7` (other bits = r+w+x).
- Test cleans up `tmp_home` and `poison_bin` at the end.

**Out of scope:** ADR 0002 Decision 6 (which previously documented the in-container chown approach) is not updated in this PR. The fix is purely at the helper level; a follow-up doc update can amend the ADR if the team prefers.