### PR TITLE
📝 Cross-reference #155 in harness-loop add-drawer comment (issue #157)

### DIFF
--- a/tests/e2e/scenarios/04-harness-loop/run.sh
+++ b/tests/e2e/scenarios/04-harness-loop/run.sh
@@ -74,11 +74,19 @@ fi
 # Step 1 — harness-report simulation. Write a friction drawer to the
 # global harness-friction wing.
 #
-# `mempalace add-drawer` is an MCP tool, not a CLI subcommand. The CLI
-# equivalent is init + mine: write the friction content to a file, init
-# the palace from that directory structure (which creates the palace and
-# detects "frictions" as a room from the subdirectory name), then mine
-# the workspace into wing=harness-friction.
+# `mempalace add-drawer` is an MCP tool, not a CLI subcommand. Two paths
+# exist for writing a drawer from a containerised e2e scenario:
+#   1. init + mine — write the content to a file, `mempalace init` the
+#      palace from the directory (detects "frictions" as a room from
+#      the subdirectory name), then `mempalace mine` ingests it into
+#      wing=harness-friction. File-based ingestion path.
+#   2. Python-direct — invoke `tool_add_drawer` from `mempalace.mcp_server`
+#      via the venv's python (see issue #155 for the empirical proof
+#      and `~/.claude/rules/60-tools.md` for the carve-out rationale).
+#      Verbatim payload preservation.
+# This scenario INTENTIONALLY uses path 1 because it mirrors what a real
+# harness-report flow does (capture-to-file then ingest). Scenario 02 uses
+# path 2 because it asserts on verbatim drawer content.
 # --------------------------------------------------------------------------
 friction_body="$(cat "${E2E_SCENARIO_DIR}/friction.prompt")"
 friction_content=$'[FRICTION] e2e-04-build-version-drop | silent drop of metadata.provenance.version\n\nwriter_agent: '"${E2E_CLI}-harness-report"$'\ncomponent: scripts/build-components.sh\nvisible_to: ["*"]\nsymptom: build exits 0 even though metadata.provenance.version was dropped on rename\nexpected: explicit "version field missing" diagnostic; non-zero exit\n\n---\n'"$friction_body"


### PR DESCRIPTION
Comment-only update to `tests/e2e/scenarios/04-harness-loop/run.sh` cross-referencing the Python-direct write path that #155 established, and explaining why scenario 04 intentionally retains the file-based init+mine approach.

## How to read this PR?

Single-file diff in the comment block at `tests/e2e/scenarios/04-harness-loop/run.sh:77-89`. Compare before/after to see the two-path enumeration and the per-scenario rationale.

## How to test this PR?

No behaviour change. The scenario itself was not touched. `task e2e:test --scenario 04-harness-loop` still passes for all three CLIs as it did on `main`.

## Detailed description (for agents)

The original comment correctly noted that `mempalace add-drawer` is an MCP tool (not a CLI sub-command) and documented the init+mine workaround used by scenario 04. After #155 landed a second valid path (Python-direct invocation of `tool_add_drawer` from `mempalace.mcp_server`), the existing comment risked misleading future readers into "fixing" scenario 04 to use the Python-direct path without realising the file-based path was a deliberate choice.

The updated comment:

- Enumerates BOTH known-good paths (init+mine and Python-direct).
- References #155 for the empirical proof of the Python-direct path and `~/.claude/rules/60-tools.md` for the carve-out rationale.
- States explicitly that scenario 04 INTENTIONALLY picks init+mine to mirror the real harness-report flow (capture-to-file then ingest), while scenario 02 picks Python-direct because it asserts on verbatim drawer content.

Sister observation surfaced by the developer agent during #155 implementation. User authorised an inline micro-fix.

Closes #157