### PR TITLE
📝 Require verified or tagged claims in developer briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,17 @@ inherit no conversation context. Use `TaskCreate` for tracking only:
 its `description` should be a one-liner (e.g. `"Implement feature X — full brief in Agent prompt"`), not a duplicate of the Agent prompt. Never write the same
 brief in both places.
 
+**Verified-claim rule**: Technical assertions embedded in a developer
+brief (package names, install paths, command flags, file locations,
+schema fields, API shapes) MUST be either (a) sourced from the
+architect's design output for this ticket, or (b) prefixed inline with
+`UNVERIFIED —` so the developer treats them as hypotheses to validate
+before acting. The team-lead's own inline guesses are not ground
+truth. When `UNVERIFIED` claims accumulate to the point of shaping
+the approach, escalate to `architect` for a design pass before
+spawning the developer — that is the existing Template 1 step 1, not
+a new step.
+
 **Model compatibility rule**: When the orchestrating Claude Code session
 runs on a non-Anthropic backend (Ollama, Ollama Cloud, or any
 non-default model provider), every spawned `Agent` MUST use the same


### PR DESCRIPTION
Adds a **Verified-claim rule** to the Agent Team Protocol so team-leads cannot smuggle unchecked technical guesses (package names, install paths, command flags) into developer briefs. Closes #105.

## How to read this PR?

Single hunk in `AGENTS.md`, inserted inside `### On Claude Code CLI (team support available)` between `Single-source brief rule` and `Model compatibility rule`. Read the new paragraph in place — its position matters because it sits in the rule-set that governs `TaskCreate` / `Agent` spawn briefs.

## How to test this PR?

- `git diff main -- AGENTS.md` — confirm only the new rule paragraph is added (11 insertions, 0 deletions).
- Read the new paragraph in context and verify it flows between the two surrounding rules without breaking the existing numbering or references (no rule renames, no Template-1 step changes).
- No code paths are modified; `community-config/` is untouched, so `scripts/build-components.sh` is not required.

## Detailed description (for agents)

The Agent Team Protocol already constrains *where* a brief lives (`Single-source brief rule`) and *which model* spawned agents run on (`Model compatibility rule`), but it was silent on *truth value* of the technical assertions a team-lead embeds in the brief. In practice this allowed team-leads to assert package names, install paths, or CLI flags from memory; the spawned developer then treated those assertions as ground truth and burned a turn discovering they were wrong.

The new **Verified-claim rule** closes that gap with two clauses:

1. Technical assertions in a developer brief MUST be either (a) sourced from the architect's design output for the ticket, or (b) prefixed inline with `UNVERIFIED —` so the developer treats them as hypotheses to validate before acting.
2. When `UNVERIFIED` claims accumulate to the point of shaping the approach, the team-lead escalates to `architect` via the existing Template 1 step 1 — no new pipeline step is introduced.

The rule is positioned inside the Claude-Code-team-support subsection because that is where `TaskCreate` / `Agent` brief authorship lives. The sequential-`Agent`-spawn fallback section below it inherits the rule by reference to the same brief-authoring contract.

Closes #105