### PR TITLE
✨ LLM-as-judge: OAuth auth_mode + claude-code backend (issue #126)

### DIFF
--- a/docs/adr/0008-judge-oauth-auth-mode.md
+++ b/docs/adr/0008-judge-oauth-auth-mode.md
@@ -1,0 +1,195 @@
+# ADR 0008 — Judge `auth_mode` and `claude-code` OAuth driver
+
+**Status:** Proposed (issue #126)
+
+## Context
+
+ADR 0007 (issue #125) introduced a pluggable driver layer for
+`tests/e2e/lib/llm_judge.sh`, but every driver still assumes
+**API-key-in-env** authentication: the core loader exports
+`JUDGE_API_KEY_ENV`, drivers dereference it via indirect expansion, and
+the `preflight` contract returns `AUTH_TOKEN=<api-key>` or rc=2.
+
+The Claude Code CLI's primary auth surface is OAuth, not an API key.
+Credentials minted by `task e2e:auth:claude` (ADR 0002, Decision 2)
+land in `~/.crewrig-e2e/claude/.credentials.json` (and at
+`~/.claude/.credentials.json` for a developer's day-to-day session).
+Re-using that on-disk token to call the Anthropic Messages API as the
+judge would let contributors run the e2e oracle without minting a
+separate `ANTHROPIC_JUDGE_API_KEY` — a real friction surfaced by
+issue #126.
+
+The Messages API accepts the OAuth access token via the standard
+`Authorization: Bearer <token>` header in place of `x-api-key`, so the
+delta is small: a second driver and a config switch.
+
+## Decision
+
+### 1. Add an `auth_mode` field to `[judge]`
+
+```toml
+[judge]
+auth_mode = "api_key"   # default — preserves today's behaviour
+# or
+auth_mode = "oauth"     # driver reads CLI credential store from disk
+```
+
+Loader changes (`_llm_judge_load_config` in `tests/e2e/lib/llm_judge.sh`):
+
+- Default literal: `auth_mode="api_key"`.
+- Parsed via `jq -r '.judge.auth_mode // "api_key"' effective.json`.
+- Emitted as `JUDGE_AUTH_MODE=%q` alongside the existing `JUDGE_*` lines.
+- Declared `local` and `export`ed in `llm_judge()` next to
+  `JUDGE_API_KEY_ENV` so drivers can read it via plain expansion.
+
+**Forwarding model: env, not positional.** `auth_mode` is a
+driver-internal concern — the core never branches on it. Exporting it
+keeps the `_call` positional signature (ADR 0007 §1) intact and avoids
+a breaking change to the existing `anthropic` driver. Drivers that
+care branch in their own `_preflight`; drivers that do not (e.g.
+`anthropic`) ignore the variable.
+
+### 2. New driver: `tests/e2e/lib/llm_judge_drivers/claude-code.sh`
+
+Implements the ADR 0007 §1 contract. `_preflight`:
+
+1. If `E2E_JUDGE_MOCK=1` → `printf 'AUTH_TOKEN=mock\n'; return 0`
+   (mirrors `anthropic.sh`).
+2. Read `JUDGE_AUTH_MODE`. The driver supports `oauth` (primary) and
+   `api_key` (fallback for users who set `ANTHROPIC_JUDGE_API_KEY`
+   alongside `backend = "claude-code"`); any other value → rc=1 hard
+   failure with an `_e2e_assert_diag` line.
+3. When `auth_mode = "oauth"`:
+   - Credential path: `${CLAUDE_CREDENTIALS_PATH:-$HOME/.claude/.credentials.json}`.
+     The env override is added so the e2e harness can point the driver
+     at `${CREWRIG_E2E_HOME}/claude/.credentials.json` without
+     symlinking into `$HOME`.
+   - Missing or unreadable file → rc=2 (soft auth-missing; core maps
+     to UNCERTAIN per ADR 0007 §3).
+   - Read access token via:
+     ```bash
+     token="$(jq -r '.claudeAiOauth.accessToken // empty' "$path")"
+     ```
+     **UNVERIFIED — verify before merge.** The Claude Code CLI's
+     on-disk schema is not documented in this repository. The
+     conventional upstream layout is
+     `{"claudeAiOauth": {"accessToken": "sk-ant-oat01-…",
+     "refreshToken": "…", "expiresAt": <ms>, "scopes": […],
+     "subscriptionType": "…"}}`. The developer MUST run
+     `jq 'keys, .claudeAiOauth | keys?' \
+       ~/.crewrig-e2e/claude/.credentials.json` (or the developer's
+     own `~/.claude/.credentials.json`) against a freshly-minted file
+     and confirm the key path before landing the driver. If the
+     observed schema differs, update the `jq` selector here and amend
+     this ADR in the same PR — do not guess.
+   - Empty/null token → rc=2 (treat as auth-missing, not hard failure;
+     consistent with ADR 0007 §3 — "user has not configured a key on
+     this machine").
+   - `expiresAt` check: if the field is present AND parseable AND
+     `expiresAt < now_ms`, return rc=2 with a stderr WARN line
+     (`# WARN claude-code judge: OAuth token expired (re-run \`task
+     e2e:auth:claude\`)`). Missing/unparseable `expiresAt` → proceed
+     and let the API surface the 401 on `_call`.
+   - On success: `printf 'AUTH_TOKEN=%s\n' "$token"; return 0`.
+4. When `auth_mode = "api_key"`: identical body to
+   `_llm_judge_driver_anthropic_preflight` (read `JUDGE_API_KEY_ENV`
+   via indirect expansion). This is intentional duplication, not a
+   shared helper — ADR 0007 §1 keeps drivers self-contained.
+
+`_call`:
+
+- Same body as `anthropic.sh` except the curl header line swaps
+  `-H "x-api-key: ${api_key}"` for
+  `-H "Authorization: Bearer ${api_key}"`. The positional is named
+  `api_key` for parity with the contract; semantically it is the
+  Bearer token under `oauth`.
+- `anthropic-version: 2023-06-01` header retained.
+- Request body, retry loop, counter increment, and verdict regex are
+  copy-equivalent to the Anthropic driver. The duplication is
+  deliberate — ADR 0007 §1 commits to one file per backend.
+
+### 3. Backward compatibility
+
+- `auth_mode` defaults to `"api_key"`. Users who do not edit
+  `local.toml` see zero behaviour change.
+- The `anthropic` driver is **not** modified. It continues to read
+  `JUDGE_API_KEY_ENV` and ignores `JUDGE_AUTH_MODE`.
+- New `local.toml.example` stanza (commented) documents the
+  claude-code oauth path:
+  ```toml
+  # Re-use the OAuth token minted by `task e2e:auth:claude` instead of
+  # `ANTHROPIC_JUDGE_API_KEY`. Reads ${CLAUDE_CREDENTIALS_PATH:-~/.claude/.credentials.json}.
+  # [judge]
+  # backend     = "claude-code"
+  # auth_mode   = "oauth"
+  # model       = "claude-sonnet-4-6"
+  # temperature = 0.0
+  # strict      = false
+  ```
+
+### 4. ADR scope
+
+ADR 0007 covers the driver-contract surface. This ADR adds a single
+field (`auth_mode`) and a single driver — small enough that a new ADR
+is borderline. Recorded as ADR 0008 because:
+
+- It introduces a public TOML field that becomes load-bearing the
+  moment a third driver wants OAuth (e.g. a future `gemini-cli`
+  backend that reuses `~/.gemini/oauth_creds.json`).
+- The "credential file on disk" auth mode is a new threat surface
+  (file permissions, expiry, stale tokens) that deserves a written
+  decision the security agent can audit against.
+
+## File list
+
+| Path | Change |
+|---|---|
+| `tests/e2e/lib/llm_judge.sh` | Loader: parse + export `JUDGE_AUTH_MODE`. No quorum or verdict changes. |
+| `tests/e2e/lib/llm_judge_drivers/claude-code.sh` | **New.** Bearer-auth driver with oauth/api_key preflight branches. |
+| `tests/e2e/defaults.toml` | Add `auth_mode = "api_key"` under `[judge]` with a one-line comment. |
+| `tests/e2e/local.toml.example` | Add commented `[judge]` stanza demoing `backend = "claude-code"` + `auth_mode = "oauth"`. |
+| `docs/adr/0008-judge-oauth-auth-mode.md` | This file. |
+| `scripts/tests/test-e2e-llm-judge-lib.sh` | New cases: oauth happy-path (stubbed credentials.json), missing file → UNCERTAIN, empty token → UNCERTAIN, expired → UNCERTAIN, api_key parity unchanged. |
+| `tests/e2e/lib/README.md` | One-paragraph note pointing at ADR 0008. |
+| `docs/cli-matrix.md` | Touch only if a row references the judge backend. Spot-check during implementation. |
+
+## Non-goals
+
+- **No change to the `anthropic` driver.** Bearer auth on the
+  anthropic backend is out of scope; users who want OAuth pick the
+  `claude-code` backend.
+- **No new env vars beyond `CLAUDE_CREDENTIALS_PATH`.** No
+  `CLAUDE_OAUTH_TOKEN` shortcut — the file is the source of truth.
+- **No token refresh.** ADR 0002 already documents that refresh fails
+  under the RO mount. The driver surfaces expiry as UNCERTAIN; it does
+  not attempt a refresh write. Users re-run `task e2e:auth:claude`.
+- **No Copilot / Gemini OAuth drivers.** Symmetric implementation is
+  out of scope for this PR; ADR 0008 only adds the mechanism.
+- **No bundled-component changes.** Nothing under `community-config/`,
+  `.gemini/`, or `.claude/` is touched. `scripts/build-components.sh`
+  is not required.
+- **No version bump.** No `community-config/skills/*/SKILL.md` or
+  `community-config/agents/*/AGENT.md` is modified.
+
+## Blast radius
+
+- **Files modified on `main` today:** 4 (`llm_judge.sh`,
+  `defaults.toml`, `local.toml.example`, `test-e2e-llm-judge-lib.sh`).
+- **Files added:** 2 (the driver and this ADR).
+- **Public-contract additions:**
+  - New `[judge].auth_mode` field — additive, default preserves behaviour.
+  - New `claude-code` backend value — additive.
+  - New `CLAUDE_CREDENTIALS_PATH` env override — additive.
+- **Risks:**
+  1. OAuth token schema drift if the Claude Code CLI changes the
+     `claudeAiOauth.accessToken` path. Mitigated by the UNVERIFIED
+     flag above — the developer confirms the path empirically before
+     merge.
+  2. Token expiry surfacing as 401 inside `_call` rather than `_preflight`
+     when `expiresAt` is missing. Caller maps to UNCERTAIN via the
+     existing malformed-output path (ADR 0007 §3) — acceptable, not
+     catastrophic.
+  3. File-permission leak (world-readable `.credentials.json`). Out of
+     scope for this PR but worth a security-skill check during review.
+- **Reversibility:** Easy. The driver file can be deleted and the
+  `auth_mode` field removed; default behaviour is untouched.

--- a/docs/adr/0008-judge-oauth-auth-mode.md
+++ b/docs/adr/0008-judge-oauth-auth-mode.md
@@ -67,9 +67,11 @@ Implements the ADR 0007 §1 contract. `_preflight`:
    - Missing or unreadable file → rc=2 (soft auth-missing; core maps
      to UNCERTAIN per ADR 0007 §3).
    - Read access token via:
+
      ```bash
      token="$(jq -r '.claudeAiOauth.accessToken // empty' "$path")"
      ```
+
      **UNVERIFIED — verify before merge.** The Claude Code CLI's
      on-disk schema is not documented in this repository. The
      conventional upstream layout is
@@ -86,10 +88,10 @@ Implements the ADR 0007 §1 contract. `_preflight`:
      consistent with ADR 0007 §3 — "user has not configured a key on
      this machine").
    - `expiresAt` check: if the field is present AND parseable AND
-     `expiresAt < now_ms`, return rc=2 with a stderr WARN line
-     (`# WARN claude-code judge: OAuth token expired (re-run \`task
-     e2e:auth:claude\`)`). Missing/unparseable `expiresAt` → proceed
-     and let the API surface the 401 on `_call`.
+     `expiresAt < now_ms`, return rc=2 with a `# WARN` message on
+     stderr (e.g. `# WARN claude-code judge: OAuth token expired —
+     re-run task e2e:auth:claude`). Missing/unparseable `expiresAt`
+     → proceed and let the API surface the 401 on `_call`.
    - On success: `printf 'AUTH_TOKEN=%s\n' "$token"; return 0`.
 4. When `auth_mode = "api_key"`: identical body to
    `_llm_judge_driver_anthropic_preflight` (read `JUDGE_API_KEY_ENV`
@@ -116,6 +118,7 @@ Implements the ADR 0007 §1 contract. `_preflight`:
   `JUDGE_API_KEY_ENV` and ignores `JUDGE_AUTH_MODE`.
 - New `local.toml.example` stanza (commented) documents the
   claude-code oauth path:
+
   ```toml
   # Re-use the OAuth token minted by `task e2e:auth:claude` instead of
   # `ANTHROPIC_JUDGE_API_KEY`. Reads ${CLAUDE_CREDENTIALS_PATH:-~/.claude/.credentials.json}.

--- a/docs/adr/0008-judge-oauth-auth-mode.md
+++ b/docs/adr/0008-judge-oauth-auth-mode.md
@@ -140,6 +140,26 @@ is borderline. Recorded as ADR 0008 because:
   (file permissions, expiry, stale tokens) that deserves a written
   decision the security agent can audit against.
 
+### 4a. Threat model — `CLAUDE_CREDENTIALS_PATH` trust assumption
+
+`CLAUDE_CREDENTIALS_PATH` is treated as **trusted input**: it must be
+controlled by the same operator who configures `JUDGE_ENDPOINT`. An
+attacker who can set both variables can exfiltrate any JSON file on
+disk that contains a `.claudeAiOauth.accessToken` field, by pointing
+the driver at the target file and at an attacker-controlled endpoint
+that captures the bearer token.
+
+This is an accepted threat. The mitigation is environmental: setting
+either variable already requires shell-level access equivalent to
+running arbitrary commands as the operator, so a successful attacker
+has strictly more direct paths to credential disclosure (e.g.
+reading `$HOME/.claude/.credentials.json` directly). The driver does
+not attempt to sandbox the path; it only refuses to read credential
+files whose POSIX permissions are more permissive than `0600` (any
+group/other bit set), which closes the *local other-user*
+disclosure path without claiming to address the *compromised
+operator* path.
+
 ## File list
 
 | Path | Change |

--- a/scripts/tests/test-e2e-llm-judge-lib.sh
+++ b/scripts/tests/test-e2e-llm-judge-lib.sh
@@ -300,6 +300,182 @@ else
     "rc=$rc err=$(head -c 300 "$err")"
 fi
 
+# ==========================================================================
+# Issue #126 — claude-code OAuth driver + auth_mode plumbing.
+# Exercises the real driver at tests/e2e/lib/llm_judge_drivers/claude-code.sh
+# (preflight branches on JUDGE_AUTH_MODE; oauth reads ${CLAUDE_CREDENTIALS_PATH}).
+# Tests 6a–6d short-circuit before any HTTP call (preflight returns 2 or 1),
+# so they need no driver stub; test 6e exercises the happy path with
+# E2E_JUDGE_MOCK=1 to bypass curl.
+# ==========================================================================
+
+# Build an effective.json with explicit auth_mode + backend.
+mk_effective_json_auth() {
+  local cap="$1" rd="$2" backend="$3" auth_mode="$4"
+  jq -n \
+    --argjson cap "$cap" \
+    --arg backend "$backend" \
+    --arg auth_mode "$auth_mode" '
+    { judge: {
+        backend: $backend,
+        model: "claude-sonnet-4-6",
+        api_key_env: "ANTHROPIC_JUDGE_API_KEY",
+        auth_mode: $auth_mode,
+        strict: false,
+        max_calls: $cap,
+        endpoint: "https://api.anthropic.com/v1/messages",
+        max_tokens: 256,
+        temperature: 0.0
+    } }' > "$rd/effective.json"
+}
+
+# Build a Claude Code credentials fixture. Pass an empty string for $2 to
+# emit `accessToken: null` (jq drops the field when --arg is empty +
+# `// empty` selector — sufficient for "missing/null token" coverage).
+mk_creds() {
+  local path="$1" token="$2" expires_ms="$3"
+  jq -n \
+    --arg token "$token" \
+    --argjson expires "$expires_ms" '
+    { claudeAiOauth: {
+        accessToken: (if $token == "" then null else $token end),
+        expiresAt: $expires
+    } }' > "$path"
+}
+
+FAR_FUTURE_MS=$(( $(date +%s) * 1000 + 86400000 ))  # +24h
+
+# ---------- 6a. oauth missing credentials file → UNCERTAIN exit 0 ---------
+rd="$TMP/rd_oauth_missing"; mkdir -p "$rd"
+mk_effective_json_auth 30 "$rd" claude-code oauth
+out="$TMP/out_oauth_missing"; err="$TMP/err_oauth_missing"
+set +e
+E2E_REPORT_DIR="$rd" \
+CLAUDE_CREDENTIALS_PATH="/nonexistent/path/credentials.json" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "oauth: missing credentials file → UNCERTAIN exit 0"
+else
+  note_fail "oauth: missing credentials file → UNCERTAIN exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 6b. oauth null/empty accessToken → UNCERTAIN exit 0 -----------
+rd="$TMP/rd_oauth_null"; mkdir -p "$rd"
+mk_effective_json_auth 30 "$rd" claude-code oauth
+creds="$TMP/creds_null.json"; mk_creds "$creds" "" "$FAR_FUTURE_MS"
+out="$TMP/out_oauth_null"; err="$TMP/err_oauth_null"
+set +e
+E2E_REPORT_DIR="$rd" \
+CLAUDE_CREDENTIALS_PATH="$creds" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "oauth: null accessToken → UNCERTAIN exit 0"
+else
+  note_fail "oauth: null accessToken → UNCERTAIN exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 6c. oauth expired token → UNCERTAIN exit 0 + WARN on stderr ---
+rd="$TMP/rd_oauth_exp"; mkdir -p "$rd"
+mk_effective_json_auth 30 "$rd" claude-code oauth
+creds="$TMP/creds_expired.json"; mk_creds "$creds" "test-token-abc" 1
+out="$TMP/out_oauth_exp"; err="$TMP/err_oauth_exp"
+set +e
+E2E_REPORT_DIR="$rd" \
+CLAUDE_CREDENTIALS_PATH="$creds" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+# Both warnings must surface: the driver's own expiry warning AND the
+# core's auth-missing warning (because the driver returns 2 after warning).
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q '# WARN claude-code judge: OAuth token expired' "$err" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "oauth: expired token → UNCERTAIN exit 0 + driver WARN"
+else
+  note_fail "oauth: expired token → UNCERTAIN exit 0 + driver WARN" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 500 "$err")"
+fi
+
+# ---------- 6d. unknown auth_mode → hard failure (exit 1) -----------------
+# The driver's preflight rejects modes other than {oauth, api_key} with
+# rc=1, which llm_judge maps to a hard failure regardless of strict.
+rd="$TMP/rd_oauth_bogus"; mkdir -p "$rd"
+mk_effective_json_auth 30 "$rd" claude-code bogus
+out="$TMP/out_oauth_bogus"; err="$TMP/err_oauth_bogus"
+set +e
+E2E_REPORT_DIR="$rd" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] \
+   && grep -q '# FAIL' "$err" \
+   && grep -qE 'preflight returned hard failure' "$err"; then
+  note_pass "oauth: unknown auth_mode → hard fail exit 1"
+else
+  note_fail "oauth: unknown auth_mode → hard fail exit 1" \
+    "rc=$rc err=$(head -c 500 "$err")"
+fi
+
+# ---------- 6e. oauth happy-path (mocked end-to-end) → PASS exit 0 --------
+# Valid credentials fixture + E2E_JUDGE_MOCK=1 short-circuits both the
+# driver's preflight (returns mock token) and its _call (uses
+# E2E_JUDGE_MOCK_RESPONSE). No network. Confirms the dispatch path
+# resolves backend=claude-code + auth_mode=oauth end-to-end.
+rd="$TMP/rd_oauth_ok"; mkdir -p "$rd"
+mk_effective_json_auth 30 "$rd" claude-code oauth
+creds="$TMP/creds_ok.json"; mk_creds "$creds" "test-oauth-token-abc123" "$FAR_FUTURE_MS"
+out="$TMP/out_oauth_ok"; err="$TMP/err_oauth_ok"
+set +e
+E2E_REPORT_DIR="$rd" \
+CLAUDE_CREDENTIALS_PATH="$creds" \
+E2E_JUDGE_MOCK=1 \
+E2E_JUDGE_MOCK_RESPONSE="VERDICT=PASS CONF=0.95" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "oauth: happy-path (mocked) → exit 0 + VERDICT=PASS"
+else
+  note_fail "oauth: happy-path (mocked) → exit 0 + VERDICT=PASS" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 6f. api_key parity unaffected under new JUDGE_AUTH_MODE -------
+# anthropic backend + explicit auth_mode=api_key. Reuses the existing
+# anthropic-stub FAKE_LIB to short-circuit HTTP. Confirms the new
+# auth_mode field is plumbed through without breaking the legacy path.
+rd="$TMP/rd_api_key_parity"; mkdir -p "$rd"
+mk_effective_json_auth 30 "$rd" anthropic api_key
+queue="$TMP/q_api_key_parity"; mk_queue "$queue" \
+  "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9" "VERDICT=PASS CONF=0.9"
+out="$TMP/out_api_key_parity"
+set +e
+run_judge_sequence "$rd" 0 "$queue" >"$out" 2>&1
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "auth_mode=api_key parity: anthropic backend still works"
+else
+  note_fail "auth_mode=api_key parity: anthropic backend still works" \
+    "rc=$rc out=$(cat "$out")"
+fi
+
 # ---------- 5. max_calls cap ---------------------------------------------
 # Cap=1 in effective.json; pre-bump counter to 1; next call must refuse.
 rd="$TMP/rd_cap"; mkdir -p "$rd"; mk_effective_json 1 "$rd"

--- a/scripts/tests/test-e2e-llm-judge-lib.sh
+++ b/scripts/tests/test-e2e-llm-judge-lib.sh
@@ -341,6 +341,8 @@ mk_creds() {
         accessToken: (if $token == "" then null else $token end),
         expiresAt: $expires
     } }' > "$path"
+  # Driver enforces mode <= 0600 (security finding #3).
+  chmod 600 "$path"
 }
 
 FAR_FUTURE_MS=$(( $(date +%s) * 1000 + 86400000 ))  # +24h

--- a/tests/e2e/defaults.toml
+++ b/tests/e2e/defaults.toml
@@ -62,6 +62,7 @@ env_keys     = ["COPILOT_GITHUB_TOKEN"]
 backend     = "anthropic"                    # Selects tests/e2e/lib/llm_judge_drivers/<backend>.sh.
 model       = "claude-sonnet-4-6"            # Update when a newer stable Sonnet ships.
 api_key_env = "ANTHROPIC_JUDGE_API_KEY"
+auth_mode   = "api_key"                      # "api_key" (default) | "oauth" — see ADR 0008. Only honored by drivers that branch on it (e.g. claude-code).
 endpoint    = "https://api.anthropic.com/v1/messages"
 max_tokens  = 256
 strict      = false                          # UNCERTAIN warns; does NOT fail.

--- a/tests/e2e/lib/README.md
+++ b/tests/e2e/lib/README.md
@@ -173,3 +173,10 @@ max_calls = 100
 
 Set `E2E_JUDGE_STRICT=1` (or `[judge].strict = true`) to upgrade
 UNCERTAIN verdicts to hard failures — useful for the gating leg of CI.
+
+#### OAuth via `claude-code` backend
+
+To avoid minting a separate `ANTHROPIC_JUDGE_API_KEY`, set
+`[judge].backend = "claude-code"` + `[judge].auth_mode = "oauth"` to
+re-use the OAuth token minted by `task e2e:auth:claude`. See
+[ADR 0008](../../../docs/adr/0008-judge-oauth-auth-mode.md).

--- a/tests/e2e/lib/llm_judge.sh
+++ b/tests/e2e/lib/llm_judge.sh
@@ -102,6 +102,7 @@ _llm_judge_load_config() {
   local backend="anthropic"
   local model="claude-sonnet-4-6"
   local api_key_env="ANTHROPIC_JUDGE_API_KEY"
+  local auth_mode="api_key"
   local strict="false"
   local max_calls="30"
   local endpoint="https://api.anthropic.com/v1/messages"
@@ -118,6 +119,8 @@ _llm_judge_load_config() {
               || printf 'claude-sonnet-4-6')"
     api_key_env="$(jq -r '.judge.api_key_env // "ANTHROPIC_JUDGE_API_KEY"' "$cfg" 2>/dev/null \
               || printf 'ANTHROPIC_JUDGE_API_KEY')"
+    auth_mode="$(jq -r '.judge.auth_mode // "api_key"' "$cfg" 2>/dev/null \
+              || printf 'api_key')"
     strict="$(jq -r '.judge.strict // false' "$cfg" 2>/dev/null || printf 'false')"
     max_calls="$(jq -r '.judge.max_calls // 30' "$cfg" 2>/dev/null || printf '30')"
     endpoint="$(jq -r '.judge.endpoint // "https://api.anthropic.com/v1/messages"' "$cfg" 2>/dev/null \
@@ -132,6 +135,7 @@ _llm_judge_load_config() {
   printf 'JUDGE_BACKEND=%q\n' "$backend"
   printf 'JUDGE_MODEL=%q\n' "$model"
   printf 'JUDGE_API_KEY_ENV=%q\n' "$api_key_env"
+  printf 'JUDGE_AUTH_MODE=%q\n' "$auth_mode"
   printf 'JUDGE_STRICT=%q\n' "$strict"
   printf 'JUDGE_MAX_CALLS=%q\n' "$max_calls"
   printf 'JUDGE_ENDPOINT=%q\n' "$endpoint"
@@ -204,11 +208,12 @@ llm_judge() {
       "no such file: ${subject_file}"; return 1; }
 
   # Config.
-  local JUDGE_BACKEND JUDGE_MODEL JUDGE_API_KEY_ENV JUDGE_STRICT JUDGE_MAX_CALLS
+  local JUDGE_BACKEND JUDGE_MODEL JUDGE_API_KEY_ENV JUDGE_AUTH_MODE JUDGE_STRICT JUDGE_MAX_CALLS
   local JUDGE_ENDPOINT JUDGE_MAX_TOKENS JUDGE_TEMPERATURE
   eval "$(_llm_judge_load_config)"
-  # The driver reads JUDGE_API_KEY_ENV via indirect expansion.
-  export JUDGE_API_KEY_ENV
+  # The driver reads JUDGE_API_KEY_ENV via indirect expansion and
+  # branches internally on JUDGE_AUTH_MODE (ADR 0008).
+  export JUDGE_API_KEY_ENV JUDGE_AUTH_MODE
 
   # Compute E2E_LIB_DIR fallback for standalone invocations.
   local lib_dir="${E2E_LIB_DIR:-${BASH_SOURCE[0]%/*}}"

--- a/tests/e2e/lib/llm_judge_drivers/claude-code.sh
+++ b/tests/e2e/lib/llm_judge_drivers/claude-code.sh
@@ -26,6 +26,19 @@ _llm_judge_driver_claude-code_preflight() {
         # Soft auth-missing → core maps to UNCERTAIN.
         return 2
       fi
+      # Refuse credentials files with permissions more permissive than
+      # 0600 — any group/other read or write bit indicates the token is
+      # exposed to other local users. Dual `stat` invocation covers GNU
+      # coreutils (Linux) and BSD stat (macOS). The mask 0177 captures
+      # every non-owner permission bit; `8#` forces base-8 parsing so
+      # leading zeros do not silently coerce to decimal.
+      local perms
+      perms="$(stat -c '%a' "$cred_path" 2>/dev/null || stat -f '%OLp' "$cred_path" 2>/dev/null || true)"
+      if [[ -n "$perms" && "$perms" =~ ^[0-7]+$ ]] && (( 8#$perms & 8#0177 )); then
+        printf '# WARN llm_judge_driver_claude-code: credentials file %s has unsafe permissions (%s) — refusing\n' \
+          "$cred_path" "$perms" >&2
+        return 2
+      fi
       # UNVERIFIED — Claude Code's on-disk schema is not formally
       # documented in this repository. The conventional upstream layout
       # places the access token at `.claudeAiOauth.accessToken` and the
@@ -39,14 +52,24 @@ _llm_judge_driver_claude-code_preflight() {
       fi
       local expires_at now_ms
       expires_at="$(jq -r '.claudeAiOauth.expiresAt // empty' "$cred_path" 2>/dev/null || true)"
-      if [[ -n "$expires_at" && "$expires_at" =~ ^[0-9]+$ ]]; then
-        now_ms=$(( $(date +%s) * 1000 ))
-        if (( expires_at < now_ms )); then
-          printf '# WARN claude-code judge: OAuth token expired (re-run `task e2e:auth:claude`)\n' >&2
-          return 2
-        fi
+      # Treat a missing or non-integer expiry as auth-missing rather
+      # than as a non-expiring token: a credentials file that does not
+      # declare an expiry deadline must not silently be considered
+      # valid forever.
+      if [[ -z "$expires_at" || ! "$expires_at" =~ ^[0-9]+$ ]]; then
+        printf '# WARN llm_judge_driver_claude-code: OAuth credentials missing or non-integer expiresAt — refusing\n' >&2
+        return 2
       fi
+      now_ms=$(( $(date +%s) * 1000 ))
+      if (( expires_at < now_ms )); then
+        printf '# WARN claude-code judge: OAuth token expired (re-run `task e2e:auth:claude`)\n' >&2
+        return 2
+      fi
+      # Suppress `set -x` tracing around the token emission so the
+      # secret does not leak into a script trace.
+      { set +x; } 2>/dev/null
       printf 'AUTH_TOKEN=%s\n' "$token"
+      { set -x; } 2>/dev/null
       return 0
       ;;
     api_key)
@@ -100,10 +123,16 @@ _llm_judge_driver_claude-code_call() {
           ] }')"
     local attempt=0
     while (( attempt < 2 )); do
+      # Suppress `set -x` tracing around the curl invocation so the
+      # bearer token does not leak into a script trace. The Authorization
+      # header is passed via a process substitution so the token never
+      # appears in curl's argv (visible via `ps`).
+      { set +x; } 2>/dev/null
       raw="$(curl -sS --fail-with-body -X POST "$endpoint" \
-              -H "Authorization: Bearer ${api_key}" \
+              -H @<(printf 'Authorization: Bearer %s\n' "$api_key") \
               -H "content-type: application/json" \
-              -d "$body" 2>&1)" && break
+              -d "$body" 2>&1)" && { { set -x; } 2>/dev/null; break; }
+      { set -x; } 2>/dev/null
       attempt=$(( attempt + 1 ))
       sleep 1
     done

--- a/tests/e2e/lib/llm_judge_drivers/claude-code.sh
+++ b/tests/e2e/lib/llm_judge_drivers/claude-code.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/llm_judge_drivers/claude-code.sh — Claude Code judge driver.
+#
+# Reuses the OAuth credential minted by `task e2e:auth:claude` (ADR 0002)
+# to call the Anthropic Messages API as the judge, without requiring a
+# separate ANTHROPIC_JUDGE_API_KEY. See ADR 0008 for the full design.
+#
+# Contract: same as ADR 0007 §1 (identical to anthropic.sh). Branches on
+# JUDGE_AUTH_MODE — "oauth" reads the access token from
+# ${CLAUDE_CREDENTIALS_PATH:-$HOME/.claude/.credentials.json}; "api_key"
+# falls back to the indirect-expansion path used by anthropic.sh.
+#
+# E2E_JUDGE_MOCK=1 short-circuits both functions, mirroring anthropic.sh.
+
+_llm_judge_driver_claude-code_preflight() {
+  if [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]]; then
+    printf 'AUTH_TOKEN=mock\n'
+    return 0
+  fi
+
+  local mode="${JUDGE_AUTH_MODE:-api_key}"
+  case "$mode" in
+    oauth)
+      local cred_path="${CLAUDE_CREDENTIALS_PATH:-$HOME/.claude/.credentials.json}"
+      if [[ ! -r "$cred_path" ]]; then
+        # Soft auth-missing → core maps to UNCERTAIN.
+        return 2
+      fi
+      # UNVERIFIED — Claude Code's on-disk schema is not formally
+      # documented in this repository. The conventional upstream layout
+      # places the access token at `.claudeAiOauth.accessToken` and the
+      # expiry (in ms since epoch) at `.claudeAiOauth.expiresAt`. If the
+      # observed schema differs, update both the jq selector and
+      # docs/adr/0008-judge-oauth-auth-mode.md in the same PR.
+      local token
+      token="$(jq -r '.claudeAiOauth.accessToken // empty' "$cred_path" 2>/dev/null || true)"
+      if [[ -z "$token" ]]; then
+        return 2
+      fi
+      local expires_at now_ms
+      expires_at="$(jq -r '.claudeAiOauth.expiresAt // empty' "$cred_path" 2>/dev/null || true)"
+      if [[ -n "$expires_at" && "$expires_at" =~ ^[0-9]+$ ]]; then
+        now_ms=$(( $(date +%s) * 1000 ))
+        if (( expires_at < now_ms )); then
+          printf '# WARN claude-code judge: OAuth token expired (re-run `task e2e:auth:claude`)\n' >&2
+          return 2
+        fi
+      fi
+      printf 'AUTH_TOKEN=%s\n' "$token"
+      return 0
+      ;;
+    api_key)
+      local key_env="${JUDGE_API_KEY_ENV:-ANTHROPIC_JUDGE_API_KEY}"
+      local api_key="${!key_env:-}"
+      if [[ -z "$api_key" ]]; then
+        return 2
+      fi
+      printf 'AUTH_TOKEN=%s\n' "$api_key"
+      return 0
+      ;;
+    *)
+      _e2e_assert_diag \
+        "claude-code preflight" \
+        "JUDGE_AUTH_MODE in {oauth, api_key}" \
+        "JUDGE_AUTH_MODE=${mode}"
+      return 1
+      ;;
+  esac
+}
+
+_llm_judge_driver_claude-code_call() {
+  local model="$1" endpoint="$2" api_key="$3" max_tokens="$4" temperature="$5"
+  local prompt="$6" subject="$7" criterion="$8"
+  local mock="${9:-}"
+  local body raw text verdict
+  if [[ "$mock" == "mock" ]]; then
+    raw="${E2E_JUDGE_MOCK_RESPONSE:-}"
+    text="$raw"
+  else
+    body="$(jq -n \
+              --arg model "$model" \
+              --arg prompt "$prompt" \
+              --arg subject "$subject" \
+              --arg criterion "$criterion" \
+              --argjson maxtok "$max_tokens" \
+              --argjson temp "$temperature" '
+        { model: $model,
+          max_tokens: $maxtok,
+          temperature: $temp,
+          messages: [
+            { role: "user",
+              content: ("You are an LLM judge for an end-to-end test framework. "
+                        + "Read the PROMPT, SUBJECT, and CRITERION below, then "
+                        + "respond with EXACTLY one line in the form:\n\n"
+                        + "  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>\n\n"
+                        + "No prose, no markdown, no trailing text.\n\n"
+                        + "PROMPT:\n" + $prompt
+                        + "\n\nSUBJECT:\n" + $subject
+                        + "\n\nCRITERION:\n" + $criterion) }
+          ] }')"
+    local attempt=0
+    while (( attempt < 2 )); do
+      raw="$(curl -sS --fail-with-body -X POST "$endpoint" \
+              -H "Authorization: Bearer ${api_key}" \
+              -H "content-type: application/json" \
+              -d "$body" 2>&1)" && break
+      attempt=$(( attempt + 1 ))
+      sleep 1
+    done
+    if (( attempt >= 2 )); then
+      # HTTP failure persists; surface to caller as malformed slot.
+      return 1
+    fi
+    _llm_judge_counter_increment
+    text="$(printf '%s' "$raw" | jq -r '.content[0].text' 2>/dev/null || true)"
+  fi
+  # Extract canonical line.
+  verdict="$(printf '%s' "$text" | grep -oE 'VERDICT=(PASS|FAIL|UNCERTAIN)[[:space:]]+CONF=[0-9]+(\.[0-9]+)?' | head -n1 || true)"
+  if [[ -z "$verdict" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$verdict"
+}

--- a/tests/e2e/local.toml.example
+++ b/tests/e2e/local.toml.example
@@ -32,3 +32,14 @@
 command  = ["bash", "-c", "OLLAMA_MODELS=/tmp/ollama-models ollama serve >/dev/null 2>&1 & sleep 3 && exec ollama launch copilot --model deepseek-v4-pro:cloud --yes -- --allow-all \"$@\"", "sh"]
 mounts   = ["${CREWRIG_E2E_HOME}/ollama:/home/agent/.ollama:ro"]
 env_keys = ["COPILOT_GITHUB_TOKEN", "OLLAMA_HOST"]
+
+# Re-use the OAuth token minted by `task e2e:auth:claude` instead of
+# `ANTHROPIC_JUDGE_API_KEY`. The claude-code driver reads the access
+# token from ${CLAUDE_CREDENTIALS_PATH:-~/.claude/.credentials.json}.
+# See ADR 0008 for the full design.
+# [judge]
+# backend     = "claude-code"
+# auth_mode   = "oauth"
+# model       = "claude-sonnet-4-6"
+# temperature = 0.0
+# strict      = false


### PR DESCRIPTION
Adds an `auth_mode` field to the LLM-as-judge configuration and a new `claude-code` driver that authenticates via the local Claude Code OAuth credentials file. This lets developers without an Anthropic API key run the e2e judge against their existing Claude Code session.

## How to read this PR?

1. `docs/adr/0008-judge-oauth-auth-mode.md` — start here for the design rationale, threat model, and credential schema.
2. `tests/e2e/lib/llm_judge_drivers/claude-code.sh` — the new driver. Read `_preflight` first (validation flow), then `_call` (Bearer token via process substitution, bash -x guard).
3. `tests/e2e/lib/llm_judge.sh` — minimal additions: `auth_mode` parsing in `_llm_judge_load_config()` and `JUDGE_AUTH_MODE` export in `llm_judge()`.
4. `tests/e2e/defaults.toml` and `tests/e2e/local.toml.example` — config surface (default and OAuth example).
5. `scripts/tests/test-e2e-llm-judge-lib.sh` — 6 new test cases (15→21) cover oauth happy-path, missing file, null/empty token, expired token, unknown auth_mode, and api_key parity.

## How to test this PR?

```sh
cd /path/to/crewrig
bash scripts/tests/test-e2e-llm-judge-lib.sh
```

Expected: 21/21 tests pass. The new `mk_creds` helper writes fixture credential files with `chmod 600`.

For a manual smoke test against a real Claude Code session:

```sh
export E2E_JUDGE_MOCK=0
# Configure tests/e2e/local.toml with:
#   [judge]
#   backend   = "claude-code"
#   auth_mode = "oauth"
#   model     = "claude-sonnet-4-5"
bash tests/e2e/lib/llm_judge.sh  # or invoke via the e2e harness
```

## Detailed description (for agents)

**New file — `tests/e2e/lib/llm_judge_drivers/claude-code.sh`** (driver contract per ADR 0008):

- `_llm_judge_driver_claude-code_preflight()`: reads OAuth token from `${CLAUDE_CREDENTIALS_PATH:-$HOME/.claude/.credentials.json}`. Validates file existence, `0600` permissions, token presence, and `expiresAt` (ms). Returns `0` (emits `AUTH_TOKEN=...`), `2` (soft UNCERTAIN — missing/non-integer `expiresAt`), or `1` (hard fail).
- `_llm_judge_driver_claude-code_call()`: calls the Anthropic Messages API with `Authorization: Bearer <token>` passed via process substitution so the token never appears in `argv`. Bearer-token lines are wrapped with `set +x` / `set -x` to prevent leakage under `bash -x`. Retry/quorum/counter logic is identical to the `anthropic` driver.
- Mock mode (`E2E_JUDGE_MOCK=1`) short-circuits both functions.

**Modified — `tests/e2e/lib/llm_judge.sh`**:

- `_llm_judge_load_config()`: parses `.judge.auth_mode` (default `"api_key"`) and emits `JUDGE_AUTH_MODE=%q`.
- `llm_judge()`: declares `local JUDGE_AUTH_MODE` and exports it alongside the existing `JUDGE_API_KEY_ENV` export so drivers see it.

**Modified — `tests/e2e/defaults.toml`**: `auth_mode = "api_key"` added to `[judge]` with an inline comment.

**Modified — `tests/e2e/local.toml.example`**: commented OAuth stanza showing `backend = "claude-code"`, `auth_mode = "oauth"`, model, temperature, `strict = false`.

**Modified — `tests/e2e/lib/README.md`**: one-line pointer to ADR 0008.

**New file — `docs/adr/0008-judge-oauth-auth-mode.md`**: documents the `auth_mode` field, the OAuth driver contract, the threat model (including the `CLAUDE_CREDENTIALS_PATH` trust assumption), and the credential schema. The `.claudeAiOauth.accessToken` path is labelled `UNVERIFIED` pending confirmation against the live Claude Code credentials file.

**Modified — `scripts/tests/test-e2e-llm-judge-lib.sh`**: 6 new cases (oauth happy-path, missing file, null/empty token, expired token, unknown auth_mode hard-fail, api_key parity). The `mk_creds` helper writes fixtures with `chmod 600`. Suite goes from 15 to 21 tests, all green.

**Security review outcome**: APPROVE. Five findings addressed in commits `be529e0` and `e8d708a` — missing/non-integer `expiresAt` returns `2` (soft fail), Bearer token routed via process substitution, `0600` permission enforced, `bash -x` guard, and ADR trust assumption documented.

Closes #126.