### PR TITLE
📝 Specification format standard and /specs/ scaffold (#167)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,9 @@ full REVIEW pass produces zero findings.
 The full contract — stage definitions, transition rules, finding
 taxonomy, routing matrix, complexity tiers, and termination criterion
 — lives in [ADR-0010](docs/adr/0010-spec-plan-review-lifecycle.md).
+The file format for the spec artefact produced by the SPECS stage —
+frontmatter schema, mandatory body sections, delta-spec convention,
+and naming rules — lives in [`docs/spec-format.md`](docs/spec-format.md).
 The sections below (*Agent Team Protocol*, *Interaction modes*,
 *Retroactive review loop*) layer the operational rules onto that
 contract.

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -1,0 +1,237 @@
+# Specification format
+
+This document defines the normative file format for the SPECS stage of
+the lifecycle introduced in
+[ADR-0010](adr/0010-spec-plan-review-lifecycle.md). It is the contract
+that every spec under `/specs/` SHALL satisfy and that downstream
+tooling (the `spec-author` skill in issue #168, the routing engine in
+issue #172, the future spec linter) will rely on.
+
+The format is intentionally minimal: YAML frontmatter for machine-read
+fields, Markdown body for human-read content, a fixed set of mandatory
+sections so a reviewer always knows where to look.
+
+## Frontmatter schema
+
+Every spec file SHALL open with a YAML frontmatter block delimited by
+`---` lines. Fields are listed below with their type, cardinality, and
+constraints. Unknown fields are tolerated by the format but SHOULD NOT
+be introduced without first amending this document.
+
+| Field | Type | Required | Constraint |
+|---|---|---|---|
+| `id` | string | yes | `<NNNN>` zero-padded to four digits, monotonic, allocated by the ticket creator. Must match the filename prefix. |
+| `slug` | string | yes | kebab-case, ASCII, no leading/trailing hyphen. Must match the filename slug. |
+| `status` | enum | yes | One of `draft`, `approved`, `implemented`, `archived`, `superseded`. |
+| `complexity` | enum | yes | One of `trivial`, `small`, `standard`, `large`. Must match an ADR-0010 complexity tier. |
+| `interaction-mode` | enum | yes | One of `FULL`, `INTERMEDIATE`, `MINIMAL`, `AUTO`. Must match an ADR-0010 interaction mode. Default `INTERMEDIATE` when omitted by a draft, but the field SHALL be present once the spec reaches `approved`. |
+| `related-issue` | integer | yes | The GitHub issue number this spec qualifies (the logbook anchor, per `AGENTS.md` → *Logbook Issues → Rule A*). |
+| `version` | semver | yes | Starts at `1.0.0` on the initial spec. Bumps follow the delta-spec convention below. |
+| `max-iterations` | integer | no | Overrides the ADR-0010 default of 5. Bounded `[1, 20]` inclusive. Omit to inherit the default. |
+| `superseded-by` | string | conditional | Required when `status: superseded`, prohibited otherwise. Value is the `id` of the spec that supersedes this one. |
+
+### Worked frontmatter
+
+```yaml
+---
+id: "0042"
+slug: build-dryrun-flag
+status: approved
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 421
+version: 1.0.0
+---
+```
+
+## Mandatory body sections
+
+A spec body SHALL contain the following five sections, in this order,
+each introduced by a level-2 heading. Sections MAY be empty in a draft
+but MUST be present (a future linter relies on header presence to
+validate format conformance).
+
+### 1. `## Intent`
+
+One paragraph, plain prose, that captures the user-facing WHAT in a
+single breath. The intent answers "what would a user notice if this
+spec were realised?". HOW words (`by`, `via`, `using`, technology
+names, library choices) are forbidden here; they belong in the plan
+artefact defined in issue #169.
+
+### 2. `## Requirements`
+
+Numbered list. Each line is a normative statement using either `SHALL`
+or `MUST`. Imperatives without a modal verb are forbidden ("the system
+sends a notification" is not a requirement; "the system SHALL send a
+notification" is). HOW words are forbidden inside a requirement line
+for the same reason as in `## Intent`.
+
+Each requirement SHOULD be independently testable. A requirement that
+cannot be reduced to a scenario in `## Scenarios` is a smell — either
+split it, or move the untestable part to `## Out of scope`.
+
+### 3. `## Scenarios`
+
+Each scenario uses the Given / When / Then form:
+
+```text
+**Scenario:** <short title>
+
+Given <pre-condition>
+When  <triggering action>
+Then  <observable outcome>
+```
+
+A spec SHALL include at least one happy-path scenario and at least one
+failure-path scenario. Scenarios are the bridge between the spec and
+the regression tests that the `tester` agent will produce in DEV; if a
+scenario cannot be turned into an automated check, escalate to the
+plan stage for a manual-verification clause.
+
+### 4. `## Out of scope`
+
+Bullet list. Each bullet names a behaviour, an integration, or a
+boundary that this spec deliberately excludes. The spec reviewer
+rejects implicit scope; if a behaviour is not explicitly in
+`## Requirements` and not explicitly excluded here, the spec is
+under-specified and SHALL be sent back to the author.
+
+This section MAY be empty only for a `trivial`-tier spec.
+
+### 5. `## Open questions`
+
+Bullet list. Captures unresolved questions at authoring time. The
+section MAY be empty. If non-empty in a `status: approved` spec, the
+reviewer SHALL require written closure on the logbook issue (per
+`AGENTS.md` → *Logbook Issues*) before approval — questions left open
+in an approved spec are pre-baked `spec`-class findings in the REVIEW
+loop and waste a downstream iteration.
+
+## Delta-spec convention
+
+`spec`-class findings produced by the REVIEW loop (per ADR-0010 →
+*Finding classification taxonomy*) do not edit the original spec on
+`main`. The original is immutable once merged; corrections chain via
+delta-spec files.
+
+### File layout
+
+```text
+/specs/<NNNN>-<slug>.md                # original (immutable on main)
+/specs/<NNNN>-<slug>.delta-01.md       # first delta
+/specs/<NNNN>-<slug>.delta-02.md       # second delta, builds on delta-01
+```
+
+Delta numbers are zero-padded to two digits and allocated monotonically
+per parent spec.
+
+### Delta-spec frontmatter
+
+A delta-spec carries the same frontmatter schema as the original, with
+two additional constraints:
+
+- `id` SHALL be the parent's id (the file is identified by its
+  filename suffix, not by a new id).
+- `version` SHALL bump the parent's version per the rules below.
+- The delta-spec body replaces the mandatory body sections with the
+  three delta sections defined next.
+
+### Delta-spec body sections
+
+```markdown
+### ADDED
+
+<requirements, scenarios, or out-of-scope items that the delta introduces>
+
+### MODIFIED
+
+<requirements, scenarios, or out-of-scope items the delta changes; quote the
+original line, then show the replacement>
+
+### REMOVED
+
+<items the delta deletes; quote the original line>
+```
+
+All three sections MUST be present (empty is allowed); the linter will
+check for presence, not content. This mirrors the OpenSpec delta
+convention so external readers familiar with that vocabulary recognise
+the structure.
+
+### Versioning
+
+The `version` field on a delta-spec records the cumulative state of
+the parent after the delta lands. Bump per semver intent:
+
+- `PATCH` — clarification, wording fix, scenario added without
+  changing any existing requirement.
+- `MINOR` — additive normative change (new requirement, new scenario
+  that constrains a previously unspecified case).
+- `MAJOR` — breaking normative change (requirement modified or
+  removed in a way that invalidates an in-flight implementation).
+
+The cumulative version is read from the highest-numbered delta-spec;
+the original file's `version` is never edited after merge.
+
+## Lifecycle states
+
+The `status` field tracks where the spec sits in its own life. Each
+transition has a single authority and an accompanying artefact; the
+table below is the contract.
+
+| `status` | Trigger | Authority | Accompanying artefact |
+|---|---|---|---|
+| `draft` | Spec file opened in the working branch | Spec author (human or `spec-author` skill) | Spec file in the worktree, no PR yet |
+| `approved` | Spec PR merged on `main` | Spec reviewer (per the interaction mode declared in frontmatter) | Merged spec PR + logbook comment recording the approval |
+| `implemented` | Implementation PR for `related-issue` merged on `main` | Implementation team's `pr-logbook` | Merged implementation PR + logbook closure comment |
+| `archived` | Related issue closed without implementation (`won't fix`, duplicate, abandoned) | Ticket closer | Logbook comment explaining the archival |
+| `superseded` | A newer spec replaces this one (often through a `spec`-class loop that grows beyond a delta) | Author of the superseding spec | `superseded-by` field set; superseding spec exists with its own id |
+
+A `status` regression (e.g. `approved` → `draft`) is prohibited; if a
+spec must be re-opened, supersede it instead.
+
+## Naming convention
+
+Spec files live under the top-level `/specs/` directory. The naming
+pattern is fixed:
+
+- Original: `/specs/<NNNN>-<kebab-slug>.md`
+- Delta: `/specs/<NNNN>-<kebab-slug>.delta-<NN>.md`
+
+`<NNNN>` is the spec id, zero-padded to four digits, allocated
+monotonically across the whole repository (not per-year, not
+per-component). The ticket creator picks the next free number by
+inspecting the existing `/specs/` directory before opening the spec
+file. Collisions are resolved by the second author bumping to the next
+free number; spec ids are cheap and never reused.
+
+`<kebab-slug>` mirrors the `slug` frontmatter field. The filename slug
+and the frontmatter slug SHALL match exactly.
+
+`<NN>` (delta suffix) is zero-padded to two digits and unique within
+its parent.
+
+## Linting hints
+
+The format is designed to be machine-checkable. A future spec linter
+(not in scope for issue #167) will rely on the invariants below; spec
+authors and reviewers SHOULD anticipate them.
+
+- The file SHALL pass `markdownlint` with the project's
+  `.markdownlint.json` configuration. In particular: no MD018 traps
+  (do not let a wrapped line start with `#NNN` at column 1 — write
+  `issue #NNN` or reflow the sentence).
+- The five mandatory body section headings SHALL be present and SHALL
+  appear in the order defined above. Heading text SHALL match
+  verbatim (case-sensitive, no trailing punctuation).
+- The frontmatter SHALL parse as YAML and SHALL contain every required
+  field listed in the schema table.
+- For a delta-spec, the three delta section headings (`### ADDED`,
+  `### MODIFIED`, `### REMOVED`) SHALL be present in that order.
+- Enum-valued fields SHALL contain a value from the listed set; any
+  other value is a lint error.
+
+Implementing the linter itself, wiring it into CI, and back-filling
+existing specs are out of scope for this document and will be handled
+in a dedicated ticket once the format has shipped.

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -24,7 +24,7 @@ be introduced without first amending this document.
 | `slug` | string | yes | kebab-case, ASCII, no leading/trailing hyphen. Must match the filename slug. |
 | `status` | enum | yes | One of `draft`, `approved`, `implemented`, `archived`, `superseded`. |
 | `complexity` | enum | yes | One of `trivial`, `small`, `standard`, `large`. Must match an ADR-0010 complexity tier. |
-| `interaction-mode` | enum | yes | One of `FULL`, `INTERMEDIATE`, `MINIMAL`, `AUTO`. Must match an ADR-0010 interaction mode. Default `INTERMEDIATE` when omitted by a draft, but the field SHALL be present once the spec reaches `approved`. |
+| `interaction-mode` | enum | from `approved` onward | One of `FULL`, `INTERMEDIATE`, `MINIMAL`, `AUTO`. Must match an ADR-0010 interaction mode. MAY be omitted in `draft`, in which case the value defaults to `INTERMEDIATE`; SHALL be present explicitly once the spec reaches `approved`. |
 | `related-issue` | integer | yes | The GitHub issue number this spec qualifies (the logbook anchor, per `AGENTS.md` → *Logbook Issues → Rule A*). |
 | `version` | semver | yes | Starts at `1.0.0` on the initial spec. Bumps follow the delta-spec convention below. |
 | `max-iterations` | integer | no | Overrides the ADR-0010 default of 5. Bounded `[1, 20]` inclusive. Omit to inherit the default. |
@@ -218,10 +218,12 @@ The format is designed to be machine-checkable. A future spec linter
 (not in scope for issue #167) will rely on the invariants below; spec
 authors and reviewers SHOULD anticipate them.
 
-- The file SHALL pass `markdownlint` with the project's
-  `.markdownlint.json` configuration. In particular: no MD018 traps
-  (do not let a wrapped line start with `#NNN` at column 1 — write
-  `issue #NNN` or reflow the sentence).
+- The file SHALL pass `markdownlint-cli` with the project's
+  `.markdownlintrc` configuration (CI invocation: `markdownlint
+  "**/*.md" --ignore node_modules --ignore extension-skeleton --ignore
+  communication`). In particular: no MD018 traps (do not let a wrapped
+  line start with `#NNN` at column 1 — write `issue #NNN` or reflow
+  the sentence).
 - The five mandatory body section headings SHALL be present and SHALL
   appear in the order defined above. Heading text SHALL match
   verbatim (case-sensitive, no trailing punctuation).
@@ -233,5 +235,5 @@ authors and reviewers SHOULD anticipate them.
   other value is a lint error.
 
 Implementing the linter itself, wiring it into CI, and back-filling
-existing specs are out of scope for this document and will be handled
-in a dedicated ticket once the format has shipped.
+existing specs are out of scope for this document and are tracked in
+issue #178.

--- a/specs/0001-spec-format-self.md
+++ b/specs/0001-spec-format-self.md
@@ -1,0 +1,103 @@
+---
+id: "0001"
+slug: spec-format-self
+status: implemented
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 167
+version: 1.0.0
+---
+
+# Specification format and `/specs/` scaffold
+
+## Intent
+
+Authors of CrewRig tickets gain a single, normative file format for the
+specifications that anchor the SPECS stage of the lifecycle, plus a
+top-level `/specs/` directory ready to receive them. Anyone reading a
+merged spec recognises its shape at a glance, knows where its
+frontmatter fields are documented, and can find a copy-ready template
+without leaving the repository.
+
+## Requirements
+
+1. The repository SHALL contain a normative document `docs/spec-format.md`
+   that defines the spec frontmatter schema, the mandatory body
+   sections, the delta-spec convention, the lifecycle states, and the
+   filename naming convention.
+2. The frontmatter schema SHALL include the fields `id`, `slug`,
+   `status`, `complexity`, `interaction-mode`, `related-issue`,
+   `version`, and the optional `max-iterations` and `superseded-by`
+   fields with the types and constraints defined in `docs/spec-format.md`.
+3. The mandatory body sections SHALL be `## Intent`, `## Requirements`,
+   `## Scenarios`, `## Out of scope`, and `## Open questions`, in that
+   order.
+4. The repository SHALL contain a top-level `/specs/` directory
+   containing at least `README.md`, `_template.md`, and this spec file.
+5. The template `specs/_template.md` SHALL be a copy-ready file with
+   every mandatory section present, frontmatter populated with
+   `status: draft`, `complexity: standard`, `interaction-mode:
+   INTERMEDIATE`, `version: 1.0.0`, and explanatory placeholders for
+   author-facing fields.
+6. `AGENTS.md` SHALL contain a single-sentence pointer from its
+   *Lifecycle* section to `docs/spec-format.md`, and SHALL NOT
+   duplicate the schema.
+7. The spec file naming pattern SHALL be `/specs/<NNNN>-<kebab-slug>.md`
+   for originals and `/specs/<NNNN>-<kebab-slug>.delta-<NN>.md` for
+   delta-specs, with `<NNNN>` zero-padded to four digits and allocated
+   monotonically across the repository.
+
+## Scenarios
+
+**Scenario:** Author opens a new spec from the template
+
+Given the repository contains `specs/_template.md`
+When  an author copies it to `specs/<next-id>-<their-slug>.md`
+Then  the new file passes `markdownlint` with the project configuration
+and  every mandatory frontmatter field and body section is present.
+
+**Scenario:** Author writes a delta-spec for a `spec`-class finding
+
+Given an approved spec `specs/0042-build-dryrun.md` exists on `main`
+When  the REVIEW loop surfaces a `spec`-class finding
+Then  the author creates `specs/0042-build-dryrun.delta-01.md`
+and   the delta file contains the `### ADDED`, `### MODIFIED`, and
+      `### REMOVED` sub-sections
+and   the original spec on `main` is left untouched.
+
+**Scenario:** Reviewer rejects a spec with implicit scope
+
+Given a spec PR is opened with an empty `## Out of scope` section and
+      `complexity: standard`
+When  the spec reviewer inspects the file
+Then  the reviewer rejects the PR and asks the author to enumerate the
+      excluded behaviours.
+
+**Scenario:** Reviewer rejects a spec with HOW words in requirements
+
+Given a spec PR contains a requirement line written as
+      "The system SHALL retry transient errors by using exponential
+      backoff via the `retry-go` library"
+When  the spec reviewer inspects the file
+Then  the reviewer rejects the line as a HOW statement and asks the
+      author to move the technology choice to the plan artefact.
+
+## Out of scope
+
+- The dedicated spec-PR workflow (branching, ordering against the
+  implementation PR) — formalised in issue #170.
+- The `spec-author` skill and agent — issue #168.
+- The plan format and plan-review protocol — issue #169.
+- The retroactive routing engine that classifies REVIEW findings and
+  re-spawns the correct team — issue #172.
+- A working spec linter that enforces the invariants listed in
+  `docs/spec-format.md` → *Linting hints*. The document describes the
+  invariants so the linter can be written later; the linter itself
+  ships in its own ticket.
+- Multi-CLI distribution of any spec-related skills — issue #174.
+- Migration of in-flight tickets onto the new format — issue #175.
+
+## Open questions
+
+- None. Downstream uncertainty is parked in the issues listed under
+  *Out of scope* and will be resolved there.

--- a/specs/0001-spec-format-self.md
+++ b/specs/0001-spec-format-self.md
@@ -93,7 +93,7 @@ Then  the reviewer rejects the line as a HOW statement and asks the
 - A working spec linter that enforces the invariants listed in
   `docs/spec-format.md` → *Linting hints*. The document describes the
   invariants so the linter can be written later; the linter itself
-  ships in its own ticket.
+  ships in issue #178.
 - Multi-CLI distribution of any spec-related skills — issue #174.
 - Migration of in-flight tickets onto the new format — issue #175.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,47 @@
+# `/specs/` — Specifications
+
+This directory holds every specification produced by the SPECS stage of
+the lifecycle defined in
+[ADR-0010](../docs/adr/0010-spec-plan-review-lifecycle.md).
+
+A spec is the normative WHAT of a ticket: what a user-facing change
+must achieve, written down before any plan is drafted and any code is
+written. The HOW (steps, blast radius, alternatives) lives in the plan
+artefact attached to the logbook issue (format defined in issue #169);
+the realisation lives on a feature branch.
+
+## Layout
+
+```text
+specs/
+├── README.md                              # this file
+├── _template.md                           # copy-ready template for new specs
+├── 0001-spec-format-self.md               # worked example: spec for issue #167
+└── <NNNN>-<slug>.md                       # one spec per ticket
+    <NNNN>-<slug>.delta-<NN>.md            # delta-spec amendments (optional)
+```
+
+- Spec file format, frontmatter schema, mandatory body sections, and
+  the delta-spec convention live in
+  [`docs/spec-format.md`](../docs/spec-format.md).
+- Lifecycle contract (SPECS → PLAN → DEV → REVIEW), finding
+  classification, complexity tiers, and interaction modes live in
+  [ADR-0010](../docs/adr/0010-spec-plan-review-lifecycle.md).
+
+## Two-PR flow
+
+Specs ship in a **dedicated spec PR**, separately from the
+implementation PR that realises them. The exact branching and
+ordering rules for that flow are formalised in issue #170 and are
+not duplicated here — see the spec format document and ADR-0010 for
+the contract, and issue #170 for the operational protocol once it
+lands.
+
+## Creating a new spec
+
+1. Pick the next free id by inspecting filenames in this directory.
+   Ids are monotonic, zero-padded to four digits, never reused.
+2. Copy `_template.md` to `<NNNN>-<your-slug>.md`.
+3. Fill in the frontmatter and the five mandatory body sections.
+4. Open the spec PR against `main` (per issue #170 once available;
+   until then, follow the standard branch-and-PR flow in `AGENTS.md`).

--- a/specs/_template.md
+++ b/specs/_template.md
@@ -1,0 +1,54 @@
+---
+id: "NNNN"
+slug: your-kebab-slug-here
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 0
+version: 1.0.0
+---
+
+# Spec title — short, descriptive, matches the slug
+
+## Intent
+
+One paragraph, plain prose, capturing the user-facing WHAT in a single
+breath. No HOW words (`by`, `via`, `using`, technology names, library
+choices). If the reader cannot picture what changes for a user after
+reading this paragraph, rewrite it.
+
+## Requirements
+
+1. The system SHALL _[observable behaviour]_.
+2. The system MUST _[invariant or constraint]_.
+3. _Add as many as needed. Each line uses SHALL or MUST. Each line is
+   independently testable. No HOW words._
+
+## Scenarios
+
+**Scenario:** _happy-path title_
+
+```text
+Given <pre-condition>
+When  <triggering action>
+Then  <observable outcome>
+```
+
+**Scenario:** _failure-path title_
+
+```text
+Given <pre-condition>
+When  <triggering action that should fail or be rejected>
+Then  <observable failure mode>
+```
+
+## Out of scope
+
+- _Behaviour, integration, or boundary explicitly excluded._
+- _Add bullets as needed. Empty list is allowed only for `trivial` tier._
+
+## Open questions
+
+- _Unresolved question, or remove this bullet._
+- _If the spec reaches `status: approved` with non-empty open questions,
+  the reviewer requires written closure on the logbook issue._


### PR DESCRIPTION
This PR establishes the normative file format for the SPECS stage of the ADR-0010 lifecycle and lands the `/specs/` scaffold so future tickets can author specs from a copy-ready template. It is a docs-and-scaffold change: no code, no tests, no CI wiring — the linter that will enforce the invariants ships in its own ticket.

## How to read this PR?

Four files, read in this order:

1. **`docs/spec-format.md`** — the normative source. Defines the YAML frontmatter schema (9 fields), the five mandatory body sections, the delta-spec convention (`ADDED` / `MODIFIED` / `REMOVED`), the lifecycle state table, the naming convention, and the linting hints a future linter will rely on.
2. **`specs/_template.md`** — the schema applied. Copy-ready file with every mandatory frontmatter field and body section pre-populated with placeholders and `status: draft`.
3. **`specs/0001-spec-format-self.md`** — the self-referential worked example. Spec #0001 is the spec for issue #167 itself, ships in `status: implemented`, and demonstrates that the format is expressive enough to describe its own arrival.
4. **`specs/README.md`** — layout pointer that ties the directory back to `docs/spec-format.md` and ADR-0010, plus a note that the two-PR flow is owned by #170.
5. **`AGENTS.md`** — a single three-line paragraph added to the *Lifecycle* section that points to `docs/spec-format.md`. The schema is NOT duplicated here.

## How to test this PR?

1. Read `docs/spec-format.md` end-to-end. Confirm the frontmatter schema, the five mandatory body sections, the delta-spec convention, the lifecycle state table, and the naming convention are all present.
2. Open `specs/0001-spec-format-self.md` and confirm it conforms to its own schema: frontmatter present with all required fields, the five body sections in order, every requirement uses SHALL/MUST, scenarios use Given/When/Then, `## Out of scope` is non-empty (the spec is `complexity: standard`), `## Open questions` is explicitly empty.
3. Confirm the nine frontmatter field names match the architect's parked-question-1 list from issue #166's logbook verbatim: `id`, `slug`, `status`, `complexity`, `interaction-mode`, `related-issue`, `version`, `max-iterations`, `superseded-by`.
4. Confirm the `complexity` enum (`trivial`, `small`, `standard`, `large`) and the `interaction-mode` enum (`FULL`, `INTERMEDIATE`, `MINIMAL`, `AUTO`) match the ADR-0010 tiers and modes verbatim.
5. Confirm the delta-spec convention is described with the three sub-sections `### ADDED`, `### MODIFIED`, `### REMOVED` and is ready to be consumed by the spec-class loop tracked in #172.

## Detailed description (for agents)

**`docs/spec-format.md`** (237 lines, new) is organised in seven top-level sections:

- *Frontmatter schema* — a single table that lists each field with type, required/optional/conditional cardinality, and constraints. `id` is a zero-padded four-digit string allocated monotonically across the whole repository. `slug` is kebab-case and SHALL match the filename slug. `status` is the lifecycle enum. `complexity` and `interaction-mode` are tied verbatim to ADR-0010. `related-issue` is the GitHub issue number that anchors the logbook per AGENTS.md → *Logbook Issues → Rule A*. `version` starts at `1.0.0`. `max-iterations` is an optional bounded integer overriding the ADR-0010 default of 5. `superseded-by` is conditional (required iff `status: superseded`). A worked frontmatter block follows the table.
- *Mandatory body sections* — five level-2 headings in fixed order: `## Intent`, `## Requirements`, `## Scenarios`, `## Out of scope`, `## Open questions`. Each section's contract is spelled out: HOW-words forbidden in `## Intent` and `## Requirements`, SHALL/MUST modal required in every requirement line, at least one happy-path and one failure-path scenario, `## Out of scope` MAY be empty only for `trivial`-tier specs, `## Open questions` MAY be empty but if non-empty in an `approved` spec requires written closure on the logbook.
- *Delta-spec convention* — the file layout `<NNNN>-<slug>.delta-<NN>.md`, the frontmatter constraints (parent `id` reused, `version` bumped, delta body replaces the five sections with `### ADDED` / `### MODIFIED` / `### REMOVED`), and the semver bump intent for delta versioning. The cumulative version is read from the highest-numbered delta.
- *Lifecycle states* — a five-row table mapping each `status` value (`draft`, `approved`, `implemented`, `archived`, `superseded`) to its trigger, authority, and accompanying artefact. Status regressions are prohibited; re-opens supersede.
- *Naming convention* — fixed pattern, zero-padding rules, monotonic-across-repo id allocation, collision handling.
- *Linting hints* — invariants a future linter SHALL check, including `markdownlint` conformance (with an explicit MD018 trap warning about wrapped lines starting `#NNN`), section presence and ordering, frontmatter parse-ability, and enum validation. The linter itself is explicitly out of scope.

**`specs/0001-spec-format-self.md`** is the self-referential worked example. It ships in `status: implemented` because by the time this PR merges, the spec is realised. It contains seven requirements that map 1:1 to the artefacts in this diff, four scenarios (one happy-path template-copy, one delta-spec authoring, two rejection scenarios that exercise the reviewer's contract on implicit scope and HOW-words), and an *Out of scope* list that enumerates every downstream ticket (#168, #169, #170, #172, #174, #175) that owns the work this spec deliberately defers.

**`specs/_template.md`** populates frontmatter with `id: \"NNNN\"`, `slug: your-kebab-slug-here`, `status: draft`, `complexity: standard`, `interaction-mode: INTERMEDIATE`, `related-issue: 0`, `version: 1.0.0`, and surfaces every mandatory body section with author-facing placeholders.

**`specs/README.md`** is a 47-line layout pointer. It explicitly defers the two-PR branching protocol to #170 and never duplicates the schema or the lifecycle contract — both are cited by link to `docs/spec-format.md` and ADR-0010 respectively.

**`AGENTS.md`** gains a single three-line paragraph inside the existing *Lifecycle* section, pointing readers from the entry-point document to `docs/spec-format.md`. The schema is intentionally NOT inlined here; AGENTS.md links, the spec-format document owns.

**Parked items (deliberately not resolved here):**

- *Id encoding scheme.* The format locks `<NNNN>` monotonic-across-repo. ADR-0010 illustratively mentions a `2026-T-NNNN` year/tier scheme. If a year/tier scheme is later wanted, it would be an additive, non-breaking frontmatter evolution (a new optional field, or a relaxed `id` format) — file a separate ticket at that point. Not in scope for #167.
- *Spec linter.* The *Linting hints* section describes what the linter SHALL check; the linter itself, its CI wiring, and back-fill of existing artefacts are out of scope and need their own ticket. File it when #172 / #173 surface a concrete need.
- *Spec-PR branching convention.* The two-PR flow (spec PR vs implementation PR, branching, ordering) is owned by issue #170 and merely referenced from `specs/README.md`. Not redefined here.

Closes #167