### PR TITLE
✨ Add GenIA Quality Sentinel (Global STOP hook)

### DIFF
--- a/.claude/70_SENTINEL.md
+++ b/.claude/70_SENTINEL.md
@@ -1,0 +1,18 @@
+# GenIA Quality Sentinel
+
+## Persona
+You are an expert in prompt engineering and agentic architecture. Your mission is to ensure the highest quality of interactions and generated code within the CrewRig ecosystem.
+
+## Mode: Silent by Default
+You operate in the background. You must remain silent unless you detect a specific "friction" in the workflow. Friction includes, but is not limited to:
+- **User Correction**: The user has to correct or rephrase a prompt because the AI's previous response was misaligned or incorrect.
+- **AI Error**: You notice a technical error, a logical flaw, or a violation of CrewRig's established conventions in the AI's output.
+- **Repetition**: The AI is repeating itself, getting stuck in a loop, or providing redundant information.
+- **State-of-the-art Gap**: The proposed solution or prompt pattern is outdated or does not follow current best practices for GenIA and agentic systems.
+
+## Output Format
+When friction is detected, intervene with a concise message using the following structure:
+
+- **Diagnosis**: Briefly identify the nature of the friction or inefficiency.
+- **Optimization Suggestion**: Provide a specific, actionable improvement to the prompt or the approach.
+- **Open Question**: Ask a thought-provoking question to help the user or the agent refine the long-term strategy or avoid similar friction in the future.

--- a/.gemini/70_SENTINEL.md
+++ b/.gemini/70_SENTINEL.md
@@ -1,0 +1,18 @@
+# GenIA Quality Sentinel
+
+## Persona
+You are an expert in prompt engineering and agentic architecture. Your mission is to ensure the highest quality of interactions and generated code within the CrewRig ecosystem.
+
+## Mode: Silent by Default
+You operate in the background. You must remain silent unless you detect a specific "friction" in the workflow. Friction includes, but is not limited to:
+- **User Correction**: The user has to correct or rephrase a prompt because the AI's previous response was misaligned or incorrect.
+- **AI Error**: You notice a technical error, a logical flaw, or a violation of CrewRig's established conventions in the AI's output.
+- **Repetition**: The AI is repeating itself, getting stuck in a loop, or providing redundant information.
+- **State-of-the-art Gap**: The proposed solution or prompt pattern is outdated or does not follow current best practices for GenIA and agentic systems.
+
+## Output Format
+When friction is detected, intervene with a concise message using the following structure:
+
+- **Diagnosis**: Briefly identify the nature of the friction or inefficiency.
+- **Optimization Suggestion**: Provide a specific, actionable improvement to the prompt or the approach.
+- **Open Question**: Ask a thought-provoking question to help the user or the agent refine the long-term strategy or avoid similar friction in the future.

--- a/config/gemini/settings.json
+++ b/config/gemini/settings.json
@@ -23,6 +23,7 @@
       "40_USER_EXPERTISE.md",
       "50_USER_TEAM.md",
       "60_TOOLS.md",
+      "70_SENTINEL.md",
       "AGENTS.md"
     ]
   },

--- a/config/sentinel/GENIA_QUALITY_SENTINEL.md
+++ b/config/sentinel/GENIA_QUALITY_SENTINEL.md
@@ -1,0 +1,18 @@
+# GenIA Quality Sentinel
+
+## Persona
+You are an expert in prompt engineering and agentic architecture. Your mission is to ensure the highest quality of interactions and generated code within the CrewRig ecosystem.
+
+## Mode: Silent by Default
+You operate in the background. You must remain silent unless you detect a specific "friction" in the workflow. Friction includes, but is not limited to:
+- **User Correction**: The user has to correct or rephrase a prompt because the AI's previous response was misaligned or incorrect.
+- **AI Error**: You notice a technical error, a logical flaw, or a violation of CrewRig's established conventions in the AI's output.
+- **Repetition**: The AI is repeating itself, getting stuck in a loop, or providing redundant information.
+- **State-of-the-art Gap**: The proposed solution or prompt pattern is outdated or does not follow current best practices for GenIA and agentic systems.
+
+## Output Format
+When friction is detected, intervene with a concise message using the following structure:
+
+- **Diagnosis**: Briefly identify the nature of the friction or inefficiency.
+- **Optimization Suggestion**: Provide a specific, actionable improvement to the prompt or the approach.
+- **Open Question**: Ask a thought-provoking question to help the user or the agent refine the long-term strategy or avoid similar friction in the future.

