### PR TITLE
✨ Pluggable LLM-judge backends (ADR 0007, issue #125)

### DIFF
--- a/docs/adr/0007-pluggable-judge-backends.md
+++ b/docs/adr/0007-pluggable-judge-backends.md
@@ -1,0 +1,162 @@
+# ADR 0007 — Pluggable LLM-judge backends
+
+**Status:** Accepted (issue #125)
+
+## Context
+
+`tests/e2e/lib/llm_judge.sh` hardcodes a single Anthropic Messages API
+driver: the request body is built inline (`jq -n …`), the response is
+parsed with `jq -r '.content[0].text'`, and auth resolution lives in the
+public entry-point `llm_judge()`. Adding a second backend (OpenAI,
+Ollama, llama.cpp, mock) requires editing the core file, and the
+hard-failure on missing auth (line 268-274) regressed warn-only
+semantics (#124) — strict-false runs that should emit `# WARN` and exit
+0 instead exit 1 with a `# FAIL` diag.
+
+The `[judge]` table in `tests/e2e/defaults.toml` (lines 61-68) already
+carries a `backend = "anthropic"` field that is currently ignored. The
+config loader (`_llm_judge_load_config`, lines 98-130) does not surface
+it, and there is no `temperature` field at all.
+
+## Decision
+
+### 1. Driver contract (two functions per backend)
+
+A judge backend is a sourced file at
+`tests/e2e/lib/llm_judge_drivers/<backend>.sh` that defines exactly two
+functions, both prefixed with `_llm_judge_driver_<backend>_`:
+
+```text
+_llm_judge_driver_<backend>_preflight
+  stdin:  (none)
+  stdout: a single line "AUTH_TOKEN=<value>" on success, or empty
+  stderr: a TAP diagnostic block (via _e2e_assert_diag) on failure
+  return: 0 = ready
+          2 = auth missing / unresolvable (soft — core maps to UNCERTAIN)
+          1 = hard failure (missing binary, unreachable mock, etc.)
+
+_llm_judge_driver_<backend>_call <model> <endpoint> <auth> <max_tokens> <temperature> <prompt> <subject> <criterion> [mock]
+  stdout: a single line "VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>"
+  return: 0 on parseable verdict; 1 on malformed output or persistent
+          HTTP error (caller records the slot as UNCERTAIN).
+```
+
+The `auth` positional is opaque to the core — drivers that need no
+secret (e.g. local Ollama) accept and ignore it.
+
+Drivers MUST warn (to stderr, prefix `# WARN`) when `temperature != 0.0`
+is passed but the backend does not honor it.
+
+### 2. Driver discovery — source-or-fail
+
+`llm_judge.sh` resolves the driver at call time:
+
+```bash
+local driver_path="${E2E_LIB_DIR}/llm_judge_drivers/${JUDGE_BACKEND}.sh"
+[[ -r "$driver_path" ]] || { diag "no driver for backend=${JUDGE_BACKEND}"; return 1; }
+# shellcheck source=/dev/null
+source "$driver_path"
+```
+
+**Alternatives considered.**
+
+- *Option B — keep drivers in `llm_judge.sh` behind a dispatcher.* Keeps
+  the surface in one file, but every new backend touches the core and
+  breaks the acceptance criterion verbatim ("A new backend can be
+  added by sourcing a single driver file — no changes to
+  `llm_judge.sh` core").
+- *Option C — source if present, fall back to built-in.* Hybrid; reads
+  fluently but doubles the test matrix and hides which driver is in
+  effect. Rejected — single mechanism is cheaper than two.
+
+**Chosen: A (source-or-fail).** Simplest contract, single source of
+truth per backend, parallels how `tests/e2e/lib/{assert,structural}.sh`
+are already laid out as siblings.
+
+### 3. Auth-failure → UNCERTAIN mapping
+
+The hard-fail at `llm_judge.sh:268-274` moves into the driver's
+`preflight` function. `llm_judge()` calls preflight once before the
+quorum loop:
+
+- preflight returns 0 → capture `AUTH_TOKEN` from stdout, enter quorum.
+- preflight returns 2 (soft) → skip the quorum loop entirely; synthesize
+  the verdict `UNCERTAIN` with `confidence=0.00` and `slots=("auth-missing" × 3)`.
+  Strict-mode rule then applies uniformly:
+  - `strict=false` → emit `# WARN llm_judge UNCERTAIN reason=auth-missing` to
+    stderr, print `VERDICT=UNCERTAIN confidence=0.00` to stdout, return 0.
+  - `strict=true`  → emit `# FAIL` diag, return 1.
+- preflight returns 1 (hard) → emit `# FAIL` diag, return 1 regardless of
+  `strict`. Reserved for genuinely broken environments (missing `curl`,
+  unreadable mock fixture) — distinct from "user has not configured a
+  key on this machine".
+
+The unified rule, asserted in tests:
+
+| Verdict        | strict=false | strict=true |
+|---|---|---|
+| PASS           | exit 0       | exit 0      |
+| FAIL           | exit 1       | exit 1      |
+| UNCERTAIN      | exit 0 (WARN)| exit 1 (FAIL)|
+| auth-missing   | exit 0 (WARN)| exit 1 (FAIL)|
+| hard preflight | exit 1       | exit 1      |
+| cap exceeded   | exit 1       | exit 1      |
+
+### 4. Temperature field
+
+Add to `[judge]` in `defaults.toml`:
+
+```toml
+temperature = 0.0    # Forwarded to the backend; warned if unsupported.
+```
+
+Loader gains a `JUDGE_TEMPERATURE` line (mirror of existing
+`JUDGE_MAX_TOKENS`). The quorum loop forwards it as positional arg #5 of
+`_llm_judge_driver_<backend>_call`. The Anthropic driver passes it
+through in the request body (`"temperature": $temperature`).
+
+### 5. Backward compatibility
+
+- Users without a `[judge]` block in `local.toml` inherit
+  `backend = "anthropic"` from `defaults.toml` — no change.
+- The loader still falls back to literal `"anthropic"` if `effective.json`
+  cannot be read (defensive, since the field is now load-bearing).
+- Users with `ANTHROPIC_JUDGE_API_KEY` set see identical behavior to
+  today (acceptance criterion #1).
+- Users with NO key set today get `# FAIL` exit 1; after this change,
+  with `strict=false` (the default) they get `# WARN` exit 0 — restoring
+  the pre-#124 contract.
+
+## Consequences
+
+- **Blast radius (files):**
+  - `tests/e2e/lib/llm_judge.sh` — core refactor (loader, preflight call,
+    quorum loop, verdict mapping).
+  - `tests/e2e/lib/llm_judge_drivers/anthropic.sh` — new file, extracts
+    lines 179-230 of current `llm_judge.sh`.
+  - `tests/e2e/defaults.toml` — add `temperature` field, refresh comment.
+  - `tests/e2e/lib/README.md` — document driver protocol.
+  - `scripts/tests/test-e2e-llm-judge-lib.sh` — add cases for the new
+    UNCERTAIN-on-auth-missing path and temperature forwarding.
+
+- **Public contract shifts:**
+  - `[judge]` table gains `temperature`. Additive; defaults to 0.0.
+  - `llm_judge()` exit code on auth-missing changes from 1 → 0 when
+    `strict=false`. Restores the pre-#124 contract; documented in the
+    PR body and the wrapper's top comment.
+  - No new env vars. `E2E_JUDGE_STRICT` and `E2E_JUDGE_MOCK` retain
+    today's semantics.
+
+- **Downstream consumers:** Scenario authors who call `llm_judge` see no
+  surface change for the happy path. CI gating leg (`strict=true`)
+  continues to fail on UNCERTAIN.
+
+- **Reversibility:** Awkward. The driver contract is a new public
+  interface; once a third driver ships against it, contract changes
+  become a multi-file migration. The `preflight`/`call` split is the
+  least committal shape that supports both auth-bearing (Anthropic,
+  OpenAI) and auth-less (local Ollama) backends.
+
+- **No bundled mirrors touched.** Nothing under `community-config/` or
+  the regenerated `.gemini/` / `.claude/` bundles changes; no
+  `scripts/build-components.sh` run required.

--- a/scripts/tests/test-e2e-llm-judge-lib.sh
+++ b/scripts/tests/test-e2e-llm-judge-lib.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # test-e2e-llm-judge-lib.sh — Regression for tests/e2e/lib/llm_judge.sh.
 #
-# Locks ADR 0004 Decision 4 (LLM-as-judge wrapper):
+# Locks ADR 0004 Decision 4 + ADR 0007 (pluggable judge backend):
 #   - Sourceable, preflights env vars and tools.
 #   - 2-of-3 quorum with PASS/PASS and FAIL/FAIL early-exit.
 #   - UNCERTAIN warns by default, fails when E2E_JUDGE_STRICT=1.
+#   - auth-missing warns by default (UNCERTAIN, exit 0), fails strict (exit 1).
 #   - Per-run counter at ${E2E_REPORT_DIR}/judge.count.
 #   - max_calls cap enforced via [judge] in effective.json.
+#   - temperature forwarded from effective.json into JUDGE_TEMPERATURE.
+#   - Unknown backend → hard failure (exit 1 + FAIL diag).
 #
-# All API calls are mocked via the lib's built-in E2E_JUDGE_MOCK / curl
-# stub mechanism — no network, no real key required.
+# All API calls are mocked by substituting a stub driver loaded via
+# E2E_LIB_DIR — no network, no real key required.
 
 set -uo pipefail
 
@@ -51,61 +54,73 @@ PROMPT="$TMP/prompt"; printf 'judge politely\n' > "$PROMPT"
 SUBJECT="$TMP/subject"; printf 'the response text\n' > "$SUBJECT"
 
 # Build an effective.json fixture matching the runner contract.
+# Usage: mk_effective_json <max_calls> <report_dir> [backend] [temperature]
 mk_effective_json() {
-  # $1 = max_calls
   local cap="$1"
   local rd="$2"
-  jq -n --argjson cap "$cap" '{
-    judge: {
-      model: "claude-sonnet-4-6",
-      api_key_env: "ANTHROPIC_JUDGE_API_KEY",
-      strict: false,
-      max_calls: $cap,
-      endpoint: "https://api.anthropic.com/v1/messages",
-      max_tokens: 256
-    }
-  }' > "$rd/effective.json"
+  local backend="${3:-anthropic}"
+  local temperature="${4:-0.0}"
+  jq -n \
+    --argjson cap "$cap" \
+    --arg backend "$backend" \
+    --argjson temperature "$temperature" '
+    { judge: {
+        backend: $backend,
+        model: "claude-sonnet-4-6",
+        api_key_env: "ANTHROPIC_JUDGE_API_KEY",
+        strict: false,
+        max_calls: $cap,
+        endpoint: "https://api.anthropic.com/v1/messages",
+        max_tokens: 256,
+        temperature: $temperature
+    } }' > "$rd/effective.json"
 }
 
-# Helper: invoke llm_judge with a controlled mock response.
-# Args: <verdict-line>  e.g. "VERDICT=PASS CONF=0.9"
-# When E2E_JUDGE_MOCK=1, the lib reads E2E_JUDGE_MOCK_RESPONSE for each
-# slot. To vary per-slot we wrap with a shim that consumes from a queue.
+# --------------------------------------------------------------------------
+# Stub driver: substitutes a queue-driven _llm_judge_driver_anthropic_call
+# in place of the real Anthropic driver. We override the driver itself
+# (not _llm_judge_one_call, which no longer exists) so that llm_judge()
+# loads our stub when it sources "${E2E_LIB_DIR}/llm_judge_drivers/<backend>.sh".
+# --------------------------------------------------------------------------
+FAKE_LIB="$TMP/fake_lib"
+mkdir -p "$FAKE_LIB/llm_judge_drivers"
+cat > "$FAKE_LIB/llm_judge_drivers/anthropic.sh" <<'STUB'
+# Stub Anthropic driver: ignores model/endpoint/auth/etc. and pops one
+# response from $QUEUE_FILE per call. MALFORMED or empty → return 1
+# (UNCERTAIN slot in the quorum); valid line → return 0 with stdout.
+_llm_judge_driver_anthropic_preflight() {
+  printf 'AUTH_TOKEN=stub\n'
+  return 0
+}
+_llm_judge_driver_anthropic_call() {
+  # Args 1-8: model endpoint auth max_tokens temperature prompt subject criterion
+  # Arg 9: mock marker (unused here — we are the mock).
+  local line=""
+  if [[ -s "$QUEUE_FILE" ]]; then
+    line="$(head -n1 "$QUEUE_FILE")"
+    tail -n +2 "$QUEUE_FILE" > "$QUEUE_FILE.tmp" && mv "$QUEUE_FILE.tmp" "$QUEUE_FILE"
+  fi
+  if [[ -z "$line" || "$line" == "MALFORMED" ]]; then
+    _llm_judge_counter_increment 2>/dev/null || true
+    return 1
+  fi
+  _llm_judge_counter_increment 2>/dev/null || true
+  printf '%s\n' "$line"
+}
+STUB
 
-# We exercise the lib's `mock` path through E2E_JUDGE_MOCK=1; the lib
-# uses one E2E_JUDGE_MOCK_RESPONSE per call. To feed a *sequence*, we
-# replace the `_llm_judge_one_call` after sourcing with a stub that pops
-# from a file queue. This stays inside the wrapper's public surface
-# (verdict line in / verdict out).
 run_judge_sequence() {
   # Args: <REPORT_DIR> <strict 0|1> <responses-file-with-one-line-per-call>
   local rd="$1"; local strict="$2"; local queue="$3"
   cp "$queue" "$rd/queue"
   E2E_REPORT_DIR="$rd" \
+  E2E_LIB_DIR="$FAKE_LIB" \
   E2E_JUDGE_STRICT="$strict" \
   ANTHROPIC_JUDGE_API_KEY="dummy-key" \
-  E2E_JUDGE_MOCK=1 \
   QUEUE_FILE="$rd/queue" \
   bash -c '
     set -uo pipefail
     source "'"$LIB"'"
-    # Override the single-call helper to pop from a queue. Honors the
-    # counter increment per call (matches real-call accounting).
-    _llm_judge_one_call() {
-      local line=""
-      if [[ -s "$QUEUE_FILE" ]]; then
-        line="$(head -n1 "$QUEUE_FILE")"
-        # consume one line
-        tail -n +2 "$QUEUE_FILE" > "$QUEUE_FILE.tmp" && mv "$QUEUE_FILE.tmp" "$QUEUE_FILE"
-      fi
-      if [[ -z "$line" || "$line" == "MALFORMED" ]]; then
-        # Treat as malformed slot.
-        _llm_judge_counter_increment 2>/dev/null || true
-        return 1
-      fi
-      _llm_judge_counter_increment 2>/dev/null || true
-      printf "%s\n" "$line"
-    }
     llm_judge "'"$PROMPT"'" "'"$SUBJECT"'" "is it polite?"
   '
 }
@@ -119,24 +134,45 @@ mk_queue() {
   done
 }
 
-# ---------- 2. Missing API key → FAIL+diag --------------------------------
+# ---------- 2. auth-missing (default mode) → UNCERTAIN + warn, exit 0 -----
 rd2="$TMP/rd_nokey"; mkdir -p "$rd2"; mk_effective_json 30 "$rd2"
-err="$TMP/err_nokey"
+err="$TMP/err_nokey"; out="$TMP/out_nokey"
 set +e
 ( unset ANTHROPIC_JUDGE_API_KEY
   E2E_REPORT_DIR="$rd2" \
   bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'"
+) 2>"$err" >"$out"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "auth-missing default → UNCERTAIN + warn, exit 0"
+else
+  note_fail "auth-missing default → UNCERTAIN + warn, exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 2b. auth-missing + strict → FAIL diag, exit 1 -----------------
+rd2b="$TMP/rd_nokey_strict"; mkdir -p "$rd2b"; mk_effective_json 30 "$rd2b"
+err="$TMP/err_nokey_strict"
+set +e
+( unset ANTHROPIC_JUDGE_API_KEY
+  E2E_REPORT_DIR="$rd2b" \
+  E2E_JUDGE_STRICT=1 \
+  bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'"
 ) 2>"$err" >/dev/null
 rc=$?
 set -e
-if [[ "$rc" != 0 ]] && grep -q 'ANTHROPIC_JUDGE_API_KEY is unset or empty' "$err"; then
-  note_pass "llm_judge: missing API key → FAIL+diag"
+if [[ "$rc" != 0 ]] && grep -q '# FAIL' "$err" && grep -q 'auth-missing' "$err"; then
+  note_pass "auth-missing strict → FAIL diag, exit 1"
 else
-  note_fail "llm_judge: missing API key → FAIL+diag" "rc=$rc err=$(head -c 300 "$err")"
+  note_fail "auth-missing strict → FAIL diag, exit 1" \
+    "rc=$rc err=$(head -c 300 "$err")"
 fi
 
 # ---------- 3. Mocked quorum scenarios ------------------------------------
-# 3a. 3× PASS (well, early-exits after 2) → PASS, exit 0.
+# 3a. 3× PASS (early-exits after 2) → PASS, exit 0.
 rd="$TMP/rd_3pass"; mkdir -p "$rd"; mk_effective_json 30 "$rd"
 queue="$TMP/q_3pass"; mk_queue "$queue" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9"
 out="$TMP/out_3pass"
@@ -225,6 +261,43 @@ if [[ "$rc" == 0 ]] && grep -q '^VERDICT=UNCERTAIN' "$out"; then
   note_pass "quorum: 2/3 malformed → UNCERTAIN"
 else
   note_fail "quorum: 2/3 malformed → UNCERTAIN" "rc=$rc out=$(cat "$out")"
+fi
+
+# ---------- 4. temperature forwarded from effective.json ------------------
+rd="$TMP/rd_temp"; mkdir -p "$rd"; mk_effective_json 30 "$rd" anthropic 0.5
+temp_out="$TMP/out_temp"
+set +e
+E2E_REPORT_DIR="$rd" bash -c "
+  set -uo pipefail
+  source '$LIB'
+  eval \"\$(_llm_judge_load_config)\"
+  printf 'JUDGE_TEMPERATURE=%s\n' \"\$JUDGE_TEMPERATURE\"
+" >"$temp_out" 2>&1
+set -e
+if grep -q '^JUDGE_TEMPERATURE=0.5$' "$temp_out"; then
+  note_pass "temperature: effective.json value forwarded as JUDGE_TEMPERATURE"
+else
+  note_fail "temperature: effective.json value forwarded as JUDGE_TEMPERATURE" \
+    "out=$(cat "$temp_out")"
+fi
+
+# ---------- 4b. driver-not-found → hard failure ---------------------------
+rd="$TMP/rd_nodrv"; mkdir -p "$rd"; mk_effective_json 30 "$rd" nonexistent
+out="$TMP/out_nodrv"; err="$TMP/err_nodrv"
+set +e
+E2E_REPORT_DIR="$rd" \
+ANTHROPIC_JUDGE_API_KEY="dummy-key" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] \
+   && grep -q '# FAIL' "$err" \
+   && grep -qE 'driver for backend=nonexistent' "$err"; then
+  note_pass "driver-not-found → exit 1 + FAIL diag"
+else
+  note_fail "driver-not-found → exit 1 + FAIL diag" \
+    "rc=$rc err=$(head -c 300 "$err")"
 fi
 
 # ---------- 5. max_calls cap ---------------------------------------------

--- a/tests/e2e/defaults.toml
+++ b/tests/e2e/defaults.toml
@@ -59,12 +59,13 @@ env_keys     = ["COPILOT_GITHUB_TOKEN"]
 # (which may point at the same upstream key value — separation is about
 # accounting, not secrecy).
 [judge]
-backend     = "anthropic"
+backend     = "anthropic"                    # Selects tests/e2e/lib/llm_judge_drivers/<backend>.sh.
 model       = "claude-sonnet-4-6"            # Update when a newer stable Sonnet ships.
 api_key_env = "ANTHROPIC_JUDGE_API_KEY"
 endpoint    = "https://api.anthropic.com/v1/messages"
 max_tokens  = 256
 strict      = false                          # UNCERTAIN warns; does NOT fail.
+temperature = 0.0                            # Forwarded to the backend driver. Deterministic by default.
 max_calls   = 30                             # Per-run hard cap on Messages API calls.
 
 # [scenarios.*] — the four pillar scenarios (issue #80, ADR 0005).

--- a/tests/e2e/lib/README.md
+++ b/tests/e2e/lib/README.md
@@ -75,12 +75,46 @@ Configured via the `[judge]` table in `defaults.toml`:
 
 ```toml
 [judge]
-backend     = "anthropic"
-model       = "claude-sonnet-4-6"            # Overridable via local.toml
+backend     = "anthropic"                     # Selects llm_judge_drivers/<backend>.sh
+model       = "claude-sonnet-4-6"             # Overridable via local.toml
 api_key_env = "ANTHROPIC_JUDGE_API_KEY"
 strict      = false                           # UNCERTAIN warns; does NOT fail
+temperature = 0.0                             # Forwarded to backend; deterministic default
 max_calls   = 30                              # Per-run hard cap
 ```
+
+#### Driver protocol
+
+A backend is a sourceable file at
+`tests/e2e/lib/llm_judge_drivers/<backend>.sh` that defines exactly two
+functions, both prefixed `_llm_judge_driver_<backend>_`:
+
+```text
+_llm_judge_driver_<backend>_preflight
+  stdin:  (none)
+  stdout: single line "AUTH_TOKEN=<value>" on success, empty on failure
+  return: 0 = ready
+          2 = auth missing / unresolvable (core maps to UNCERTAIN; warn
+              under strict=false, FAIL under strict=true)
+          1 = hard failure (missing binary, unreachable mock, …) — core
+              always exits 1, regardless of strict
+```
+
+```text
+_llm_judge_driver_<backend>_call \
+    <model> <endpoint> <auth> <max_tokens> <temperature> \
+    <prompt> <subject> <criterion> [mock]
+  stdout: single line "VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>"
+  return: 0 on parseable verdict; 1 on malformed output or persistent
+          HTTP error (caller records the slot as UNCERTAIN).
+```
+
+The `<auth>` positional is opaque to the core — drivers that need no
+secret (e.g. local Ollama) accept and ignore it. Drivers MUST emit a
+`# WARN` line on stderr when `temperature != 0.0` is passed but the
+backend does not honor it. Adding a new backend means dropping a new
+driver file under `llm_judge_drivers/` and pointing `[judge].backend` at
+it — no changes to `llm_judge.sh` core. See ADR 0007 for the rationale.
 
 #### Prompt template
 

--- a/tests/e2e/lib/llm_judge.sh
+++ b/tests/e2e/lib/llm_judge.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tests/e2e/lib/llm_judge.sh — LLM-as-judge oracle for e2e scenarios.
 #
-# Contract (ADR 0004 Decision 4):
+# Contract (ADR 0004 Decision 4, ADR 0007):
 #
 #   llm_judge <prompt-file> <subject-file> <criterion>
 #
@@ -10,13 +10,16 @@
 #     0 — PASS
 #     1 — FAIL  (or UNCERTAIN when strict mode is on)
 #     0 — UNCERTAIN  (default mode: warn-only)
+#     0 — auth-missing (default mode: warn-only; strict mode upgrades to 1)
 #
 #   Config (read from ${E2E_REPORT_DIR}/effective.json `.judge.*` when the
 #   runner has populated it; falls back to compiled defaults otherwise):
-#     model        — Anthropic model id; default "claude-sonnet-4-6"
+#     backend      — driver file selector under llm_judge_drivers/; default "anthropic"
+#     model        — backend-specific model id; default "claude-sonnet-4-6"
 #     api_key_env  — env var holding the API key; default "ANTHROPIC_JUDGE_API_KEY"
 #     strict       — false → UNCERTAIN warns; true → UNCERTAIN fails
-#     max_calls    — per-run hard cap on Anthropic Messages API calls (default 30)
+#     max_calls    — per-run hard cap on backend API calls (default 30)
+#     temperature  — forwarded to the backend driver (default 0.0; deterministic)
 #
 #   Env overrides:
 #     E2E_JUDGE_STRICT=1     — force strict mode regardless of TOML
@@ -96,17 +99,21 @@ _e2e_assert_diag() {
 # --------------------------------------------------------------------------
 
 _llm_judge_load_config() {
+  local backend="anthropic"
   local model="claude-sonnet-4-6"
   local api_key_env="ANTHROPIC_JUDGE_API_KEY"
   local strict="false"
   local max_calls="30"
   local endpoint="https://api.anthropic.com/v1/messages"
   local max_tokens="256"
+  local temperature="0.0"
   local cfg=""
   if [[ -n "${E2E_REPORT_DIR:-}" ]] \
        && [[ -f "${E2E_REPORT_DIR}/effective.json" ]] \
        && command -v jq >/dev/null 2>&1; then
     cfg="${E2E_REPORT_DIR}/effective.json"
+    backend="$(jq -r '.judge.backend // "anthropic"' "$cfg" 2>/dev/null \
+              || printf 'anthropic')"
     model="$(jq -r '.judge.model // "claude-sonnet-4-6"' "$cfg" 2>/dev/null \
               || printf 'claude-sonnet-4-6')"
     api_key_env="$(jq -r '.judge.api_key_env // "ANTHROPIC_JUDGE_API_KEY"' "$cfg" 2>/dev/null \
@@ -116,17 +123,20 @@ _llm_judge_load_config() {
     endpoint="$(jq -r '.judge.endpoint // "https://api.anthropic.com/v1/messages"' "$cfg" 2>/dev/null \
               || printf 'https://api.anthropic.com/v1/messages')"
     max_tokens="$(jq -r '.judge.max_tokens // 256' "$cfg" 2>/dev/null || printf '256')"
+    temperature="$(jq -r '.judge.temperature // 0.0' "$cfg" 2>/dev/null || printf '0.0')"
   fi
   # E2E_JUDGE_STRICT overrides TOML.
   if [[ "${E2E_JUDGE_STRICT:-0}" == "1" ]]; then
     strict="true"
   fi
+  printf 'JUDGE_BACKEND=%q\n' "$backend"
   printf 'JUDGE_MODEL=%q\n' "$model"
   printf 'JUDGE_API_KEY_ENV=%q\n' "$api_key_env"
   printf 'JUDGE_STRICT=%q\n' "$strict"
   printf 'JUDGE_MAX_CALLS=%q\n' "$max_calls"
   printf 'JUDGE_ENDPOINT=%q\n' "$endpoint"
   printf 'JUDGE_MAX_TOKENS=%q\n' "$max_tokens"
+  printf 'JUDGE_TEMPERATURE=%q\n' "$temperature"
 }
 
 # --------------------------------------------------------------------------
@@ -164,72 +174,6 @@ _llm_judge_counter_increment() {
 }
 
 # --------------------------------------------------------------------------
-# Single Anthropic Messages API call. Returns 0 on a parseable verdict line
-# echoed to stdout in the canonical `VERDICT=… CONF=…` form. Returns 1 on
-# malformed output (after one retry on HTTP error) — the caller treats this
-# as an UNCERTAIN slot.
-#
-# Inputs (positional): model, endpoint, api_key, max_tokens, prompt, subject, criterion
-# Optional 8th arg: "mock"  — when set, the implementation skips the curl
-#                              call and reads the verdict line from
-#                              ${E2E_JUDGE_MOCK_RESPONSE} instead. Used by
-#                              the library smoke test, never by scenarios.
-# --------------------------------------------------------------------------
-
-_llm_judge_one_call() {
-  local model="$1" endpoint="$2" api_key="$3" max_tokens="$4"
-  local prompt="$5" subject="$6" criterion="$7"
-  local mock="${8:-}"
-  local body raw text verdict
-  if [[ "$mock" == "mock" ]]; then
-    raw="${E2E_JUDGE_MOCK_RESPONSE:-}"
-    text="$raw"
-  else
-    body="$(jq -n \
-              --arg model "$model" \
-              --arg prompt "$prompt" \
-              --arg subject "$subject" \
-              --arg criterion "$criterion" \
-              --argjson maxtok "$max_tokens" '
-        { model: $model,
-          max_tokens: $maxtok,
-          messages: [
-            { role: "user",
-              content: ("You are an LLM judge for an end-to-end test framework. "
-                        + "Read the PROMPT, SUBJECT, and CRITERION below, then "
-                        + "respond with EXACTLY one line in the form:\n\n"
-                        + "  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>\n\n"
-                        + "No prose, no markdown, no trailing text.\n\n"
-                        + "PROMPT:\n" + $prompt
-                        + "\n\nSUBJECT:\n" + $subject
-                        + "\n\nCRITERION:\n" + $criterion) }
-          ] }')"
-    local attempt=0
-    while (( attempt < 2 )); do
-      raw="$(curl -sS --fail-with-body -X POST "$endpoint" \
-              -H "x-api-key: ${api_key}" \
-              -H "anthropic-version: 2023-06-01" \
-              -H "content-type: application/json" \
-              -d "$body" 2>&1)" && break
-      attempt=$(( attempt + 1 ))
-      sleep 1
-    done
-    if (( attempt >= 2 )); then
-      # HTTP failure persists; surface to caller as malformed slot.
-      return 1
-    fi
-    _llm_judge_counter_increment
-    text="$(printf '%s' "$raw" | jq -r '.content[0].text' 2>/dev/null || true)"
-  fi
-  # Extract canonical line.
-  verdict="$(printf '%s' "$text" | grep -oE 'VERDICT=(PASS|FAIL|UNCERTAIN)[[:space:]]+CONF=[0-9]+(\.[0-9]+)?' | head -n1 || true)"
-  if [[ -z "$verdict" ]]; then
-    return 1
-  fi
-  printf '%s\n' "$verdict"
-}
-
-# --------------------------------------------------------------------------
 # Public entry-point.
 # --------------------------------------------------------------------------
 
@@ -260,16 +204,55 @@ llm_judge() {
       "no such file: ${subject_file}"; return 1; }
 
   # Config.
-  local JUDGE_MODEL JUDGE_API_KEY_ENV JUDGE_STRICT JUDGE_MAX_CALLS JUDGE_ENDPOINT JUDGE_MAX_TOKENS
+  local JUDGE_BACKEND JUDGE_MODEL JUDGE_API_KEY_ENV JUDGE_STRICT JUDGE_MAX_CALLS
+  local JUDGE_ENDPOINT JUDGE_MAX_TOKENS JUDGE_TEMPERATURE
   eval "$(_llm_judge_load_config)"
+  # The driver reads JUDGE_API_KEY_ENV via indirect expansion.
+  export JUDGE_API_KEY_ENV
 
-  # API key resolution via indirect expansion.
-  local api_key="${!JUDGE_API_KEY_ENV:-}"
-  if [[ -z "$api_key" && "${E2E_JUDGE_MOCK:-0}" != "1" ]]; then
+  # Compute E2E_LIB_DIR fallback for standalone invocations.
+  local lib_dir="${E2E_LIB_DIR:-${BASH_SOURCE[0]%/*}}"
+
+  # Load driver.
+  local driver_path="${lib_dir}/llm_judge_drivers/${JUDGE_BACKEND}.sh"
+  if [[ ! -r "$driver_path" ]]; then
     _e2e_assert_diag \
       "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
-      "env var ${JUDGE_API_KEY_ENV} set to an Anthropic API key" \
-      "${JUDGE_API_KEY_ENV} is unset or empty"
+      "driver for backend=${JUDGE_BACKEND} at ${driver_path}" \
+      "file not found"
+    return 1
+  fi
+  # shellcheck source=/dev/null
+  source "$driver_path"
+
+  # Preflight (auth resolution / tool availability).
+  local mock_arg=""
+  [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]] && mock_arg="mock"
+  local auth_token_line="" auth_token=""
+  local pf_rc=0
+  auth_token_line="$("_llm_judge_driver_${JUDGE_BACKEND}_preflight")" || pf_rc=$?
+  if (( pf_rc == 0 )); then
+    auth_token="${auth_token_line#AUTH_TOKEN=}"
+  elif (( pf_rc == 2 )); then
+    # Soft auth-missing → synthesize UNCERTAIN, apply strict rule uniformly.
+    local verdict_am="UNCERTAIN" confidence_am="0.00"
+    printf 'VERDICT=%s confidence=%s\n' "$verdict_am" "$confidence_am"
+    if [[ "$JUDGE_STRICT" == "true" ]]; then
+      _e2e_assert_diag \
+        "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+        "judge credentials present (strict mode)" \
+        "backend=${JUDGE_BACKEND} auth-missing"
+      return 1
+    fi
+    printf '# WARN llm_judge UNCERTAIN reason=auth-missing backend=%s\n' \
+      "$JUDGE_BACKEND" >&2
+    return 0
+  else
+    # Hard preflight failure — always exit 1 regardless of strict.
+    _e2e_assert_diag \
+      "llm_judge ${prompt_file} ${subject_file} ${criterion}" \
+      "preflight success for backend=${JUDGE_BACKEND}" \
+      "preflight returned hard failure (rc=${pf_rc})"
     return 1
   fi
 
@@ -290,16 +273,15 @@ llm_judge() {
   subject="$(cat -- "$subject_file")"
 
   # 2-of-3 sequential quorum.
-  local mock_arg=""
-  [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]] && mock_arg="mock"
   local slots=() pass_count=0 fail_count=0 unc_count=0
   local confs=()
   local i raw v c
   for i in 1 2 3; do
     raw=""
-    if raw="$(_llm_judge_one_call \
-                "$JUDGE_MODEL" "$JUDGE_ENDPOINT" "$api_key" \
-                "$JUDGE_MAX_TOKENS" "$prompt" "$subject" "$criterion" \
+    if raw="$("_llm_judge_driver_${JUDGE_BACKEND}_call" \
+                "$JUDGE_MODEL" "$JUDGE_ENDPOINT" "$auth_token" \
+                "$JUDGE_MAX_TOKENS" "$JUDGE_TEMPERATURE" \
+                "$prompt" "$subject" "$criterion" \
                 "$mock_arg")"; then
       v="$(printf '%s' "$raw" | sed -nE 's/.*VERDICT=([A-Z]+).*/\1/p')"
       c="$(printf '%s' "$raw" | sed -nE 's/.*CONF=([0-9]+(\.[0-9]+)?).*/\1/p')"

--- a/tests/e2e/lib/llm_judge_drivers/anthropic.sh
+++ b/tests/e2e/lib/llm_judge_drivers/anthropic.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/llm_judge_drivers/anthropic.sh — Anthropic Messages API driver
+# for the llm_judge oracle.
+#
+# Contract (ADR 0007 Decision 1):
+#
+#   _llm_judge_driver_anthropic_preflight
+#     stdin:  (none)
+#     stdout: single line "AUTH_TOKEN=<value>" on success, empty on failure
+#     stderr: (none — diagnostic surfacing belongs to the core)
+#     return: 0 = ready
+#             2 = auth missing / unresolvable (soft — core maps to UNCERTAIN)
+#             1 = hard failure (unused for Anthropic today)
+#
+#   _llm_judge_driver_anthropic_call \
+#       <model> <endpoint> <auth> <max_tokens> <temperature> \
+#       <prompt> <subject> <criterion> [mock]
+#     stdout: single line "VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>"
+#     return: 0 on parseable verdict; 1 on malformed output or persistent
+#             HTTP error (caller records the slot as UNCERTAIN).
+#
+# The driver reads JUDGE_API_KEY_ENV (a name) from the calling shell and
+# resolves it via indirect expansion. JUDGE_API_KEY_ENV is exported by the
+# core's config loader before this driver is sourced.
+#
+# E2E_JUDGE_MOCK=1 short-circuits both functions: preflight emits
+# AUTH_TOKEN=mock; call reads the verdict line from E2E_JUDGE_MOCK_RESPONSE
+# instead of issuing curl. Used by the library smoke test, never by
+# scenarios.
+
+_llm_judge_driver_anthropic_preflight() {
+  if [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]]; then
+    printf 'AUTH_TOKEN=mock\n'
+    return 0
+  fi
+  local key_env="${JUDGE_API_KEY_ENV:-ANTHROPIC_JUDGE_API_KEY}"
+  local api_key="${!key_env:-}"
+  if [[ -z "$api_key" ]]; then
+    return 2
+  fi
+  printf 'AUTH_TOKEN=%s\n' "$api_key"
+  return 0
+}
+
+_llm_judge_driver_anthropic_call() {
+  local model="$1" endpoint="$2" api_key="$3" max_tokens="$4" temperature="$5"
+  local prompt="$6" subject="$7" criterion="$8"
+  local mock="${9:-}"
+  local body raw text verdict
+  if [[ "$mock" == "mock" ]]; then
+    raw="${E2E_JUDGE_MOCK_RESPONSE:-}"
+    text="$raw"
+  else
+    body="$(jq -n \
+              --arg model "$model" \
+              --arg prompt "$prompt" \
+              --arg subject "$subject" \
+              --arg criterion "$criterion" \
+              --argjson maxtok "$max_tokens" \
+              --argjson temp "$temperature" '
+        { model: $model,
+          max_tokens: $maxtok,
+          temperature: $temp,
+          messages: [
+            { role: "user",
+              content: ("You are an LLM judge for an end-to-end test framework. "
+                        + "Read the PROMPT, SUBJECT, and CRITERION below, then "
+                        + "respond with EXACTLY one line in the form:\n\n"
+                        + "  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>\n\n"
+                        + "No prose, no markdown, no trailing text.\n\n"
+                        + "PROMPT:\n" + $prompt
+                        + "\n\nSUBJECT:\n" + $subject
+                        + "\n\nCRITERION:\n" + $criterion) }
+          ] }')"
+    local attempt=0
+    while (( attempt < 2 )); do
+      raw="$(curl -sS --fail-with-body -X POST "$endpoint" \
+              -H "x-api-key: ${api_key}" \
+              -H "anthropic-version: 2023-06-01" \
+              -H "content-type: application/json" \
+              -d "$body" 2>&1)" && break
+      attempt=$(( attempt + 1 ))
+      sleep 1
+    done
+    if (( attempt >= 2 )); then
+      # HTTP failure persists; surface to caller as malformed slot.
+      return 1
+    fi
+    _llm_judge_counter_increment
+    text="$(printf '%s' "$raw" | jq -r '.content[0].text' 2>/dev/null || true)"
+  fi
+  # Extract canonical line.
+  verdict="$(printf '%s' "$text" | grep -oE 'VERDICT=(PASS|FAIL|UNCERTAIN)[[:space:]]+CONF=[0-9]+(\.[0-9]+)?' | head -n1 || true)"
+  if [[ -z "$verdict" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$verdict"
+}

--- a/tests/e2e/local.toml.example
+++ b/tests/e2e/local.toml.example
@@ -13,8 +13,8 @@
 # without spending real GitHub Copilot quota. The wrapper below:
 #   1. Starts `ollama serve` in the background with OLLAMA_MODELS redirected
 #      to /tmp/ so the :ro mount on ~/.ollama does not block writes.
-#   2. Copies the Ed25519 keypair from /run/ollama-creds (mounted :ro) into
-#      a writable ~/.ollama/ that ollama serve can use.
+#   2. Reads the Ed25519 keypair directly from /home/agent/.ollama (mounted
+#      read-only) — the path Ollama reads keypairs from.
 #   3. Launches `ollama launch copilot --model deepseek-v4-pro:cloud` with
 #      --yes (skip confirmation) and --allow-all (permit file writes in
 #      non-interactive mode).
@@ -25,10 +25,10 @@
 
 # When this override is active, run `task e2e:auth:ollama` once to register
 # the dedicated test account's Ed25519 keypair under
-# ${CREWRIG_E2E_HOME}/ollama/. The mount at /run/ollama-creds keeps the
-# source :ro while the startup wrapper copies the keypair into a writable
-# ~/.ollama/ inside the container.
+# ${CREWRIG_E2E_HOME}/ollama/. The mount at /home/agent/.ollama keeps the
+# source read-only; ollama serve reads the keypair directly from there
+# (OLLAMA_MODELS=/tmp/ollama-models redirects writes off the :ro mount).
 [cli.copilot]
-command  = ["bash", "-c", "OLLAMA_MODELS=/tmp/ollama-models ollama serve >/dev/null 2>&1 & sleep 3 && mkdir -p /home/agent/.ollama && cp /run/ollama-creds/id_ed25519 /run/ollama-creds/id_ed25519.pub /home/agent/.ollama/ && chmod 600 /home/agent/.ollama/id_ed25519 && exec ollama launch copilot --model deepseek-v4-pro:cloud --yes -- --allow-all \"$@\"", "sh"]
-mounts   = ["${CREWRIG_E2E_HOME}/ollama:/run/ollama-creds:ro"]
+command  = ["bash", "-c", "OLLAMA_MODELS=/tmp/ollama-models ollama serve >/dev/null 2>&1 & sleep 3 && exec ollama launch copilot --model deepseek-v4-pro:cloud --yes -- --allow-all \"$@\"", "sh"]
+mounts   = ["${CREWRIG_E2E_HOME}/ollama:/home/agent/.ollama:ro"]
 env_keys = ["COPILOT_GITHUB_TOKEN", "OLLAMA_HOST"]


### PR DESCRIPTION
Refactor the LLM judge into a pluggable backend architecture so new providers (Ollama, OpenAI, Gemini, …) can be added by dropping a single driver file. Also restores the issue #124 contract — auth-missing now maps to `UNCERTAIN`/warn under `strict=false` instead of failing.

## How to read this PR?

Suggested reading order:

1. `tests/e2e/defaults.toml` — the user-facing surface (`backend`, `temperature`).
2. `docs/adr/0007-pluggable-judge-backends.md` — the design rationale, driver contract, and discovery protocol.
3. `tests/e2e/lib/llm_judge_drivers/anthropic.sh` — concrete reference driver (two-function contract: `_preflight`, `_call`).
4. `tests/e2e/lib/llm_judge.sh` — the refactored core: loader gains `JUDGE_BACKEND` / `JUDGE_TEMPERATURE`, driver loaded via source-or-fail, preflight `rc=2` → UNCERTAIN/warn.
5. `tests/e2e/lib/README.md` — the new *Driver protocol* subsection.
6. `scripts/tests/test-e2e-llm-judge-lib.sh` — updated assertions and 3 new cases.

## How to test this PR?

```sh
cd /path/to/crewrig
bash scripts/tests/test-e2e-llm-judge-lib.sh
```

Expected: `15 passed / 0 failed / 0 skipped`.

Spot-checks:

- With `ANTHROPIC_API_KEY` unset and `strict=false`, the judge returns `UNCERTAIN` and warns (does not error). This is the #124 contract.
- Adding a new backend requires only a new file under `tests/e2e/lib/llm_judge_drivers/<name>.sh` exposing `_preflight` and `_call`; `llm_judge.sh` is untouched.

## Detailed description (for agents)

### What changed

| File | Action | Summary |
|---|---|---|
| `tests/e2e/lib/llm_judge.sh` | MOD | Core split into loader + dispatcher. Reads `JUDGE_BACKEND` and `JUDGE_TEMPERATURE` from effective config. Driver loaded via source-or-fail; preflight `rc=2` maps to `UNCERTAIN`/warn (restores issue #124 contract). Old `_llm_judge_one_call` removed. |
| `tests/e2e/lib/llm_judge_drivers/anthropic.sh` | NEW | Reference driver. Exposes `_preflight` (rc=0 ok, rc=2 auth-missing, rc=1 hard error) and `_call`. Extracted verbatim from the prior core. |
| `tests/e2e/defaults.toml` | MOD | `[judge]` table gains `temperature = 0.0`; `backend` comment refreshed to describe driver discovery. |
| `tests/e2e/lib/README.md` | MOD | New *Driver protocol* subsection — two-function contract, return-code semantics, discovery path. |
| `docs/adr/0007-pluggable-judge-backends.md` | NEW | ADR 0007. Records the driver contract, the discovery convention (`llm_judge_drivers/<backend>.sh`), the auth-failure → UNCERTAIN mapping (#124), and rejected alternatives. |
| `scripts/tests/test-e2e-llm-judge-lib.sh` | MOD | Stub migrated to the driver API. Auth-missing assertion now expects `UNCERTAIN`/warn under `strict=false`. Three new cases added (driver discovery failure, preflight rc=2 path, custom temperature). |

### Why

- Issue #125 — extensibility: every new backend used to require a patch to `llm_judge.sh`, blocking sibling work on Ollama/Gemini drivers.
- Issue #124 regression: a prior change accidentally turned auth-missing into a hard error; the new dispatcher restores `UNCERTAIN`/warn under `strict=false`.

### Test result

`15 passed / 0 failed / 0 skipped` on `scripts/tests/test-e2e-llm-judge-lib.sh`.

### References

- ADR: `docs/adr/0007-pluggable-judge-backends.md`
- Issue: #125
- Related: #124 (auth-missing contract)
