### PR TITLE
🐛 e2e: populate claude rules dir + replace add-drawer with init+mine (issue #134)

### DIFF
--- a/scripts/e2e/auth-claude.sh
+++ b/scripts/e2e/auth-claude.sh
@@ -7,9 +7,15 @@
 # OAuth browser flow on the host. Subsequent scenario runs mount the same dir
 # read-only.
 #
+# Rules directory: regardless of the auth backend, this script populates
+# ~/.crewrig-e2e/claude/rules/ by copying ~/.claude/rules/*.md from the host.
+# The 01-layered-context scenario mounts that directory as /home/agent/.claude
+# inside the container. Running `task setup:claude` (or the interactive
+# equivalent) first is a prerequisite.
+#
 # Idempotent: safe to re-run on an already-authenticated dir. Existing
 # credential files are preserved by claude itself (it skips the login prompt if
-# the session is still valid).
+# the session is still valid). Rules files are always refreshed from the host.
 #
 # See docs/adr/0002-e2e-auth-flow.md (Decision 2) for the full rationale.
 set -euo pipefail
@@ -28,6 +34,32 @@ e2e_require_image "$IMAGE" "task e2e:build:claude"
 e2e_info "[$CLI] Preparing ${DIR}…"
 mkdir -p "$DIR"
 touch "${DIR}/.claude.json"
+
+# -----------------------------------------------------------------------
+# Rules directory — populate from host (mirrors auth-copilot.sh issue #120).
+# -----------------------------------------------------------------------
+HOST_RULES="${HOME}/.claude/rules"
+RULES_DIR="${DIR}/rules"
+
+if [[ ! -d "$HOST_RULES" ]]; then
+  e2e_die "[$CLI] ~/.claude/rules/ not found. Run \`task setup:claude\` (or the interactive equivalent) first to deploy layered-context files."
+fi
+
+e2e_info "[$CLI] Populating ${RULES_DIR} from ${HOST_RULES}…"
+mkdir -p "$RULES_DIR"
+
+shopt -s nullglob
+src_files=("${HOST_RULES}"/*.md)
+shopt -u nullglob
+
+if [[ ${#src_files[@]} -eq 0 ]]; then
+  e2e_die "[$CLI] No *.md files found in ${HOST_RULES}. Run \`task setup:claude\` to deploy them."
+fi
+
+for f in "${src_files[@]}"; do
+  cp "$f" "${RULES_DIR}/$(basename "$f")"
+done
+e2e_info "[$CLI] Copied ${#src_files[@]} rule file(s) → ${RULES_DIR}."
 
 # Decision 6: chown bootstrap is mandatory (macOS) and harmless (Linux).
 e2e_chown_bootstrap "$CLI" "$IMAGE"

--- a/tests/e2e/scenarios/04-harness-loop/run.sh
+++ b/tests/e2e/scenarios/04-harness-loop/run.sh
@@ -83,7 +83,7 @@ fi
 friction_body="$(cat "${E2E_SCENARIO_DIR}/friction.prompt")"
 friction_content=$'[FRICTION] e2e-04-build-version-drop | silent drop of metadata.provenance.version\n\nwriter_agent: '"${E2E_CLI}-harness-report"$'\ncomponent: scripts/build-components.sh\nvisible_to: ["*"]\nsymptom: build exits 0 even though metadata.provenance.version was dropped on rename\nexpected: explicit "version field missing" diagnostic; non-zero exit\n\n---\n'"$friction_body"
 
-# Prepare the workspace on the host (bind-mounted :ro into the container).
+# Prepare the workspace on the host (bind-mounted :rw — mempalace init writes mempalace.yaml into the dir).
 FRICTION_WORKSPACE="${E2E_REPORT_DIR}/friction-workspace"
 mkdir -p "${FRICTION_WORKSPACE}/frictions"
 printf '%s\n' "$friction_content" > "${FRICTION_WORKSPACE}/frictions/friction-01.txt"

--- a/tests/e2e/scenarios/04-harness-loop/run.sh
+++ b/tests/e2e/scenarios/04-harness-loop/run.sh
@@ -72,19 +72,28 @@ fi
 
 # --------------------------------------------------------------------------
 # Step 1 — harness-report simulation. Write a friction drawer to the
-# global harness-friction wing. The drawer content is drawn from
-# friction.prompt so the LLM-judge has the same input under test.
+# global harness-friction wing.
+#
+# `mempalace add-drawer` is an MCP tool, not a CLI subcommand. The CLI
+# equivalent is init + mine: write the friction content to a file, init
+# the palace from that directory structure (which creates the palace and
+# detects "frictions" as a room from the subdirectory name), then mine
+# the workspace into wing=harness-friction.
 # --------------------------------------------------------------------------
 friction_body="$(cat "${E2E_SCENARIO_DIR}/friction.prompt")"
 friction_content=$'[FRICTION] e2e-04-build-version-drop | silent drop of metadata.provenance.version\n\nwriter_agent: '"${E2E_CLI}-harness-report"$'\ncomponent: scripts/build-components.sh\nvisible_to: ["*"]\nsymptom: build exits 0 even though metadata.provenance.version was dropped on rename\nexpected: explicit "version field missing" diagnostic; non-zero exit\n\n---\n'"$friction_body"
 
+# Prepare the workspace on the host (bind-mounted :ro into the container).
+FRICTION_WORKSPACE="${E2E_REPORT_DIR}/friction-workspace"
+mkdir -p "${FRICTION_WORKSPACE}/frictions"
+printf '%s\n' "$friction_content" > "${FRICTION_WORKSPACE}/frictions/friction-01.txt"
+
 if ! docker run --rm \
       -v "${VOLUME}:/home/agent/.mempalace" \
-      "$MEMPALACE_IMAGE" \
-      mempalace add-drawer \
-        --wing harness-friction \
-        --room frictions \
-        --content "$friction_content" \
+      -v "${FRICTION_WORKSPACE}:/tmp/harness-ws" \
+      "$MEMPALACE_IMAGE" bash -c \
+        'mempalace init --yes /tmp/harness-ws &&
+         mempalace mine /tmp/harness-ws --wing harness-friction' \
       >"${E2E_REPORT_DIR}/report.stdout" \
       2>"${E2E_REPORT_DIR}/report.stderr"
 then


### PR DESCRIPTION
Fixes two e2e harness bugs discovered during local validation of the copilot+Ollama+OAuth judge flow.

## How to read this PR?

Two independent bug fixes in two files. Read `scripts/e2e/auth-claude.sh` first (simpler, mirrors issue #120), then `tests/e2e/scenarios/04-harness-loop/run.sh` (more involved — replaces a non-existent CLI subcommand with the documented `init + mine` path).

## How to test this PR?

```bash
# Bug 1 — auth-claude rules population
task e2e:auth:claude
ls ~/.crewrig-e2e/claude/rules/   # must contain 00-soul.md … 60-tools.md

# Bug 2 — 04-harness-loop
task e2e:test:cli -- copilot      # ok 2 - copilot/04-harness-loop must pass

# Full scenario smoke
CLAUDE_CREDENTIALS_PATH="$HOME/.crewrig-e2e/claude/.credentials.json" \
  task e2e:test:scenario -- 01-layered-context
```

## Detailed description (for agents)

### `scripts/e2e/auth-claude.sh`

Added a rules-population block (mirroring `auth-copilot.sh` / issue #120). After the chown bootstrap and before the interactive login, the script now:
- Guards against an absent `~/.claude/rules/` (dies with a clear message pointing to `task setup:claude`).
- Creates `~/.crewrig-e2e/claude/rules/` and copies all `*.md` files from `~/.claude/rules/`.
- Updated the header comment to document the new behaviour.

Without this fix, the 01-layered-context scenario mounted an empty `~/.crewrig-e2e/claude/` dir and Claude had no profile rules, causing the location probe to return an empty answer instead of "Nantes".

### `tests/e2e/scenarios/04-harness-loop/run.sh`

Replaced the non-existent `mempalace add-drawer` subcommand (MCP tool, not in the v3.3.x CLI) with the `init + mine` path:

1. The friction content is written to a host-side temp directory (`$E2E_REPORT_DIR/friction-workspace/frictions/friction-01.txt`).
2. The directory is bind-mounted read-write into a one-shot container.
3. `mempalace init --yes /tmp/harness-ws` detects `frictions/` as a room from the subdirectory name and creates the palace on the shared volume.
4. `mempalace mine /tmp/harness-ws --wing harness-friction` ingests the file into wing `harness-friction`, room `frictions`.
5. The subsequent `mempalace search "[FRICTION]"` finds the drawer.

The stale `mempalace init` call on the palace directory (wrong argument) was removed; init is now part of step 1 above, on the correct workspace path.

Closes #134