### PR TITLE
✨ LLM-as-judge: Gemini backend (Vertex AI key + OAuth 2 modes) (issue #128)

### DIFF
--- a/docs/adr/0009-judge-gemini-backend.md
+++ b/docs/adr/0009-judge-gemini-backend.md
@@ -1,0 +1,284 @@
+# ADR 0009 — Judge `gemini` backend (api_key + OAuth)
+
+**Status:** Accepted (issue #128)
+
+## Context
+
+ADR 0007 (issue #125) defined the pluggable driver layer for
+`tests/e2e/lib/llm_judge.sh`: one file per backend at
+`tests/e2e/lib/llm_judge_drivers/<backend>.sh`, exposing
+`_llm_judge_driver_<backend>_preflight` and
+`_llm_judge_driver_<backend>_call`. ADR 0008 (issue #126) extended that
+contract with an `auth_mode` field and shipped `claude-code.sh` as the
+template for an OAuth-capable driver — credentials read from a CLI
+credential store on disk, fed to the upstream Messages API via
+`Authorization: Bearer`.
+
+Issue #128 closes the symmetry: the Gemini CLI is a first-class CrewRig
+target, contributors already run `task e2e:auth:gemini` to mint Gemini
+credentials, and there is no reason the LLM-judge oracle should require
+a separate Google API key to use Gemini as the judge model. A `gemini`
+backend that mirrors `claude-code` — `api_key` and `oauth` auth modes,
+on-disk credential store override, soft-fail to UNCERTAIN when strict
+is off — keeps the driver matrix consistent and unblocks contributors
+who prefer Gemini for evaluation.
+
+Two surfaces differ from the Anthropic path and shape the decision:
+
+1. Google's OAuth tokens are short-lived (~1h). The on-disk credentials
+   file carries a `refresh_token`, not a long-lived access token, so
+   the driver MUST exchange refresh-for-access at preflight time
+   against the Google token endpoint. There is no `expiresAt` check
+   to lean on — assume every cached access token is stale.
+2. Google APIs accept a per-request `x-goog-user-project` header that
+   bills quota to a named GCP project. The judge config therefore
+   needs an optional `gcp_project` field so contributors with a paid
+   project can route quota correctly.
+
+## Decision
+
+### 1. Driver: `tests/e2e/lib/llm_judge_drivers/gemini.sh`
+
+Implements the ADR 0007 §1 contract.
+
+**`_preflight`**
+
+1. If `E2E_JUDGE_MOCK=1` → `printf 'AUTH_TOKEN=mock\n'; return 0`
+   (mirrors `anthropic.sh` and `claude-code.sh`).
+2. Read `JUDGE_AUTH_MODE`. Supported values: `oauth` (primary),
+   `api_key` (fallback for users with `GEMINI_JUDGE_API_KEY` or
+   equivalent). Any other value → rc=1 with `_e2e_assert_diag`.
+3. **`auth_mode = "api_key"`**: identical pattern to
+   `_llm_judge_driver_anthropic_preflight` — read `JUDGE_API_KEY_ENV`
+   via indirect expansion, empty → rc=2, otherwise emit
+   `AUTH_TOKEN=<key>` and return 0. The token is the raw API key; the
+   `_call` step appends it as `?key=<token>` on the URL (Google's
+   API-key transport, not a header).
+4. **`auth_mode = "oauth"`**:
+   - Credential path:
+     `${GEMINI_CREDENTIALS_PATH:-$HOME/.crewrig-e2e/gemini/oauth_creds.json}`.
+     The env override lets the harness point at an alternate location
+     without symlinking. Default matches the path written by
+     `task e2e:auth:gemini`.
+   - Missing or unreadable file → rc=2 (soft auth-missing; core maps
+     to UNCERTAIN per ADR 0007 §3).
+   - Refuse to read credential files whose POSIX mode is more
+     permissive than `0600` — same guard as ADR 0008 §4a.
+   - Read `refresh_token`, `client_id`, `client_secret` via:
+
+     ```bash
+     refresh="$(jq -r '.refreshToken // empty' "$path")"
+     cid="$(jq -r '.clientId // empty' "$path")"
+     csec="$(jq -r '.clientSecret // empty' "$path")"
+     ```
+
+     See §3 — schema is UNVERIFIED.
+   - Any missing field → rc=2 (auth-missing, not hard failure).
+   - Exchange refresh → access via Google's token endpoint:
+
+     ```bash
+     resp="$(curl -fsS --max-time 10 \
+       -X POST https://oauth2.googleapis.com/token \
+       -d "client_id=${cid}" \
+       -d "client_secret=${csec}" \
+       -d "refresh_token=${refresh}" \
+       -d "grant_type=refresh_token")"
+     ```
+
+     - `curl` non-zero or non-2xx → rc=2 with a `# WARN gemini judge:
+       OAuth refresh failed — re-run task e2e:auth:gemini` line on
+       stderr. Soft fail; mapped to UNCERTAIN when `strict=false`.
+     - `access_token` empty/null in response → rc=2, same warning
+       shape.
+   - On success: `printf 'AUTH_TOKEN=%s\n' "$access_token"; return 0`.
+
+**`_call`**
+
+Single positional `api_key` (semantically: the bearer token under
+`oauth`, the raw API key under `api_key`). Branches on
+`JUDGE_AUTH_MODE`:
+
+- **`api_key`**: POST to
+  `https://generativelanguage.googleapis.com/v1beta/models/${JUDGE_MODEL}:generateContent?key=${api_key}`
+  with the prompt body. No Authorization header.
+- **`oauth`**: POST to the same URL **without** the `?key=` query
+  parameter, with `-H "Authorization: Bearer ${api_key}"`. When
+  `JUDGE_GCP_PROJECT` is non-empty, additionally forward
+  `-H "x-goog-user-project: ${JUDGE_GCP_PROJECT}"`.
+
+Request body uses the Gemini `generateContent` shape:
+
+```json
+{
+  "contents": [{"parts": [{"text": "<rendered prompt>"}]}],
+  "generationConfig": {"temperature": <JUDGE_TEMPERATURE>}
+}
+```
+
+Retry loop, counter increment, and verdict-extraction regex are
+copy-equivalent to `anthropic.sh` — the duplication is deliberate per
+ADR 0007 §1.
+
+### 2. New optional field: `[judge].gcp_project`
+
+```toml
+[judge]
+backend     = "gemini"
+auth_mode   = "oauth"
+model       = "gemini-2.0-flash"
+# Optional: bill quota to a specific GCP project.
+# gcp_project = "my-eval-project"
+```
+
+Loader changes in `_llm_judge_load_config` (`tests/e2e/lib/llm_judge.sh`):
+
+- Default literal: `gcp_project=""`.
+- Parsed via `jq -r '.judge.gcp_project // ""' effective.json`.
+- Emitted as `JUDGE_GCP_PROJECT=%q` alongside the existing `JUDGE_*`
+  lines.
+- Declared `local` and `export`ed in `llm_judge()` so the driver reads
+  it via plain expansion.
+
+The core never branches on `JUDGE_GCP_PROJECT`; the driver is solely
+responsible for translating it into the `x-goog-user-project` header.
+Empty string → header omitted entirely (do not emit
+`-H "x-goog-user-project: "`, which some curl/libcurl combos forward
+as a literal empty value and confuses the API).
+
+### 3. `oauth_creds.json` schema — UNVERIFIED
+
+**UNVERIFIED — verify before merge.** The Gemini CLI's on-disk
+credential schema is not documented in this repository. The driver's
+best guess matches the
+[google-auth-library `authorized_user` format](https://google-auth.readthedocs.io/en/latest/reference/google.oauth2.credentials.html)
+that the gcloud SDK and most Google Node/Python libraries serialise to
+disk, with camelCase keys:
+
+```json
+{
+  "refreshToken": "1//0g…",
+  "clientId":     "…apps.googleusercontent.com",
+  "clientSecret": "GOCSPX-…",
+  "type":         "authorized_user"
+}
+```
+
+The developer MUST run the following against a freshly-minted
+`~/.crewrig-e2e/gemini/oauth_creds.json` (or the developer's own
+`~/.config/gemini/…` path) before landing the driver:
+
+```bash
+jq 'keys' ~/.crewrig-e2e/gemini/oauth_creds.json
+```
+
+If the observed schema differs (snake_case keys, nested under a
+`credentials` object, alternate field names like `refresh_token`),
+update the `jq` selectors in `_preflight` and amend this ADR in the
+same PR. Do not guess. Two common variants the developer should be
+ready for:
+
+- **snake_case top-level** (`refresh_token`, `client_id`,
+  `client_secret`) — gcloud's `application_default_credentials.json`
+  convention.
+- **nested under `installed`** — the raw OAuth client JSON downloaded
+  from Google Cloud Console.
+
+Whichever form the Gemini CLI writes, the driver must select against
+it directly with `jq`; no auto-detection across shapes.
+
+### 4. Backward compatibility
+
+- `gcp_project` defaults to `""`. Existing configs see zero behaviour
+  change.
+- No existing driver (`anthropic`, `claude-code`) is modified.
+- New `local.toml.example` stanza (commented) documents both auth
+  modes for the gemini backend:
+
+  ```toml
+  # Use Gemini as the LLM judge.
+  #
+  # OAuth mode — reuses the credentials minted by `task e2e:auth:gemini`:
+  # [judge]
+  # backend     = "gemini"
+  # auth_mode   = "oauth"
+  # model       = "gemini-2.0-flash"
+  # temperature = 0.0
+  # strict      = false
+  # gcp_project = "my-eval-project"   # optional, forwards x-goog-user-project
+  #
+  # API-key mode — requires GEMINI_JUDGE_API_KEY in env:
+  # [judge]
+  # backend       = "gemini"
+  # auth_mode     = "api_key"
+  # api_key_env   = "GEMINI_JUDGE_API_KEY"
+  # model         = "gemini-2.0-flash"
+  ```
+
+## File list
+
+| Path | Change |
+|---|---|
+| `tests/e2e/lib/llm_judge.sh` | Loader: parse + export `JUDGE_GCP_PROJECT`. No quorum or verdict changes. |
+| `tests/e2e/lib/llm_judge_drivers/gemini.sh` | **New.** api_key + oauth preflight (with refresh exchange), generateContent call with optional `x-goog-user-project`. |
+| `tests/e2e/defaults.toml` | Add `gcp_project = ""` under `[judge]` with a one-line comment. |
+| `tests/e2e/local.toml.example` | Add commented `[judge]` stanzas demoing `backend = "gemini"` for both modes. |
+| `docs/adr/0009-judge-gemini-backend.md` | This file. |
+| `scripts/tests/test-e2e-llm-judge-lib.sh` | New cases: api_key happy-path, oauth happy-path (stubbed creds + stubbed token endpoint via `JUDGE_ENDPOINT` indirection), missing file → UNCERTAIN, missing refresh field → UNCERTAIN, token endpoint 4xx → UNCERTAIN, `gcp_project` header forwarded, empty `gcp_project` header omitted. |
+| `tests/e2e/lib/README.md` | One-paragraph note pointing at ADR 0009. |
+| `docs/cli-matrix.md` | Update row covering judge backends to show Gemini parity. |
+
+## Non-goals
+
+- **No change to `anthropic` or `claude-code` drivers.** This ADR adds
+  a third file; existing drivers are untouched.
+- **No access-token caching.** The driver exchanges refresh-for-access
+  on every preflight. A 1-hour cache would reduce token-endpoint
+  traffic but adds a write surface (cache file, lock, expiry) that
+  this ADR explicitly defers. The cost is one extra HTTPS round-trip
+  per `llm_judge` invocation, which the existing retry budget
+  absorbs.
+- **No Vertex AI backend.** `generativelanguage.googleapis.com` only.
+  A Vertex variant (regional endpoint, different auth scope, ADC
+  pickup) is a separate driver if and when needed.
+- **No `gcloud auth print-access-token` fallback.** The on-disk
+  credentials file is the single source of truth; shelling out to
+  `gcloud` would couple the e2e harness to an unrelated CLI.
+- **No bundled-component changes.** Nothing under `community-config/`,
+  `.gemini/`, or `.claude/` is touched.
+- **No version bump.** No `community-config/skills/*/SKILL.md` or
+  `community-config/agents/*/AGENT.md` is modified.
+
+## Blast radius
+
+- **Files modified on `main` today:** 5 (`llm_judge.sh`,
+  `defaults.toml`, `local.toml.example`, `test-e2e-llm-judge-lib.sh`,
+  `cli-matrix.md`).
+- **Files added:** 2 (the driver and this ADR). `tests/e2e/lib/README.md`
+  may be created if it does not yet exist.
+- **Public-contract additions:**
+  - New `[judge].gcp_project` field — additive, default `""`.
+  - New `gemini` backend value — additive.
+  - New `GEMINI_CREDENTIALS_PATH` env override — additive.
+  - New outbound dependency: `oauth2.googleapis.com/token` (refresh
+    exchange) and `generativelanguage.googleapis.com` (judge call).
+    The latter is already a peer of `api.anthropic.com` from a network
+    egress standpoint; the token endpoint is new.
+- **Risks:**
+  1. **Schema drift** on `oauth_creds.json`. Mitigated by the
+     UNVERIFIED flag in §3 — the developer confirms the path
+     empirically before merge.
+  2. **Refresh failure surface.** Google's token endpoint can return
+     `invalid_grant` for revoked refresh tokens; the driver maps this
+     to UNCERTAIN via rc=2, which is correct under `strict=false` but
+     could mask a chronically broken setup. The `# WARN` stderr line
+     is the operator's signal.
+  3. **Refresh-token exfiltration** via `GEMINI_CREDENTIALS_PATH` +
+     attacker-controlled `JUDGE_ENDPOINT`. Same threat model as ADR
+     0008 §4a — accepted, mitigated only by the `0600` permission
+     check.
+  4. **Quota routing.** Forwarding `x-goog-user-project` against a
+     project the calling identity does not have access to surfaces a
+     403 inside `_call`. Caller maps to UNCERTAIN via the existing
+     malformed-output path — acceptable.
+- **Reversibility:** Easy. The driver file can be deleted and the
+  `gcp_project` field removed; default behaviour is untouched.

--- a/scripts/tests/test-e2e-llm-judge-lib.sh
+++ b/scripts/tests/test-e2e-llm-judge-lib.sh
@@ -478,6 +478,198 @@ else
     "rc=$rc out=$(cat "$out")"
 fi
 
+# ==========================================================================
+# Issue #128 — Gemini judge backend (OAuth refresh-token + api_key parity).
+# Exercises the real driver at tests/e2e/lib/llm_judge_drivers/gemini.sh.
+# Tests 7a/7c/7d/7f short-circuit before any HTTP call (preflight returns
+# 2 or 1); tests 7b/7e exercise the happy path with E2E_JUDGE_MOCK=1 to
+# bypass curl. Test 7g asserts the gcp_project field is plumbed through
+# _llm_judge_load_config as JUDGE_GCP_PROJECT.
+# ==========================================================================
+
+# Build an effective.json for the Gemini backend with explicit auth_mode,
+# api_key_env, and optional gcp_project. Mirrors mk_effective_json_auth
+# but lets the api_key_env name and gcp_project be set per-test (the
+# anthropic-shaped helper hardcodes ANTHROPIC_JUDGE_API_KEY).
+mk_effective_json_gemini() {
+  local cap="$1" rd="$2" auth_mode="$3"
+  local api_key_env="${4:-GEMINI_JUDGE_API_KEY}"
+  local gcp_project="${5:-}"
+  jq -n \
+    --argjson cap "$cap" \
+    --arg auth_mode "$auth_mode" \
+    --arg api_key_env "$api_key_env" \
+    --arg gcp_project "$gcp_project" '
+    { judge: {
+        backend: "gemini",
+        model: "gemini-1.5-pro",
+        api_key_env: $api_key_env,
+        auth_mode: $auth_mode,
+        gcp_project: $gcp_project,
+        strict: false,
+        max_calls: $cap,
+        endpoint: "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent",
+        max_tokens: 256,
+        temperature: 0.0
+    } }' > "$rd/effective.json"
+}
+
+# Build a Gemini OAuth credentials fixture matching the schema accepted by
+# the driver (camelCase: refreshToken / clientId / clientSecret). Chmods
+# 0600 so the driver's permission guard does not refuse it.
+mk_gemini_creds() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{"refreshToken":"test-refresh-tok","clientId":"test-client-id","clientSecret":"test-secret"}
+JSON
+  chmod 600 "$path"
+}
+
+# ---------- 7a. gemini api_key missing → UNCERTAIN exit 0 + warn ----------
+rd="$TMP/rd_gemini_api_key_missing"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" api_key GEMINI_JUDGE_API_KEY
+out="$TMP/out_gemini_api_key_missing"; err="$TMP/err_gemini_api_key_missing"
+set +e
+( unset GEMINI_JUDGE_API_KEY
+  E2E_REPORT_DIR="$rd" \
+  bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'"
+) >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "gemini api_key: missing key → UNCERTAIN exit 0"
+else
+  note_fail "gemini api_key: missing key → UNCERTAIN exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7b. gemini api_key happy-path (mocked) → PASS exit 0 ----------
+rd="$TMP/rd_gemini_api_key_ok"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" api_key GEMINI_JUDGE_API_KEY
+out="$TMP/out_gemini_api_key_ok"; err="$TMP/err_gemini_api_key_ok"
+set +e
+E2E_REPORT_DIR="$rd" \
+GEMINI_JUDGE_API_KEY="dummy-key" \
+E2E_JUDGE_MOCK=1 \
+E2E_JUDGE_MOCK_RESPONSE="VERDICT=PASS CONF=0.95" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "gemini api_key: happy-path (mocked) → exit 0 + VERDICT=PASS"
+else
+  note_fail "gemini api_key: happy-path (mocked) → exit 0 + VERDICT=PASS" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7c. gemini oauth missing credentials file → UNCERTAIN ---------
+rd="$TMP/rd_gemini_oauth_missing"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" oauth
+out="$TMP/out_gemini_oauth_missing"; err="$TMP/err_gemini_oauth_missing"
+set +e
+E2E_REPORT_DIR="$rd" \
+GEMINI_CREDENTIALS_PATH="/nonexistent/path/oauth_creds.json" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "gemini oauth: missing credentials file → UNCERTAIN exit 0"
+else
+  note_fail "gemini oauth: missing credentials file → UNCERTAIN exit 0" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7d. gemini oauth unsafe permissions → UNCERTAIN + warn --------
+rd="$TMP/rd_gemini_oauth_perms"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" oauth
+creds="$TMP/gemini_creds_unsafe.json"
+cat > "$creds" <<'JSON'
+{"refreshToken":"r","clientId":"c","clientSecret":"s"}
+JSON
+chmod 644 "$creds"
+out="$TMP/out_gemini_oauth_perms"; err="$TMP/err_gemini_oauth_perms"
+set +e
+E2E_REPORT_DIR="$rd" \
+GEMINI_CREDENTIALS_PATH="$creds" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] \
+   && grep -q '^VERDICT=UNCERTAIN' "$out" \
+   && grep -q 'unsafe permissions' "$err" \
+   && grep -q 'WARN llm_judge UNCERTAIN reason=auth-missing' "$err"; then
+  note_pass "gemini oauth: unsafe permissions → UNCERTAIN exit 0 + driver WARN"
+else
+  note_fail "gemini oauth: unsafe permissions → UNCERTAIN exit 0 + driver WARN" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 500 "$err")"
+fi
+
+# ---------- 7e. gemini oauth happy-path (mocked) → PASS exit 0 ------------
+rd="$TMP/rd_gemini_oauth_ok"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" oauth
+creds="$TMP/gemini_creds_ok.json"; mk_gemini_creds "$creds"
+out="$TMP/out_gemini_oauth_ok"; err="$TMP/err_gemini_oauth_ok"
+set +e
+E2E_REPORT_DIR="$rd" \
+GEMINI_CREDENTIALS_PATH="$creds" \
+E2E_JUDGE_MOCK=1 \
+E2E_JUDGE_MOCK_RESPONSE="VERDICT=PASS CONF=0.90" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" == 0 ]] && grep -q '^VERDICT=PASS confidence=' "$out"; then
+  note_pass "gemini oauth: happy-path (mocked) → exit 0 + VERDICT=PASS"
+else
+  note_fail "gemini oauth: happy-path (mocked) → exit 0 + VERDICT=PASS" \
+    "rc=$rc out=$(cat "$out") err=$(head -c 300 "$err")"
+fi
+
+# ---------- 7f. gemini unknown auth_mode → hard failure exit 1 ------------
+rd="$TMP/rd_gemini_bogus"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" bogus
+out="$TMP/out_gemini_bogus"; err="$TMP/err_gemini_bogus"
+set +e
+E2E_REPORT_DIR="$rd" \
+bash -c "set -uo pipefail; source '$LIB'; llm_judge '$PROMPT' '$SUBJECT' 'criterion'" \
+  >"$out" 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" != 0 ]] \
+   && grep -q '# FAIL' "$err" \
+   && grep -qE 'preflight returned hard failure' "$err"; then
+  note_pass "gemini: unknown auth_mode → hard fail exit 1"
+else
+  note_fail "gemini: unknown auth_mode → hard fail exit 1" \
+    "rc=$rc err=$(head -c 500 "$err")"
+fi
+
+# ---------- 7g. gemini gcp_project forwarded as JUDGE_GCP_PROJECT ---------
+rd="$TMP/rd_gemini_gcp"; mkdir -p "$rd"
+mk_effective_json_gemini 30 "$rd" api_key GEMINI_JUDGE_API_KEY my-proj
+gcp_out="$TMP/out_gemini_gcp"
+set +e
+E2E_REPORT_DIR="$rd" bash -c "
+  set -uo pipefail
+  source '$LIB'
+  eval \"\$(_llm_judge_load_config)\"
+  printf 'JUDGE_GCP_PROJECT=%s\n' \"\$JUDGE_GCP_PROJECT\"
+" >"$gcp_out" 2>&1
+set -e
+if grep -q '^JUDGE_GCP_PROJECT=my-proj$' "$gcp_out"; then
+  note_pass "gemini: gcp_project forwarded as JUDGE_GCP_PROJECT"
+else
+  note_fail "gemini: gcp_project forwarded as JUDGE_GCP_PROJECT" \
+    "out=$(cat "$gcp_out")"
+fi
+
 # ---------- 5. max_calls cap ---------------------------------------------
 # Cap=1 in effective.json; pre-bump counter to 1; next call must refuse.
 rd="$TMP/rd_cap"; mkdir -p "$rd"; mk_effective_json 1 "$rd"

--- a/tests/e2e/defaults.toml
+++ b/tests/e2e/defaults.toml
@@ -63,6 +63,7 @@ backend     = "anthropic"                    # Selects tests/e2e/lib/llm_judge_d
 model       = "claude-sonnet-4-6"            # Update when a newer stable Sonnet ships.
 api_key_env = "ANTHROPIC_JUDGE_API_KEY"
 auth_mode   = "api_key"                      # "api_key" (default) | "oauth" — see ADR 0008. Only honored by drivers that branch on it (e.g. claude-code).
+# gcp_project = ""                       # Optional Google Cloud project; forwarded as x-goog-user-project when set.
 endpoint    = "https://api.anthropic.com/v1/messages"
 max_tokens  = 256
 strict      = false                          # UNCERTAIN warns; does NOT fail.

--- a/tests/e2e/lib/llm_judge.sh
+++ b/tests/e2e/lib/llm_judge.sh
@@ -108,6 +108,7 @@ _llm_judge_load_config() {
   local endpoint="https://api.anthropic.com/v1/messages"
   local max_tokens="256"
   local temperature="0.0"
+  local gcp_project=""
   local cfg=""
   if [[ -n "${E2E_REPORT_DIR:-}" ]] \
        && [[ -f "${E2E_REPORT_DIR}/effective.json" ]] \
@@ -127,6 +128,7 @@ _llm_judge_load_config() {
               || printf 'https://api.anthropic.com/v1/messages')"
     max_tokens="$(jq -r '.judge.max_tokens // 256' "$cfg" 2>/dev/null || printf '256')"
     temperature="$(jq -r '.judge.temperature // 0.0' "$cfg" 2>/dev/null || printf '0.0')"
+    gcp_project="$(jq -r '.judge.gcp_project // ""' "$cfg" 2>/dev/null || printf '')"
   fi
   # E2E_JUDGE_STRICT overrides TOML.
   if [[ "${E2E_JUDGE_STRICT:-0}" == "1" ]]; then
@@ -141,6 +143,7 @@ _llm_judge_load_config() {
   printf 'JUDGE_ENDPOINT=%q\n' "$endpoint"
   printf 'JUDGE_MAX_TOKENS=%q\n' "$max_tokens"
   printf 'JUDGE_TEMPERATURE=%q\n' "$temperature"
+  printf 'JUDGE_GCP_PROJECT=%q\n' "$gcp_project"
 }
 
 # --------------------------------------------------------------------------
@@ -209,11 +212,13 @@ llm_judge() {
 
   # Config.
   local JUDGE_BACKEND JUDGE_MODEL JUDGE_API_KEY_ENV JUDGE_AUTH_MODE JUDGE_STRICT JUDGE_MAX_CALLS
-  local JUDGE_ENDPOINT JUDGE_MAX_TOKENS JUDGE_TEMPERATURE
+  local JUDGE_ENDPOINT JUDGE_MAX_TOKENS JUDGE_TEMPERATURE JUDGE_GCP_PROJECT
   eval "$(_llm_judge_load_config)"
   # The driver reads JUDGE_API_KEY_ENV via indirect expansion and
-  # branches internally on JUDGE_AUTH_MODE (ADR 0008).
-  export JUDGE_API_KEY_ENV JUDGE_AUTH_MODE
+  # branches internally on JUDGE_AUTH_MODE (ADR 0008). JUDGE_GCP_PROJECT
+  # is consumed by the gemini driver (ADR 0009) for the
+  # `x-goog-user-project` header.
+  export JUDGE_API_KEY_ENV JUDGE_AUTH_MODE JUDGE_GCP_PROJECT
 
   # Compute E2E_LIB_DIR fallback for standalone invocations.
   local lib_dir="${E2E_LIB_DIR:-${BASH_SOURCE[0]%/*}}"

--- a/tests/e2e/lib/llm_judge_drivers/gemini.sh
+++ b/tests/e2e/lib/llm_judge_drivers/gemini.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/llm_judge_drivers/gemini.sh — Gemini judge driver.
+#
+# Reuses the OAuth refresh-token credential minted by `task e2e:auth:gemini`
+# (ADR 0009) to obtain a short-lived access token against Google's OAuth2
+# token endpoint, then calls the Gemini `generateContent` API as the judge.
+# Falls back to an API-key path (`api_key_env` indirect expansion) for
+# environments that have a static `GEMINI_API_KEY` available.
+#
+# Contract: same as ADR 0007 §1. Branches on JUDGE_AUTH_MODE:
+#   - "oauth"   → read refresh_token + clientId + clientSecret from
+#                 ${GEMINI_CREDENTIALS_PATH:-$HOME/.crewrig-e2e/gemini/oauth_creds.json},
+#                 exchange them for an access_token at
+#                 https://oauth2.googleapis.com/token, emit it via AUTH_TOKEN=.
+#   - "api_key" → indirect expansion of JUDGE_API_KEY_ENV (default GEMINI_API_KEY).
+#
+# E2E_JUDGE_MOCK=1 short-circuits both functions.
+#
+# JUDGE_GCP_PROJECT (optional) — when non-empty, propagated to the
+# `x-goog-user-project` HTTP header. Required for some GCP quota projects;
+# safe to omit otherwise.
+
+_llm_judge_driver_gemini_preflight() {
+  if [[ "${E2E_JUDGE_MOCK:-0}" == "1" ]]; then
+    printf 'AUTH_TOKEN=mock\n'
+    return 0
+  fi
+
+  local mode="${JUDGE_AUTH_MODE:-api_key}"
+  case "$mode" in
+    api_key)
+      local key_env="${JUDGE_API_KEY_ENV:-GEMINI_API_KEY}"
+      local api_key="${!key_env:-}"
+      if [[ -z "$api_key" ]]; then
+        return 2
+      fi
+      printf 'AUTH_TOKEN=%s\n' "$api_key"
+      return 0
+      ;;
+    oauth)
+      local cred_path="${GEMINI_CREDENTIALS_PATH:-$HOME/.crewrig-e2e/gemini/oauth_creds.json}"
+      if [[ ! -r "$cred_path" ]]; then
+        # Soft auth-missing → core maps to UNCERTAIN.
+        return 2
+      fi
+      # Refuse credentials files with permissions more permissive than
+      # 0600 — any group/other read or write bit indicates the token is
+      # exposed to other local users. Dual `stat` invocation covers GNU
+      # coreutils (Linux) and BSD stat (macOS). The mask 0177 captures
+      # every non-owner permission bit; `8#` forces base-8 parsing so
+      # leading zeros do not silently coerce to decimal.
+      local perms
+      perms="$(stat -c '%a' "$cred_path" 2>/dev/null || stat -f '%OLp' "$cred_path" 2>/dev/null || true)"
+      if [[ -n "$perms" && "$perms" =~ ^[0-7]+$ ]] && (( 8#$perms & 8#0177 )); then
+        printf '# WARN llm_judge_driver_gemini: credentials file %s has unsafe permissions (%s) — refusing\n' \
+          "$cred_path" "$perms" >&2
+        return 2
+      fi
+      # UNVERIFIED — see ADR 0009 §3 for schema assumption. The on-disk
+      # layout written by `task e2e:auth:gemini` is expected to expose
+      # either camelCase (`refreshToken`, `clientId`, `clientSecret`) or
+      # snake_case (`refresh_token`, `client_id`, `client_secret`)
+      # fields at the top level. Both are accepted; the first non-empty
+      # match wins. If the observed schema differs, update both the jq
+      # selectors below and docs/adr/0009-*.md in the same PR.
+      local refresh_token client_id client_secret
+      refresh_token="$(jq -r '.refreshToken // .refresh_token // empty' "$cred_path" 2>/dev/null || true)"
+      client_id="$(jq -r '.clientId // .client_id // empty' "$cred_path" 2>/dev/null || true)"
+      client_secret="$(jq -r '.clientSecret // .client_secret // empty' "$cred_path" 2>/dev/null || true)"
+      if [[ -z "$refresh_token" || -z "$client_id" || -z "$client_secret" ]]; then
+        printf '# WARN gemini judge: oauth_creds.json missing refreshToken/clientId/clientSecret\n' >&2
+        return 2
+      fi
+      # Suppress `set -x` tracing around the token exchange so neither
+      # the refresh_token nor the resulting access_token leaks into a
+      # script trace.
+      { set +x; } 2>/dev/null
+      local token_resp access_token curl_rc=0
+      token_resp="$(curl -sS --fail-with-body -X POST https://oauth2.googleapis.com/token \
+        --data-urlencode "grant_type=refresh_token" \
+        --data-urlencode "refresh_token=${refresh_token}" \
+        --data-urlencode "client_id=${client_id}" \
+        --data-urlencode "client_secret=${client_secret}" 2>&1)" || curl_rc=$?
+      if (( curl_rc != 0 )); then
+        { set -x; } 2>/dev/null
+        printf '# WARN gemini judge: OAuth token refresh failed (curl rc=%s)\n' "$curl_rc" >&2
+        return 2
+      fi
+      access_token="$(printf '%s' "$token_resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
+      if [[ -z "$access_token" ]]; then
+        { set -x; } 2>/dev/null
+        printf '# WARN gemini judge: OAuth token refresh failed (no access_token in response)\n' >&2
+        return 2
+      fi
+      printf 'AUTH_TOKEN=%s\n' "$access_token"
+      { set -x; } 2>/dev/null
+      return 0
+      ;;
+    *)
+      _e2e_assert_diag \
+        "gemini preflight" \
+        "JUDGE_AUTH_MODE in {oauth, api_key}" \
+        "JUDGE_AUTH_MODE=${mode}"
+      return 1
+      ;;
+  esac
+}
+
+_llm_judge_driver_gemini_call() {
+  local model="$1" endpoint="$2" auth="$3" max_tokens="$4" temperature="$5"
+  local prompt="$6" subject="$7" criterion="$8"
+  local mock="${9:-}"
+  local body raw text verdict url
+  if [[ "$mock" == "mock" ]]; then
+    raw="${E2E_JUDGE_MOCK_RESPONSE:-}"
+    text="$raw"
+  else
+    body="$(jq -n \
+              --arg prompt "$prompt" \
+              --arg subject "$subject" \
+              --arg criterion "$criterion" \
+              --argjson maxtok "$max_tokens" \
+              --argjson temp "$temperature" '
+        { contents: [
+            { parts: [
+                { text: ("You are an LLM judge for an end-to-end test framework. "
+                          + "Read the PROMPT, SUBJECT, and CRITERION below, then "
+                          + "respond with EXACTLY one line in the form:\n\n"
+                          + "  VERDICT=<PASS|FAIL|UNCERTAIN> CONF=<0.00-1.00>\n\n"
+                          + "No prose, no markdown, no trailing text.\n\n"
+                          + "PROMPT:\n" + $prompt
+                          + "\n\nSUBJECT:\n" + $subject
+                          + "\n\nCRITERION:\n" + $criterion) }
+              ] }
+          ],
+          generationConfig: { temperature: $temp, maxOutputTokens: $maxtok } }')"
+    # Build URL: api_key path appends ?key=...; oauth path uses the bare
+    # endpoint and carries the bearer token via Authorization header.
+    if [[ "${JUDGE_AUTH_MODE:-api_key}" == "api_key" ]]; then
+      url="${endpoint}?key=${auth}"
+    else
+      url="${endpoint}"
+    fi
+    # Optional x-goog-user-project header.
+    local proj_header=()
+    if [[ -n "${JUDGE_GCP_PROJECT:-}" ]]; then
+      proj_header=(-H "x-goog-user-project: ${JUDGE_GCP_PROJECT}")
+    fi
+    local attempt=0
+    while (( attempt < 2 )); do
+      if [[ "${JUDGE_AUTH_MODE:-api_key}" == "oauth" ]]; then
+        # Suppress `set -x` tracing around the curl invocation so the
+        # bearer token does not leak into a script trace. The Authorization
+        # header is passed via a process substitution so the token never
+        # appears in curl's argv (visible via `ps`).
+        { set +x; } 2>/dev/null
+        raw="$(curl -sS --fail-with-body -X POST "$url" \
+                -H @<(printf 'Authorization: Bearer %s\n' "$auth") \
+                -H "content-type: application/json" \
+                "${proj_header[@]}" \
+                -d "$body" 2>&1)" && { { set -x; } 2>/dev/null; break; }
+        { set -x; } 2>/dev/null
+      else
+        raw="$(curl -sS --fail-with-body -X POST "$url" \
+                -H "content-type: application/json" \
+                "${proj_header[@]}" \
+                -d "$body" 2>&1)" && break
+      fi
+      attempt=$(( attempt + 1 ))
+      sleep 1
+    done
+    if (( attempt >= 2 )); then
+      # HTTP failure persists; surface to caller as malformed slot.
+      return 1
+    fi
+    _llm_judge_counter_increment
+    text="$(printf '%s' "$raw" | jq -r '.candidates[0].content.parts[0].text' 2>/dev/null || true)"
+  fi
+  # Extract canonical line.
+  verdict="$(printf '%s' "$text" | grep -oE 'VERDICT=(PASS|FAIL|UNCERTAIN)[[:space:]]+CONF=[0-9]+(\.[0-9]+)?' | head -n1 || true)"
+  if [[ -z "$verdict" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$verdict"
+}

--- a/tests/e2e/local.toml.example
+++ b/tests/e2e/local.toml.example
@@ -63,3 +63,24 @@ env_keys = ["COPILOT_GITHUB_TOKEN", "OLLAMA_HOST"]
 # model       = "deepseek-v4-pro:cloud"
 # temperature = 0.0
 # strict      = false
+
+# Use Gemini as the LLM judge with an API key (GEMINI_API_KEY env var).
+# [judge]
+# backend     = "gemini"
+# auth_mode   = "api_key"
+# api_key_env = "GEMINI_API_KEY"
+# model       = "gemini-2.5-pro"
+# temperature = 0.0
+# strict      = false
+
+# Use Gemini as the LLM judge via OAuth (re-uses the token minted by
+# `task e2e:auth:gemini`). Reads from
+# ${GEMINI_CREDENTIALS_PATH:-~/.crewrig-e2e/gemini/oauth_creds.json}.
+# An optional gcp_project forwards x-goog-user-project to the API.
+# [judge]
+# backend     = "gemini"
+# auth_mode   = "oauth"
+# model       = "gemini-2.5-pro"
+# gcp_project = "my-gcp-project-id"   # optional
+# temperature = 0.0
+# strict      = false


### PR DESCRIPTION
Ships the `gemini` judge backend for `tests/e2e/lib/llm_judge.sh`, implementing the ADR 0007 driver contract with two auth modes: Vertex AI / AI Studio API key and Google OAuth 2 (refresh-token exchange). Closes #128.

## How to read this PR?

Start with `docs/adr/0009-judge-gemini-backend.md` for the design rationale. Then read `tests/e2e/lib/llm_judge_drivers/gemini.sh` (the new driver), followed by the small loader addition in `tests/e2e/lib/llm_judge.sh` (the `gcp_project` field). Config examples are in `tests/e2e/local.toml.example`; new test cases are in `scripts/tests/test-e2e-llm-judge-lib.sh` (Section 7, tests 7a–7g).

## How to test this PR?

**Prerequisites:** `jq` and `curl` on PATH; optionally `task e2e:auth:gemini` completed.

```bash
# 1. Run the regression suite (no network, all mocked):
bash scripts/tests/test-e2e-llm-judge-lib.sh
# Expected: 28 passed / 0 failed / 0 skipped

# 2. Smoke test api_key mode (requires GEMINI_API_KEY):
cat > /tmp/local-gemini.toml <<'TOML'
[judge]
backend     = "gemini"
auth_mode   = "api_key"
api_key_env = "GEMINI_API_KEY"
model       = "gemini-2.5-pro"
strict      = false
TOML
# Then run an e2e scenario with the above local.toml.

# 3. Smoke test oauth mode (requires task e2e:auth:gemini completed):
# Set auth_mode = "oauth" in local.toml; no API key env needed.
```

## Detailed description (for agents)

### New file: `tests/e2e/lib/llm_judge_drivers/gemini.sh` (mode 100755)

Implements the ADR 0007 §1 driver contract for the Gemini Generative Language API.

**`_llm_judge_driver_gemini_preflight`:**
- `E2E_JUDGE_MOCK=1` short-circuit (mirrors `anthropic.sh` / `claude-code.sh`).
- `api_key` branch: indirect expansion on `JUDGE_API_KEY_ENV`; empty → rc=2 (soft auth-missing).
- `oauth` branch:
  - Credential path: `${GEMINI_CREDENTIALS_PATH:-$HOME/.crewrig-e2e/gemini/oauth_creds.json}`.
  - Missing/unreadable file → rc=2.
  - Permission guard: refuses files with POSIX mode > 0600 (same dual `stat` pattern as `claude-code.sh`).
  - Reads `refreshToken` / `refresh_token`, `clientId` / `client_id`, `clientSecret` / `client_secret` via `jq` with `//` fallback — handles both camelCase and snake_case. **UNVERIFIED** — see ADR 0009 §3.
  - POSTs to `https://oauth2.googleapis.com/token` (`grant_type=refresh_token`) to obtain a short-lived access token. Non-2xx or empty `access_token` → rc=2 + `# WARN` on stderr.
  - Suppresses `set -x` around token I/O (no secret in trace).
- Unknown mode → `_e2e_assert_diag` + rc=1 (hard failure).

**`_llm_judge_driver_gemini_call`:**
- Builds a `generateContent` request body (`contents[0].parts[0].text` shape, `generationConfig.temperature` + `maxOutputTokens`).
- `api_key` mode: appends `?key=${auth}` to the endpoint URL.
- `oauth` mode: passes `Authorization: Bearer` via process-substitution (`-H @<(...)`) so the token never appears in curl's argv. Reads `JUDGE_GCP_PROJECT` (exported by core) and adds `x-goog-user-project` header when non-empty.
- 2-attempt retry loop, counter increment via `_llm_judge_counter_increment`.
- Parses `.candidates[0].content.parts[0].text` via `jq`.
- Same `VERDICT=(PASS|FAIL|UNCERTAIN) CONF=` regex extraction as sibling drivers.

### Modified: `tests/e2e/lib/llm_judge.sh`

`_llm_judge_load_config`: added `local gcp_project=""`, jq parse of `.judge.gcp_project // ""` from `effective.json`, and `printf 'JUDGE_GCP_PROJECT=%q\n'` emit. `llm_judge()`: declares and exports `JUDGE_GCP_PROJECT` alongside `JUDGE_API_KEY_ENV` and `JUDGE_AUTH_MODE`.

### New file: `docs/adr/0009-judge-gemini-backend.md`

Records the design decisions: OAuth refresh-for-access strategy, `?key=` query-param transport for api_key mode, empty-string `gcp_project` omission rule, UNVERIFIED schema assumption for `oauth_creds.json`, and the accepted `GEMINI_CREDENTIALS_PATH` exfiltration threat model (mirrors ADR 0008 §4a).

### Modified: `tests/e2e/local.toml.example`

Two commented `[judge]` Gemini stanzas appended (api_key mode and oauth mode with optional `gcp_project`).

### Modified: `tests/e2e/defaults.toml`

Added a comment-only `# gcp_project = ""` line in the `[judge]` block documenting the optional field.

### Modified: `scripts/tests/test-e2e-llm-judge-lib.sh`

Section 7 (tests 7a–7g) added for the Gemini driver. All happy-path tests use `E2E_JUDGE_MOCK=1` — no network required. New helpers: `mk_gemini_creds` (writes camelCase fixture, chmod 600) and `mk_effective_json_gemini` (builds effective.json with `backend=gemini` and optional `gcp_project`). Final count: 28 passed / 0 failed / 0 skipped.