### PR TITLE
🐛 Populate ~/.crewrig-e2e/copilot/instructions/ from auth script (issue #120)

### DIFF
--- a/scripts/e2e/auth-copilot.sh
+++ b/scripts/e2e/auth-copilot.sh
@@ -5,11 +5,16 @@
 # Per ADR 0002 Decision 4, the v1 path is env-var token (PAT): the developer
 # mints a fine-grained PAT for the dedicated test account and exports it as
 # COPILOT_GITHUB_TOKEN in their shell. Scenarios consume the env var at run
-# time via `docker run -e COPILOT_GITHUB_TOKEN ...`; nothing is persisted under
-# ~/.crewrig-e2e/copilot/.
+# time via `docker run -e COPILOT_GITHUB_TOKEN ...`.
 #
-# If COPILOT_GITHUB_TOKEN is already set in the calling shell, the script runs
-# a 5-second sanity test against the e2e image and reports the result.
+# Rules directory (issue #120): regardless of which auth backend is used
+# (PAT, Ollama Cloud), this script populates ~/.crewrig-e2e/copilot/instructions/
+# by copying ~/.copilot/instructions/*.instructions.md from the host. The
+# 01-layered-context scenario mounts that directory as /home/agent/.copilot
+# inside the container. Running `task setup:copilot` first is a prerequisite.
+#
+# If COPILOT_GITHUB_TOKEN is already set in the calling shell, the script also
+# runs a 5-second sanity test against the e2e image and reports the result.
 #
 # See docs/adr/0002-e2e-auth-flow.md (Decision 4) for the full rationale,
 # including why we deferred device flow despite the empirical fallback path
@@ -23,13 +28,41 @@ source "${SCRIPT_DIR}/lib/auth-common.sh"
 CLI="copilot"
 IMAGE="crewrig/e2e-${CLI}:latest"
 
+# -----------------------------------------------------------------------
+# Rules directory — populate regardless of auth backend (issue #120).
+# -----------------------------------------------------------------------
+HOST_INSTRUCTIONS="${HOME}/.copilot/instructions"
+DIR="$(e2e_cli_dir "$CLI")"
+RULES_DIR="${DIR}/instructions"
+
+if [[ ! -d "$HOST_INSTRUCTIONS" ]]; then
+  e2e_die "[$CLI] ~/.copilot/instructions/ not found. Run \`task setup:copilot\` first to deploy layered-context files."
+fi
+
+e2e_info "[$CLI] Populating ${RULES_DIR} from ${HOST_INSTRUCTIONS}…"
+mkdir -p "$RULES_DIR"
+
+shopt -s nullglob
+src_files=("${HOST_INSTRUCTIONS}"/*.instructions.md)
+shopt -u nullglob
+
+if [[ ${#src_files[@]} -eq 0 ]]; then
+  e2e_die "[$CLI] No *.instructions.md files found in ${HOST_INSTRUCTIONS}. Run \`task setup:copilot\` to deploy them."
+fi
+
+for f in "${src_files[@]}"; do
+  cp "$f" "${RULES_DIR}/$(basename "$f")"
+done
+e2e_info "[$CLI] Copied ${#src_files[@]} instruction file(s) → ${RULES_DIR}."
+
 cat >&2 <<'BANNER'
 ================================================================================
  e2e auth — GitHub Copilot CLI (PAT-based, v1)
 ================================================================================
 Copilot CLI in our containers reads its credential from the env var
 COPILOT_GITHUB_TOKEN at run time (precedence: COPILOT_GITHUB_TOKEN >
-GITHUB_TOKEN > GH_TOKEN). No file is written under ~/.crewrig-e2e/copilot/.
+GITHUB_TOKEN > GH_TOKEN). Layered-context rule files are written under
+~/.crewrig-e2e/copilot/instructions/ by this script (see issue #120).
 
 Steps (do these on your host, in the shell you will run scenarios from):
 


### PR DESCRIPTION
`task e2e:auth:copilot` was the only auth task that did not populate `~/.crewrig-e2e/<cli>/`, causing the `01-layered-context` scenario to hard-skip for the `copilot` CLI despite `e2e_auth_ready` returning 0.

## How to read this PR?

Single file change: `scripts/e2e/auth-copilot.sh`. The new block (lines 31–56) runs unconditionally before the PAT/token section, making the rules-directory population independent of which auth backend is in use (PAT or Ollama Cloud).

## How to test this PR?

```sh
task e2e:auth:copilot
ls ~/.crewrig-e2e/copilot/instructions/   # must list *.instructions.md files
task e2e -- --cli copilot --scenario 01-layered-context   # must not SKIP
```

Prerequisites: `task setup:copilot` must have been run at least once, and `~/.copilot/instructions/` must contain `*.instructions.md` files.

## Detailed description (for agents)

- **`scripts/e2e/auth-copilot.sh`**: added a rules-population block that:
  1. Resolves `HOST_INSTRUCTIONS` (`~/.copilot/instructions`) and `RULES_DIR` (`~/.crewrig-e2e/copilot/instructions`).
  2. Aborts with `e2e_die` if `HOST_INSTRUCTIONS` is absent (prerequisite guard).
  3. `mkdir -p` the destination (idempotent).
  4. Collects `*.instructions.md` via `nullglob`; aborts if none found.
  5. Copies each file with `cp` (idempotent — overwrites on re-run).
  6. Updated the inline BANNER to remove the stale claim that "no file is written under `~/.crewrig-e2e/copilot/`".

Fixes #120.