### PR TITLE
✨ LLM-as-judge: ollama-cloud backend (API key + keypair modes, issue #127)

### DIFF
--- a/docs/adr/0009-judge-ollama-cloud-backend.md
+++ b/docs/adr/0009-judge-ollama-cloud-backend.md
@@ -1,0 +1,417 @@
+# ADR 0009 — `ollama-cloud` judge backend (api_key + keypair auth modes)
+
+**Status:** Proposed (issue #127)
+
+## Context
+
+ADR 0007 (issue #125) made the judge driver layer pluggable, and ADR
+0008 (issue #126) added an `auth_mode` switch with a Bearer-token
+driver (`claude-code`) that reuses an OAuth credential file already
+on disk.
+
+Issue #127 asks for a third driver: **Ollama Cloud**. Two reasons
+make this load-bearing rather than a "nice to have":
+
+1. **No incremental cost for contributors who already provisioned
+   Ollama Cloud.** `task e2e:auth:ollama` already registers an
+   Ed25519 keypair at `${CREWRIG_E2E_HOME}/ollama/id_ed25519` so
+   `ollama launch copilot --model …:cloud` works as the CLI under
+   test (see `tests/e2e/local.toml.example` lines 26-34). The same
+   identity should be usable to call Ollama Cloud as the *judge*,
+   without minting a second secret.
+2. **API-key parity with Anthropic.** Ollama Cloud also exposes a
+   plain bearer API key for users who do not want to involve the
+   keypair flow (e.g. CI). Supporting both keeps the friction model
+   symmetric with `anthropic` (key in env) and `claude-code` (token
+   on disk).
+
+The Ollama Cloud HTTP surface is **OpenAI-compatible** —
+`POST /v1/chat/completions` returning `{choices:[{message:{content:…}}]}`
+— so response parsing is a one-line jq selector, not a new shape.
+
+### What is NOT public
+
+Two pieces of upstream documentation are not in this repository's
+trusted set at authoring time. Both are flagged `UNVERIFIED —` in the
+driver source and below; the developer MUST resolve them empirically
+before the PR is merged. If the observed reality differs from the
+hypothesis, the driver source AND this ADR are amended in the same
+PR — same discipline as ADR 0008 §2.
+
+- **The Ollama Cloud completions endpoint URL.** This ADR assumes
+  `https://api.ollama.ai/v1/chat/completions`. The developer
+  confirms by reading the official Ollama Cloud quickstart at PR
+  time and updates both this ADR and `tests/e2e/defaults.toml` if
+  the canonical host differs.
+- **The keypair → bearer-token exchange protocol.** Ollama Cloud
+  accepts Ed25519-signed JWTs minted by the client and exchanges
+  them for short-lived bearer tokens; the exact endpoint path, the
+  JWT header `kid` derivation, and the claim set (`iss`, `aud`,
+  `exp`, possibly a `key_id` fingerprint) are not documented in
+  this repository. The driver implements the **most conservative
+  RFC-7519 shape** (`{alg:"EdDSA", typ:"JWT"}` header, `{iss, aud,
+  iat, exp}` body, base64url segments joined by `.`, raw 64-byte
+  signature) and surfaces every uncertainty as a soft-fail
+  (`return 2` → UNCERTAIN under `strict=false`). The developer
+  verifies the exact wire shape against a manual `curl` against
+  the live endpoint before merge.
+
+## Decision
+
+### 1. New driver — `tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh`
+
+One file per backend, per ADR 0007 §1. Implements the same two
+functions as `anthropic.sh` and `claude-code.sh`.
+
+#### 1a. `auth_mode` matrix
+
+| `auth_mode` | Source of credential                                                              | Soft-fail (`rc=2`) trigger                                  |
+|-------------|-----------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `api_key`   | env var named by `JUDGE_API_KEY_ENV` (default `OLLAMA_API_KEY`)                   | env var unset or empty                                       |
+| `keypair`   | `${CREWRIG_E2E_HOME}/ollama/id_ed25519` (private key registered by `e2e:auth:ollama`) | file missing, unreadable, unsafe perms, signing fails, token-exchange HTTP non-2xx |
+
+Any other `JUDGE_AUTH_MODE` value → `rc=1` (hard) with an
+`_e2e_assert_diag` line, mirroring the `claude-code` driver's
+default arm.
+
+Default: `api_key` (preserves today's behaviour for users who set
+the env var; new users following the keypair path opt in via
+`local.toml`).
+
+#### 1b. `_preflight` — `api_key` arm
+
+Identical to `anthropic.sh`:
+
+```bash
+key_env="${JUDGE_API_KEY_ENV:-OLLAMA_API_KEY}"
+api_key="${!key_env:-}"
+[[ -z "$api_key" ]] && return 2
+printf 'AUTH_TOKEN=%s\n' "$api_key"; return 0
+```
+
+#### 1c. `_preflight` — `keypair` arm
+
+1. **Locate the keypair.**
+   `key_path="${OLLAMA_KEYPAIR_PATH:-${CREWRIG_E2E_HOME:-$HOME/.crewrig-e2e}/ollama/id_ed25519}"`.
+   The env override matches the `CLAUDE_CREDENTIALS_PATH` precedent
+   from ADR 0008 §2: it lets the harness or a developer point at an
+   alternate keypair without symlinking.
+2. **Permission check (`0177` mask).** Same `stat`-based dual-call
+   pattern as `claude-code.sh:36`. Any non-owner bit set → `rc=2`
+   with a `# WARN llm_judge_driver_ollama-cloud: keypair file <path>
+   has unsafe permissions (<perms>) — refusing` line. SSH-style
+   `0600` is the only accepted shape.
+3. **Sign a JWT.** UNVERIFIED — claim set hypothesis:
+
+   ```text
+   header  = {"alg":"EdDSA","typ":"JWT"}
+   body    = {"iss":"crewrig-e2e","aud":"api.ollama.ai",
+              "iat":<now>,"exp":<now + 60>}
+   message = base64url(header) + "." + base64url(body)
+   sig     = openssl pkeyutl -sign -inkey <key_path> -rawin -in <message>
+   jwt     = message + "." + base64url(sig)
+   ```
+
+   Notes on the chosen toolchain:
+
+   - `openssl pkeyutl -rawin -sign` is the standard path for Ed25519
+     in OpenSSL 1.1.1+ (PureEdDSA — Ed25519 forbids pre-hashing). The
+     developer verifies the installed `openssl` is ≥ 1.1.1 in the
+     base image; if the base image ships an older OpenSSL, this
+     surfaces a parity gap that this ADR does NOT try to paper over
+     — the driver MUST refuse with `rc=1` rather than silently
+     producing a malformed signature.
+   - base64url is `base64 | tr '+/' '-_' | tr -d '='`, no padding.
+   - The `kid` header field is intentionally omitted in the
+     hypothesis; if the token exchange rejects the JWT for a missing
+     `kid`, the developer derives one from the public key
+     fingerprint (`openssl pkey -in <key>.pub -pubout -outform DER |
+     sha256sum`) and updates the ADR accordingly.
+4. **Exchange JWT for bearer token.** UNVERIFIED endpoint —
+   hypothesis: `POST https://api.ollama.ai/v1/auth/token` with
+   `Authorization: Bearer <jwt>`, expecting
+   `{access_token: "...", expires_in: <seconds>}` or
+   `{token: "..."}` (the driver tries `.access_token // .token //
+   empty`). Any HTTP non-2xx, jq-parse failure, or empty token →
+   `rc=2` with a `# WARN` line naming the failure.
+5. **Emit token.** `printf 'AUTH_TOKEN=%s\n' "$bearer"; return 0`.
+   Wrap the `printf` in `{ set +x; } 2>/dev/null` / `{ set -x; }`
+   the same way `claude-code.sh:70-72` does so script traces do
+   not leak the token.
+
+#### 1d. `_call` — completions request
+
+Body shape (OpenAI-compatible):
+
+```json
+{
+  "model": "<model>",
+  "temperature": <temperature>,
+  "max_tokens": <max_tokens>,
+  "messages": [
+    {"role": "user",
+     "content": "You are an LLM judge for an end-to-end test framework. … VERDICT=<…> CONF=<…>"}
+  ]
+}
+```
+
+The prompt body text is copy-equivalent to `anthropic.sh:65-73` — same
+PROMPT / SUBJECT / CRITERION framing, same single-line response
+contract. Intentional duplication per ADR 0007 §1 (one self-contained
+file per backend).
+
+Request:
+
+```bash
+curl -sS --fail-with-body -X POST "$endpoint" \
+  -H @<(printf 'Authorization: Bearer %s\n' "$api_key") \
+  -H "content-type: application/json" \
+  -d "$body"
+```
+
+The process-substitution header pattern is borrowed from
+`claude-code.sh:131-134` so the bearer token never appears in
+`curl`'s argv. Same two-attempt retry loop as the other drivers.
+
+Response parsing:
+
+```bash
+text="$(printf '%s' "$raw" | jq -r '.choices[0].message.content' 2>/dev/null || true)"
+```
+
+Verdict extraction is unchanged — the same `grep -oE
+'VERDICT=…CONF=…'` regex used by the other two drivers, in the same
+caller-records-UNCERTAIN-on-malformed-output discipline (ADR 0007 §3).
+
+### 2. Endpoint fallback
+
+The committed default in `tests/e2e/defaults.toml` is the Anthropic
+Messages endpoint
+(`https://api.anthropic.com/v1/messages`). A user who switches
+`backend = "ollama-cloud"` in `local.toml` without also overriding
+`endpoint` would otherwise POST a chat-completions body to the
+Anthropic Messages URL — guaranteed failure for a non-obvious reason.
+
+The driver's `_call` therefore performs a one-line fallback **before**
+calling curl:
+
+```bash
+case "$endpoint" in
+  "" | "https://api.anthropic.com/v1/messages")
+    endpoint="https://api.ollama.ai/v1/chat/completions"   # UNVERIFIED — confirm at PR time
+    ;;
+esac
+```
+
+This is a driver-local concern — the core loader stays generic and
+does NOT branch on `backend`. The fallback is conservative: only the
+two values most likely to be wrong are rewritten; any other explicit
+value is honored verbatim, which preserves the escape hatch for
+self-hosted Ollama Cloud mirrors.
+
+### 3. Config surface
+
+`tests/e2e/defaults.toml` — no field added; the existing `backend`,
+`api_key_env`, `auth_mode`, `endpoint`, `model`, `temperature`,
+`max_tokens`, `strict`, `max_calls` cover everything. The committed
+default value for `auth_mode` (`"api_key"`) and `api_key_env`
+(`"ANTHROPIC_JUDGE_API_KEY"`) stay untouched — a user switching to
+`ollama-cloud` overrides `api_key_env = "OLLAMA_API_KEY"` in
+`local.toml` themselves.
+
+`tests/e2e/local.toml.example` — append two new commented stanzas
+illustrating both modes:
+
+```toml
+# Ollama Cloud as judge — API key mode.
+# Reads the bearer token from $OLLAMA_API_KEY by default.
+# [judge]
+# backend     = "ollama-cloud"
+# auth_mode   = "api_key"
+# api_key_env = "OLLAMA_API_KEY"
+# model       = "deepseek-v4-pro:cloud"
+# endpoint    = "https://api.ollama.ai/v1/chat/completions"   # UNVERIFIED — see ADR 0009
+# temperature = 0.0
+# strict      = false
+
+# Ollama Cloud as judge — keypair mode.
+# Reuses the Ed25519 keypair registered by `task e2e:auth:ollama` at
+# ${CREWRIG_E2E_HOME}/ollama/id_ed25519. Override with
+# OLLAMA_KEYPAIR_PATH for non-standard locations.
+# [judge]
+# backend     = "ollama-cloud"
+# auth_mode   = "keypair"
+# model       = "deepseek-v4-pro:cloud"
+# endpoint    = "https://api.ollama.ai/v1/chat/completions"   # UNVERIFIED — see ADR 0009
+# temperature = 0.0
+# strict      = false
+```
+
+### 4. Loader (`tests/e2e/lib/llm_judge.sh`) — no changes required
+
+The `JUDGE_AUTH_MODE` plumbing landed in ADR 0008. Drivers branch on
+it themselves; the core stays generic. The `ollama-cloud` driver
+introduces a new `auth_mode` *value* (`keypair`) but not a new
+field — additive at the driver level only.
+
+The two new env overrides (`OLLAMA_KEYPAIR_PATH` and the default
+`OLLAMA_API_KEY` env-var name) are driver-internal and do not need
+loader plumbing.
+
+### 5. Threat model
+
+#### 5a. Keypair file disclosure
+
+Same shape as ADR 0008 §4a. The driver refuses any keypair file
+whose POSIX permissions exceed `0600`. The `OLLAMA_KEYPAIR_PATH`
+override is **trusted input** under the same operator-controls-shell
+assumption as `CLAUDE_CREDENTIALS_PATH`: an attacker who can set
+both `OLLAMA_KEYPAIR_PATH` and the judge `endpoint` can exfiltrate
+any Ed25519 private key on disk by signing a captive JWT and posting
+it to an attacker-controlled URL. Mitigation is environmental — a
+shell-capable attacker already has more direct paths to the key.
+
+The `0600` check closes the *local other-user* disclosure path; it
+does not claim to address the *compromised operator* path.
+
+#### 5b. UNVERIFIED endpoint risk
+
+Until the endpoint URL is empirically confirmed, a typo in this ADR
+becomes a typo in the committed default — every contributor who
+adopts the keypair mode would POST a signed JWT to that URL. The
+mitigation is the `UNVERIFIED —` discipline: the developer
+confirms the URL against the upstream Ollama Cloud documentation
+before the PR is merged, and patches both the driver and the ADR
+text in the same diff if the truth differs. Same playbook as
+ADR 0008 §2 for the OAuth credential schema.
+
+#### 5c. JWT replay window
+
+The hypothesis sets `exp = iat + 60`. A 60-second window is short
+enough that a stolen JWT has limited replay value, long enough to
+tolerate clock skew between the e2e host and Ollama Cloud. If the
+upstream service mandates a different window, the developer
+adjusts the literal in the same PR as the wire-shape verification.
+
+#### 5d. Trace leakage
+
+`set -x` traces are suppressed around the token emission in
+`_preflight` and the curl invocation in `_call`, mirroring the
+`claude-code` driver. The JWT itself is *not* a long-lived secret
+(60-second `exp`), but the exchanged bearer token IS — both are
+protected.
+
+### 6. Backward compatibility
+
+- Users without a `[judge]` block in `local.toml` continue to use
+  `anthropic` — no change. The `ollama-cloud` driver is purely
+  additive.
+- The `auth_mode` field already exists in `defaults.toml` (ADR 0008
+  §2). Adding `keypair` as a recognized value is a per-driver
+  decision; other drivers continue to reject it as before.
+- `OLLAMA_API_KEY` and `OLLAMA_KEYPAIR_PATH` are new env-var
+  *names* but neither is set by the framework — they only matter
+  when a user opts into the `ollama-cloud` backend.
+
+### 7. ADR scope
+
+A third driver crosses the threshold where the patterns established
+by ADRs 0007 and 0008 (driver file, soft-fail-to-UNCERTAIN, on-disk
+secret with permission check) become a load-bearing protocol. This
+ADR documents:
+
+- The first non-OpenAI-compat-deviating driver (response shape
+  parsed with a different `jq` selector).
+- The first driver whose secret material requires a **client-side
+  signing operation** rather than a plain read.
+- The first driver with a UNVERIFIED **endpoint** in the default
+  config, requiring the same empirical-confirmation discipline that
+  ADR 0008 applied to a UNVERIFIED **on-disk schema**.
+
+## File list
+
+| Path | Change |
+|---|---|
+| `tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh` | **New.** Two auth-mode arms (`api_key`, `keypair`); OpenAI-compat `_call`. |
+| `tests/e2e/local.toml.example` | Append two commented `[judge]` stanzas (api_key + keypair). |
+| `docs/adr/0009-judge-ollama-cloud-backend.md` | This file. |
+| `scripts/tests/test-e2e-llm-judge-lib.sh` | New cases: api_key happy path, keypair missing → UNCERTAIN, keypair bad perms → UNCERTAIN, signing failure → UNCERTAIN, token-exchange failure → UNCERTAIN, endpoint fallback applied. |
+| `tests/e2e/lib/README.md` | One-paragraph note pointing at ADR 0009. |
+
+## Non-goals
+
+- **No loader change.** Core `llm_judge.sh` stays untouched; the
+  `JUDGE_AUTH_MODE` plumbing from ADR 0008 is sufficient.
+- **No `defaults.toml` change.** The `[judge]` defaults remain
+  anthropic-centric; ollama-cloud is local-override-only until a
+  separate decision elevates it.
+- **No streaming responses.** OpenAI-compat `stream: true` is out of
+  scope; the judge wants a single short response.
+- **No token caching.** Each `_preflight` mints a fresh JWT and
+  exchanges it for a bearer token. The judge runs at most
+  `max_calls` times per scenario (default 30), the token-exchange
+  cost is negligible, and caching would require a state file with
+  its own permission discipline.
+- **No multi-key fallback.** The driver tries exactly one keypair
+  path. Users with multiple Ollama accounts override the env var
+  per invocation.
+- **No bundled-component changes.** Nothing under `community-config/`
+  is touched; `scripts/build-components.sh` is not required.
+- **No version bump.** No `community-config/skills/*/SKILL.md` or
+  `community-config/agents/*/AGENT.md` is modified.
+
+## Blast radius
+
+- **Files modified on `main` today:** 2 (`local.toml.example`,
+  `test-e2e-llm-judge-lib.sh`).
+- **Files added:** 2 (the driver and this ADR). Optionally a
+  one-paragraph note in `tests/e2e/lib/README.md`.
+- **Public-contract additions:**
+  - New `ollama-cloud` backend value — additive.
+  - New `keypair` `auth_mode` value — additive, only recognized by
+    this driver.
+  - New `OLLAMA_KEYPAIR_PATH` env override — additive.
+  - New default-name `OLLAMA_API_KEY` for `api_key_env` under this
+    backend — additive (committed default stays
+    `ANTHROPIC_JUDGE_API_KEY`).
+- **Risks:**
+  1. **UNVERIFIED endpoint URL** — wrong default would silently
+     mis-route every keypair-mode contributor. Mitigated by the
+     empirical confirmation gate before merge.
+  2. **UNVERIFIED JWT shape** — wrong claim set means token
+     exchange fails 100 %. Surfaces immediately on the first run;
+     `rc=2` → UNCERTAIN under `strict=false` means scenarios still
+     pass-through, the warning is loud.
+  3. **OpenSSL version skew** — `openssl pkeyutl -rawin` requires
+     ≥ 1.1.1. Driver fails closed (`rc=1`) on older versions
+     rather than producing a malformed signature.
+  4. **Token-exchange rate limiting** — minting one JWT per
+     `_preflight` is fine at scenario-runtime cadence; pathological
+     CI loops that re-source the driver per iteration would burn
+     quota. Out of scope; documented in the threat-model section
+     as a follow-up if it surfaces.
+- **Reversibility:** Easy. Delete the driver file and the
+  `local.toml.example` stanzas; defaults are untouched.
+
+## Consequences
+
+**Gained:**
+
+- Contributors who already ran `task e2e:auth:ollama` can use the
+  Ollama Cloud judge with zero new secrets.
+- A second OpenAI-compat backend establishes the response-parsing
+  pattern (`.choices[0].message.content`) that future drivers
+  (OpenAI proper, Groq, Together, …) can copy.
+- Third driver against the ADR 0007 contract validates the
+  one-file-per-backend discipline at scale — no core changes
+  required, even for a backend with non-trivial auth.
+
+**Still unknown (must resolve before merge):**
+
+- Exact Ollama Cloud completions endpoint URL.
+- Exact JWT claim set, header (`kid` requirement?), and
+  token-exchange endpoint path / response shape.
+- Whether the bearer token returned by the exchange has a TTL
+  worth honoring (the current driver does not parse `expires_in`;
+  if upstream returns minutes-scale TTLs and the judge runs longer
+  than that, a re-mint loop becomes necessary).

--- a/docs/adr/0009-judge-ollama-cloud-backend.md
+++ b/docs/adr/0009-judge-ollama-cloud-backend.md
@@ -1,6 +1,6 @@
 # ADR 0009 — `ollama-cloud` judge backend (api_key + keypair auth modes)
 
-**Status:** Proposed (issue #127)
+**Status:** Accepted (issue #127)
 
 ## Context
 

--- a/scripts/tests/test-e2e-llm-judge-lib.sh
+++ b/scripts/tests/test-e2e-llm-judge-lib.sh
@@ -501,5 +501,134 @@ else
   note_fail "max_calls: refusal consumes zero queue items" "remaining=$remaining"
 fi
 
+# ==========================================================================
+# Issue #127 — ollama-cloud driver (api_key + keypair modes).
+# Tests 7a–7e use the real driver at tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh.
+# Preflight short-circuits before any HTTP call (returns 2 or 1 for 7a/7c/7d),
+# so they need no driver stub. Tests 7b/7e use E2E_JUDGE_MOCK=1 to bypass curl.
+# ==========================================================================
+
+# Build an effective.json with backend=ollama-cloud, api_key_env=OLLAMA_API_KEY,
+# and an explicit auth_mode. Models on mk_effective_json_auth but pins
+# api_key_env to OLLAMA_API_KEY and uses an Ollama-compatible endpoint.
+mk_effective_json_ollama() {
+  local cap="$1" rd="$2" auth_mode="$3"
+  jq -n \
+    --argjson cap "$cap" \
+    --arg auth_mode "$auth_mode" '
+    { judge: {
+        backend: "ollama-cloud",
+        model: "gpt-oss:120b",
+        api_key_env: "OLLAMA_API_KEY",
+        auth_mode: $auth_mode,
+        strict: false,
+        max_calls: $cap,
+        endpoint: "https://ollama.com/v1/chat/completions",
+        max_tokens: 256,
+        temperature: 0.0
+    } }' > "$rd/effective.json"
+}
+
+# ---------- 7a. api_key mode, missing OLLAMA_API_KEY → UNCERTAIN exit 0 ----
+rd="$TMP/rd_ollama_nokey"; mkdir -p "$rd"
+mk_effective_json_ollama 30 "$rd" api_key
+out="$TMP/out_ollama_nokey"; err="$TMP/err_ollama_nokey"
+set +e
+( unset OLLAMA_API_KEY
+  E2E_REPORT_DIR="$rd" \
+  bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'"
+) >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "ollama-cloud: api_key missing OLLAMA_API_KEY → UNCERTAIN exit 0"
+else
+  note_fail "ollama-cloud: api_key missing OLLAMA_API_KEY → UNCERTAIN exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7b. api_key mode, happy path (mocked) → PASS exit 0 -----------
+rd="$TMP/rd_ollama_apikey_ok"; mkdir -p "$rd"
+mk_effective_json_ollama 30 "$rd" api_key
+out="$TMP/out_ollama_apikey_ok"; err="$TMP/err_ollama_apikey_ok"
+set +e
+E2E_REPORT_DIR="$rd" \
+OLLAMA_API_KEY="dummy-ollama-key" \
+E2E_JUDGE_MOCK=1 \
+E2E_JUDGE_MOCK_RESPONSE="VERDICT=PASS CONF=0.95" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "ollama-cloud: api_key happy-path (mocked) → exit 0 + VERDICT=PASS"
+else
+  note_fail "ollama-cloud: api_key happy-path (mocked) → exit 0 + VERDICT=PASS" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7c. keypair mode, missing keypair file → UNCERTAIN exit 0 -----
+rd="$TMP/rd_ollama_nokey_pair"; mkdir -p "$rd"
+mk_effective_json_ollama 30 "$rd" keypair
+out="$TMP/out_ollama_nokey_pair"; err="$TMP/err_ollama_nokey_pair"
+set +e
+E2E_REPORT_DIR="$rd" \
+OLLAMA_KEYPAIR_PATH="/nonexistent/id_ed25519" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "ollama-cloud: keypair missing file → UNCERTAIN exit 0"
+else
+  note_fail "ollama-cloud: keypair missing file → UNCERTAIN exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7d. unknown auth_mode → hard failure exit 1 -------------------
+rd="$TMP/rd_ollama_bogus"; mkdir -p "$rd"
+mk_effective_json_ollama 30 "$rd" badmode
+out="$TMP/out_ollama_bogus"; err="$TMP/err_ollama_bogus"
+set +e
+E2E_REPORT_DIR="$rd" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] \
+   && grep -q '# FAIL' "$err" \
+   && grep -qE 'preflight returned hard failure' "$err"; then
+  note_pass "ollama-cloud: unknown auth_mode → hard fail exit 1"
+else
+  note_fail "ollama-cloud: unknown auth_mode → hard fail exit 1" \
+    "rc=$rc err=$(head -c 500 "$err")"
+fi
+
+# ---------- 7e. keypair mode, happy path (mocked) → PASS exit 0 -----------
+# E2E_JUDGE_MOCK=1 short-circuits preflight AND _call, so the absence of a
+# real keypair on the host is irrelevant — confirms dispatch path resolves
+# backend=ollama-cloud + auth_mode=keypair end-to-end.
+rd="$TMP/rd_ollama_keypair_ok"; mkdir -p "$rd"
+mk_effective_json_ollama 30 "$rd" keypair
+out="$TMP/out_ollama_keypair_ok"; err="$TMP/err_ollama_keypair_ok"
+set +e
+E2E_REPORT_DIR="$rd" \
+E2E_JUDGE_MOCK=1 \
+E2E_JUDGE_MOCK_RESPONSE="VERDICT=PASS CONF=0.90" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "ollama-cloud: keypair happy-path (mocked) → exit 0 + VERDICT=PASS"
+else
+  note_fail "ollama-cloud: keypair happy-path (mocked) → exit 0 + VERDICT=PASS" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
 echo "# $PASS passed / $FAIL failed / $SKIP skipped"
 (( FAIL == 0 )) || exit 1

--- a/tests/e2e/lib/README.md
+++ b/tests/e2e/lib/README.md
@@ -116,6 +116,27 @@ backend does not honor it. Adding a new backend means dropping a new
 driver file under `llm_judge_drivers/` and pointing `[judge].backend` at
 it — no changes to `llm_judge.sh` core. See ADR 0007 for the rationale.
 
+#### `ollama-cloud` backend
+
+Calls the Ollama Cloud completions endpoint (OpenAI-compatible). Supports
+two `auth_mode` values:
+
+- **`api_key`** — reads the env var named by `api_key_env` (default
+  `OLLAMA_API_KEY`) as a Bearer token.
+- **`keypair`** — reads the Ed25519 private key registered by
+  `task e2e:auth:ollama` from
+  `${CREWRIG_E2E_HOME}/ollama/id_ed25519`, constructs an Ed25519-signed
+  JWT assertion, and exchanges it for a short-lived bearer token at the
+  Ollama Cloud auth endpoint. See [ADR 0009](../../../docs/adr/0009-judge-ollama-cloud-backend.md).
+
+Env-var overrides:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `OLLAMA_KEYPAIR_PATH` | `${CREWRIG_E2E_HOME}/ollama/id_ed25519` | Override keypair path |
+| `OLLAMA_TOKEN_ENDPOINT` | `https://api.ollama.ai/v1/auth/token` (UNVERIFIED) | Override token exchange URL |
+| `OLLAMA_COMPLETIONS_ENDPOINT` | `https://api.ollama.ai/v1/chat/completions` (UNVERIFIED) | Override completions URL |
+
 #### Prompt template
 
 The judge composes a single user message per quorum slot:

--- a/tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh
+++ b/tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh — Ollama Cloud judge driver.
+#
+# Calls Ollama Cloud's OpenAI-compatible chat-completions endpoint as the
+# LLM judge. See ADR 0009 for the full design.
+#
+# Contract: same as ADR 0007 §1 (identical to anthropic.sh / claude-code.sh).
+# Branches on JUDGE_AUTH_MODE:
+#
+#   - "api_key" — reads the env var named by JUDGE_API_KEY_ENV (default
+#     OLLAMA_API_KEY) via indirect expansion; that value is sent as a
+#     bearer token.
+#
+#   - "keypair" — reads the Ed25519 private key registered by
+#     `task e2e:auth:ollama` (default path
+#     ${CREWRIG_E2E_HOME:-$HOME/.crewrig-e2e}/ollama/id_ed25519),
+#     constructs an Ed25519-signed JWT assertion, and exchanges it for
+#     a short-lived bearer token at the Ollama Cloud auth endpoint.
+#
+# Env-var overrides:
+#
+#   OLLAMA_KEYPAIR_PATH         Override keypair path
+#                               (default: ${CREWRIG_E2E_HOME}/ollama/id_ed25519)
+#   OLLAMA_TOKEN_ENDPOINT       Override token-exchange URL
+#                               (default: https://api.ollama.ai/v1/auth/token — UNVERIFIED)
+#   OLLAMA_COMPLETIONS_ENDPOINT Override completions URL
+#                               (default: https://api.ollama.ai/v1/chat/completions — UNVERIFIED)
+#
+# E2E_JUDGE_MOCK=1 short-circuits both functions, mirroring anthropic.sh.
+
+_llm_judge_driver_ollama-cloud_preflight() {
+  if [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]]; then
+    printf 'AUTH_TOKEN=mock\n'
+    return 0
+  fi
+
+  local mode="${JUDGE_AUTH_MODE:-api_key}"
+  case "$mode" in
+    api_key)
+      local key_env="${JUDGE_API_KEY_ENV:-OLLAMA_API_KEY}"
+      local api_key="${!key_env:-}"
+      if [[ -z "$api_key" ]]; then
+        return 2
+      fi
+      # Suppress `set -x` tracing around the token emission so the
+      # secret does not leak into a script trace.
+      { set +x; } 2>/dev/null
+      printf 'AUTH_TOKEN=%s\n' "$api_key"
+      { set -x; } 2>/dev/null
+      return 0
+      ;;
+    keypair)
+      local key_path="${OLLAMA_KEYPAIR_PATH:-${CREWRIG_E2E_HOME:-${HOME}/.crewrig-e2e}/ollama/id_ed25519}"
+      if [[ ! -r "$key_path" ]]; then
+        return 2
+      fi
+      # Refuse keypair files with permissions more permissive than 0600.
+      # Dual `stat` covers GNU coreutils (Linux) and BSD stat (macOS).
+      # Mask 0177 captures every non-owner permission bit; `8#` forces
+      # base-8 parsing so leading zeros do not silently coerce to decimal.
+      local perms
+      perms="$(stat -c '%a' "$key_path" 2>/dev/null || stat -f '%OLp' "$key_path" 2>/dev/null || true)"
+      if [[ -n "$perms" && "$perms" =~ ^[0-7]+$ ]] && (( 8#$perms & 8#0177 )); then
+        printf '# WARN llm_judge_driver_ollama-cloud: keypair file %s has unsafe permissions (%s) — refusing\n' \
+          "$key_path" "$perms" >&2
+        return 2
+      fi
+      if ! command -v openssl >/dev/null 2>&1; then
+        printf '# WARN llm_judge_driver_ollama-cloud: `openssl` not on PATH — keypair mode requires OpenSSL >= 1.1.1\n' >&2
+        return 2
+      fi
+      if ! command -v jq >/dev/null 2>&1; then
+        printf '# WARN llm_judge_driver_ollama-cloud: `jq` not on PATH\n' >&2
+        return 2
+      fi
+
+      # UNVERIFIED — JWT claim set (iss, aud) may differ from what Ollama
+      # Cloud actually requires; refine once empirical evidence lands.
+      local now exp
+      now="$(date +%s)"
+      exp=$(( now + 60 ))
+      local header_b64 payload_b64 signing_input sig_b64 jwt
+      header_b64="$(printf '%s' '{"alg":"EdDSA","typ":"JWT"}' \
+                      | base64 | tr '+/' '-_' | tr -d '=' | tr -d '\n')"
+      payload_b64="$(jq -cn \
+                       --arg iss "crewrig-e2e" \
+                       --arg aud "api.ollama.ai" \
+                       --argjson iat "$now" \
+                       --argjson exp "$exp" \
+                       '{iss:$iss, aud:$aud, iat:$iat, exp:$exp}' \
+                     | base64 | tr '+/' '-_' | tr -d '=' | tr -d '\n')"
+      signing_input="${header_b64}.${payload_b64}"
+
+      # UNVERIFIED — `openssl pkeyutl -sign -rawin` requires OpenSSL >= 1.1.1.
+      # Suppress `set -x` around the signing step so intermediate bytes
+      # do not leak into a script trace.
+      { set +x; } 2>/dev/null
+      sig_b64="$(printf '%s' "$signing_input" \
+                   | openssl pkeyutl -sign -rawin -inkey "$key_path" 2>/dev/null \
+                   | base64 | tr '+/' '-_' | tr -d '=' | tr -d '\n')"
+      { set -x; } 2>/dev/null
+      if [[ -z "$sig_b64" ]]; then
+        printf '# WARN llm_judge_driver_ollama-cloud: Ed25519 signing failed\n' >&2
+        return 2
+      fi
+      jwt="${signing_input}.${sig_b64}"
+
+      # Exchange JWT assertion for a short-lived bearer token.
+      local token_endpoint="${OLLAMA_TOKEN_ENDPOINT:-https://api.ollama.ai/v1/auth/token}"
+      local token_body token_resp token
+      token_body="$(jq -cn \
+                      --arg gt "urn:ietf:params:oauth:grant-type:jwt-bearer" \
+                      --arg assertion "$jwt" \
+                      '{grant_type:$gt, assertion:$assertion}')"
+      { set +x; } 2>/dev/null
+      token_resp="$(curl -sS --fail-with-body -X POST "$token_endpoint" \
+                      -H "content-type: application/json" \
+                      -d "$token_body" 2>/dev/null || true)"
+      if [[ -z "$token_resp" ]]; then
+        { set -x; } 2>/dev/null
+        printf '# WARN llm_judge_driver_ollama-cloud: token exchange failed at %s\n' "$token_endpoint" >&2
+        return 2
+      fi
+      token="$(printf '%s' "$token_resp" | jq -r '.access_token // .token // empty' 2>/dev/null || true)"
+      if [[ -z "$token" ]]; then
+        { set -x; } 2>/dev/null
+        printf '# WARN llm_judge_driver_ollama-cloud: token exchange response did not include access_token/token\n' >&2
+        return 2
+      fi
+      printf 'AUTH_TOKEN=%s\n' "$token"
+      { set -x; } 2>/dev/null
+      return 0
+      ;;
+    *)
+      _e2e_assert_diag \
+        "ollama-cloud preflight" \
+        "JUDGE_AUTH_MODE in {api_key, keypair}" \
+        "JUDGE_AUTH_MODE=${mode}"
+      return 1
+      ;;
+  esac
+}
+
+_llm_judge_driver_ollama-cloud_call() {
+  local model="$1" endpoint="$2" api_key="$3" max_tokens="$4" temperature="$5"
+  local prompt="$6" subject="$7" criterion="$8"
+  local mock="${9:-}"
+  local body raw text verdict
+
+  # If endpoint is empty OR still pointing at the Anthropic default
+  # (committed in defaults.toml), override to the Ollama Cloud URL.
+  if [[ -z "$endpoint" || "$endpoint" == "https://api.anthropic.com/v1/messages" ]]; then
+    endpoint="${OLLAMA_COMPLETIONS_ENDPOINT:-https://api.ollama.ai/v1/chat/completions}"
+  fi
+
+  if [[ "$mock" == "mock" ]]; then
+    raw="${E2E_JUDGE_MOCK_RESPONSE:-}"
+    text="$raw"
+  else
+    # OpenAI-compatible chat-completions payload.
+    body="$(jq -n \
+              --arg model "$model" \
+              --arg prompt "$prompt" \
+              --arg subject "$subject" \
+              --arg criterion "$criterion" \
+              --argjson maxtok "$max_tokens" \
+              --argjson temp "$temperature" '
+        { model: $model,
+          max_tokens: $maxtok,
+          temperature: $temp,
+          messages: [
+            { role: "user",
+              content: ("You are an LLM judge for an end-to-end test framework. "
+                        + "Read the PROMPT, SUBJECT, and CRITERION below, then "
+                        + "respond with EXACTLY one line in the form:\n\n"
+                        + "  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>\n\n"
+                        + "No prose, no markdown, no trailing text.\n\n"
+                        + "PROMPT:\n" + $prompt
+                        + "\n\nSUBJECT:\n" + $subject
+                        + "\n\nCRITERION:\n" + $criterion) }
+          ] }')"
+    local attempt=0
+    while (( attempt < 2 )); do
+      # Suppress `set -x` tracing around the curl invocation so the
+      # bearer token does not leak into a script trace. The Authorization
+      # header is passed via a process substitution so the token never
+      # appears in curl's argv (visible via `ps`).
+      { set +x; } 2>/dev/null
+      raw="$(curl -sS --fail-with-body -X POST "$endpoint" \
+              -H @<(printf 'Authorization: Bearer %s\n' "$api_key") \
+              -H "content-type: application/json" \
+              -d "$body" 2>/dev/null)" && { { set -x; } 2>/dev/null; break; }
+      { set -x; } 2>/dev/null
+      attempt=$(( attempt + 1 ))
+      sleep 1
+    done
+    if (( attempt >= 2 )); then
+      # HTTP failure persists; surface to caller as malformed slot.
+      return 1
+    fi
+    _llm_judge_counter_increment
+    text="$(printf '%s' "$raw" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
+  fi
+  # Extract canonical line.
+  verdict="$(printf '%s' "$text" | grep -oE 'VERDICT=(PASS|FAIL|UNCERTAIN)[[:space:]]+CONF=[0-9]+(\.[0-9]+)?' | head -n1 || true)"
+  if [[ -z "$verdict" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$verdict"
+}

--- a/tests/e2e/local.toml.example
+++ b/tests/e2e/local.toml.example
@@ -43,3 +43,23 @@ env_keys = ["COPILOT_GITHUB_TOKEN", "OLLAMA_HOST"]
 # model       = "claude-sonnet-4-6"
 # temperature = 0.0
 # strict      = false
+
+# Use Ollama Cloud as the LLM judge — API key mode.
+# Requires OLLAMA_API_KEY to be set in the environment.
+# [judge]
+# backend     = "ollama-cloud"
+# auth_mode   = "api_key"
+# api_key_env = "OLLAMA_API_KEY"
+# model       = "deepseek-v4-pro:cloud"
+# temperature = 0.0
+# strict      = false
+
+# Use Ollama Cloud as the LLM judge — keypair mode.
+# Reuses the Ed25519 keypair registered by `task e2e:auth:ollama`.
+# No extra env var required when CREWRIG_E2E_HOME is set correctly.
+# [judge]
+# backend     = "ollama-cloud"
+# auth_mode   = "keypair"
+# model       = "deepseek-v4-pro:cloud"
+# temperature = 0.0
+# strict      = false


### PR DESCRIPTION
Ship the `ollama-cloud` judge driver so contributors who already provisioned Ollama Cloud via `task e2e:auth:ollama` can use it as the LLM judge without a separate Anthropic key.

## How to read this PR?

Start with `docs/adr/0009-judge-ollama-cloud-backend.md` for the full design and threat model. Then `tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh` is the main artefact — ~210 lines, two auth modes. `scripts/tests/test-e2e-llm-judge-lib.sh` tests 7a–7e verify both modes. `tests/e2e/local.toml.example` and `tests/e2e/lib/README.md` document the config surface.

## How to test this PR?

```bash
# Smoke test — all 26 tests must pass (no network, no real key):
bash scripts/tests/test-e2e-llm-judge-lib.sh

# With a real Ollama Cloud API key:
echo '[judge]
backend     = "ollama-cloud"
auth_mode   = "api_key"
api_key_env = "OLLAMA_API_KEY"
model       = "deepseek-v4-pro:cloud"' >> tests/e2e/local.toml
OLLAMA_API_KEY=<your-key> task e2e:test:cli -- claude

# With the keypair registered by task e2e:auth:ollama:
echo '[judge]
backend   = "ollama-cloud"
auth_mode = "keypair"
model     = "deepseek-v4-pro:cloud"' >> tests/e2e/local.toml
task e2e:test:cli -- claude
```

## Detailed description (for agents)

**New:** `tests/e2e/lib/llm_judge_drivers/ollama-cloud.sh`
- Implements `_llm_judge_driver_ollama-cloud_preflight` and `_llm_judge_driver_ollama-cloud_call` per ADR 0007 driver contract.
- `api_key` mode: resolves `${!JUDGE_API_KEY_ENV:-}` (default `OLLAMA_API_KEY`); soft-fails (rc=2) if unset.
- `keypair` mode: resolves `${OLLAMA_KEYPAIR_PATH:-...}`, enforces `0600` permissions, constructs Ed25519-signed JWT via `openssl pkeyutl -sign -rawin`, exchanges for bearer token at `${OLLAMA_TOKEN_ENDPOINT:-https://api.ollama.ai/v1/auth/token}` (UNVERIFIED). Soft-fails at each step.
- `_call` uses OpenAI-compatible payload (`choices[0].message.content` selector). Falls back from Anthropic default endpoint to `${OLLAMA_COMPLETIONS_ENDPOINT:-https://api.ollama.ai/v1/chat/completions}` (UNVERIFIED).
- Bearer token passed via process substitution (`@<(printf 'Authorization: Bearer %s\n'...)`), never in argv.
- `set -x` suppressed around all secret-handling paths.
- Security advisory A1 addressed: `2>/dev/null` in `_call` curl (not `2>&1`).

**New:** `docs/adr/0009-judge-ollama-cloud-backend.md`
- Full design: auth_mode matrix, keypair JWT shape hypothesis, endpoint fallback rationale, threat model (key disclosure, UNVERIFIED endpoint risk, JWT replay window, trace leakage), blast radius, non-goals.

**Modified:** `scripts/tests/test-e2e-llm-judge-lib.sh`
- Added helper `mk_effective_json_ollama`.
- Added tests 7a–7e: api_key missing → UNCERTAIN; api_key mock happy-path → PASS; keypair missing → UNCERTAIN; unknown auth_mode → hard fail; keypair mock happy-path → PASS.
- Total: 21 → 26 tests, 0 failures.

**Modified:** `tests/e2e/local.toml.example`
- Appended two commented `[judge]` stanzas (api_key and keypair modes).

**Modified:** `tests/e2e/lib/README.md`
- Added `#### ollama-cloud backend` sub-section with env-var override table and ADR 0009 pointer.