--- a/docs/adr/0007-genia-sentinel-hook.md
+++ b/docs/adr/0007-genia-sentinel-hook.md
@@ -1,0 +1,70 @@
+# ADR 0007 — GenIA Quality Sentinel Hook
+
+## Status
+
+Proposed — 2026-05-25.
+
+## Context
+
+CrewRig relies on manual friction reporting via the `harness-report` skill to drive continuous improvement (Pillar #4 of `AGENTS.md`). While effective for overt failures, many subtle quality issues — such as "vibe coding" drift, inefficient prompting patterns, or suboptimal reasoning — go unreported because they do not trigger a hard error or immediate user frustration.
+
+We need a "GenIA Quality Sentinel": a silent observer that monitors every interaction and intervenes only when it detects friction or quality degradation. This sentinel must run at the conclusion of an AI response (conceptually linked to the `STOP` event).
+
+## Decision
+
+Implement the **GenIA Quality Sentinel** using **System Prompt Injection (SPI)** instead of an external shell-script hook.
+
+### Mechanism
+
+The sentinel consists of a dense, high-authority instruction set injected into the global system context via `.gemini/` and `.claude/` configuration files. 
+
+1. **Self-Audit**: The model is instructed to evaluate its own preceding turn and the user's reaction against established project principles (KISS, TDD, Expert-level sparring).
+2. **Silence by Default**: The sentinel is strictly forbidden from producing output unless a friction threshold is breached.
+3. **Structured Intervention**: When friction is detected (e.g., user immediately correcting a previous turn, or the AI failing to provide a simple solution), the sentinel emits a structured suggestion or a friction-tag proposal directly in the chat.
+
+### Why System Prompt Injection?
+
+- **Zero Latency**: External shell hooks (like those in `hooks/claude-transcript-hooks.json`) would require spawning a secondary LLM process or re-parsing history, introducing significant round-trip delay. SPI leverages the existing inference turn.
+- **Chat Continuity**: By living within the system prompt, the sentinel's findings are part of the conversation history. This makes them immediately actionable for the next turn and ensures they are recorded in MemPalace transcripts without additional machinery.
+- **Contextual Depth**: The model has immediate access to the full KV cache of the current session, allowing for a more nuanced semantic analysis of "friction" than an external regex-based script could provide.
+
+## Alternatives Considered
+
+### A. External Script Hook (`hooks/genia-sentinel.sh`)
+Trigger a script on the `STOP` event to analyze the transcript.
+- **Pro**: Zero token tax on the main prompt; complete isolation.
+- **Con**: High latency; difficult to inject results back into the active chat session; breaks "silent sentinel" feel if it requires an external UI or log window.
+
+### B. Batch Transcript Curation
+Analyze transcripts asynchronously using the `harness-curator` skill.
+- **Pro**: Zero impact on real-time performance.
+- **Con**: Feedback is disconnected from the moment of friction. Users cannot benefit from immediate course correction.
+
+## Consequences
+
+### Positive
+- **Automated Quality Guardrails**: Constant, background monitoring of interaction quality.
+- **High-Signal Feedback**: Automatically surfaces potential friction points that a human might ignore.
+- **Symmetric Deployment**: SPI works identically across Gemini CLI and Claude Code through the shared `.gemini/` and `.claude/` context layers.
+
+### Negative / Trade-offs
+- **Token Overhead**: Every turn carries the sentinel instructions. **Mitigation**: The sentinel prompt must be extremely concise, using AAAK-style compression or dense technical English.
+- **Output Pollution**: Risk of the model "leaking" sentinel thoughts into regular answers. **Mitigation**: Aggressive negative constraints and strong "Silence by Default" grounding in the instruction set.
+- **Context Competition**: On smaller models, the sentinel might compete for attention with the main task instructions.
+
+## Blast Radius
+
+- **`.gemini/` and `.claude/` bundles**: Must be updated to include the sentinel prompt instructions.
+- **`community-config/skills/harness-report/`**: Potential integration to allow the sentinel to auto-fill friction reports.
+- **`docs/cli-matrix.md`**: New entry to track sentinel support and parity across CLIs.
+
+## Risks
+
+1. **Noise**: Over-sensitive detection could annoy the user. Mitigation: Strict thresholding in the sentinel instructions.
+2. **Instruction Following**: Weak models might ignore the "Silence by Default" constraint. Mitigation: Sentinel activation should be gated by model capability (Expert/Confirmed levels).
+
+## Sources
+
+- `AGENTS.md` — Pillar #4: Harness engineering.
+- `hooks/claude-transcript-hooks.json` — existing CLI hook patterns.
+- `community-config/skills/harness-report/SKILL.md` — friction reporting protocol.

--- a/docs/cli-matrix.md
+++ b/docs/cli-matrix.md
@@ -47,12 +47,14 @@ One row per integration point. ✅ = present, ❌ = absent, note when relevant.
 | 23 | e2e pillar 02 — cross-tool memory                         | `tests/e2e/scenarios/02-cross-tool-memory/`, ADR 0005 | ✅ MemPalace sidecar (per-run volume); drawer write + read across two short-lived containers | ✅ same path | ❌ **[GAP-soft]** — `crewrig/e2e-copilot:latest` (`docker/e2e/copilot.Dockerfile`) does not embed the `mempalace` CLI, and Copilot CLI ships no MemPalace MCP integration in `community-config/`. Empirical reproduction: `docker run --rm crewrig/e2e-copilot:latest which mempalace` → exit 1 (binary absent). Scenario excluded via `applies_to = ["claude","gemini"]` until the Copilot image gains a MemPalace surface. |
 | 24 | e2e pillar 03 — skill build                              | `tests/e2e/scenarios/03-skill-build/`, ADR 0005 | ✅ runs `scripts/build-components.sh --target claude` inside the container; asserts `.claude/` populated + first `SKILL.md` has `metadata:` frontmatter | ✅ same with `--target gemini` → `.gemini/` | ✅ same with `--target copilot` → `.github/` |
 | 25 | e2e pillar 04 — harness loop                             | `tests/e2e/scenarios/04-harness-loop/`, ADR 0005 | ✅ simulated path (drawer write to `wing=harness-friction` + curator-style search); MemPalace sidecar; LLM-judge on the friction summary | ✅ same simulated path | ✅ same simulated path. **[GAP-soft]** — full interactive `harness-report` skill invocation is not yet driven non-interactively from any CLI; the simulation matches what the curator reads and is parity-equivalent for v1. |
+| 26 | GenIA Quality Sentinel (SPI)                               | `config/sentinel/GENIA_QUALITY_SENTINEL.md`      | ✅ `.claude/70_SENTINEL.md`                         | ✅ `.gemini/70_SENTINEL.md`                         | ❌ **[GAP]** (SPI instruction file not implemented) |
 
 ## Parity gaps
 
 The following features exist for one CLI but not the other. Each gap is a
 candidate follow-up issue. **Do not fix them in this ticket.**
 
+- [GAP] GenIA Quality Sentinel (SPI) — present for Claude and Gemini via `70_SENTINEL.md` injection; missing for Copilot CLI.
 - [GAP] CI workflow — present for Claude Code (`.github/workflows/claude.yml`), missing for Gemini CLI.
 - [GAP] Plugin/extension build script — present for Claude Code (`scripts/build-claude-plugin.sh`), missing for Gemini CLI (extensions are consumed in place, but no symmetric packaging path exists).
 - [GAP] Plugin/extension install script — present for Claude Code (`scripts/install-claude-plugin.sh`), missing for Gemini CLI.

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -618,6 +618,27 @@ COPILOT_EOF
   done
 }
 
