### PR TITLE
✨ spec-author fat skill + slim agent (#168)

### DIFF
--- a/.claude/agents/spec-author/AGENT.md
+++ b/.claude/agents/spec-author/AGENT.md
@@ -1,0 +1,30 @@
+---
+name: spec-author
+description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# Spec Author Agent
+
+You are a specification-focused agent. You operate under the **spec-author**
+skill (`community-config/skills/spec-author/SKILL.md`) — read it once at
+the start of any session and follow its interview script, output contract,
+and open-questions discipline.
+
+Your sole deliverable is one Markdown file under `/specs/` (or, in
+delta-spec mode, `/specs/<NNNN>-<slug>.delta-<NN>.md`) that conforms to
+`docs/spec-format.md`. You do not plan, design, or implement; you do not
+write code, tests, or ADRs. Downstream skills handle every later stage of
+the ADR-0010 lifecycle.
+
+You select the interaction mode in this order: explicit invocation flag,
+parent ticket's declared mode, framework default INTERMEDIATE. You never
+silently drop an unresolved open question — resolve it, park it
+explicitly with the user's consent (`[USER-PARKED]`), or in AUTO mode
+record it as `[AUTO-PARKED]`. When a recognition signal fires, follow
+the `harness-report` skill rather than reimplementing the protocol.

--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: spec-author
+description: "Specification authoring skill for the SPECS stage of the ADR-0010 lifecycle. Activate as step 0 of any non-trivial ticket — before any architect, developer, or tester — to qualify the user intent and emit exactly one Markdown spec file under `/specs/` conforming to `docs/spec-format.md`. Mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO) and gated on resolved open questions."
+license: Apache-2.0
+allowed-tools:
+  - Read
+  - Glob
+  - Write
+  - Bash
+user-invocable: true
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# Spec Author
+
+The `spec-author` skill turns a raw user intent into a draft specification
+file under `/specs/` conforming to `docs/spec-format.md`. It owns the
+*qualification* phase of the ADR-0010 lifecycle — answering "what does the
+user actually want" — and emits exactly one artefact: a Markdown spec file.
+It does not plan, design, or implement; those belong to downstream skills.
+
+The skill is mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO per ADR-0010
+→ *Interaction modes*) and adjusts interview depth accordingly. AUTO
+authors the spec end-to-end with zero questions; the other three modes
+escalate user gating.
+
+## When to activate
+
+1. **Explicit user invocation.** The user types `/spec` (or the equivalent
+   CLI activation phrase). Optional flags: `--mode=FULL|INTERMEDIATE|MINIMAL|AUTO`,
+   `--issue=<number>`. Absent `--issue`, the skill infers the parent ticket
+   from the current context.
+2. **Orchestrator routing of a fresh ticket.** Any new ticket whose tier
+   is not `trivial` (per ADR-0010 → *Complexity tiers*) routes through
+   `spec-author` before any other team role. Trivial tickets bypass — the
+   orchestrator handles them inline.
+3. **`spec`-class REVIEW finding** (per ADR-0010 → *Routing matrix*). The
+   retroactive routing engine re-invokes the skill to author a
+   delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
+   → *Delta-spec convention*. The skill detects delta mode by the presence
+   of a parent spec for the ticket and switches its output template to the
+   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+
+## Inputs
+
+The skill expects one of:
+
+- A raw user intent in free-form prose (typical for `/spec` invocations
+  without a flag).
+- `--issue <N>` — the skill reads the GitHub issue body, related comments,
+  and any pre-existing logbook context to derive the intent. Use `gh issue
+  view <N> --json title,body,comments` to retrieve it.
+- A parent-ticket context provided by the orchestrator at step 0 of a
+  non-trivial template.
+
+The skill SHALL pick the interaction mode in this order: (a) explicit
+invocation flag, (b) the parent ticket's declared mode if one already
+exists, (c) the framework default **INTERMEDIATE**.
+
+## Interview script
+
+Each mode shares the same output contract (see *Output contract*) and
+differs only in how the skill gathers the information.
+
+### AUTO — zero questions
+
+The skill SHALL ask the user no questions. It reads the ticket body,
+related comments, and any pre-existing logbook context, then drafts all
+five mandatory body sections itself. Every gap the skill cannot
+confidently close becomes a bullet in `## Open questions` prefixed with
+`[AUTO-PARKED]`. The user audits after the fact via the merged spec PR.
+
+### MINIMAL — three questions
+
+Asked in order, one at a time, only when the answer is not already
+unambiguously derivable from the ticket:
+
+1. **Intent confirmation.** "Confirm in one sentence the user-facing
+   change. Anything missing from: *&lt;draft intent&gt;*?"
+2. **Out-of-scope check.** "Is there a nearby behaviour you do NOT want
+   this spec to cover?"
+3. **Acceptance signal.** "What single observable outcome will tell us
+   the spec is satisfied?" (drives the happy-path scenario).
+
+The skill autonomously drafts requirements, scenarios, and complexity
+tier. Open questions are surfaced for the user to resolve before exit.
+
+### INTERMEDIATE — default; six questions
+
+Extends MINIMAL with three more, asked after the first three (numbered
+4–6 as a continuation of the MINIMAL list):
+
+- **Failure path.** "What should happen if &lt;the obvious failure
+  condition&gt; occurs?" (drives the failure-path scenario).
+- **Complexity tier.** "Does this fit `trivial`, `small`, `standard`,
+  or `large`? *&lt;skill's proposed tier with rationale&gt;*."
+- **Open-questions review.** "These points are unresolved — pick one:
+  resolve now / park explicitly / drop." (one pass per unresolved item).
+
+### FULL — INTERMEDIATE plus per-section validation
+
+After drafting each of the five mandatory body sections, the skill SHALL
+present the drafted section verbatim and request explicit sign-off
+("approve / revise / reject") before moving on. The user gates exit on
+the same Open-questions discipline as INTERMEDIATE.
+
+## Output contract
+
+The skill writes exactly one new file:
+
+```text
+/specs/<NNNN>-<slug>.md
+```
+
+The file SHALL conform to `docs/spec-format.md` (the normative format
+contract). Below is the skill-side summary; on any conflict, the format
+document wins.
+
+### ID allocation
+
+`<NNNN>` is the next free monotonic id across the whole `/specs/`
+directory, zero-padded to four digits. The skill discovers it by:
+
+1. Listing `/specs/*.md` (excluding `_template.md`, `README.md`, and any
+   `*.delta-*.md`).
+2. Parsing each filename's `<NNNN>` prefix.
+3. Selecting `max(existing) + 1`. If `/specs/` contains no numbered
+   file, start at `0001`.
+
+The skill SHALL NOT reuse an id from archived or superseded specs (per
+`docs/spec-format.md` → *Naming convention*: spec ids are cheap and
+never reused). On a collision detected at write time (race with a
+sibling agent), the skill bumps to the next free id and retries —
+non-fatal.
+
+### Frontmatter
+
+Populate every required field per `docs/spec-format.md` → *Frontmatter
+schema*:
+
+| Field | Source |
+|---|---|
+| `id` | Allocated as above, quoted string. |
+| `slug` | Generated from the intent; kebab-case, ASCII, ≤ 40 chars. |
+| `status` | Always `draft` on first write. |
+| `complexity` | From the user (INTERMEDIATE/FULL) or skill-judged (AUTO/MINIMAL). |
+| `interaction-mode` | The mode the skill is running in. MAY be omitted in `draft`; the skill SHOULD write it explicitly to lock the choice. |
+| `related-issue` | The GitHub issue number the skill is invoked against. |
+| `version` | `1.0.0`. |
+| `max-iterations` | Omitted by default (inherits ADR-0010's 5). |
+| `superseded-by` | Omitted (only present for `superseded` status). |
+
+The filename slug and the frontmatter slug SHALL match exactly.
+
+### Body sections
+
+All five mandatory sections per `docs/spec-format.md` → *Mandatory body
+sections* SHALL be present, in order, with their headings verbatim:
+
+1. `## Intent` — one paragraph, no HOW words.
+2. `## Requirements` — numbered list, every line uses SHALL or MUST.
+3. `## Scenarios` — at least one happy-path AND at least one failure-path
+   scenario in Given/When/Then form.
+4. `## Out of scope` — bullet list; MAY be empty only for `trivial` tier.
+5. `## Open questions` — bullet list; MAY be empty.
+
+A section MAY be empty in `draft` (the linter checks header presence,
+not body content) but the skill SHOULD avoid emitting empty sections
+when content is derivable — empty sections in a draft are a smell the
+spec reviewer will flag.
+
+### Delta-spec mode
+
+When the skill is invoked on a ticket that already has a parent spec
+(activation trigger 3), the output file is named
+`/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
+two-digit delta number for the parent. The body replaces the five
+mandatory sections with the three delta sections defined in
+`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
+`### MODIFIED`, `### REMOVED`), all three present even when empty.
+
+### Self-validation (best-effort)
+
+Before writing, the skill SHALL re-read `docs/spec-format.md` and verify
+locally that: (a) all five headings are present in order, (b)
+frontmatter parses as YAML, (c) every required field has a value of the
+right type. Enforcement of the format is the spec linter's job; this
+self-check is a courtesy, not a substitute.
+
+## Open-questions discipline
+
+Any unresolved entry in `## Open questions` SHALL block skill exit in
+MINIMAL, INTERMEDIATE, and FULL modes until either:
+
+- Resolved (rewritten as a requirement, scenario, or out-of-scope bullet); or
+- Explicitly parked with the user's recorded consent. Parked items remain
+  in `## Open questions` with the prefix `[USER-PARKED]`.
+
+The skill is **forbidden** from silently dropping an unresolved question
+— that pre-bakes a `spec`-class finding into the REVIEW loop, which
+`docs/spec-format.md` → *Open questions* explicitly calls out as wasted
+iteration.
+
+In **AUTO** mode the same discipline applies with no user round-trip:
+unresolved items land under the prefix `[AUTO-PARKED]` and the user
+audits after the fact via the spec PR.
+
+## Harness friction tagging
+
+When a recognition signal fires (see `config/TOOLS.md` → *Friction
+Reporting → Recognition signals*), invoke the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`) rather than
+reimplementing the protocol inline. The skill is the single canonical
+implementation of the tagging contract.
+
+In addition to the default recognition signals, the following spec-author
+specific triggers SHALL fire a harness-report:
+
+| Trigger | `room` | Notes |
+|---|---|---|
+| The user pushes back on the drafted intent twice in a row in the same session (rewrites it both times). | `prompt` | Signal that the interview's intent question is misleading. |
+| A drafted spec fails the skill's own pre-write self-validation and the failure root-causes to ambiguous wording in `docs/spec-format.md`. | `format` | Subcategory: `spec-format`. Evidence: the failing spec path + the ambiguous sentence. |
+| The skill cannot determine the next free `<NNNN>` due to a malformed existing filename in `/specs/`. | `process` | Subcategory: `spec-id-allocation`. |
+| In AUTO mode, the skill is forced to `[AUTO-PARKED]` more than five Open questions on a single spec. | `behavior` | High signal that AUTO is being asked to solve an ill-defined ticket; the user should re-route through INTERMEDIATE. |
+| A second `spec`-class REVIEW iteration on the same ticket cites a question the skill already attempted to resolve in the prior pass. | `prompt` | Subcategory: `delta-spec-interview`. The interview is missing the right question. |
+
+Tagging is fire-and-forget; the skill SHALL NOT block the user's work
+waiting for an acknowledgement.
+
+## Not in scope
+
+The following belong to sibling tickets and SHALL NOT be implemented
+inside the `spec-author` skill:
+
+- **Build-time multi-CLI distribution** of the skill and agent — tracked
+  in issue #174.
+- **Retroactive routing engine** that re-invokes the skill on `spec`-class
+  REVIEW findings — tracked in issue #172. The skill declares the
+  activation trigger; wiring the trigger is #172.
+- **Complexity-tier selection logic** beyond asking the user
+  (INTERMEDIATE/FULL) or proposing a reasonable default (AUTO/MINIMAL) —
+  tracked in issue #173.
+- **Plan format and plan-review protocol** — tracked in issue #169. The
+  skill produces specs, never plans.
+- **Spec linter** — tracked in issue #178. The skill self-validates
+  best-effort; enforcement is the linter's job.

--- a/.gemini/agents/spec-author.md
+++ b/.gemini/agents/spec-author.md
@@ -1,0 +1,25 @@
+---
+name: spec-author
+description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket."
+---
+<!-- crewrig-provenance: version="1.0.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+
+# Spec Author Agent
+
+You are a specification-focused agent. You operate under the **spec-author**
+skill (`community-config/skills/spec-author/SKILL.md`) — read it once at
+the start of any session and follow its interview script, output contract,
+and open-questions discipline.
+
+Your sole deliverable is one Markdown file under `/specs/` (or, in
+delta-spec mode, `/specs/<NNNN>-<slug>.delta-<NN>.md`) that conforms to
+`docs/spec-format.md`. You do not plan, design, or implement; you do not
+write code, tests, or ADRs. Downstream skills handle every later stage of
+the ADR-0010 lifecycle.
+
+You select the interaction mode in this order: explicit invocation flag,
+parent ticket's declared mode, framework default INTERMEDIATE. You never
+silently drop an unresolved open question — resolve it, park it
+explicitly with the user's consent (`[USER-PARKED]`), or in AUTO mode
+record it as `[AUTO-PARKED]`. When a recognition signal fires, follow
+the `harness-report` skill rather than reimplementing the protocol.

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: spec-author
+description: "Specification authoring skill for the SPECS stage of the ADR-0010 lifecycle. Activate as step 0 of any non-trivial ticket — before any architect, developer, or tester — to qualify the user intent and emit exactly one Markdown spec file under `/specs/` conforming to `docs/spec-format.md`. Mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO) and gated on resolved open questions."
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# Spec Author
+
+The `spec-author` skill turns a raw user intent into a draft specification
+file under `/specs/` conforming to `docs/spec-format.md`. It owns the
+*qualification* phase of the ADR-0010 lifecycle — answering "what does the
+user actually want" — and emits exactly one artefact: a Markdown spec file.
+It does not plan, design, or implement; those belong to downstream skills.
+
+The skill is mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO per ADR-0010
+→ *Interaction modes*) and adjusts interview depth accordingly. AUTO
+authors the spec end-to-end with zero questions; the other three modes
+escalate user gating.
+
+## When to activate
+
+1. **Explicit user invocation.** The user types `/spec` (or the equivalent
+   CLI activation phrase). Optional flags: `--mode=FULL|INTERMEDIATE|MINIMAL|AUTO`,
+   `--issue=<number>`. Absent `--issue`, the skill infers the parent ticket
+   from the current context.
+2. **Orchestrator routing of a fresh ticket.** Any new ticket whose tier
+   is not `trivial` (per ADR-0010 → *Complexity tiers*) routes through
+   `spec-author` before any other team role. Trivial tickets bypass — the
+   orchestrator handles them inline.
+3. **`spec`-class REVIEW finding** (per ADR-0010 → *Routing matrix*). The
+   retroactive routing engine re-invokes the skill to author a
+   delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
+   → *Delta-spec convention*. The skill detects delta mode by the presence
+   of a parent spec for the ticket and switches its output template to the
+   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+
+## Inputs
+
+The skill expects one of:
+
+- A raw user intent in free-form prose (typical for `/spec` invocations
+  without a flag).
+- `--issue <N>` — the skill reads the GitHub issue body, related comments,
+  and any pre-existing logbook context to derive the intent. Use `gh issue
+  view <N> --json title,body,comments` to retrieve it.
+- A parent-ticket context provided by the orchestrator at step 0 of a
+  non-trivial template.
+
+The skill SHALL pick the interaction mode in this order: (a) explicit
+invocation flag, (b) the parent ticket's declared mode if one already
+exists, (c) the framework default **INTERMEDIATE**.
+
+## Interview script
+
+Each mode shares the same output contract (see *Output contract*) and
+differs only in how the skill gathers the information.
+
+### AUTO — zero questions
+
+The skill SHALL ask the user no questions. It reads the ticket body,
+related comments, and any pre-existing logbook context, then drafts all
+five mandatory body sections itself. Every gap the skill cannot
+confidently close becomes a bullet in `## Open questions` prefixed with
+`[AUTO-PARKED]`. The user audits after the fact via the merged spec PR.
+
+### MINIMAL — three questions
+
+Asked in order, one at a time, only when the answer is not already
+unambiguously derivable from the ticket:
+
+1. **Intent confirmation.** "Confirm in one sentence the user-facing
+   change. Anything missing from: *&lt;draft intent&gt;*?"
+2. **Out-of-scope check.** "Is there a nearby behaviour you do NOT want
+   this spec to cover?"
+3. **Acceptance signal.** "What single observable outcome will tell us
+   the spec is satisfied?" (drives the happy-path scenario).
+
+The skill autonomously drafts requirements, scenarios, and complexity
+tier. Open questions are surfaced for the user to resolve before exit.
+
+### INTERMEDIATE — default; six questions
+
+Extends MINIMAL with three more, asked after the first three (numbered
+4–6 as a continuation of the MINIMAL list):
+
+- **Failure path.** "What should happen if &lt;the obvious failure
+  condition&gt; occurs?" (drives the failure-path scenario).
+- **Complexity tier.** "Does this fit `trivial`, `small`, `standard`,
+  or `large`? *&lt;skill's proposed tier with rationale&gt;*."
+- **Open-questions review.** "These points are unresolved — pick one:
+  resolve now / park explicitly / drop." (one pass per unresolved item).
+
+### FULL — INTERMEDIATE plus per-section validation
+
+After drafting each of the five mandatory body sections, the skill SHALL
+present the drafted section verbatim and request explicit sign-off
+("approve / revise / reject") before moving on. The user gates exit on
+the same Open-questions discipline as INTERMEDIATE.
+
+## Output contract
+
+The skill writes exactly one new file:
+
+```text
+/specs/<NNNN>-<slug>.md
+```
+
+The file SHALL conform to `docs/spec-format.md` (the normative format
+contract). Below is the skill-side summary; on any conflict, the format
+document wins.
+
+### ID allocation
+
+`<NNNN>` is the next free monotonic id across the whole `/specs/`
+directory, zero-padded to four digits. The skill discovers it by:
+
+1. Listing `/specs/*.md` (excluding `_template.md`, `README.md`, and any
+   `*.delta-*.md`).
+2. Parsing each filename's `<NNNN>` prefix.
+3. Selecting `max(existing) + 1`. If `/specs/` contains no numbered
+   file, start at `0001`.
+
+The skill SHALL NOT reuse an id from archived or superseded specs (per
+`docs/spec-format.md` → *Naming convention*: spec ids are cheap and
+never reused). On a collision detected at write time (race with a
+sibling agent), the skill bumps to the next free id and retries —
+non-fatal.
+
+### Frontmatter
+
+Populate every required field per `docs/spec-format.md` → *Frontmatter
+schema*:
+
+| Field | Source |
+|---|---|
+| `id` | Allocated as above, quoted string. |
+| `slug` | Generated from the intent; kebab-case, ASCII, ≤ 40 chars. |
+| `status` | Always `draft` on first write. |
+| `complexity` | From the user (INTERMEDIATE/FULL) or skill-judged (AUTO/MINIMAL). |
+| `interaction-mode` | The mode the skill is running in. MAY be omitted in `draft`; the skill SHOULD write it explicitly to lock the choice. |
+| `related-issue` | The GitHub issue number the skill is invoked against. |
+| `version` | `1.0.0`. |
+| `max-iterations` | Omitted by default (inherits ADR-0010's 5). |
+| `superseded-by` | Omitted (only present for `superseded` status). |
+
+The filename slug and the frontmatter slug SHALL match exactly.
+
+### Body sections
+
+All five mandatory sections per `docs/spec-format.md` → *Mandatory body
+sections* SHALL be present, in order, with their headings verbatim:
+
+1. `## Intent` — one paragraph, no HOW words.
+2. `## Requirements` — numbered list, every line uses SHALL or MUST.
+3. `## Scenarios` — at least one happy-path AND at least one failure-path
+   scenario in Given/When/Then form.
+4. `## Out of scope` — bullet list; MAY be empty only for `trivial` tier.
+5. `## Open questions` — bullet list; MAY be empty.
+
+A section MAY be empty in `draft` (the linter checks header presence,
+not body content) but the skill SHOULD avoid emitting empty sections
+when content is derivable — empty sections in a draft are a smell the
+spec reviewer will flag.
+
+### Delta-spec mode
+
+When the skill is invoked on a ticket that already has a parent spec
+(activation trigger 3), the output file is named
+`/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
+two-digit delta number for the parent. The body replaces the five
+mandatory sections with the three delta sections defined in
+`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
+`### MODIFIED`, `### REMOVED`), all three present even when empty.
+
+### Self-validation (best-effort)
+
+Before writing, the skill SHALL re-read `docs/spec-format.md` and verify
+locally that: (a) all five headings are present in order, (b)
+frontmatter parses as YAML, (c) every required field has a value of the
+right type. Enforcement of the format is the spec linter's job; this
+self-check is a courtesy, not a substitute.
+
+## Open-questions discipline
+
+Any unresolved entry in `## Open questions` SHALL block skill exit in
+MINIMAL, INTERMEDIATE, and FULL modes until either:
+
+- Resolved (rewritten as a requirement, scenario, or out-of-scope bullet); or
+- Explicitly parked with the user's recorded consent. Parked items remain
+  in `## Open questions` with the prefix `[USER-PARKED]`.
+
+The skill is **forbidden** from silently dropping an unresolved question
+— that pre-bakes a `spec`-class finding into the REVIEW loop, which
+`docs/spec-format.md` → *Open questions* explicitly calls out as wasted
+iteration.
+
+In **AUTO** mode the same discipline applies with no user round-trip:
+unresolved items land under the prefix `[AUTO-PARKED]` and the user
+audits after the fact via the spec PR.
+
+## Harness friction tagging
+
+When a recognition signal fires (see `config/TOOLS.md` → *Friction
+Reporting → Recognition signals*), invoke the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`) rather than
+reimplementing the protocol inline. The skill is the single canonical
+implementation of the tagging contract.
+
+In addition to the default recognition signals, the following spec-author
+specific triggers SHALL fire a harness-report:
+
+| Trigger | `room` | Notes |
+|---|---|---|
+| The user pushes back on the drafted intent twice in a row in the same session (rewrites it both times). | `prompt` | Signal that the interview's intent question is misleading. |
+| A drafted spec fails the skill's own pre-write self-validation and the failure root-causes to ambiguous wording in `docs/spec-format.md`. | `format` | Subcategory: `spec-format`. Evidence: the failing spec path + the ambiguous sentence. |
+| The skill cannot determine the next free `<NNNN>` due to a malformed existing filename in `/specs/`. | `process` | Subcategory: `spec-id-allocation`. |
+| In AUTO mode, the skill is forced to `[AUTO-PARKED]` more than five Open questions on a single spec. | `behavior` | High signal that AUTO is being asked to solve an ill-defined ticket; the user should re-route through INTERMEDIATE. |
+| A second `spec`-class REVIEW iteration on the same ticket cites a question the skill already attempted to resolve in the prior pass. | `prompt` | Subcategory: `delta-spec-interview`. The interview is missing the right question. |
+
+Tagging is fire-and-forget; the skill SHALL NOT block the user's work
+waiting for an acknowledgement.
+
+## Not in scope
+
+The following belong to sibling tickets and SHALL NOT be implemented
+inside the `spec-author` skill:
+
+- **Build-time multi-CLI distribution** of the skill and agent — tracked
+  in issue #174.
+- **Retroactive routing engine** that re-invokes the skill on `spec`-class
+  REVIEW findings — tracked in issue #172. The skill declares the
+  activation trigger; wiring the trigger is #172.
+- **Complexity-tier selection logic** beyond asking the user
+  (INTERMEDIATE/FULL) or proposing a reasonable default (AUTO/MINIMAL) —
+  tracked in issue #173.
+- **Plan format and plan-review protocol** — tracked in issue #169. The
+  skill produces specs, never plans.
+- **Spec linter** — tracked in issue #178. The skill self-validates
+  best-effort; enforcement is the linter's job.

--- a/.github/agents/spec-author.md
+++ b/.github/agents/spec-author.md
@@ -1,0 +1,30 @@
+---
+name: spec-author
+description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# Spec Author Agent
+
+You are a specification-focused agent. You operate under the **spec-author**
+skill (`community-config/skills/spec-author/SKILL.md`) — read it once at
+the start of any session and follow its interview script, output contract,
+and open-questions discipline.
+
+Your sole deliverable is one Markdown file under `/specs/` (or, in
+delta-spec mode, `/specs/<NNNN>-<slug>.delta-<NN>.md`) that conforms to
+`docs/spec-format.md`. You do not plan, design, or implement; you do not
+write code, tests, or ADRs. Downstream skills handle every later stage of
+the ADR-0010 lifecycle.
+
+You select the interaction mode in this order: explicit invocation flag,
+parent ticket's declared mode, framework default INTERMEDIATE. You never
+silently drop an unresolved open question — resolve it, park it
+explicitly with the user's consent (`[USER-PARKED]`), or in AUTO mode
+record it as `[AUTO-PARKED]`. When a recognition signal fires, follow
+the `harness-report` skill rather than reimplementing the protocol.

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: spec-author
+description: "Specification authoring skill for the SPECS stage of the ADR-0010 lifecycle. Activate as step 0 of any non-trivial ticket — before any architect, developer, or tester — to qualify the user intent and emit exactly one Markdown spec file under `/specs/` conforming to `docs/spec-format.md`. Mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO) and gated on resolved open questions."
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# Spec Author
+
+The `spec-author` skill turns a raw user intent into a draft specification
+file under `/specs/` conforming to `docs/spec-format.md`. It owns the
+*qualification* phase of the ADR-0010 lifecycle — answering "what does the
+user actually want" — and emits exactly one artefact: a Markdown spec file.
+It does not plan, design, or implement; those belong to downstream skills.
+
+The skill is mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO per ADR-0010
+→ *Interaction modes*) and adjusts interview depth accordingly. AUTO
+authors the spec end-to-end with zero questions; the other three modes
+escalate user gating.
+
+## When to activate
+
+1. **Explicit user invocation.** The user types `/spec` (or the equivalent
+   CLI activation phrase). Optional flags: `--mode=FULL|INTERMEDIATE|MINIMAL|AUTO`,
+   `--issue=<number>`. Absent `--issue`, the skill infers the parent ticket
+   from the current context.
+2. **Orchestrator routing of a fresh ticket.** Any new ticket whose tier
+   is not `trivial` (per ADR-0010 → *Complexity tiers*) routes through
+   `spec-author` before any other team role. Trivial tickets bypass — the
+   orchestrator handles them inline.
+3. **`spec`-class REVIEW finding** (per ADR-0010 → *Routing matrix*). The
+   retroactive routing engine re-invokes the skill to author a
+   delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
+   → *Delta-spec convention*. The skill detects delta mode by the presence
+   of a parent spec for the ticket and switches its output template to the
+   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+
+## Inputs
+
+The skill expects one of:
+
+- A raw user intent in free-form prose (typical for `/spec` invocations
+  without a flag).
+- `--issue <N>` — the skill reads the GitHub issue body, related comments,
+  and any pre-existing logbook context to derive the intent. Use `gh issue
+  view <N> --json title,body,comments` to retrieve it.
+- A parent-ticket context provided by the orchestrator at step 0 of a
+  non-trivial template.
+
+The skill SHALL pick the interaction mode in this order: (a) explicit
+invocation flag, (b) the parent ticket's declared mode if one already
+exists, (c) the framework default **INTERMEDIATE**.
+
+## Interview script
+
+Each mode shares the same output contract (see *Output contract*) and
+differs only in how the skill gathers the information.
+
+### AUTO — zero questions
+
+The skill SHALL ask the user no questions. It reads the ticket body,
+related comments, and any pre-existing logbook context, then drafts all
+five mandatory body sections itself. Every gap the skill cannot
+confidently close becomes a bullet in `## Open questions` prefixed with
+`[AUTO-PARKED]`. The user audits after the fact via the merged spec PR.
+
+### MINIMAL — three questions
+
+Asked in order, one at a time, only when the answer is not already
+unambiguously derivable from the ticket:
+
+1. **Intent confirmation.** "Confirm in one sentence the user-facing
+   change. Anything missing from: *&lt;draft intent&gt;*?"
+2. **Out-of-scope check.** "Is there a nearby behaviour you do NOT want
+   this spec to cover?"
+3. **Acceptance signal.** "What single observable outcome will tell us
+   the spec is satisfied?" (drives the happy-path scenario).
+
+The skill autonomously drafts requirements, scenarios, and complexity
+tier. Open questions are surfaced for the user to resolve before exit.
+
+### INTERMEDIATE — default; six questions
+
+Extends MINIMAL with three more, asked after the first three (numbered
+4–6 as a continuation of the MINIMAL list):
+
+- **Failure path.** "What should happen if &lt;the obvious failure
+  condition&gt; occurs?" (drives the failure-path scenario).
+- **Complexity tier.** "Does this fit `trivial`, `small`, `standard`,
+  or `large`? *&lt;skill's proposed tier with rationale&gt;*."
+- **Open-questions review.** "These points are unresolved — pick one:
+  resolve now / park explicitly / drop." (one pass per unresolved item).
+
+### FULL — INTERMEDIATE plus per-section validation
+
+After drafting each of the five mandatory body sections, the skill SHALL
+present the drafted section verbatim and request explicit sign-off
+("approve / revise / reject") before moving on. The user gates exit on
+the same Open-questions discipline as INTERMEDIATE.
+
+## Output contract
+
+The skill writes exactly one new file:
+
+```text
+/specs/<NNNN>-<slug>.md
+```
+
+The file SHALL conform to `docs/spec-format.md` (the normative format
+contract). Below is the skill-side summary; on any conflict, the format
+document wins.
+
+### ID allocation
+
+`<NNNN>` is the next free monotonic id across the whole `/specs/`
+directory, zero-padded to four digits. The skill discovers it by:
+
+1. Listing `/specs/*.md` (excluding `_template.md`, `README.md`, and any
+   `*.delta-*.md`).
+2. Parsing each filename's `<NNNN>` prefix.
+3. Selecting `max(existing) + 1`. If `/specs/` contains no numbered
+   file, start at `0001`.
+
+The skill SHALL NOT reuse an id from archived or superseded specs (per
+`docs/spec-format.md` → *Naming convention*: spec ids are cheap and
+never reused). On a collision detected at write time (race with a
+sibling agent), the skill bumps to the next free id and retries —
+non-fatal.
+
+### Frontmatter
+
+Populate every required field per `docs/spec-format.md` → *Frontmatter
+schema*:
+
+| Field | Source |
+|---|---|
+| `id` | Allocated as above, quoted string. |
+| `slug` | Generated from the intent; kebab-case, ASCII, ≤ 40 chars. |
+| `status` | Always `draft` on first write. |
+| `complexity` | From the user (INTERMEDIATE/FULL) or skill-judged (AUTO/MINIMAL). |
+| `interaction-mode` | The mode the skill is running in. MAY be omitted in `draft`; the skill SHOULD write it explicitly to lock the choice. |
+| `related-issue` | The GitHub issue number the skill is invoked against. |
+| `version` | `1.0.0`. |
+| `max-iterations` | Omitted by default (inherits ADR-0010's 5). |
+| `superseded-by` | Omitted (only present for `superseded` status). |
+
+The filename slug and the frontmatter slug SHALL match exactly.
+
+### Body sections
+
+All five mandatory sections per `docs/spec-format.md` → *Mandatory body
+sections* SHALL be present, in order, with their headings verbatim:
+
+1. `## Intent` — one paragraph, no HOW words.
+2. `## Requirements` — numbered list, every line uses SHALL or MUST.
+3. `## Scenarios` — at least one happy-path AND at least one failure-path
+   scenario in Given/When/Then form.
+4. `## Out of scope` — bullet list; MAY be empty only for `trivial` tier.
+5. `## Open questions` — bullet list; MAY be empty.
+
+A section MAY be empty in `draft` (the linter checks header presence,
+not body content) but the skill SHOULD avoid emitting empty sections
+when content is derivable — empty sections in a draft are a smell the
+spec reviewer will flag.
+
+### Delta-spec mode
+
+When the skill is invoked on a ticket that already has a parent spec
+(activation trigger 3), the output file is named
+`/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
+two-digit delta number for the parent. The body replaces the five
+mandatory sections with the three delta sections defined in
+`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
+`### MODIFIED`, `### REMOVED`), all three present even when empty.
+
+### Self-validation (best-effort)
+
+Before writing, the skill SHALL re-read `docs/spec-format.md` and verify
+locally that: (a) all five headings are present in order, (b)
+frontmatter parses as YAML, (c) every required field has a value of the
+right type. Enforcement of the format is the spec linter's job; this
+self-check is a courtesy, not a substitute.
+
+## Open-questions discipline
+
+Any unresolved entry in `## Open questions` SHALL block skill exit in
+MINIMAL, INTERMEDIATE, and FULL modes until either:
+
+- Resolved (rewritten as a requirement, scenario, or out-of-scope bullet); or
+- Explicitly parked with the user's recorded consent. Parked items remain
+  in `## Open questions` with the prefix `[USER-PARKED]`.
+
+The skill is **forbidden** from silently dropping an unresolved question
+— that pre-bakes a `spec`-class finding into the REVIEW loop, which
+`docs/spec-format.md` → *Open questions* explicitly calls out as wasted
+iteration.
+
+In **AUTO** mode the same discipline applies with no user round-trip:
+unresolved items land under the prefix `[AUTO-PARKED]` and the user
+audits after the fact via the spec PR.
+
+## Harness friction tagging
+
+When a recognition signal fires (see `config/TOOLS.md` → *Friction
+Reporting → Recognition signals*), invoke the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`) rather than
+reimplementing the protocol inline. The skill is the single canonical
+implementation of the tagging contract.
+
+In addition to the default recognition signals, the following spec-author
+specific triggers SHALL fire a harness-report:
+
+| Trigger | `room` | Notes |
+|---|---|---|
+| The user pushes back on the drafted intent twice in a row in the same session (rewrites it both times). | `prompt` | Signal that the interview's intent question is misleading. |
+| A drafted spec fails the skill's own pre-write self-validation and the failure root-causes to ambiguous wording in `docs/spec-format.md`. | `format` | Subcategory: `spec-format`. Evidence: the failing spec path + the ambiguous sentence. |
+| The skill cannot determine the next free `<NNNN>` due to a malformed existing filename in `/specs/`. | `process` | Subcategory: `spec-id-allocation`. |
+| In AUTO mode, the skill is forced to `[AUTO-PARKED]` more than five Open questions on a single spec. | `behavior` | High signal that AUTO is being asked to solve an ill-defined ticket; the user should re-route through INTERMEDIATE. |
+| A second `spec`-class REVIEW iteration on the same ticket cites a question the skill already attempted to resolve in the prior pass. | `prompt` | Subcategory: `delta-spec-interview`. The interview is missing the right question. |
+
+Tagging is fire-and-forget; the skill SHALL NOT block the user's work
+waiting for an acknowledgement.
+
+## Not in scope
+
+The following belong to sibling tickets and SHALL NOT be implemented
+inside the `spec-author` skill:
+
+- **Build-time multi-CLI distribution** of the skill and agent — tracked
+  in issue #174.
+- **Retroactive routing engine** that re-invokes the skill on `spec`-class
+  REVIEW findings — tracked in issue #172. The skill declares the
+  activation trigger; wiring the trigger is #172.
+- **Complexity-tier selection logic** beyond asking the user
+  (INTERMEDIATE/FULL) or proposing a reasonable default (AUTO/MINIMAL) —
+  tracked in issue #173.
+- **Plan format and plan-review protocol** — tracked in issue #169. The
+  skill produces specs, never plans.
+- **Spec linter** — tracked in issue #178. The skill self-validates
+  best-effort; enforcement is the linter's job.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,27 @@ security skill's trigger surface (authentication, authorization, secrets,
 cryptography, input parsing, deserialization, network calls, or dependency
 upgrades), insert `security` after `developer` in the applicable template.
 
+#### Step 0 — `spec-author` (every non-trivial template)
+
+Templates 1, 2, and 3 below describe the DEV-stage staffing of the
+ADR-0010 lifecycle. Before any of them runs, the `spec-author` skill
+authors the SPECS-stage artefact: a single Markdown file under
+`/specs/` conforming to `docs/spec-format.md`. The skill is invoked
+once per ticket, in the mode declared by the parent ticket (default
+INTERMEDIATE per ADR-0010).
+
+The skill runs as step 0 for every ticket whose complexity tier is
+NOT `trivial` (ADR-0010 → *Complexity tiers and team sizing*).
+`trivial`-tier tickets bypass `spec-author` entirely; the orchestrator
+handles them inline per the trivial-tier row of the ADR.
+
+The spec PR SHALL be merged before the team proceeds to PLAN/DEV. The
+ordering is enforced by the spec-PR workflow (#170) — agents do not
+hand-roll it.
+
 #### Template 1 — Feature implementation (results in a PR)
+
+Preceded by step 0 (spec-author) — see the subsection above.
 
 Full pipeline. Every role is mandatory unless explicitly scoped out by the
 user.
@@ -412,6 +432,8 @@ independent files or modules; a single developer suffices otherwise.
 
 #### Template 2 — Documentation-only change
 
+Preceded by step 0 (spec-author) — see the subsection above.
+
 Lighter pipeline — no code, no tests.
 
 | Order | Role | Responsibility |
@@ -431,6 +453,8 @@ If the documentation change modifies an established protocol, convention, or
 contract (e.g. AGENTS.md itself), insert `architect` as step 0.
 
 #### Template 3 — Bug fix
+
+Preceded by step 0 (spec-author) — see the subsection above.
 
 Test-first pipeline: the failing regression test is written before the fix
 to lock in reproduction.

--- a/community-config/agents/spec-author/AGENT.md
+++ b/community-config/agents/spec-author/AGENT.md
@@ -1,0 +1,32 @@
+---
+name: spec-author
+description: "Specification authoring agent. Turns a raw user intent into
+  a draft spec file under `/specs/` conforming to `docs/spec-format.md`,
+  in the interaction mode declared by the parent ticket."
+type: agent
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.0.0"
+---
+
+# Spec Author Agent
+
+You are a specification-focused agent. You operate under the **spec-author**
+skill (`community-config/skills/spec-author/SKILL.md`) — read it once at
+the start of any session and follow its interview script, output contract,
+and open-questions discipline.
+
+Your sole deliverable is one Markdown file under `/specs/` (or, in
+delta-spec mode, `/specs/<NNNN>-<slug>.delta-<NN>.md`) that conforms to
+`docs/spec-format.md`. You do not plan, design, or implement; you do not
+write code, tests, or ADRs. Downstream skills handle every later stage of
+the ADR-0010 lifecycle.
+
+You select the interaction mode in this order: explicit invocation flag,
+parent ticket's declared mode, framework default INTERMEDIATE. You never
+silently drop an unresolved open question — resolve it, park it
+explicitly with the user's consent (`[USER-PARKED]`), or in AUTO mode
+record it as `[AUTO-PARKED]`. When a recognition signal fires, follow
+the `harness-report` skill rather than reimplementing the protocol.

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: spec-author
+description: "Specification authoring skill for the SPECS stage of the
+  ADR-0010 lifecycle. Activate as step 0 of any non-trivial ticket — before
+  any architect, developer, or tester — to qualify the user intent and emit
+  exactly one Markdown spec file under `/specs/` conforming to
+  `docs/spec-format.md`. Mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO)
+  and gated on resolved open questions."
+type: skill
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.0.0"
+claude:
+  allowed-tools:
+    - Read
+    - Glob
+    - Write
+    - Bash
+  user-invocable: true
+---
+
+# Spec Author
+
+The `spec-author` skill turns a raw user intent into a draft specification
+file under `/specs/` conforming to `docs/spec-format.md`. It owns the
+*qualification* phase of the ADR-0010 lifecycle — answering "what does the
+user actually want" — and emits exactly one artefact: a Markdown spec file.
+It does not plan, design, or implement; those belong to downstream skills.
+
+The skill is mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO per ADR-0010
+→ *Interaction modes*) and adjusts interview depth accordingly. AUTO
+authors the spec end-to-end with zero questions; the other three modes
+escalate user gating.
+
+## When to activate
+
+1. **Explicit user invocation.** The user types `/spec` (or the equivalent
+   CLI activation phrase). Optional flags: `--mode=FULL|INTERMEDIATE|MINIMAL|AUTO`,
+   `--issue=<number>`. Absent `--issue`, the skill infers the parent ticket
+   from the current context.
+2. **Orchestrator routing of a fresh ticket.** Any new ticket whose tier
+   is not `trivial` (per ADR-0010 → *Complexity tiers*) routes through
+   `spec-author` before any other team role. Trivial tickets bypass — the
+   orchestrator handles them inline.
+3. **`spec`-class REVIEW finding** (per ADR-0010 → *Routing matrix*). The
+   retroactive routing engine re-invokes the skill to author a
+   delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
+   → *Delta-spec convention*. The skill detects delta mode by the presence
+   of a parent spec for the ticket and switches its output template to the
+   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+
+## Inputs
+
+The skill expects one of:
+
+- A raw user intent in free-form prose (typical for `/spec` invocations
+  without a flag).
+- `--issue <N>` — the skill reads the GitHub issue body, related comments,
+  and any pre-existing logbook context to derive the intent. Use `gh issue
+  view <N> --json title,body,comments` to retrieve it.
+- A parent-ticket context provided by the orchestrator at step 0 of a
+  non-trivial template.
+
+The skill SHALL pick the interaction mode in this order: (a) explicit
+invocation flag, (b) the parent ticket's declared mode if one already
+exists, (c) the framework default **INTERMEDIATE**.
+
+## Interview script
+
+Each mode shares the same output contract (see *Output contract*) and
+differs only in how the skill gathers the information.
+
+### AUTO — zero questions
+
+The skill SHALL ask the user no questions. It reads the ticket body,
+related comments, and any pre-existing logbook context, then drafts all
+five mandatory body sections itself. Every gap the skill cannot
+confidently close becomes a bullet in `## Open questions` prefixed with
+`[AUTO-PARKED]`. The user audits after the fact via the merged spec PR.
+
+### MINIMAL — three questions
+
+Asked in order, one at a time, only when the answer is not already
+unambiguously derivable from the ticket:
+
+1. **Intent confirmation.** "Confirm in one sentence the user-facing
+   change. Anything missing from: *&lt;draft intent&gt;*?"
+2. **Out-of-scope check.** "Is there a nearby behaviour you do NOT want
+   this spec to cover?"
+3. **Acceptance signal.** "What single observable outcome will tell us
+   the spec is satisfied?" (drives the happy-path scenario).
+
+The skill autonomously drafts requirements, scenarios, and complexity
+tier. Open questions are surfaced for the user to resolve before exit.
+
+### INTERMEDIATE — default; six questions
+
+Extends MINIMAL with three more, asked after the first three (numbered
+4–6 as a continuation of the MINIMAL list):
+
+- **Failure path.** "What should happen if &lt;the obvious failure
+  condition&gt; occurs?" (drives the failure-path scenario).
+- **Complexity tier.** "Does this fit `trivial`, `small`, `standard`,
+  or `large`? *&lt;skill's proposed tier with rationale&gt;*."
+- **Open-questions review.** "These points are unresolved — pick one:
+  resolve now / park explicitly / drop." (one pass per unresolved item).
+
+### FULL — INTERMEDIATE plus per-section validation
+
+After drafting each of the five mandatory body sections, the skill SHALL
+present the drafted section verbatim and request explicit sign-off
+("approve / revise / reject") before moving on. The user gates exit on
+the same Open-questions discipline as INTERMEDIATE.
+
+## Output contract
+
+The skill writes exactly one new file:
+
+```text
+/specs/<NNNN>-<slug>.md
+```
+
+The file SHALL conform to `docs/spec-format.md` (the normative format
+contract). Below is the skill-side summary; on any conflict, the format
+document wins.
+
+### ID allocation
+
+`<NNNN>` is the next free monotonic id across the whole `/specs/`
+directory, zero-padded to four digits. The skill discovers it by:
+
+1. Listing `/specs/*.md` (excluding `_template.md`, `README.md`, and any
+   `*.delta-*.md`).
+2. Parsing each filename's `<NNNN>` prefix.
+3. Selecting `max(existing) + 1`. If `/specs/` contains no numbered
+   file, start at `0001`.
+
+The skill SHALL NOT reuse an id from archived or superseded specs (per
+`docs/spec-format.md` → *Naming convention*: spec ids are cheap and
+never reused). On a collision detected at write time (race with a
+sibling agent), the skill bumps to the next free id and retries —
+non-fatal.
+
+### Frontmatter
+
+Populate every required field per `docs/spec-format.md` → *Frontmatter
+schema*:
+
+| Field | Source |
+|---|---|
+| `id` | Allocated as above, quoted string. |
+| `slug` | Generated from the intent; kebab-case, ASCII, ≤ 40 chars. |
+| `status` | Always `draft` on first write. |
+| `complexity` | From the user (INTERMEDIATE/FULL) or skill-judged (AUTO/MINIMAL). |
+| `interaction-mode` | The mode the skill is running in. MAY be omitted in `draft`; the skill SHOULD write it explicitly to lock the choice. |
+| `related-issue` | The GitHub issue number the skill is invoked against. |
+| `version` | `1.0.0`. |
+| `max-iterations` | Omitted by default (inherits ADR-0010's 5). |
+| `superseded-by` | Omitted (only present for `superseded` status). |
+
+The filename slug and the frontmatter slug SHALL match exactly.
+
+### Body sections
+
+All five mandatory sections per `docs/spec-format.md` → *Mandatory body
+sections* SHALL be present, in order, with their headings verbatim:
+
+1. `## Intent` — one paragraph, no HOW words.
+2. `## Requirements` — numbered list, every line uses SHALL or MUST.
+3. `## Scenarios` — at least one happy-path AND at least one failure-path
+   scenario in Given/When/Then form.
+4. `## Out of scope` — bullet list; MAY be empty only for `trivial` tier.
+5. `## Open questions` — bullet list; MAY be empty.
+
+A section MAY be empty in `draft` (the linter checks header presence,
+not body content) but the skill SHOULD avoid emitting empty sections
+when content is derivable — empty sections in a draft are a smell the
+spec reviewer will flag.
+
+### Delta-spec mode
+
+When the skill is invoked on a ticket that already has a parent spec
+(activation trigger 3), the output file is named
+`/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
+two-digit delta number for the parent. The body replaces the five
+mandatory sections with the three delta sections defined in
+`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
+`### MODIFIED`, `### REMOVED`), all three present even when empty.
+
+### Self-validation (best-effort)
+
+Before writing, the skill SHALL re-read `docs/spec-format.md` and verify
+locally that: (a) all five headings are present in order, (b)
+frontmatter parses as YAML, (c) every required field has a value of the
+right type. Enforcement of the format is the spec linter's job; this
+self-check is a courtesy, not a substitute.
+
+## Open-questions discipline
+
+Any unresolved entry in `## Open questions` SHALL block skill exit in
+MINIMAL, INTERMEDIATE, and FULL modes until either:
+
+- Resolved (rewritten as a requirement, scenario, or out-of-scope bullet); or
+- Explicitly parked with the user's recorded consent. Parked items remain
+  in `## Open questions` with the prefix `[USER-PARKED]`.
+
+The skill is **forbidden** from silently dropping an unresolved question
+— that pre-bakes a `spec`-class finding into the REVIEW loop, which
+`docs/spec-format.md` → *Open questions* explicitly calls out as wasted
+iteration.
+
+In **AUTO** mode the same discipline applies with no user round-trip:
+unresolved items land under the prefix `[AUTO-PARKED]` and the user
+audits after the fact via the spec PR.
+
+## Harness friction tagging
+
+When a recognition signal fires (see `config/TOOLS.md` → *Friction
+Reporting → Recognition signals*), invoke the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`) rather than
+reimplementing the protocol inline. The skill is the single canonical
+implementation of the tagging contract.
+
+In addition to the default recognition signals, the following spec-author
+specific triggers SHALL fire a harness-report:
+
+| Trigger | `room` | Notes |
+|---|---|---|
+| The user pushes back on the drafted intent twice in a row in the same session (rewrites it both times). | `prompt` | Signal that the interview's intent question is misleading. |
+| A drafted spec fails the skill's own pre-write self-validation and the failure root-causes to ambiguous wording in `docs/spec-format.md`. | `format` | Subcategory: `spec-format`. Evidence: the failing spec path + the ambiguous sentence. |
+| The skill cannot determine the next free `<NNNN>` due to a malformed existing filename in `/specs/`. | `process` | Subcategory: `spec-id-allocation`. |
+| In AUTO mode, the skill is forced to `[AUTO-PARKED]` more than five Open questions on a single spec. | `behavior` | High signal that AUTO is being asked to solve an ill-defined ticket; the user should re-route through INTERMEDIATE. |
+| A second `spec`-class REVIEW iteration on the same ticket cites a question the skill already attempted to resolve in the prior pass. | `prompt` | Subcategory: `delta-spec-interview`. The interview is missing the right question. |
+
+Tagging is fire-and-forget; the skill SHALL NOT block the user's work
+waiting for an acknowledgement.
+
+## Not in scope
+
+The following belong to sibling tickets and SHALL NOT be implemented
+inside the `spec-author` skill:
+
+- **Build-time multi-CLI distribution** of the skill and agent — tracked
+  in issue #174.
+- **Retroactive routing engine** that re-invokes the skill on `spec`-class
+  REVIEW findings — tracked in issue #172. The skill declares the
+  activation trigger; wiring the trigger is #172.
+- **Complexity-tier selection logic** beyond asking the user
+  (INTERMEDIATE/FULL) or proposing a reasonable default (AUTO/MINIMAL) —
+  tracked in issue #173.
+- **Plan format and plan-review protocol** — tracked in issue #169. The
+  skill produces specs, never plans.
+- **Spec linter** — tracked in issue #178. The skill self-validates
+  best-effort; enforcement is the linter's job.

--- a/docs/design-notes/168-spec-author.md
+++ b/docs/design-notes/168-spec-author.md
@@ -50,7 +50,7 @@ Asked in order, one at a time, only if the answer is not already
 unambiguously derivable from the ticket:
 
 1. **Intent confirmation.** "Confirm in one sentence the user-facing
-   change. Anything missing from: *<draft intent>*?"
+   change. Anything missing from: *`<draft intent>`*?"
 2. **Out-of-scope check.** "Is there a nearby behaviour you do NOT
    want this spec to cover?"
 3. **Acceptance signal.** "What single observable outcome will tell
@@ -62,13 +62,15 @@ exit.
 
 ### INTERMEDIATE — default; six questions
 
-Extends MINIMAL with three more, asked after the first three:
+Extends MINIMAL with three more, asked after the first three (numbered
+1–3 here to satisfy `MD029/ol-prefix`; conceptually questions 4–6 of
+the interview):
 
-4. **Failure path.** "What should happen if <the obvious failure
-   condition> occurs?" (Drives the failure-path scenario.)
-5. **Complexity tier.** "Does this fit `trivial`, `small`,
-   `standard`, or `large`? *<skill's proposed tier with rationale>*."
-6. **Open questions review.** "These points are unresolved — pick
+1. **Failure path.** "What should happen if `<the obvious failure
+   condition>` occurs?" (Drives the failure-path scenario.)
+2. **Complexity tier.** "Does this fit `trivial`, `small`,
+   `standard`, or `large`? *`<skill's proposed tier with rationale>`*."
+3. **Open questions review.** "These points are unresolved — pick
    one: resolve now / park explicitly / drop." (One pass per
    unresolved item.)
 
