### PR TITLE
🐛 Fix e2e_gemini_refresh_access_token to use existing token when valid (issue #142)

### DIFF
--- a/scripts/e2e/lib/auth-common.sh
+++ b/scripts/e2e/lib/auth-common.sh
@@ -104,7 +104,7 @@ e2e_gemini_refresh_access_token() {
   local refresh_token response
   refresh_token=$(jq -r '.refresh_token // empty' "$creds_file")
   [[ -n "$refresh_token" ]] \
-    || e2e_die "[gemini] access token expired and refresh failed — re-run: task e2e:auth:gemini"
+    || e2e_die "[gemini] oauth_creds.json has no refresh_token — re-run: task e2e:auth:gemini"
   response=$(curl -s -X POST https://oauth2.googleapis.com/token \
     --data-urlencode "client_id=681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com" \
     --data-urlencode "client_secret=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" \

--- a/scripts/e2e/lib/auth-common.sh
+++ b/scripts/e2e/lib/auth-common.sh
@@ -81,29 +81,38 @@ e2e_chown_bootstrap() {
     || e2e_die "[$cli] writability bootstrap failed — cannot chmod ${dir}."
 }
 
-# e2e_gemini_refresh_access_token [creds_file] — refresh the Gemini OAuth access
-# token from oauth_creds.json using the Google token endpoint. Prints the
-# access_token to stdout or calls e2e_die on failure.
-# oauth_creds.json fields: client_id, client_secret, refresh_token (standard
-# Google OAuth installed-app format). curl and jq are required on the host.
+# e2e_gemini_refresh_access_token [creds_file] — return a usable Gemini OAuth
+# access token. Reads access_token + expiry_date from oauth_creds.json (the
+# shape the Gemini CLI itself writes: no client_id/client_secret embedded —
+# those live in the CLI bundle). If the stored access_token still has more
+# than 5 min of life, it is printed verbatim with no network call. Otherwise
+# the refresh_token is exchanged at the Google token endpoint using the same
+# OAuth client the Gemini CLI uses internally. Prints the access_token to
+# stdout or calls e2e_die on failure. curl and jq are required on the host.
 e2e_gemini_refresh_access_token() {
   local creds_file="${1:-$(e2e_cli_dir gemini)/oauth_creds.json}"
   [[ -f "$creds_file" ]] || e2e_die "[gemini] oauth_creds.json not found at ${creds_file}"
+  local access_token expiry_date now_ms
+  access_token=$(jq -r '.access_token // empty' "$creds_file")
+  expiry_date=$(jq -r '.expiry_date  // 0'     "$creds_file")
+  now_ms=$(( $(date +%s) * 1000 ))
+  if [[ -n "$access_token" ]] && (( expiry_date - 300000 > now_ms )); then
+    printf '%s' "$access_token"
+    return 0
+  fi
   command -v curl >/dev/null 2>&1 || e2e_die "[gemini] curl is required to refresh the OAuth access token"
-  local client_id client_secret refresh_token response access_token
-  client_id=$(jq -r '.client_id // empty'     "$creds_file")
-  client_secret=$(jq -r '.client_secret // empty' "$creds_file")
-  refresh_token=$(jq -r '.refresh_token // empty'  "$creds_file")
-  [[ -n "$client_id" && -n "$client_secret" && -n "$refresh_token" ]] \
-    || e2e_die "[gemini] oauth_creds.json missing client_id, client_secret, or refresh_token"
+  local refresh_token response
+  refresh_token=$(jq -r '.refresh_token // empty' "$creds_file")
+  [[ -n "$refresh_token" ]] \
+    || e2e_die "[gemini] access token expired and refresh failed — re-run: task e2e:auth:gemini"
   response=$(curl -s -X POST https://oauth2.googleapis.com/token \
-    --data-urlencode "client_id=${client_id}" \
-    --data-urlencode "client_secret=${client_secret}" \
+    --data-urlencode "client_id=681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com" \
+    --data-urlencode "client_secret=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" \
     --data-urlencode "refresh_token=${refresh_token}" \
     --data-urlencode "grant_type=refresh_token")
   access_token=$(printf '%s' "$response" | jq -r '.access_token // empty')
   [[ -n "$access_token" ]] \
-    || e2e_die "[gemini] token refresh failed: $(printf '%s' "$response" | jq -r '.error_description // .error // "unknown error"')"
+    || e2e_die "[gemini] access token expired and refresh failed — re-run: task e2e:auth:gemini"
   printf '%s' "$access_token"
 }
 

--- a/tests/e2e/lib/test-token-refresh.sh
+++ b/tests/e2e/lib/test-token-refresh.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/test-token-refresh.sh — regression test for issue #142.
+#
+# Failure mode under test:
+#
+#   The Gemini CLI persists OAuth state in oauth_creds.json with the shape
+#   {access_token, expiry_date, id_token, refresh_token, scope, token_type}.
+#   It does NOT store client_id / client_secret — those are compiled into the
+#   CLI itself.
+#
+#   The current implementation of e2e_gemini_refresh_access_token() insists on
+#   reading client_id and client_secret from oauth_creds.json, so it dies
+#   immediately with:
+#     ERROR: [gemini] oauth_creds.json missing client_id, client_secret, or refresh_token
+#   …even when a perfectly valid, non-expired access_token is sitting right
+#   there in the file.
+#
+# Test A locks the desired post-fix behaviour: when access_token is present
+# and expiry_date is at least 5 min in the future, the function must echo
+# the access_token to stdout without touching the network and without dying.
+#
+# Run standalone: bash tests/e2e/lib/test-token-refresh.sh
+# TAP output: ok N - ... / not ok N - ...
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+AUTH_LIB="${REPO_ROOT}/scripts/e2e/lib/auth-common.sh"
+
+TAP_INDEX=0
+TAP_NOK=0
+
+emit() {
+  TAP_INDEX=$((TAP_INDEX + 1))
+  case "$1" in
+    ok)     printf 'ok %d - %s\n'     "$TAP_INDEX" "$2" ;;
+    not_ok) printf 'not ok %d - %s\n' "$TAP_INDEX" "$2"; TAP_NOK=$((TAP_NOK + 1)) ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
+# Preconditions
+# --------------------------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '1..0 # SKIP jq not found on PATH\n'
+  exit 78
+fi
+
+if [[ ! -f "$AUTH_LIB" ]]; then
+  printf '1..0 # SKIP auth-common.sh not found at %s\n' "$AUTH_LIB"
+  exit 78
+fi
+
+# Source the library under test. Subshells below isolate `e2e_die`'s exit.
+# shellcheck disable=SC1090
+source "$AUTH_LIB"
+
+# --------------------------------------------------------------------------
+# Test A — valid token returned directly (no refresh needed).
+#
+# Build an oauth_creds.json that mirrors what the Gemini CLI actually writes:
+# access_token + expiry_date (ms epoch) + refresh_token, NO client_id /
+# client_secret. With expiry_date set to NOW + 1 hour, the function must
+# return the access_token verbatim without contacting the network.
+# --------------------------------------------------------------------------
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+CREDS_FILE="${WORK_DIR}/oauth_creds.json"
+FUTURE_MS=$(( ($(date +%s) + 3600) * 1000 ))
+
+cat >"$CREDS_FILE" <<EOF
+{
+  "access_token": "test-token-abc",
+  "expiry_date": ${FUTURE_MS},
+  "id_token": "dummy-id-token",
+  "refresh_token": "dummy-refresh-token",
+  "scope": "https://www.googleapis.com/auth/cloud-platform",
+  "token_type": "Bearer"
+}
+EOF
+
+# Run in a subshell so e2e_die's `exit 1` does not kill this test runner.
+set +e
+ACTUAL_OUTPUT=$(
+  e2e_gemini_refresh_access_token "$CREDS_FILE" 2>"${WORK_DIR}/stderr.txt"
+)
+ACTUAL_EXIT=$?
+set -e
+
+if (( ACTUAL_EXIT == 0 )) && [[ "$ACTUAL_OUTPUT" == "test-token-abc" ]]; then
+  emit ok "valid token (>=5 min remaining) is returned directly without refresh"
+else
+  emit not_ok "expected stdout='test-token-abc' exit=0, got stdout='${ACTUAL_OUTPUT}' exit=${ACTUAL_EXIT}; stderr: $(tr '\n' ' ' <"${WORK_DIR}/stderr.txt")"
+fi
+
+printf '1..%d\n' "$TAP_INDEX"
+
+if (( TAP_NOK > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Fixes the `e2e_gemini_refresh_access_token()` helper introduced in PR #140 which died immediately because it expected `client_id`/`client_secret` in `oauth_creds.json` — fields the Gemini CLI never writes there. The function now uses the stored `access_token` directly when valid, and falls back to the Google token endpoint with the CLI's embedded client credentials when the token is expired.

## How to read this PR?

Start with `scripts/e2e/lib/auth-common.sh`: the redesigned function (lines 84–117) is the sole change to production code. Then read `tests/e2e/lib/test-token-refresh.sh`: a standalone TAP unit test that mocks `oauth_creds.json` and asserts the valid-token fast path works without any network call.

## How to test this PR?

```bash
# Unit test (no docker, no network, no credentials needed)
bash tests/e2e/lib/test-token-refresh.sh
# Expected: ok 1 - valid token (>=5 min remaining) is returned directly without refresh

# Full integration (requires Gemini OAuth credentials)
task e2e:test:scenario -- 01-layered-context
```

## Detailed description (for agents)

**`scripts/e2e/lib/auth-common.sh`** — `e2e_gemini_refresh_access_token()`:
- Removed: extraction of `client_id` and `client_secret` from the creds file (those fields do not exist in the Gemini CLI credential format).
- Added: validity check — reads `expiry_date` (ms epoch) and `access_token`; if `expiry_date - 300000 > now_ms` (≥5 min remaining), echoes `access_token` and returns 0 with no network call.
- Kept: refresh path using `refresh_token`, now with hardcoded Gemini CLI client credentials (`OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET` from `chunk-W2MTI7FK.js` in the CLI bundle). Uses `$(date +%s) * 1000` for portable millisecond epoch (avoids GNU-only `%3N`).
- On any failure: `e2e_die` with message directing the user to re-run `task e2e:auth:gemini`.

**`tests/e2e/lib/test-token-refresh.sh`** (new file):
- TAP runner, standalone, no docker, no network.
- Test A: builds a mock `oauth_creds.json` shaped exactly like what the Gemini CLI writes (no `client_id`/`client_secret`), sets `expiry_date` to `now + 1h`, calls the function in a subshell, asserts stdout == `test-token-abc` and exit == 0.
- Was confirmed failing before the fix, green after.