### PR TITLE
📝 Document idle_notification delivery tolerance in Team Communication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,7 +372,7 @@ design flaw rather than a localized defect.
 
 ### Team Communication
 
-Two rules govern how teammates report back inside a team.
+Four rules govern how teammates report back inside a team and how the team-lead interprets their signals.
 
 **Rule 1 — Report before idle.** Every agent operating inside a team
 (spawned via `TeamCreate` / `TaskCreate`) MUST send a message to
@@ -392,7 +392,37 @@ can resume rather than restart from scratch. Direct `Agent` spawns (without team
 reliably complete and return results; `SendMessage` to a stuck idle
 agent does not.
 
-**Rule 3 — Review findings are not auto-deferrals.** When a reviewer
+**Rule 3 — Idle notifications can race result messages.** When the
+team-lead receives an `idle_notification` for a teammate, that signal
+does NOT prove the teammate skipped Rule 1. Result messages and idle
+notifications travel as separate events on the harness bus, and the
+idle notification can arrive first even when the teammate sent its
+result correctly. Before treating an apparent silence as a Rule 1
+violation, the team-lead MUST:
+
+1. **Let the channel drain.** Do not send anything to the idle
+   teammate on the same turn the idle notification arrives. The
+   in-flight result message — if one exists — will be delivered on
+   the team-lead's next turn without any prompting.
+2. **Check observable side-effects first.** Inspect the artifacts the
+   teammate was tasked to produce: `git status` and `git log` in the
+   ticket worktree, `gh pr view <num>` for PR state, the logbook
+   issue for comments, or the specific file the task targeted. A
+   completed task almost always leaves a trace that confirms the
+   outcome without the result message itself.
+3. **Only then escalate.** If, after the next turn, no result message
+   has landed AND no side-effect confirms completion, treat the
+   silence as an actual Rule 1 violation and apply Rule 2 (spawn a
+   fresh direct `Agent`). Do NOT send a status-check `SendMessage` to
+   the idle teammate — it wastes the teammate's next turn
+   re-confirming work already done, and Rule 2 is the prescribed
+   remedy for genuine non-response.
+
+Sending a status-check ping on every idle notification is itself a
+protocol violation: it manufactures the very noise this rule exists
+to prevent.
+
+**Rule 4 — Review findings are not auto-deferrals.** When a reviewer
 lists findings marked "non-blocking", that label means the PR can merge
 without them — it does NOT mean the findings should be deferred to a
 follow-up ticket without asking the user. The agent MUST present every


### PR DESCRIPTION
Codifies that `idle_notification` events can race ahead of a teammate's result message on the harness bus, so the team-lead must not treat an apparent silence as a Rule 1 violation on first sight. Adds a three-step procedure (drain, check side-effects, escalate via Rule 2) and explicitly forbids status-check pings on idle notifications.

Closes #102

## How to read this PR?

Single-file diff to `AGENTS.md`, *Agent Team Protocol → Team Communication* section. Read in order:

1. The lead-in change: "Two rules" → "Four rules govern how teammates report back inside a team and how the team-lead interprets their signals." The phrasing widens the section's scope from teammate behaviour to team-lead interpretation.
2. The new **Rule 3 — Idle notifications can race result messages** between the existing Rule 2 and what is now Rule 4. The three numbered sub-steps are load-bearing; the trailing sentence ("Sending a status-check ping on every idle notification is itself a protocol violation…") is the operative prohibition.
3. The mechanical rename of the prior Rule 3 to **Rule 4 — Review findings are not auto-deferrals** (unchanged body).

Non-obvious design decision: Rule 3 deliberately reuses Rule 2's existing remedy (spawn a fresh direct `Agent`) rather than introducing a fourth resolution path. This keeps the contract surface narrow — there is exactly one escalation lever for genuine non-response.

## How to test this PR?

Documentation-only change. To verify:

```
cd .worktrees/issue-102
git diff main -- AGENTS.md
```

Expected: 32 insertions, 2 deletions, scoped to the *Team Communication* sub-section. The lead-in line changes, Rule 3 is added, the former Rule 3 is renumbered to Rule 4. No other sections are touched.

Optionally render the section locally (`glow AGENTS.md` or any Markdown viewer) and confirm the four rules read in sequence without numbering gaps.

## Detailed description (for agents)

Single edit to `AGENTS.md` under *Agent Team Protocol → Team Communication*:

1. **Lead-in updated.** The sentence "Two rules govern how teammates report back inside a team." becomes "Four rules govern how teammates report back inside a team and how the team-lead interprets their signals." Two changes in one line: the count, and the scope (the section now covers team-lead interpretation, not only teammate behaviour).

2. **Rule 3 inserted.** New rule titled *Idle notifications can race result messages*. The rule body asserts that result messages and idle notifications travel as separate harness-bus events with no ordering guarantee, then prescribes a three-step procedure for the team-lead on receipt of an `idle_notification`:
   - **Step 1 — Let the channel drain.** Do not send to the idle teammate on the same turn; an in-flight result message lands on the team-lead's next turn without prompting.
   - **Step 2 — Check observable side-effects first.** Inspect the artifacts the teammate was tasked to produce: `git status`/`git log` in the worktree, `gh pr view <num>`, logbook issue comments, or the targeted file. A completed task almost always leaves a trace.
   - **Step 3 — Only then escalate.** If the next turn produces neither a result message nor a side-effect confirmation, apply Rule 2 (fresh direct `Agent` spawn). The rule explicitly forbids sending a status-check `SendMessage` to the idle teammate — Rule 2 is the only prescribed remedy.
   The rule closes with the operative prohibition: "Sending a status-check ping on every idle notification is itself a protocol violation: it manufactures the very noise this rule exists to prevent."

3. **Rule 3 → Rule 4 rename.** The pre-existing *Review findings are not auto-deferrals* rule is renumbered from Rule 3 to Rule 4. Body is unchanged.

No other files touched. No `community-config/` sources modified — the version-bump rule (`scripts/check-skill-versions.sh`) does not apply. No code, no tests, no CLI matrix impact.