### PR TITLE
🐛 Accept Ollama Cloud keypair as copilot auth in e2e_auth_ready (#118)

### DIFF
--- a/scripts/e2e/lib/auth-common.sh
+++ b/scripts/e2e/lib/auth-common.sh
@@ -91,8 +91,8 @@ e2e_chown_bootstrap() {
 #              else ANTHROPIC_API_KEY in the host shell.
 #   gemini   → on-disk marker (~/.crewrig-e2e/gemini/oauth_creds.json),
 #              else GEMINI_API_KEY in the host shell.
-#   copilot  → no on-disk creds (ADR 0002 Decision 4); precedence is
-#              COPILOT_GITHUB_TOKEN, then GH_TOKEN.
+#   copilot  → COPILOT_GITHUB_TOKEN, then GH_TOKEN, then Ollama Cloud
+#              keypair (~/.crewrig-e2e/ollama/id_ed25519, ADR 0002 Decision 8).
 #
 # The on-disk markers come from ADR 0002's auth-<cli>.sh post-flight
 # assertions and were chosen as the load-bearing files in those scripts.
@@ -134,7 +134,14 @@ e2e_auth_ready() {
         e2e_info "[$cli] auth ready: GH_TOKEN set in host shell (fallback)"
         return 0
       fi
-      e2e_info "[$cli] auth NOT ready: neither COPILOT_GITHUB_TOKEN nor GH_TOKEN set"
+      # Ollama Cloud path (ADR 0002 Decision 8): no GitHub token needed when
+      # Copilot is routed through Ollama Cloud — the Ed25519 keypair is the
+      # credential. Accept if the keypair is present and non-empty.
+      if [[ -s "$(e2e_cli_dir ollama)/id_ed25519" ]]; then
+        e2e_info "[$cli] auth ready: Ollama Cloud keypair present ($(e2e_cli_dir ollama)/id_ed25519)"
+        return 0
+      fi
+      e2e_info "[$cli] auth NOT ready: neither COPILOT_GITHUB_TOKEN nor GH_TOKEN set, and no Ollama Cloud keypair found"
       return 78
       ;;
     *)


### PR DESCRIPTION
All copilot scenarios were silently skipped when using the Ollama Cloud backend because `e2e_auth_ready copilot` only accepted `COPILOT_GITHUB_TOKEN` / `GH_TOKEN`, with no fallback for the Ed25519 keypair auth path.

## How to read this PR?

Single file: `scripts/e2e/lib/auth-common.sh`. In `e2e_auth_ready`, the `copilot` arm gains a third fallback: if `~/.crewrig-e2e/ollama/id_ed25519` is present and non-empty (written by `task e2e:auth:ollama`), copilot is considered auth-ready. The existing token checks are unchanged and still take precedence.

## How to test this PR?

```bash
task e2e:auth:ollama        # ensure ~/.crewrig-e2e/ollama/id_ed25519 exists
task e2e:test:cli -- copilot # should now run (not skip) all copilot scenarios
```

## Detailed description (for agents)

**`scripts/e2e/lib/auth-common.sh` — `e2e_auth_ready` copilot arm:**

Added after the `GH_TOKEN` check:
```bash
if [[ -s "$(e2e_cli_dir ollama)/id_ed25519" ]]; then
  e2e_info "[copilot] auth ready: Ollama Cloud keypair present"
  return 0
fi
```

Updated the comment block above `e2e_auth_ready` to document the new fallback. Updated the "NOT ready" message to include the Ollama path in the diagnosis.

This implements the gating decision deferred by the architect in issue #114 ("leave the gating decision to a follow-up if a scenario needs to skip when the ollama dir is missing").

Closes #118