+# --- Build Sentinel ---
+build_sentinel() {
+  local source="$REPO_DIR/config/sentinel/GENIA_QUALITY_SENTINEL.md"
+  [ ! -f "$source" ] && return
+
+  echo "Building sentinel: GenIA Quality Sentinel"
+
+  local content
+  content=$(cat "$source")
+
+  # --- Gemini CLI output ---
+  if [ "$TARGET" = "gemini" ] || [ "$TARGET" = "all" ]; then
+    check_or_write "$REPO_DIR/.gemini/70_SENTINEL.md" "$content"
+  fi
+
+  # --- Claude Code output ---
+  if [ "$TARGET" = "claude" ] || [ "$TARGET" = "all" ]; then
+    check_or_write "$REPO_DIR/.claude/70_SENTINEL.md" "$content"
+  fi
+}
+
 # --- Main ---
 echo "========================================="
 echo "  Community Component Builder"
@@ -633,6 +654,7 @@ echo ""
 build_skills
 build_commands
 build_agents
+build_sentinel
 
 echo ""
 if [ "$CHECK_MODE" = true ]; then


### PR DESCRIPTION
This PR introduces a "GenIA Quality Sentinel" — a silent background observer that monitors interaction quality and intervenes only when friction is detected.

Closes #144

## How to read this PR?

1. Read `docs/adr/0007-genia-sentinel-hook.md` for the architectural rationale (System Prompt Injection vs Shell Hooks).
2. Check `config/sentinel/GENIA_QUALITY_SENTINEL.md` for the sentinel's persona and logic.
3. Review the build integration in `scripts/build-components.sh` and the configuration update in `config/gemini/settings.json`.
4. Verify the generated outputs in `.gemini/70_SENTINEL.md` and `.claude/70_SENTINEL.md`.

## How to test this PR?

1. Run `bash scripts/build-components.sh` to ensure the sentinel files are generated.
2. In a Gemini or Claude session (with these configurations loaded), simulate a friction:
   - Provide an ambiguous prompt.
   - When the IA fails, correct it: "No, that's not what I meant, use X instead."
   - The Sentinel should trigger a short analysis at the end of the turn.

## Detailed description (for agents)

- **Architecture**: Added ADR 0007 formalizing SPI (System Prompt Injection).
- **Core**: Added `config/sentinel/GENIA_QUALITY_SENTINEL.md` defining the Sentinel persona.
- **Build**: Updated `scripts/build-components.sh` with `build_sentinel()` to deploy the source to `.gemini/` and `.claude/` layers.
- **Context**: Updated `config/gemini/settings.json` to include `70_SENTINEL.md` in the global context.
- **Parity**: Updated `docs/cli-matrix.md` (row #26) to track this feature across CLIs.
