### PR TITLE
📝 Document team shutdown sequence (shutdown_request before TeamDelete)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,39 @@ the user explicitly decides to skip or defer it. The user sets the
 scope, not the reviewer's severity labels. Auto-deferring findings to
 follow-up tickets without user authorization is prohibited.
 
+### Team Shutdown
+
+Calling `TeamDelete` directly — without first requesting each teammate's
+shutdown — leaves teammates running as orphaned idle processes on the
+harness. This is a protocol violation. Every team disposal MUST follow
+the two-phase sequence below.
+
+**Phase 1 — Request shutdown from every teammate.** For each teammate
+still registered on the team, the team-lead sends a structured shutdown
+request via `SendMessage` and waits for the matching response before
+moving on:
+
+1. `SendMessage({to: "<teammate>", message: {type: "shutdown_request"}})`
+2. Await the teammate's reply: `{type: "shutdown_response", request_id: "...", approve: true}`. Approving the request terminates the teammate's process — that is the intended effect.
+3. If a teammate replies with `approve: false`, the team-lead MUST resolve the blocker the teammate cites (in `reason`) before retrying. Forcing `TeamDelete` over an explicit rejection discards in-flight work.
+4. If a teammate goes idle without responding, apply *Team Communication → Rule 3* (let the channel drain, check side-effects) before escalating. If the silence persists past the next turn, the team-lead MAY proceed to Phase 2 for that teammate only, after recording the unresponsive shutdown in the logbook (see *Logbook Issues → Rule B*).
+
+**Phase 2 — Dispose of the team.** Once every teammate has either
+approved its shutdown or been declared unresponsive per Phase 1 step 4,
+call `TeamDelete` to remove the team record itself.
+
+**Triggers.** Run the sequence above whenever:
+
+- The ticket's PR has been merged and the logbook closed (the standard end-of-ticket path — see *Logbook Issues → Rule C*).
+- The user cancels the ticket or pivots scope to a different team composition.
+- A fatal error makes the current team unrecoverable and a fresh team is needed.
+
+**Prohibition.** Invoking `TeamDelete` without a preceding
+`shutdown_request` round-trip for every teammate is a protocol
+violation, regardless of whether the teammates appear idle. "Idle" is a
+harness display state, not a confirmation that the underlying process
+has released its resources.
+
 ## Pull Request Format
 
 Every PR must follow this structure:


### PR DESCRIPTION
Documents the mandatory two-phase shutdown sequence that team-leads must follow before disposing of a team. Closes the gap that allowed `TeamDelete` to be called directly, leaving teammates running as orphaned idle processes.

## How to read this PR?

Single-file change. Read `AGENTS.md` around the new `### Team Shutdown` sub-section (inserted between `### Team Communication` and `## Pull Request Format`). The section codifies:

1. Phase 1 — per-teammate `shutdown_request` / `shutdown_response` round-trip, with explicit handling for `approve: false` and unresponsive teammates (defers to *Team Communication → Rule 3*).
2. Phase 2 — `TeamDelete` only after every teammate has approved or been declared unresponsive.
3. Triggers (end-of-ticket, scope pivot, fatal error) and the explicit prohibition against bypassing Phase 1.

## How to test this PR?

Documentation-only change — no executable code. Verify:

- `git diff main -- AGENTS.md` shows exactly one added block, no removals.
- The new section nests under `## Agent Team Protocol` (sibling of `### Team Communication`).
- Cross-references to *Team Communication → Rule 3* and *Logbook Issues → Rule B/C* resolve to existing anchors in the same document.

## Detailed description (for agents)

- **File:** `AGENTS.md`
- **Insertion point:** after the closing paragraph of `### Team Communication` (Rule 3) and before `## Pull Request Format`.
- **Heading level:** `###` to sit at the same depth as the other sub-sections of `## Agent Team Protocol` (`### When this applies`, `### Worktree Isolation`, `### Standard Team Templates`, `### Team Communication`).
- **Content shape:** four labelled blocks — *Phase 1*, *Phase 2*, *Triggers*, *Prohibition*. Phase 1 carries a 4-step numbered list covering happy path, explicit rejection, and silence.
- **Protocol contract introduced:**
  - `SendMessage({to: "<teammate>", message: {type: "shutdown_request"}})` is the only legal precursor to `TeamDelete`.
  - The teammate's `shutdown_response` with `approve: true` is the terminating effect, not a precondition for a second call.
  - `approve: false` requires the team-lead to resolve the cited `reason` before retrying — forcing `TeamDelete` over a rejection is prohibited.
  - Unresponsive teammates flow through *Team Communication → Rule 3* first; only after persistent silence may the team-lead proceed for that teammate, with a logbook entry per *Logbook Issues → Rule B*.
- **Triggers enumerated:** post-merge cleanup (Rule C), user-initiated scope pivot, fatal unrecoverable error.
- **No code, no tests, no build artifacts touched** — `community-config/` is untouched, so `scripts/build-components.sh` is a no-op.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)