### PR TITLE
📝 Document correct post-merge worktree cleanup sequence (#103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,10 +270,21 @@ git fetch crewrig && git rebase crewrig/main
 
 If the rebase raises conflicts, resolve them, then `git rebase --continue`. Log the conflict on the issue logbook before resuming (Rule B).
 
-Once the PR is merged and the linked logbook issue closed (see *Logbook Issues → Rule C*), remove the worktree to keep the repository clean:
+Once the PR is merged and the linked logbook issue closed (see *Logbook Issues → Rule C*), clean up the worktree and its branch in this **exact order**:
+
+1. **Verify the merge landed.** `gh pr view <pr-number> --json state,mergedAt` — proceed only when `state == MERGED`.
+2. **Remove the worktree.** `git worktree remove .worktrees/<ticket-id>` — this releases the branch reference held by the worktree.
+3. **Delete the local branch.** `git branch -D <branch-name>` — required because `gh pr merge --delete-branch` only deletes the **remote** branch; the local ref survives.
+4. **Close the logbook issue** per *Logbook Issues → Rule C* (if not already closed by the merge).
+
+**Why this order matters.** Git refuses to delete a branch that is checked out by an active worktree. Running `gh pr merge --delete-branch` (or `git branch -D`) while the worktree still exists fails with `error: cannot delete branch '<name>' checked out at '.worktrees/<ticket-id>'`. Removing the worktree first releases the ref so step 3 can proceed cleanly.
 
 ```sh
+# canonical sequence
+gh pr view <pr-number> --json state,mergedAt
 git worktree remove .worktrees/<ticket-id>
+git branch -D <branch-name>
+gh issue close <issue-number> --reason completed
 ```
 
 Any obstacle encountered during the worktree lifecycle — merge conflicts, CI failures, friction declarations, scope changes, rebases that resolve conflicts — must be logged on the issue logbook before resuming work. See **Rule B** for the full trigger list.


### PR DESCRIPTION
Document the exact post-merge sequence for cleaning up a ticket worktree and its local branch. Closes a process gap where agents ran `gh pr merge --delete-branch` and then hit `cannot delete branch checked out at .worktrees/...` on the next ticket.

## How to read this PR?

Single file changed: `AGENTS.md`, *Worktree Isolation* section. Read the replaced paragraph (around line 270) — the old one-line "remove the worktree" sentence is now a 4-step numbered list with a *Why this order matters* paragraph and a canonical shell block. No code, no scripts, no parity surface touched.

## How to test this PR?

Documentation-only change. To validate locally:

1. `git diff main -- AGENTS.md` — confirm the diff matches the 4-step procedure (verify merge → remove worktree → delete local branch → close logbook).
2. Read the *Why this order matters* paragraph and confirm it names the Git failure mode (`cannot delete branch '<name>' checked out at '.worktrees/<ticket-id>'`).
3. Optional dry-run on a throwaway worktree to confirm the documented sequence actually succeeds end-to-end.

## Detailed description (for agents)

**Changed file:** `AGENTS.md`, *Worktree Isolation* section.

**Before:** a single sentence directed agents to `git worktree remove .worktrees/<ticket-id>` after merge. No mention of the local branch ref, no mention that `gh pr merge --delete-branch` only deletes the remote ref, no ordering guidance.

**After:** the same paragraph now expands into:

1. A 4-step numbered cleanup procedure (verify merge via `gh pr view`, remove the worktree, delete the local branch with `git branch -D`, close the logbook issue per Rule C).
2. A *Why this order matters* paragraph that names the exact Git error message agents will hit if they invert the order (`error: cannot delete branch '<name>' checked out at '.worktrees/<ticket-id>'`) and explains that removing the worktree first releases the ref held by the worktree's HEAD.
3. A canonical shell block showing the 4 commands in order, for agents that prefer to copy-paste rather than parse prose.

**Why MAJOR/MINOR/PATCH does not apply:** this change touches `AGENTS.md`, not a `community-config/skills/*/SKILL.md` or `community-config/agents/*/AGENT.md` source — the version-bump rule does not apply. `scripts/check-skill-versions.sh` will not flag this PR.

**No parity surface touched:** the trigger surface listed under *CLI Matrix Maintenance* is untouched (no `.claude/**`, no `.gemini/**`, no `community-config/**`, no scripts). `docs/cli-matrix.md` does not need updating.

Closes #103