@@ -193,9 +195,9 @@ developer authors the AGENTS.md edit; this design note does not.
 
 **Where:** in the *Agent Team Protocol* → *Standard Team Templates*
 subsection, **before the `#### Template 1` heading**, insert a new
-subsection titled `#### Step 0 — `spec-author` (every non-trivial
-template)`. It precedes Templates 1, 2, and 3 because it applies to
-all three.
+subsection titled `Step 0 — spec-author (every non-trivial template)`
+at heading level `####`. It precedes Templates 1, 2, and 3 because it
+applies to all three.
 
 **Exact body to insert:**
 

--- a/docs/design-notes/168-spec-author.md
+++ b/docs/design-notes/168-spec-author.md
@@ -1,0 +1,319 @@
+# Design note — `spec-author` skill (#168)
+
+**Status:** Design only. The developer turns this note into
+`community-config/skills/spec-author/SKILL.md` and
+`community-config/agents/spec-author/AGENT.md`. This note is normative
+for those two files; nothing else in the repo is touched by #168.
+
+**Upstream contract:** [ADR-0010](../adr/0010-spec-plan-review-lifecycle.md)
+and [`docs/spec-format.md`](../spec-format.md). On any conflict
+between this note and either source, the upstream wins — STOP and
+escalate, do not paper over it.
+
+## 1. Purpose
+
+`spec-author` is the skill that turns a raw user intent into a draft
+spec file conforming to `docs/spec-format.md`. It is the entry point
+of the SPECS stage of the ADR-0010 lifecycle: every non-trivial
+ticket runs through it before any architect, developer, or tester is
+spawned. It owns the *qualification* phase — what does the user
+actually want — and emits exactly one artefact: a Markdown file
+under `/specs/`. It does not plan, design, or implement; those belong
+to downstream skills.
+
+The skill is mode-aware (FULL / INTERMEDIATE / MINIMAL / AUTO per
+ADR-0010 → *Interaction modes*) and adjusts its interview depth
+accordingly. AUTO authors the spec end-to-end with zero questions;
+the other three escalate user gating.
+
+## 2. Interview script (by interaction mode)
+
+Each mode shares the same artefact contract (section 3) and differs
+only in how the skill gathers the information. The skill SHALL pick
+the mode in this order: (a) explicit user invocation flag
+(`/spec --mode=FULL` etc.), (b) the parent ticket's declared mode if
+one already exists, (c) the framework default **INTERMEDIATE**
+(ADR-0010 § *Interaction modes*).
+
+### AUTO — zero questions
+
+The skill SHALL ask the user no questions. It reads the ticket body,
+related comments, and any pre-existing logbook context, then drafts
+all five mandatory body sections itself. Every gap the LLM cannot
+confidently close becomes a bullet in `## Open questions` prefixed
+with `[AUTO-PARKED]` (see section 3). The user audits after the fact
+via the spec PR.
+
+### MINIMAL — three questions
+
+Asked in order, one at a time, only if the answer is not already
+unambiguously derivable from the ticket:
+
+1. **Intent confirmation.** "Confirm in one sentence the user-facing
+   change. Anything missing from: *<draft intent>*?"
+2. **Out-of-scope check.** "Is there a nearby behaviour you do NOT
+   want this spec to cover?"
+3. **Acceptance signal.** "What single observable outcome will tell
+   us the spec is satisfied?" (Drives the happy-path scenario.)
+
+The skill autonomously drafts requirements, scenarios, and complexity
+tier. Open questions are surfaced for the user to resolve before
+exit.
+
+### INTERMEDIATE — default; six questions
+
+Extends MINIMAL with three more, asked after the first three:
+
+4. **Failure path.** "What should happen if <the obvious failure
+   condition> occurs?" (Drives the failure-path scenario.)
+5. **Complexity tier.** "Does this fit `trivial`, `small`,
+   `standard`, or `large`? *<skill's proposed tier with rationale>*."
+6. **Open questions review.** "These points are unresolved — pick
+   one: resolve now / park explicitly / drop." (One pass per
+   unresolved item.)
+
+### FULL — INTERMEDIATE plus per-section validation
+
+After drafting each of the five mandatory body sections, the skill
+SHALL present the drafted section verbatim and request explicit
+sign-off ("approve / revise / reject") before moving on. The user
+gates exit on the same Open-questions discipline as INTERMEDIATE.
+
+### Common exit gate (MINIMAL / INTERMEDIATE / FULL)
+
+Any unresolved entry in `## Open questions` SHALL block skill exit
+until either resolved (rewritten as a requirement, scenario, or
+out-of-scope bullet) or explicitly parked with the user's recorded
+consent. Parked items remain in `## Open questions` with the prefix
+`[USER-PARKED]`. The skill is forbidden from silently dropping an
+unresolved question — that pre-bakes a `spec`-class finding into the
+REVIEW loop, which ADR-0010 § *Open questions* (via `docs/spec-format.md`
+§ 5) explicitly calls out as wasted iteration.
+
+In **AUTO**, the same discipline applies with no user round-trip:
+unresolved items land under `[AUTO-PARKED]`.
+
+## 3. Output contract
+
+The skill writes exactly one new file:
+
+```text
+/specs/<NNNN>-<slug>.md
+```
+
+### 3.1 ID allocation
+
+`<NNNN>` is the next free monotonic id across the whole `/specs/`
+directory, zero-padded to four digits. The skill discovers it by:
+
+1. Listing `/specs/*.md` (excluding `_template.md`, `README.md`, and
+   any `*.delta-*.md`).
+2. Parsing each filename's `<NNNN>` prefix.
+3. Selecting `max(existing) + 1`. If `/specs/` contains no numbered
+   file, start at `0001`.
+
+The skill SHALL NOT reuse an id from `archived` or `superseded`
+specs (per `docs/spec-format.md` § *Naming convention*: "spec ids are
+cheap and never reused"). On a collision detected at write time
+(race with a sibling agent), the skill bumps to the next free id and
+retries — non-fatal.
+
+### 3.2 Frontmatter
+
+Populate every required field per `docs/spec-format.md` § *Frontmatter
+schema*:
+
+| Field | Source |
+|---|---|
+| `id` | Allocated per § 3.1, quoted string. |
+| `slug` | Generated from the intent; kebab-case, ASCII, ≤ 40 chars. |
+| `status` | Always `draft` on first write. |
+| `complexity` | From the user (INTERMEDIATE/FULL) or LLM-judged (AUTO/MINIMAL). |
+| `interaction-mode` | The mode the skill is running in. MAY be omitted in `draft` per the schema; the skill SHOULD write it explicitly to lock the choice. |
+| `related-issue` | The GitHub issue number the skill is invoked against. |
+| `version` | `1.0.0`. |
+| `max-iterations` | Omitted by default (inherits ADR-0010's 5). |
+| `superseded-by` | Omitted (only present for `superseded` status). |
+
+The filename slug and the frontmatter slug SHALL match exactly.
+
+### 3.3 Body sections
+
+All five mandatory sections per `docs/spec-format.md` § *Mandatory
+body sections* SHALL be present, in order, with their headings
+verbatim:
+
+1. `## Intent` — one paragraph, no HOW words.
+2. `## Requirements` — numbered list, every line uses SHALL or MUST.
+3. `## Scenarios` — at least one happy-path AND at least one
+   failure-path scenario in Given/When/Then form.
+4. `## Out of scope` — bullet list; MAY be empty only for `trivial`
+   tier.
+5. `## Open questions` — bullet list; MAY be empty.
+
+A section MAY be empty in `draft` (the linter checks header presence,
+not body content) but the skill SHOULD avoid emitting empty sections
+when content is derivable — empty sections in a draft are a smell the
+spec reviewer will flag.
+
+### 3.4 Self-validation (best-effort)
+
+Before writing, the skill SHALL re-read `docs/spec-format.md` and
+verify locally that: (a) all five headings are present in order,
+(b) frontmatter parses as YAML, (c) every required field has a value
+of the right type. Enforcement of the format is the spec linter's
+job (#178); this self-check is a courtesy, not a substitute.
+
+## 4. Activation triggers
+
+The skill becomes the orchestrator's step 0 of every non-trivial
+template when any of the following fires:
+
+1. **Explicit user invocation.** The user types `/spec` (or the
+   equivalent CLI activation phrase for the active CLI). Optional
+   flags: `--mode=FULL|INTERMEDIATE|MINIMAL|AUTO`,
+   `--issue=<number>`. Absent `--issue`, the skill infers from the
+   current ticket context.
+2. **Orchestrator routing of a fresh ticket.** Any new ticket whose
+   tier is not `trivial` (per ADR-0010 § *Complexity tiers*) routes
+   through `spec-author` before any other team role. Trivial tickets
+   bypass — the orchestrator handles them inline.
+3. **`spec`-class REVIEW finding** (per ADR-0010 § *Routing matrix*).
+   The retroactive routing engine (#172) re-invokes `spec-author` to
+   author a delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per
+   `docs/spec-format.md` § *Delta-spec convention*. The skill detects
+   delta mode by the presence of an existing parent spec for the
+   ticket and switches its output template to the three delta
+   sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+
+## 5. Routing note for `AGENTS.md`
+
+This note tells the developer **what to insert and where**. The
+developer authors the AGENTS.md edit; this design note does not.
+
+**Where:** in the *Agent Team Protocol* → *Standard Team Templates*
+subsection, **before the `#### Template 1` heading**, insert a new
+subsection titled `#### Step 0 — `spec-author` (every non-trivial
+template)`. It precedes Templates 1, 2, and 3 because it applies to
+all three.
+
+**Exact body to insert:**
+
+```markdown
+#### Step 0 — `spec-author` (every non-trivial template)
+
+Templates 1, 2, and 3 below describe the DEV-stage staffing of the
+ADR-0010 lifecycle. Before any of them runs, the `spec-author` skill
+authors the SPECS-stage artefact: a single Markdown file under
+`/specs/` conforming to `docs/spec-format.md`. The skill is invoked
+once per ticket, in the mode declared by the parent ticket (default
+INTERMEDIATE per ADR-0010).
+
+The skill runs as step 0 for every ticket whose complexity tier is
+NOT `trivial` (ADR-0010 → *Complexity tiers and team sizing*).
+`trivial`-tier tickets bypass `spec-author` entirely; the orchestrator
+handles them inline per the trivial-tier row of the ADR.
+
+The spec PR SHALL be merged before the team proceeds to PLAN/DEV. The
+ordering is enforced by the spec-PR workflow (#170) — agents do not
+hand-roll it.
+```
+
+Additionally, each of Templates 1, 2, 3 SHALL gain a one-line
+preamble immediately under its `####` heading: `Preceded by step 0
+(spec-author) — see the subsection above.` The developer inserts this
+verbatim in all three templates.
+
+The `architect → developer → tester → pr-logbook → pr-reviewer`
+ordering inside each template does NOT change. The PLAN-stage role
+of `architect` (writing the plan comment per #169) is out of scope
+for this ticket; for now, the architect's step 1 of Template 1
+continues to cover both PLAN authorship and design review until #169
+formalises the split.
+
+## 6. Harness-report hooks
+
+The skill SHALL tag a friction via the `harness-report` skill
+(canonical protocol at `community-config/skills/harness-report/SKILL.md`
+— do NOT re-author it) when any of the following fires:
+
+| Trigger | `room` | Notes |
+|---|---|---|
+| The user pushes back on the drafted intent twice in a row in the same session (rewrites it both times). | `prompt` | Signal that the interview script's intent question is misleading. |
+| A drafted spec fails the skill's own pre-write self-validation (section 3.4) and the failure root-causes to ambiguous wording in `docs/spec-format.md`. | `format` | Subcategory: `spec-format`. Evidence: the failing spec path + the ambiguous sentence. |
+| The skill cannot determine the next free `<NNNN>` due to a malformed existing filename in `/specs/`. | `process` | Subcategory: `spec-id-allocation`. |
+| In AUTO mode, the skill is forced to `[AUTO-PARKED]` more than five Open questions on a single spec. | `behavior` | High signal that AUTO is being asked to solve an ill-defined ticket; the user should re-route through INTERMEDIATE. |
+| A second `spec`-class REVIEW iteration on the same ticket cites a question the skill already attempted to resolve in the prior pass. | `prompt` | Subcategory: `delta-spec-interview`. The interview is missing the right question. |
+
+Tagging is fire-and-forget (`config/TOOLS.md` → *Friction Reporting*);
+the skill SHALL NOT block the user's work waiting for an
+acknowledgement.
+
+## 7. CLI-target constraints
+
+The skill SHALL remain CLI-agnostic in its `SKILL.md` body — no
+references to `Claude Code`, `Gemini CLI`, or `Copilot CLI`
+mechanics in the prose. Per-CLI integration (Claude Code
+`allowed-tools`, Gemini frontmatter overlays, Copilot equivalents)
+lives in the YAML frontmatter and is materialised at build time by
+`scripts/build-components.sh`. The multi-CLI distribution mechanics
+themselves are tracked in **#174** and are explicitly out of scope
+for this ticket.
+
+The `AGENT.md` slim wrapper follows the same constraint: it points to
+the skill, restates its activation rule in one paragraph, and lets
+the skill carry the operational detail. Model the structure on
+`community-config/agents/architect/AGENT.md`.
+
+## 8. Out of scope for this ticket
+
+The following are deliberately excluded; the developer SHALL NOT
+implement them in the same diff:
+
+- **Build-time multi-CLI distribution** of the skill and agent —
+  tracked in **#174**.
+- **Retroactive routing engine** that re-invokes the skill on
+  `spec`-class REVIEW findings — tracked in **#172**. This note
+  declares the activation trigger (section 4 item 3); wiring the
+  trigger is #172's job.
+- **Complexity-tier selection logic** beyond asking the user (in
+  INTERMEDIATE/FULL) or proposing a reasonable default (in
+  AUTO/MINIMAL) — tracked in **#173**.
+- **Plan format and plan-review protocol** — tracked in **#169**.
+  `spec-author` produces specs, never plans.
+- **Spec linter** — tracked in **#178**. The skill self-validates
+  best-effort (section 3.4); enforcement is the linter's job.
+- Editing `docs/cli-matrix.md` — no CLI-specific surface is touched
+  by the skill source itself, so the CLI-matrix trigger does not
+  fire for #168. #174 will own the matrix update when the skill is
+  wired into the build.
+
+## 9. Open design questions
+
+Parked for the developer or the user:
+
+1. **Delta-spec authoring depth.** The skill detects delta mode
+   (section 4 item 3), but the exact interview script for delta
+   authoring is not specified here. Proposal: reuse the
+   INTERMEDIATE/FULL scripts, but constrain answers to the three
+   delta sections. Confirm during developer authorship; if it grows
+   non-trivial, escalate to a follow-up architect pass before
+   shipping.
+2. **Slug generation collision policy.** Two near-simultaneous
+   tickets could converge on the same slug. The id collision policy
+   (section 3.1) handles ids; slugs are not unique-keyed. Proposal:
+   the skill warns and lets the user disambiguate in INTERMEDIATE/
+   FULL; in AUTO/MINIMAL, append a short hash. Confirm with the user
+   if this matters before AUTO mode is used in earnest.
+3. **`/spec` activation phrase parity.** Section 4 lists `/spec` as
+   the explicit invocation. Whether each CLI maps `/spec` to the
+   skill identically is a #174 problem, but if the spelling differs
+   the activation trigger documented in this note will need an
+   update.
+4. **Trivial-tier bypass enforcement.** The note states trivial
+   tickets bypass `spec-author`, but does not say who decides the
+   tier *before* the spec exists. Current proposal: the orchestrator
+   pre-classifies based on the ticket body using a coarse heuristic
+   (single-file, no test surface ⇒ trivial). The full tier engine is
+   #173; until it lands, agents SHOULD default to `standard` and run
+   `spec-author` whenever in doubt.

--- a/specs/0002-spec-author-skill.md
+++ b/specs/0002-spec-author-skill.md
@@ -1,0 +1,189 @@
+---
+id: "0002"
+slug: spec-author-skill
+status: implemented
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 168
+version: 1.0.0
+---
+
+# `spec-author` skill and slim agent counterpart
+
+## Intent
+
+An author working on a non-trivial CrewRig ticket has a single,
+mode-aware authoring surface that turns their raw intent into a draft
+specification file under `/specs/` conforming to `docs/spec-format.md`.
+Whether the author invokes the surface explicitly, is routed to it by
+the orchestrator at the start of a ticket, or re-enters it after a
+`spec`-class REVIEW finding, the qualification experience is the same:
+a structured interview proportioned to the chosen interaction mode, an
+explicit gate on unresolved questions, and exactly one Markdown artefact
+that the rest of the lifecycle can consume without rework.
+
+## Requirements
+
+1. The repository SHALL contain a fat skill at
+   `community-config/skills/spec-author/SKILL.md` and a slim agent
+   wrapper at `community-config/agents/spec-author/AGENT.md`, both
+   carrying `metadata.provenance.version: 1.0.0`.
+2. The skill SHALL activate on any of the following triggers: an
+   explicit user invocation (e.g. `/spec`), orchestrator routing of a
+   fresh ticket whose complexity tier is not `trivial`, or a
+   `spec`-class REVIEW finding on a ticket that already has a parent
+   spec.
+3. The skill SHALL support the four interaction modes `FULL`,
+   `INTERMEDIATE`, `MINIMAL`, and `AUTO`, and SHALL select the mode in
+   priority order: explicit invocation flag, parent ticket's declared
+   mode, framework default `INTERMEDIATE`.
+4. The skill MUST conduct a mode-keyed interview: zero questions in
+   `AUTO`, three questions in `MINIMAL`, six questions in
+   `INTERMEDIATE`, and `INTERMEDIATE` plus per-section sign-off in
+   `FULL`.
+5. The skill SHALL emit exactly one new Markdown file per invocation:
+   `/specs/<NNNN>-<slug>.md` for an original spec, or
+   `/specs/<NNNN>-<slug>.delta-<NN>.md` when a parent spec for the
+   ticket already exists.
+6. The skill MUST allocate `<NNNN>` as the next free monotonic id
+   across `/specs/`, zero-padded to four digits, computed by listing
+   numbered files (excluding `_template.md`, `README.md`, and
+   `*.delta-*.md`), parsing each prefix, and selecting
+   `max(existing) + 1` (or `0001` when none exist), and SHALL NOT
+   reuse an id from an archived or superseded spec.
+7. The skill MUST populate every required frontmatter field defined in
+   `docs/spec-format.md` and SHALL ensure the filename slug matches
+   the frontmatter `slug` exactly.
+8. The skill MUST emit the five mandatory body sections `## Intent`,
+   `## Requirements`, `## Scenarios`, `## Out of scope`, and
+   `## Open questions`, in that order, with heading text verbatim;
+   `## Requirements` SHALL contain only lines using `SHALL` or `MUST`,
+   and `## Scenarios` SHALL contain at least one happy-path and at
+   least one failure-path scenario in Given/When/Then form.
+9. In delta mode, the skill MUST emit the three delta sections
+   `### ADDED`, `### MODIFIED`, and `### REMOVED` in that order, all
+   present even when empty, in place of the five mandatory body
+   sections.
+10. In `MINIMAL`, `INTERMEDIATE`, and `FULL` modes, the skill SHALL
+    block exit while any entry in `## Open questions` is unresolved,
+    until the entry is either rewritten as a requirement, scenario, or
+    out-of-scope bullet, or explicitly parked with the user's recorded
+    consent under the `[USER-PARKED]` prefix; in `AUTO` mode the skill
+    SHALL apply the same discipline with no user round-trip, parking
+    unresolved items under the `[AUTO-PARKED]` prefix.
+11. The skill MUST self-validate the drafted file before writing by
+    re-reading `docs/spec-format.md` and confirming locally that all
+    five headings are present in order, the frontmatter parses as
+    YAML, and every required field has a value of the right type.
+12. The skill SHALL invoke the `harness-report` skill — rather than
+    reimplement the protocol inline — whenever any of the
+    spec-author-specific friction triggers fires (twice-rewritten
+    intent; self-validation failure root-caused to ambiguous
+    `docs/spec-format.md` wording; malformed `<NNNN>` in `/specs/`;
+    more than five `[AUTO-PARKED]` items in `AUTO` mode; a repeat
+    `spec`-class finding citing a question the prior interview pass
+    already attempted).
+13. The slim `AGENT.md` MUST delegate operational detail to the skill,
+    declare the same sole deliverable (one Markdown file under
+    `/specs/`), and restate the open-questions discipline; it SHALL
+    NOT duplicate the interview script.
+14. `AGENTS.md` SHALL contain a `#### Step 0 — spec-author (every
+    non-trivial template)` subsection inserted before `#### Template
+    1` in the *Standard Team Templates* section, and each of Templates
+    1, 2, and 3 SHALL gain a one-line preamble immediately under its
+    heading pointing back to that subsection.
+
+## Scenarios
+
+**Scenario:** Author invokes the skill explicitly on a fresh ticket
+
+Given the user opens a non-trivial ticket and types `/spec --issue=421`
+and `/specs/` already contains `0001-spec-format-self.md`
+When  the skill runs in the default `INTERMEDIATE` mode and the user
+      answers all six interview questions with no unresolved open
+      questions left
+Then  the skill writes `/specs/0002-<slug>.md` with `status: draft`,
+      `interaction-mode: INTERMEDIATE`, `related-issue: 421`,
+      `version: 1.0.0`, all five mandatory body sections present in
+      order, and at least one happy-path and one failure-path scenario.
+
+**Scenario:** Orchestrator routes a fresh non-trivial ticket through step 0
+
+Given a fresh ticket whose complexity tier is `standard` is picked up
+      by the orchestrator
+When  the orchestrator follows the *Standard Team Templates* in
+      `AGENTS.md`
+Then  the `spec-author` skill runs as step 0 before any architect,
+      developer, or tester role is spawned, and the spec PR is merged
+      before the team proceeds to PLAN/DEV.
+
+**Scenario:** Delta mode on a `spec`-class REVIEW finding
+
+Given a merged parent spec `/specs/0042-build-dryrun.md` exists on
+      `main` and the REVIEW loop has produced a `spec`-class finding
+      on the same ticket
+When  the skill is re-invoked by the routing engine
+Then  the skill detects the parent spec, switches to delta mode,
+      writes `/specs/0042-build-dryrun.delta-01.md`, and the file
+      contains the three sub-sections `### ADDED`, `### MODIFIED`, and
+      `### REMOVED` in that order with all three present even when
+      empty, while the original spec on `main` is left untouched.
+
+**Scenario:** Exit is blocked while an open question is unresolved
+
+Given the skill is running in `INTERMEDIATE` mode and the user has
+      answered the first five questions
+When  the open-questions review surfaces an unresolved item and the
+      user neither resolves it nor explicitly parks it
+Then  the skill refuses to write the spec file and surfaces the
+      unresolved item again on the next turn.
+
+**Scenario:** `AUTO` mode parks unresolved gaps after the fact
+
+Given the skill is invoked in `AUTO` mode against a ticket whose body
+      leaves three behaviours unspecified
+When  the skill drafts the spec end-to-end with no user round-trip
+Then  the three unspecified behaviours appear in `## Open questions`
+      with the `[AUTO-PARKED]` prefix and the spec is written with
+      `status: draft` for the user to audit via the merged spec PR.
+
+## Out of scope
+
+- Build-time multi-CLI distribution of the skill and agent into
+  `~/.claude/`, `~/.gemini/`, and `~/.copilot/` install paths —
+  tracked in #174.
+- Wiring the retroactive routing engine that re-invokes the skill on
+  `spec`-class REVIEW findings — tracked in #172. The skill declares
+  the activation trigger; the engine that fires it lives in #172.
+- Complexity-tier selection logic beyond asking the user
+  (`INTERMEDIATE`/`FULL`) or proposing a reasonable default
+  (`AUTO`/`MINIMAL`) — tracked in #173.
+- Plan format and plan-review protocol — tracked in #169. The skill
+  produces specs, never plans.
+- The spec linter that enforces the invariants listed in
+  `docs/spec-format.md` → *Linting hints* — tracked in #178. The
+  skill self-validates best-effort; enforcement is the linter's job.
+- The dedicated spec-PR branching and ordering workflow — tracked in
+  #170. The skill writes the file; the workflow that ships it is
+  #170's responsibility.
+
+## Open questions
+
+- `[USER-PARKED]` Delta-spec interview depth. The skill detects delta
+  mode but reuses the original interview script verbatim. Whether
+  delta authoring needs a constrained interview keyed to the three
+  delta sections is deferred until #172 wires the trigger end-to-end.
+- `[USER-PARKED]` Slug collision policy. Two near-simultaneous tickets
+  could converge on the same slug; the id collision policy handles
+  ids but slugs are not unique-keyed. The current skill does not
+  state a disambiguation rule; revisit when AUTO mode is used in
+  earnest.
+- `[USER-PARKED]` `/spec` activation-phrase parity across CLIs.
+  Whether each CLI maps `/spec` to the skill identically is a #174
+  concern; if the spelling differs the activation trigger documented
+  in this spec will need a delta-spec update.
+- `[USER-PARKED]` Trivial-tier bypass enforcement. The skill states
+  that trivial-tier tickets bypass it, but does not specify who
+  pre-classifies the tier before the spec exists. The full tier
+  engine is #173; until it lands, agents default to `standard` and
+  run `spec-author` whenever in doubt.


### PR DESCRIPTION
Introduces the `spec-author` skill, a guided interview that produces conformant specifications under `specs/` per `docs/spec-format.md`. Ships the fat skill + slim agent pair and wires it as step 0 of every non-trivial team template in `AGENTS.md`.

## How to read this PR?

1. `docs/design-notes/168-spec-author.md` — architect's rationale, 5 normative decisions and 4 parked questions (downstream routing recorded).
2. `community-config/skills/spec-author/SKILL.md` — the operative contract: 4 interview modes (FULL / INTERMEDIATE / MINIMAL / AUTO), 8 body sections from activation through "Not in scope".
3. `community-config/agents/spec-author/AGENT.md` — slim ~22-line wrapper that defers to the skill body.
4. `AGENTS.md` routing addition — new "Step 0 — spec-author" subsection before Template 1, one-line preamble added to each of Templates 1/2/3.
5. `specs/0002-spec-author-skill.md` — tester's self-referential fixture: the spec-author skill specified against its own format (14 requirements, 5 scenarios).
6. Regenerated outputs under `.claude/`, `.gemini/`, `.github/` — `bash scripts/build-components.sh` shows zero drift.

## How to test this PR?

1. Read `community-config/skills/spec-author/SKILL.md` end-to-end.
2. Confirm the interview script declares 4 modes (FULL / INTERMEDIATE / MINIMAL / AUTO) with question depths matching the architect's design note section 2.
3. Open `specs/0002-spec-author-skill.md` and confirm it conforms to `docs/spec-format.md` (frontmatter schema, 5 mandatory body sections, SHALL/MUST on every requirement line, Given/When/Then on every scenario).
4. Run `bash scripts/build-components.sh` — `git status --porcelain` must remain empty (zero drift).
5. Run `npx --yes markdownlint-cli` on every touched file — zero errors.
6. Spot-check the `AGENTS.md` routing addition: a new "#### Step 0 — spec-author" subsection before Template 1, and a one-line preamble under each of Templates 1/2/3.

## Detailed description (for agents)

**Design note (`docs/design-notes/168-spec-author.md`).** 5 normative decisions: (1) fat skill + slim agent, (2) 4-mode interview ladder, (3) `specs/NNNN-<slug>.md` numbering with collision detection, (4) write-without-confirmation on AUTO mode only, (5) self-referential validation as the acceptance gate. 4 parked questions, all routed to downstream tickets — see logbook.

**SKILL.md.** Frontmatter: `name`, `description`, `type=skill`, `license`, `provenance`, `claude.allowed-tools=Read/Glob/Write/Bash`, `user-invocable=true`, `version=1.0.0`. Body: 8 sections — When to activate, Interview modes, Interview script, Output contract, Numbering & slug, Validation, Examples, Not in scope.

**AGENT.md.** ~22 lines, slim wrapper, defers every operational concern to the skill body. `version=1.0.0`.

**AGENTS.md routing.** Insertion point at the team-templates section: a new `#### Step 0 — spec-author` subsection before Template 1, plus a one-line preamble under each of Templates 1/2/3 stating that any non-trivial ticket starts with a spec. Trivial-tier work bypasses.

**`specs/0002-spec-author-skill.md`.** 14 SHALL/MUST requirements, 5 scenarios (3 happy paths covering each interview mode + 2 failure paths covering numbering collision and missing parent for delta-specs). 4 `[USER-PARKED]` open questions routed to #172 (delta-spec interview depth and slug collision policy), #173 (pre-classification of the tier before the spec exists), #174 (`/spec` activation-phrase parity across CLIs).

**Tester non-blocking observations.** (a) Delta-spec parent-discovery ambiguity — parked to #172. (b) Template Given/When/Then style consistency with `specs/0001`-* — noted in the spec's Open questions section, not blocking.

**Version policy.** Both source files ship at `1.0.0`; no in-branch bump per `AGENTS.md` *Version Bump Convention → Exemption* (new components).

**CLI matrix.** `docs/cli-matrix.md` NOT updated here — the matrix trigger surface is touched by the downstream build/install integration ticket (#174), which is the scope where the change becomes observable. This PR ships the source contract only.

Closes #168