### PR TITLE
🐛 Start ollama daemon before signin in auth-ollama.sh (#116)

### DIFF
--- a/scripts/e2e/auth-ollama.sh
+++ b/scripts/e2e/auth-ollama.sh
@@ -40,7 +40,7 @@ e2e_info "[$CLI] (The CLI will print a URL; open it on the host, approve, then r
 docker run --rm -it \
   -v "${DIR}:/home/agent/.${CLI}" \
   "$IMAGE" \
-  ollama signin \
+  bash -c 'ollama serve >/dev/null 2>&1 & sleep 2 && ollama signin' \
   || e2e_die "[$CLI] interactive container exited non-zero. Re-run after resolving the error above."
 
 # Post-flight: id_ed25519 is the load-bearing private key; id_ed25519.pub


### PR DESCRIPTION
`task e2e:auth:ollama` crashed immediately because `ollama signin` requires a local daemon but none was running in the container.

## How to read this PR?

Single-line change in `scripts/e2e/auth-ollama.sh`: the bare `ollama signin` entrypoint is replaced with a compound command that starts `ollama serve` in the background, waits 2 seconds for it to be ready, then runs `ollama signin`.

## How to test this PR?

```bash
task e2e:build:copilot   # ensure image is up to date
task e2e:auth:ollama     # should now reach the browser OAuth prompt
```

## Detailed description (for agents)

**`scripts/e2e/auth-ollama.sh` (line 43):**

Before: `ollama signin`
After: `bash -c 'ollama serve >/dev/null 2>&1 & sleep 2 && ollama signin'`

The Ollama CLI requires a local daemon on `localhost:11434` even for the signin flow. Without `ollama serve` running first, the client exits immediately with "could not connect to ollama server". Starting the daemon in the background before signin resolves the error.

Closes #116