### PR TITLE
📐 ADR-0010 — SPECS → PLAN → DEV → REVIEW lifecycle (#166)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,7 +607,7 @@ AUTO).
 Definitions of each class, canonical and borderline examples, and the
 disambiguation rule (escalate upstream on tie) live in ADR-0010 →
 *Finding classification taxonomy*. The routing engine itself lands in
-#172 — this section states the contract.
+issue #172 — this section states the contract.
 
 ## Pull Request Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,50 @@ five pillars without needing to read README.md or ADRs:
    every parity gap requires concrete evidence that the missing mechanism does
    not exist in the target CLI.
 
+## Lifecycle
+
+Every non-trivial ticket SHALL flow through the four-stage lifecycle
+**SPECS → PLAN → DEV → REVIEW**. REVIEW loops back into the upstream
+stage corresponding to the class of each finding (`tech` → DEV,
+`arch` → PLAN, `spec` → SPECS). The lifecycle terminates only when a
+full REVIEW pass produces zero findings.
+
+```text
+   user intent
+       │
+       ▼
+┌──────────────┐    spec PR    ┌──────────────┐
+│   SPECS      │ ───────────▶  │  spec merged │
+│  (WHAT)      │  /specs/<id>  │  on main     │
+└──────┬───────┘               └──────┬───────┘
+       │                              │
+       │ (loop on spec finding)       ▼
+       │                       ┌──────────────┐
+       │                       │    PLAN      │  reviewed in
+       │                       │   (HOW)      │  logbook issue
+       │                       └──────┬───────┘
+       │                              │
+       │ (loop on arch finding)       ▼
+       │                       ┌──────────────┐
+       │                       │     DEV      │  feature branch + PR
+       │                       └──────┬───────┘
+       │                              │
+       │ (loop on tech finding)       ▼
+       │                       ┌──────────────┐
+       └───────────────────────│   REVIEW     │
+                               └──────┬───────┘
+                                      │ clean
+                                      ▼
+                                    MERGE
+```
+
+The full contract — stage definitions, transition rules, finding
+taxonomy, routing matrix, complexity tiers, and termination criterion
+— lives in [ADR-0010](docs/adr/0010-spec-plan-review-lifecycle.md).
+The sections below (*Agent Team Protocol*, *Interaction modes*,
+*Retroactive review loop*) layer the operational rules onto that
+contract.
+
 ## Language
 
 All **project content must be written in English**. "Project content" covers
@@ -195,6 +239,17 @@ issue. Agent-initiated deferral of a symmetric script is prohibited.
 ## Agent Team Protocol
 
 Project tickets are multi-step work. They must be treated by a **team of specialist agents**, not by a single agent working solo inline.
+
+The team protocol below governs the **DEV stage** of the lifecycle
+defined in [ADR-0010](docs/adr/0010-spec-plan-review-lifecycle.md).
+SPECS and PLAN run before DEV (with their own artefacts: a spec file
+under `/specs/` and a plan comment on the logbook issue); REVIEW runs
+after, and its findings may re-enter DEV (`tech`), PLAN (`arch`), or
+SPECS (`spec`) per the routing matrix in *Retroactive review loop*
+below. Templates 1 / 2 / 3 in this section describe how the DEV stage
+is staffed for a `standard`-tier ticket; trivial / small / large
+tiers adjust the composition per ADR-0010 → *Complexity tiers and
+team sizing*.
 
 ### When this applies
 
@@ -487,6 +542,72 @@ call `TeamDelete` to remove the team record itself.
 violation, regardless of whether the teammates appear idle. "Idle" is a
 harness display state, not a confirmation that the underlying process
 has released its resources.
+
+## Interaction modes
+
+The lifecycle (per ADR-0010) runs in one of four modes. Mode controls
+*user gating*, not stage execution — every mode runs all four stages.
+
+| Mode | SPECS | PLAN | REVIEW loop |
+|---|---|---|---|
+| **FULL** | user interactive + validation | user interactive + validation | user notified at each iteration |
+| **INTERMEDIATE** | user interactive + validation | user interactive + validation | autonomous |
+| **MINIMAL** | user interactive + validation | autonomous | autonomous |
+| **AUTO** | LLM-authored, no user gate | autonomous | autonomous |
+
+Rules:
+
+- Default mode is **INTERMEDIATE**.
+- Mode is declared in the spec frontmatter (schema defined in #167)
+  and SHALL NOT change mid-lifecycle without re-entering SPECS.
+- In FULL mode, the orchestrator MUST post a notification on the
+  logbook issue at the start and end of every REVIEW iteration.
+  "Notify" is non-blocking; it does not gate the next iteration.
+- In AUTO mode, SPECS is authored by the `spec-author` skill (#168);
+  the user audits after the fact via the merged spec PR.
+
+The mode-driven engine — argument parsing, gate enforcement, user
+notification surface — lands in #173. This section states the
+contract.
+
+## Retroactive review loop
+
+Every REVIEW finding SHALL be tagged with exactly one class. Class
+drives the loop target.
+
+| Finding class | Loop target | Re-spawn | Spec-PR impact |
+|---|---|---|---|
+| `tech` | DEV | developer + tester | none |
+| `arch` | PLAN | architect → developer + tester | none |
+| `spec` | SPECS | spec-author → architect → developer + tester | new delta-spec PR (per #170) |
+
+Rules:
+
+- A single REVIEW pass MAY produce findings of multiple classes. The
+  routing engine SHALL pick the most upstream class present
+  (`spec` > `arch` > `tech`) and route the entire pass to that
+  stage. Mixing loop targets within a single iteration is prohibited.
+- Re-spawn columns are minimums. The `security` trigger surface (see
+  *Agent Team Protocol → Standard Team Templates → Security rule*)
+  applies to every re-spawn that touches it.
+- A `spec`-class loop SHALL produce a delta-spec PR; the original
+  spec on `main` is immutable.
+- The loop SHALL NOT change the logbook issue (Rule A still holds).
+
+**Termination.** The lifecycle terminates at MERGE iff a REVIEW pass
+verdict is APPROVE AND the pass surfaces zero findings of any class
+AND CI is green on the head commit reviewed.
+
+**Max-iteration guardrail.** The loop halts after **5 iterations**
+(configurable in the spec frontmatter, default 5) without
+termination. On halt, the orchestrator posts a structured summary on
+the logbook issue and pages the user regardless of mode (including
+AUTO).
+
+Definitions of each class, canonical and borderline examples, and the
+disambiguation rule (escalate upstream on tie) live in ADR-0010 →
+*Finding classification taxonomy*. The routing engine itself lands in
+#172 — this section states the contract.
 
 ## Pull Request Format
 

--- a/docs/adr/0010-spec-plan-review-lifecycle.md
+++ b/docs/adr/0010-spec-plan-review-lifecycle.md
@@ -1,0 +1,361 @@
+# ADR 0010 — SPECS → PLAN → DEV → REVIEW lifecycle
+
+**Status:** Accepted (issue #166, parent EPIC #165)
+
+## Context
+
+Today, every ticket on CrewRig follows a single contract: the
+orchestrator reads the issue, spawns one of the three team templates
+defined in `AGENTS.md` → *Agent Team Protocol*, and lets the team drive
+straight to a PR. The contract has no explicit *qualification* phase
+(what does the user actually want?) and no explicit *planning* phase
+(how do we intend to get there?). Both happen implicitly, in the
+orchestrator's head, between reading the issue and issuing the first
+`TaskCreate`.
+
+Two failure modes recur with enough regularity to be considered
+structural rather than incidental:
+
+1. **User drift.** The user's evoked intent and the team's first
+   implementation diverge, often subtly. Drift is caught — when caught
+   at all — at PR review, by which point the artefacts (branch,
+   commits, tests, logbook entries) are sunk cost. The corrective loop
+   is expensive: rewind to design, re-spawn the team, re-open the PR
+   or close-and-reopen, and reconcile the logbook.
+2. **Tech-finding-was-actually-spec-gap.** A reviewer surfaces a
+   "technical" finding (`pr-reviewer` flags a behaviour, a missing
+   guard, an inconsistent error path). The team fixes it locally; one
+   or two iterations later the same finding resurfaces in a different
+   shape. Root cause: the underlying specification never decided the
+   point, so every fix is locally correct but globally arbitrary, and
+   reviewers keep snagging on the absence of a normative answer.
+
+Both modes share a structural cause: there is no place in the current
+contract where the *what* (specification) and the *how* (plan) are
+written down, reviewed, and merged independently of the code that
+realises them. Adding those two artefacts — and a routing rule that
+sends review findings back to the correct layer — is what this ADR
+defines.
+
+Inspiration: [GitHub spec-kit][spec-kit] (Specify → Plan → Tasks →
+Implement) and [OpenSpec][openspec] (Markdown specs with delta-style
+proposals). Neither is adopted wholesale; both are referenced as prior
+art for the staging discipline and the filesystem-first artefact model.
+
+[spec-kit]: https://github.com/github/spec-kit
+[openspec]: https://github.com/Fission-AI/OpenSpec
+
+## Decision
+
+CrewRig adopts a **four-stage lifecycle** for every non-trivial
+ticket:
+
+```text
+SPECS  ──▶  PLAN  ──▶  DEV  ──▶  REVIEW ──▶  MERGE
+                                    │
+                                    └── loops back on findings
+```
+
+- **SPECS**, **PLAN**, and **DEV** are *linear* stages: each runs
+  once per iteration of the lifecycle, in order.
+- **REVIEW** is a *looping* stage. Findings produced by REVIEW are
+  classified (`tech` / `arch` / `spec`) and routed back to the
+  corresponding upstream stage. The lifecycle terminates only when a
+  full REVIEW pass produces zero findings across all three classes.
+
+The contract is mode-driven (FULL / INTERMEDIATE / MINIMAL / AUTO,
+see *Interaction modes* below): the same four stages run for every
+mode, but the user-gating between stages differs.
+
+This ADR defines the **contract**. The artefact formats, the skills,
+and the routing engine land in dedicated tickets:
+
+| Concern | Ticket |
+|---|---|
+| Spec file format and `/specs/` layout | #167 |
+| `spec-author` skill + agent | #168 |
+| Plan format and plan-review protocol | #169 |
+| Dedicated spec-PR workflow | #170 |
+| Retroactive routing engine | #172 |
+| Interaction modes + complexity tiers (engine) | #173 |
+| Multi-CLI build/install of `spec-author` | #174 |
+| Migration of in-flight tickets | #175 |
+
+## Stage definitions and transition rules
+
+| Stage | Produces | Artefact location | Entry criteria | Exit criteria |
+|---|---|---|---|---|
+| **SPECS** | A specification (the WHAT) | Spec file under `/specs/<spec-id>/` (format defined in #167) | A ticket exists with a user-evoked intent | Spec PR is merged on `main` (mode-dependent: see *Interaction modes*) |
+| **PLAN** | A plan (the HOW: steps, blast radius, alternatives) | Comment on the logbook issue (format defined in #169) | A merged spec on `main` for this ticket | Plan is approved on the logbook issue (mode-dependent) |
+| **DEV** | Implementation diff | Feature branch in a dedicated worktree (per `AGENTS.md` → *Worktree Isolation*) | An approved plan on the logbook | A PR is opened and CI is green |
+| **REVIEW** | A verdict + zero or more findings | PR comment (`pr-reviewer` verdict format, per `AGENTS.md`) | An open PR with green CI | Verdict is APPROVE with zero findings of any class |
+
+Normative transition rules:
+
+1. SPECS, PLAN, and DEV SHALL NOT be skipped on first entry, even in
+   AUTO mode. AUTO mode collapses the *gating* between stages, not
+   the stages themselves.
+2. REVIEW SHALL run after every DEV iteration, including iterations
+   triggered by the loop.
+3. A SPECS or PLAN stage that produces no normative change MUST still
+   emit an artefact (an "unchanged" delta spec, or a one-line plan
+   confirmation) so the audit trail records that the stage ran.
+4. The lifecycle MUST be anchored to a logbook (per `AGENTS.md` →
+   *Logbook Issues*). Stage transitions are journalled there.
+
+## Finding classification taxonomy
+
+Every REVIEW finding SHALL be tagged with exactly one of three
+classes. Class drives the loop target (see *Routing matrix*); it is
+not a severity scale.
+
+### `tech` — implementation defect
+
+The intent and design are correct; the realisation is wrong.
+
+- **Canonical example.** The spec says "retry transient HTTP errors
+  up to 3 times with exponential backoff". The code retries once,
+  with no backoff. Fix: rewrite the retry block in DEV. No design
+  change, no spec change.
+- **Borderline.** The code retries 3 times but the backoff multiplier
+  is 1.5 instead of 2.0. Still `tech` if the spec mandates the
+  multiplier; escalates to `spec` if the spec is silent and the
+  multiplier was an implementation choice.
+
+### `arch` — design defect
+
+The spec is correct; the chosen design cannot realise it cleanly, or
+realises it at a cost the plan did not acknowledge.
+
+- **Canonical example.** The spec mandates "exactly-once delivery
+  across restarts". The plan picked an in-memory queue. REVIEW
+  observes that an in-memory queue cannot satisfy the spec under
+  restart. Fix: re-do PLAN with a persistent queue option;
+  re-implement in DEV.
+- **Borderline.** The spec mandates "low-latency reads". The plan
+  picked a synchronous fan-out. REVIEW observes p99 doubles under
+  load. `arch` if low-latency is normative; `spec` if "low-latency"
+  was never quantified and the spec needs to define the SLO before a
+  design can be chosen.
+
+### `spec` — specification gap
+
+Neither the design nor the implementation is wrong against the spec;
+the spec itself fails to decide a point that REVIEW now cares about.
+
+- **Canonical example.** REVIEW asks "what happens when the input is
+  empty?". The spec says nothing. The code returns `null`; the test
+  expects an empty list; reasonable people disagree. Fix: amend the
+  spec via a delta-spec PR (per #170), then re-do PLAN and DEV.
+- **Borderline.** The spec lists "log every state transition" but
+  does not specify log level. REVIEW flags a noisy `INFO`. `spec`
+  if log level is normative for downstream consumers; `tech` if the
+  team's logging conventions already settle it via another normative
+  document.
+
+**Disambiguation rule.** When uncertain between two adjacent classes,
+escalate to the higher (more upstream) one. `tech` < `arch` < `spec`.
+A misrouted `tech` finding wastes one team-respawn; a misrouted
+`spec` finding wastes the entire downstream cycle.
+
+## Routing matrix
+
+| Finding class | Loop target | Re-spawn | Spec-PR impact |
+|---|---|---|---|
+| `tech` | DEV | developer + tester | none |
+| `arch` | PLAN | architect → developer + tester | none |
+| `spec` | SPECS | spec-author → architect → developer + tester | new delta-spec PR (per #170) |
+
+Normative rules:
+
+1. A single REVIEW pass MAY produce findings of multiple classes. The
+   routing engine (#172) SHALL pick the most upstream class present
+   (`spec` > `arch` > `tech`) and route the entire pass to that
+   stage. Mixing loop targets within a single iteration is
+   prohibited.
+2. Re-spawn columns are minimums. The orchestrator MAY add roles
+   (e.g. `security` per the trigger surface defined in `AGENTS.md` →
+   *Agent Team Protocol*).
+3. A `spec`-class loop SHALL produce a delta-spec PR, not an edit to
+   the original spec on `main`. The original spec is immutable once
+   merged; deltas chain via the format defined in #167.
+4. The loop SHALL NOT modify the logbook issue's identity. Every
+   iteration appends to the same logbook (per `AGENTS.md` → *Logbook
+   Issues*, Rule A).
+
+## Interaction modes
+
+Mode controls *user gating*, not stage execution. Every mode runs all
+four stages.
+
+| Mode | SPECS | PLAN | REVIEW loop |
+|---|---|---|---|
+| **FULL** | user interactive + validation | user interactive + validation | user notified at each iteration |
+| **INTERMEDIATE** | user interactive + validation | user interactive + validation | autonomous |
+| **MINIMAL** | user interactive + validation | autonomous | autonomous |
+| **AUTO** | LLM-authored, no user gate | autonomous | autonomous |
+
+Normative rules:
+
+1. The default mode is **INTERMEDIATE**.
+2. Mode SHALL be declared in the spec frontmatter (field name and
+   schema defined in #167). The orchestrator SHALL read the mode at
+   ticket pickup and SHALL NOT change it mid-lifecycle without
+   re-entering SPECS.
+3. In FULL mode, the orchestrator MUST notify the user at the start
+   and end of every REVIEW iteration. "Notify" means a single
+   structured message on the logbook issue; it does NOT mean blocking
+   for user approval (that would collapse FULL into a synchronous
+   step-through, which is not the intent).
+4. In AUTO mode, SPECS is authored by the `spec-author` skill (#168)
+   with no user interaction. The user can audit after the fact via
+   the merged spec PR.
+
+## Complexity tiers and team sizing
+
+The spec SHALL declare a complexity tier. The tier drives team
+composition for the DEV stage. The spec reviewer (whoever approves
+the spec PR) validates the tier.
+
+| Tier | Team for DEV | Notes |
+|---|---|---|
+| **trivial** | inline (orchestrator only) | No team spawn, no worktree, no logbook (the issue itself suffices). Reserved for single-file edits with no test surface. |
+| **small** | `developer` + `pr-logbook` + `pr-reviewer` | Worktree required. No architect, no tester. |
+| **standard** | Templates 1 / 2 / 3 from `AGENTS.md` → *Agent Team Protocol* | Current default. |
+| **large** | `architect`-led decomposition into sub-specs, then one standard team per sub-spec | Each sub-spec gets its own spec PR (chained via the delta mechanism). |
+
+Normative rules:
+
+1. The tier SHALL be defendable by the spec content. A "trivial" spec
+   that requires more than one file edit fails review.
+2. Tier escalation during a lifecycle (e.g. small → standard
+   discovered mid-DEV) SHALL be treated as an `arch` finding and
+   routed through the PLAN loop with an updated team.
+3. Tier de-escalation (standard → small) is prohibited mid-lifecycle.
+   The cost of running the larger team is already sunk.
+
+## REVIEW loop termination
+
+The lifecycle terminates at MERGE when, and only when, the following
+holds simultaneously:
+
+1. A REVIEW pass completes with verdict APPROVE.
+2. The same pass surfaces zero findings of any class (`tech`, `arch`,
+   `spec`).
+3. CI is green on the head commit reviewed.
+
+Non-termination requires a re-loop per the routing matrix.
+
+**Max-iteration guardrail.** The loop SHALL halt after **5
+iterations** (configurable per ticket via the spec frontmatter,
+default 5) without termination. On halt:
+
+- The orchestrator SHALL post a structured summary on the logbook
+  issue listing every iteration's finding class and current spec /
+  plan / branch state.
+- The orchestrator SHALL page the user regardless of mode (even
+  AUTO).
+- The lifecycle pauses at the stage of the next scheduled loop; the
+  user decides whether to continue, pivot, or abort.
+
+The guardrail exists to bound runaway autonomous loops in AUTO and
+MINIMAL modes. It is not a quality target — most lifecycles SHOULD
+terminate in 1–2 iterations.
+
+## Consequences
+
+### Easier
+
+- **User drift is caught at SPECS, not PR.** A misaligned spec costs
+  one PR (cheap); a misaligned PR costs a worktree, a team, and a
+  logbook (expensive).
+- **Review findings have a known destination.** The routing matrix
+  removes "where do I put this fix?" from every reviewer's head.
+- **Trivial tickets stop paying the team-spawn tax.** The trivial
+  tier is a first-class option, not a hack.
+- **AUTO mode becomes safe to expose.** The combination of
+  classification + termination criterion + max-iteration guardrail
+  gives the user a single audit surface (the logbook) for fully
+  autonomous runs.
+
+### Harder
+
+- **Every non-trivial ticket gains one extra PR** (the spec PR) and
+  one extra structured artefact (the plan comment). The marginal
+  cost is real and is the price of buying the two failure modes
+  back.
+- **Spec-PR / impl-PR ordering** must be respected. Out-of-order
+  merges (impl before spec) break the audit chain. Tooling per #170
+  enforces this; agents must learn the new ordering.
+- **Finding classification is a judgement call.** Agents and humans
+  will disagree on borderline cases. The disambiguation rule
+  (escalate upstream) protects correctness at the cost of occasional
+  over-routing.
+
+### Parity implications (Claude / Gemini / Copilot)
+
+The lifecycle contract is CLI-agnostic — it lives in `AGENTS.md` and
+this ADR, both of which are loaded by every CLI. Three downstream
+items carry parity load, tracked in their own tickets:
+
+- The `spec-author` skill (#168) ships through `community-config/`
+  and is compiled to all three CLIs by `scripts/build-components.sh`
+  (#174). No CLI-specific gap is anticipated.
+- The retroactive routing engine (#172) is orchestrator-side logic.
+  Claude Code's team primitives (`TeamCreate` / `TaskCreate` /
+  `SendMessage`) make it directly expressible; Gemini CLI's
+  sequential-spawn fallback (per `AGENTS.md` → *On CLIs without team
+  support*) requires loop bookkeeping in the orchestrator's
+  conversation state. Copilot CLI parity will be assessed in #172.
+- The interaction-mode notification surface (#173) reuses the
+  logbook issue, which is GitHub-side and therefore CLI-agnostic.
+
+`docs/cli-matrix.md` SHALL be updated as each of #168 / #172 / #173
+lands, not as part of this ADR.
+
+## Appendix — three worked examples
+
+These examples define expected artefacts so downstream tickets (#167,
+#169, #172, #173) can use them as fixtures.
+
+### Example 1 — Trivial change
+
+**Ticket.** "Fix typo in `README.md` line 42: `recieve` → `receive`."
+
+| Stage | Artefact | Content |
+|---|---|---|
+| SPECS | Spec id `2026-T-0001-readme-typo` | Single-line WHAT: "Fix spelling of 'receive' in README.md." Tier: `trivial`. Mode: INTERMEDIATE. |
+| PLAN | (skipped for trivial) | — |
+| DEV | Inline edit by orchestrator | One-line diff. |
+| REVIEW | Self-review by orchestrator | Expected classes: none. |
+
+Expected iterations: 1. No team spawn. Logbook is the ticket itself.
+
+### Example 2 — Standard change
+
+**Ticket.** "Add a `--dry-run` flag to `scripts/build-components.sh`."
+
+| Stage | Artefact | Content |
+|---|---|---|
+| SPECS | Spec id `2026-S-0042-build-dryrun` | WHAT: flag semantics, exit codes, output format. Tier: `standard`. Mode: INTERMEDIATE. |
+| PLAN | Logbook comment, plan section | Steps: locate write sites, gate behind flag, add tests. Blast radius: build script + its tests. Alternatives: env var (rejected). |
+| DEV | Feature branch via worktree | Template 1 from `AGENTS.md` (architect → developer → tester → pr-logbook → pr-reviewer). |
+| REVIEW | PR comment | Expected classes: `tech` (one or two iterations likely); `arch` possible if dry-run interacts with side-effects discovered late. |
+
+Expected iterations: 1–2. Standard team composition.
+
+### Example 3 — Large change
+
+**Ticket.** "Introduce a credential-vault abstraction shared by the
+e2e judge backends and the auth-bundle scripts."
+
+| Stage | Artefact | Content |
+|---|---|---|
+| SPECS | Parent spec id `2026-L-0007-cred-vault` + delta specs per sub-area | WHAT: vault contract, threat model, migration plan for existing credential stores. Tier: `large`. Mode: FULL (user requested visibility). |
+| PLAN | Logbook comment | Decomposition: 3 sub-specs (vault core; judge migration; auth-bundle migration). Sequencing: vault core first; migrations in parallel. |
+| DEV | Three feature branches, one per sub-spec, each with its own team | `architect`-led decomposition (per the *large* tier row). |
+| REVIEW | One PR review per sub-spec PR | Expected classes: all three plausible. `spec` findings on the vault core are likely to cascade to the migration sub-specs. |
+
+Expected iterations: 2–4 across the family. Each sub-spec PR runs the
+loop independently; cross-PR findings escalate to a `spec` loop on
+the parent.

--- a/docs/adr/0010-spec-plan-review-lifecycle.md
+++ b/docs/adr/0010-spec-plan-review-lifecycle.md
@@ -311,12 +311,18 @@ items carry parity load, tracked in their own tickets:
   logbook issue, which is GitHub-side and therefore CLI-agnostic.
 
 `docs/cli-matrix.md` SHALL be updated as each of #168 / #172 / #173
-lands, not as part of this ADR.
+lands, not as part of this ADR. This PR does not touch the *CLI Matrix
+Maintenance* trigger surface defined in `AGENTS.md` (no edits under
+`.claude/`, `.gemini/`, `community-config/`, `extensions/`, the
+CLI-specific hooks, the `config/` trees, `scripts/build-components.sh`,
+the CLI-prefixed scripts, the `claude.yml` / `gemini.yml` workflows,
+or the top-level CLI entry-point files), so the obligation to update
+the matrix in lockstep does not apply here.
 
 ## Appendix — three worked examples
 
-These examples define expected artefacts so downstream tickets (#167,
-#169, #172, #173) can use them as fixtures.
+These examples define expected artefacts so downstream tickets
+(#167, #169, #172, #173) can use them as fixtures.
 
 ### Example 1 — Trivial change
 


### PR DESCRIPTION
Introduces ADR-0010 defining a four-stage SPECS → PLAN → DEV → REVIEW lifecycle for every non-trivial CrewRig ticket, with a finding-classification taxonomy that routes review feedback back to the correct upstream stage. Updates `AGENTS.md` to layer the operative rules (lifecycle overview, interaction modes, retroactive review loop) onto the ADR contract.

## How to read this PR?

Read in this order:

1. **`docs/adr/0010-spec-plan-review-lifecycle.md`** — this is the **normative** document. Start at *Context*, walk through *Decision* → *Stage definitions and transition rules* → *Finding classification taxonomy* → *Routing matrix* → *Interaction modes* → *Complexity tiers* → *REVIEW loop termination* → *Consequences* → *Appendix (three worked examples)*. The appendix's three examples (trivial / standard / large) are deliberately written to act as fixtures for the downstream tickets that will implement the contract.
2. **`AGENTS.md` diff** — this is the **operative restatement**. Four touchpoints:
   - new top-level *Lifecycle* section right after *What is CrewRig?* (overview + ASCII diagram + pointer to ADR-0010);
   - amended intro paragraph at the head of *Agent Team Protocol* framing Templates 1/2/3 as the **DEV stage** of the lifecycle and forward-referencing ADR-0010 for the surrounding stages;
   - new *Interaction modes* section before *Pull Request Format* (the operative table; engine deferred to #173);
   - new *Retroactive review loop* section (the operative routing table; engine deferred to #172).

The ADR is the source of truth; `AGENTS.md` is the agent-facing restatement of the parts an orchestrator must apply at ticket pickup. Where the two could drift, the ADR wins.

**Three parked questions** flagged by the architect — they are intentionally NOT resolved in this PR and are forwarded to the downstream tickets where they belong:

1. **Frontmatter field names** for `mode` and `max_iterations` — schema lands with the spec file format in **#167**.
2. **Trivial tier vs Logbook Rule A** — ADR-0010 → *Complexity tiers* says trivial uses "the issue itself" as logbook; whether this is full Rule A compliance or a narrow tier-specific exemption is forwarded to **#175** (migration ticket) or a follow-up edit on this branch if the user prefers in-scope resolution.
3. **Tie-breaking heuristic** when REVIEW surfaces findings of multiple classes — the disambiguation rule (\"escalate upstream\") is stated; the routing-engine heuristic that implements it lands in **#172**.

## How to test this PR?

```sh
git fetch crewrig
git checkout docs/166-spec-lifecycle-adr
```

Then:

1. Read `docs/adr/0010-spec-plan-review-lifecycle.md` end to end. Confirm the *Stage definitions* table, the *Finding classification taxonomy* (with canonical + borderline examples per class), the *Routing matrix*, and the *REVIEW loop termination* criterion read as a self-consistent contract.
2. Read the `AGENTS.md` diff (`git diff crewrig/main..HEAD -- AGENTS.md`). Confirm the new *Lifecycle*, *Interaction modes*, and *Retroactive review loop* sections restate ADR-0010 without drift, and that the *Agent Team Protocol* intro correctly frames Templates 1/2/3 as DEV-stage staffing for the `standard` tier.
3. Confirm the three worked examples in the ADR appendix (trivial typo fix; `--dry-run` flag; credential-vault abstraction) are coherent with the routing matrix and complexity-tier table — each example's expected iteration count, team composition, and artefact set should follow mechanically from the normative sections above.
4. Confirm the three parked questions above are explicitly forwarded to **#167**, **#175**, and **#172** respectively — no answer is invented in this PR.
5. CI on this PR should be all-green: documentation-only change, no source files modified, no skill/agent version bumps required.

## Detailed description (for agents)

### ADR-0010 — `docs/adr/0010-spec-plan-review-lifecycle.md` (new file, 361 lines)

Section-by-section:

- **Status** — Accepted under issue #166, parent EPIC #165.
- **Context** — Names the two structural failure modes the lifecycle exists to address: (1) *user drift* (intent vs implementation diverge, caught only at PR review when artefacts are sunk cost); (2) *tech-finding-was-actually-spec-gap* (reviewers re-discover the same gap in different shapes because the spec never decided the point). References prior art: GitHub spec-kit and OpenSpec.
- **Decision** — Adopts the four-stage `SPECS → PLAN → DEV → REVIEW → MERGE` lifecycle. SPECS / PLAN / DEV are linear; REVIEW loops. Defers artefact formats, skills, and routing engine to dedicated tickets (#167, #168, #169, #170, #172, #173, #174, #175) — this ADR defines only the **contract**.
- **Stage definitions and transition rules** — Per-stage table (produces / artefact location / entry / exit criteria) plus four normative transition rules: SPECS/PLAN/DEV may not be skipped on first entry; REVIEW runs after every DEV iteration; empty stages still emit an artefact (audit trail); every lifecycle is anchored to a logbook.
- **Finding classification taxonomy** — Three classes (`tech` / `arch` / `spec`), each with a canonical example and a borderline example. Disambiguation rule: escalate upstream on tie (`tech` < `arch` < `spec`) — misrouting upstream is cheaper than misrouting downstream.
- **Routing matrix** — Class → loop target → minimum re-spawn → spec-PR impact. Plus four rules: mixed-class passes route to the most upstream class; re-spawn columns are minimums (security trigger surface still applies); `spec` loops produce delta-spec PRs, not edits to the immutable original; loops never change the logbook issue identity.
- **Interaction modes** — Four-mode table (FULL / INTERMEDIATE / MINIMAL / AUTO). Mode controls *user gating*, not stage execution. Default is INTERMEDIATE. Mode is declared in spec frontmatter (field name deferred to #167) and immutable mid-lifecycle without re-entering SPECS.
- **Complexity tiers and team sizing** — Four tiers (trivial / small / standard / large) → team composition. The `standard` tier maps to existing Templates 1/2/3 in `AGENTS.md`; `trivial` allows inline orchestrator-only work; `large` mandates architect-led decomposition into sub-specs. Tier escalation mid-lifecycle is treated as an `arch` finding; de-escalation is prohibited.
- **REVIEW loop termination** — Termination iff: APPROVE verdict AND zero findings AND green CI on head commit. Max-iteration guardrail at 5 (configurable in frontmatter); on halt, summarise on logbook and page the user regardless of mode.
- **Consequences** — Easier / Harder / Parity sections. Parity: lifecycle contract is CLI-agnostic; downstream items (#168, #172, #173) carry the actual parity load; `docs/cli-matrix.md` is updated as those tickets land, not in this ADR.
- **Appendix — three worked examples** — Trivial (README typo), standard (`--dry-run` flag), large (credential-vault abstraction). Each example specifies stage artefacts and expected iteration count. Intended as fixtures for #167 / #169 / #172 / #173.

### `AGENTS.md` (4 modifications, +121 lines, 0 deletions)

- **Lifecycle (new top-level section, inserted after *What is CrewRig?*)** — Overview of the four-stage flow with an ASCII diagram. Points at ADR-0010 for the full normative contract.
- **Agent Team Protocol intro (amended)** — Two paragraphs added at the head of the section: (1) frames the protocol as governing the **DEV stage**; (2) frames Templates 1/2/3 as `standard`-tier staffing, with other tiers adjusting composition per ADR-0010 → *Complexity tiers*.
- **Interaction modes (new section, inserted before *Pull Request Format*)** — Operative mode table + 4 rules. Implementation engine (argument parsing, gate enforcement, notification surface) deferred to #173.
- **Retroactive review loop (new section, inserted after *Interaction modes*)** — Operative routing table + 4 rules + termination criterion + max-iteration guardrail. Routing engine deferred to #172; class definitions and disambiguation rule live in ADR-0010.

### What is normative here vs deferred

| Concern | Status in this PR | Lands in |
|---|---|---|
| Four-stage lifecycle contract | **Normative (ADR + AGENTS.md)** | — |
| Finding taxonomy + routing matrix | **Normative (ADR + AGENTS.md)** | — |
| Interaction mode contract | **Normative (ADR + AGENTS.md)** | — |
| Complexity tier contract | **Normative (ADR)** | — |
| Termination + max-iteration | **Normative (ADR + AGENTS.md)** | — |
| Spec file format and `/specs/` layout | Deferred | #167 |
| `spec-author` skill + agent | Deferred | #168 |
| Plan format + plan-review protocol | Deferred | #169 |
| Dedicated spec-PR workflow | Deferred | #170 |
| Routing engine (orchestrator logic) | Deferred | #172 |
| Interaction-mode engine | Deferred | #173 |
| Multi-CLI build/install of `spec-author` | Deferred | #174 |
| Migration of in-flight tickets | Deferred | #175 |

Documentation-only change. No source files modified, no scripts touched, no skill/agent versions bumped — falls under Template 2 in `AGENTS.md`.

Closes #166.