### PR TITLE
📝 Document pr-reviewer shared-identity workaround in Template 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,8 @@ fulfil its cold-start contract without a valid PR number. `pr-reviewer`
 receives the PR number from `pr-logbook`'s result message (see *Team
 Communication → Rule 1*).
 
+**Shared-identity workaround:** When the orchestrator and `pr-reviewer` share the same GitHub identity (common in solo-dev setups), GitHub rejects `gh pr review --approve` with "Can not approve your own pull request"; in that case `pr-reviewer` MUST post its verdict as a regular PR comment opening with a `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` header. This applies to every template below that includes `pr-reviewer`.
+
 Use multiple `developer` agents in parallel when the work decomposes into
 independent files or modules; a single developer suffices otherwise.
 


### PR DESCRIPTION
Documents the GitHub limitation that blocks formal `APPROVE` reviews when the orchestrator and `pr-reviewer` share the same identity, and prescribes the comment-based verdict workaround. Closes the parity gap between AGENTS.md and the de-facto practice already in use on this project.

## How to read this PR?

Single file, two-line addition. Open `AGENTS.md` and jump to *Standard Team Templates → Template 1 — Feature implementation*. The new paragraph sits between the *Ordering constraint* block and the "Use multiple `developer` agents…" sentence. The trailing clause "This applies to every template below that includes `pr-reviewer`" is deliberate: it extends the workaround to Templates 2 (doc-only) and 3 (bug fix) without textual duplication.

## How to test this PR?

- `git diff main -- AGENTS.md` shows a 2-line insertion in Template 1.
- Render AGENTS.md and confirm the paragraph appears immediately after the *Ordering constraint* block, before the parallel-developer guidance.
- No build, no tests — documentation-only change to a non-built source.

## Detailed description (for agents)

- **File touched:** `AGENTS.md` (1 file, +2 lines, -0).
- **Section:** *Agent Team Protocol → Standard Team Templates → Template 1 — Feature implementation (results in a PR)*.
- **Insertion point:** after the `Ordering constraint:` paragraph that ends with "(see *Team Communication → Rule 1*)", before "Use multiple `developer` agents in parallel…".
- **Content added:** a `**Shared-identity workaround:**` paragraph stating that when the orchestrator and `pr-reviewer` share the same GitHub identity, `gh pr review --approve` is rejected by GitHub ("Can not approve your own pull request"), and that in that case `pr-reviewer` MUST post its verdict as a regular PR comment opening with a `## Verdict: APPROVE` or `## Verdict: REQUEST CHANGES` header.
- **Scope clause:** the final sentence "This applies to every template below that includes `pr-reviewer`" propagates the rule to Templates 2 and 3 without duplicating the paragraph.
- **No code, no tests, no built outputs.** `community-config/` is untouched, so `scripts/build-components.sh` is not required.
- **No version bump.** AGENTS.md is not a versioned skill/agent source under `community-config/skills/` or `community-config/agents/`.

Closes #106