### PR TITLE
🐛 Fix status script false-negative when daemon is supervisor-managed

### DIFF
--- a/scripts/status-chroma-server.sh
+++ b/scripts/status-chroma-server.sh
@@ -14,7 +14,12 @@ HOST="${MEMPALACE_CHROMA_HOST:-127.0.0.1}"
 PORT="${MEMPALACE_CHROMA_PORT:-8001}"
 
 if [ ! -f "${PID_FILE}" ]; then
-  echo "chroma server: NOT RUNNING (no PID file)"
+  # No PID file — daemon may be supervisor-managed (launchd/systemd); rely on heartbeat alone.
+  if curl -sf "http://${HOST}:${PORT}/api/v2/heartbeat" >/dev/null 2>&1; then
+    echo "chroma server: HEALTHY (supervisor-managed, ${HOST}:${PORT})"
+    exit 0
+  fi
+  echo "chroma server: NOT RUNNING (no PID file, heartbeat failed at ${HOST}:${PORT})"
   exit 1
 fi
 


### PR DESCRIPTION
`scripts/status-chroma-server.sh` exited 1 whenever the PID file was absent, which caused `install_chroma_daemon` (in `scripts/lib/common.sh`, line 173) to report setup failure even when the daemon was healthy and responding on port 8001. This fix adds a heartbeat-only fallback so launchd- and systemd-managed daemons are recognized as running.

Closes logbook: #100

## How to read this PR?

Single file changed: `scripts/status-chroma-server.sh`.

The original no-PID-file branch was a one-liner (`echo … ; exit 1`). The new branch (6 lines, see diff) attempts `curl -sf http://${HOST}:${PORT}/api/v2/heartbeat` before deciding the daemon is absent. If the heartbeat succeeds the script prints `chroma server: HEALTHY (supervisor-managed, …)` and exits 0; if it fails the error message now includes the host/port for easier diagnosis.

`install_chroma_daemon` in `scripts/lib/common.sh` is unchanged — it already gates the post-install health check on the script's exit code (line 173), so the fix flows through without any change to the caller.

## How to test this PR?

**Prerequisites:** chroma daemon running under launchd (macOS) or systemd (Linux), with no PID file at the path `scripts/status-chroma-server.sh` reads (`/tmp/chroma-server.pid` by default or `$MEMPALACE_CHROMA_PID_FILE`).

```bash
# 1. Confirm no PID file exists
ls /tmp/chroma-server.pid   # should say "No such file or directory"

# 2. Run the status script
bash scripts/status-chroma-server.sh
# Expected output:  chroma server: HEALTHY (supervisor-managed, 127.0.0.1:8001)
# Expected exit code: 0

# 3. Stop the daemon, then re-run
bash scripts/status-chroma-server.sh
# Expected output:  chroma server: NOT RUNNING (no PID file, heartbeat failed at 127.0.0.1:8001)
# Expected exit code: 1
```

**Golden path (PID-file-managed daemon, existing behaviour unchanged):**
```bash
# With a PID file present the code path is unaffected — the existing
# pid-file + process-existence checks run as before.
bash scripts/status-chroma-server.sh
```

## Detailed description (for agents)

**File modified:** `scripts/status-chroma-server.sh` (+6 lines, -1 line, see diff)

**Root cause.** The `if [ ! -f "${PID_FILE}" ]` branch (original line 15) unconditionally printed `NOT RUNNING` and exited 1. No PID file is written when launchd (macOS) or systemd manages the chroma process — the service manager tracks the process itself. This made every supervisor-managed installation fail the post-install health check.

**Fix.** Inside the no-PID-file branch, attempt `curl -sf http://${HOST}:${PORT}/api/v2/heartbeat` before concluding the daemon is absent:
- Heartbeat succeeds → print `HEALTHY (supervisor-managed, …)` and exit 0.
- Heartbeat fails → print `NOT RUNNING (no PID file, heartbeat failed at …)` and exit 1.

The `HOST` and `PORT` variables are already resolved from environment overrides (`MEMPALACE_CHROMA_HOST`, `MEMPALACE_CHROMA_PORT`) earlier in the script, so the fallback respects the same configuration surface.

**Caller unchanged.** `install_chroma_daemon` in `scripts/lib/common.sh` calls `bash scripts/status-chroma-server.sh` (line 173) and treats a non-zero exit as failure. No change to that caller is needed — the corrected exit code is sufficient.