### PR TITLE
✨ Spec-PR workflow — AGENTS.md + /specs/README.md (#170)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,76 @@ rule takes over.
 - Every change must go through a **feature branch** merged into `main` via a Pull Request.
 - **NEVER merge a Pull Request (PR/MR)** without asking for the user's formal permission JUST BEFORE executing the merge.
 - The `import/gitlab` branch tracks the legacy GitLab project (`gitlab` remote) and serves as inspiration only.
+- Non-trivial tickets follow the **Spec-PR workflow** (see section below): a `spec/<NNNN>-<slug>` PR qualifies the WHAT and merges to `main` before the implementation branch is cut.
+
+## Spec-PR workflow
+
+This section operationalises the SPECS stage of the lifecycle defined in
+[ADR-0010](docs/adr/0010-spec-plan-review-lifecycle.md) — specifically
+the *Stage definitions → SPECS* contract — and the two-PR convention
+mandated by [`specs/0003-spec-pr-workflow.md`](specs/0003-spec-pr-workflow.md).
+The SPECS-stage artefact (a single Markdown file under `/specs/`) MUST
+ship as its own pull request — the **spec-PR** — and be merged to `main`
+**before** any implementation branch for the same ticket is opened.
+This keeps the WHAT auditable as a standalone diff and decouples the
+qualification timeline from the realisation timeline.
+
+### Branch naming
+
+- Initial spec-branch: `spec/<NNNN>-<slug>` — where `<NNNN>` is the
+  zero-padded spec id and `<slug>` is the kebab-case slug. Both values
+  MUST match the spec file's frontmatter `id` and `slug` fields; the
+  schema is defined in [`docs/spec-format.md`](docs/spec-format.md).
+- Delta-spec branch (produced by a `spec`-class iteration of the
+  *Retroactive review loop*): `spec/<NNNN>-<slug>-delta-<NN>` — where
+  `<NN>` is the zero-padded delta sequence number for that spec id.
+
+### One-file rule
+
+A spec-branch SHALL contain **exactly one new file** under `/specs/`
+and nothing else. No co-mingling with implementation edits, no
+incidental fixes, no build outputs. The rationale: the spec-PR is the
+auditable artefact of qualification — its diff must be reviewable as a
+self-contained WHAT, without the reader having to mentally subtract
+unrelated changes.
+
+### Ordering rule
+
+The spec-PR MUST merge to `main` **before** the implementation branch
+is cut. The four valid implementation-branch prefixes — `feat/`,
+`fix/`, `docs/`, `refactor/` — all follow the `<prefix>/<NNNN>-<slug>`
+suffix convention so that implementation work traces back to its spec
+id by branch name alone. Cutting an implementation branch while the
+corresponding spec-PR is still open is a process violation; the
+*Retroactive review loop* surfaces this as a `class: tech` finding
+(see the rule there).
+
+### Independence rule
+
+The spec-PR and the implementation-PR are **independent pull
+requests**: each closes its own GitHub issue via its own
+`Closes #<related-issue>` directive, and the implementation-PR MUST
+NOT auto-close the spec-PR. Treating them as a single coupled unit
+would defeat the purpose of the two-PR flow — qualification and
+realisation are deliberately separated so that a merged spec can
+outlive a failed implementation attempt and be re-realised by a
+later PR without information loss.
+
+### Delta-spec cumulative rule
+
+A single implementation-PR MAY absorb **N delta-spec PRs** targeting
+the same ticket. Delta-specs accumulate on `main` as immutable
+amendments to the original spec; the implementation-PR realises the
+union of the original spec plus every merged delta. The originating
+loop iteration is defined in the *Retroactive review loop* section
+below — a `spec`-class finding produces a new delta-spec PR before
+the implementation-PR is retried.
+
+### Worktree pointer
+
+The *Worktree Isolation* rule (see *Agent Team Protocol → Worktree
+Isolation*) applies unchanged to both `spec/*` and the corresponding
+implementation branch — each PR runs in its own dedicated worktree.
 
 ## Post-Merge Flow
 
@@ -620,6 +690,12 @@ Rules:
 - A `spec`-class loop SHALL produce a delta-spec PR; the original
   spec on `main` is immutable.
 - The loop SHALL NOT change the logbook issue (Rule A still holds).
+- When an implementation branch (`feat/<NNNN>-<slug>` and siblings) is
+  opened against `main` while the corresponding spec-PR is still open,
+  the REVIEW pass on that implementation-PR SHALL emit a `class: tech`
+  finding citing *Spec-PR workflow → Ordering rule*, and the
+  implementation-PR SHALL NOT be retried until the spec-PR is merged
+  on `main`.
 
 **Termination.** The lifecycle terminates at MERGE iff a REVIEW pass
 verdict is APPROVE AND the pass surfaces zero findings of any class

--- a/specs/README.md
+++ b/specs/README.md
@@ -31,11 +31,18 @@ specs/
 ## Two-PR flow
 
 Specs ship in a **dedicated spec PR**, separately from the
-implementation PR that realises them. The exact branching and
-ordering rules for that flow are formalised in issue #170 and are
-not duplicated here — see the spec format document and ADR-0010 for
-the contract, and issue #170 for the operational protocol once it
-lands.
+implementation PR that realises them. The spec-branch is named
+`spec/<NNNN>-<slug>` (or `spec/<NNNN>-<slug>-delta-<NN>` for
+delta-spec amendments), carries exactly one new file under `/specs/`,
+and MUST merge to `main` before the implementation branch
+(`feat/<NNNN>-<slug>` and siblings) is cut. The two PRs are
+independent — each closes its own related issue, and the
+implementation-PR does not auto-close the spec-PR. The normative
+contract — branch naming, one-file rule, ordering, independence, and
+the delta-spec cumulative rule — lives in
+[`AGENTS.md#spec-pr-workflow`](../AGENTS.md#spec-pr-workflow); the
+classification and routing of `spec`-class loop findings live in
+[ADR-0010](../docs/adr/0010-spec-plan-review-lifecycle.md).
 
 ## Creating a new spec
 
@@ -43,5 +50,5 @@ lands.
    Ids are monotonic, zero-padded to four digits, never reused.
 2. Copy `_template.md` to `<NNNN>-<your-slug>.md`.
 3. Fill in the frontmatter and the five mandatory body sections.
-4. Open the spec PR against `main` (per issue #170 once available;
-   until then, follow the standard branch-and-PR flow in `AGENTS.md`).
+4. Open the spec PR against `main` following the
+   [Spec-PR workflow](../AGENTS.md#spec-pr-workflow) in `AGENTS.md`.


### PR DESCRIPTION
Establishes the spec-PR / impl-PR two-PR convention in `AGENTS.md` and rewires `specs/README.md` to point at it. This is the **implementation-PR** for #170 — distinct from the already-merged spec-PR #180 — and marks the first end-to-end run of the split.

## How to read this PR?

1. The spec — `specs/0003-spec-pr-workflow.md` on `main` (merged via #180) — for the WHAT (R1..R10).
2. The PLAN comment on #170 — for the HOW (validated by user before DEV).
3. `AGENTS.md` diff — new `## Spec-PR workflow` section inserted between *Branching Strategy* and *Post-Merge Flow*, plus a bullet under *Branching Strategy* and a class:tech bullet under *Retroactive review loop*.
4. `specs/README.md` diff — *Two-PR flow* paragraph rewritten as a contributor-facing summary that deep-links `AGENTS.md#spec-pr-workflow`, and *Creating a new spec* step 4 updated.

## How to test this PR?

1. `npx markdownlint-cli AGENTS.md specs/README.md` → zero errors.
2. Confirm the new `AGENTS.md` section lives between *Branching Strategy* and *Post-Merge Flow*.
3. Confirm the *Branching Strategy* bullet and the *Retroactive review loop* class:tech bullet carry the plan-mandated wording verbatim.
4. Confirm `specs/README.md` no longer references "issue #170 once available" and instead deep-links `AGENTS.md#spec-pr-workflow`.
5. Confirm zero files touched outside `AGENTS.md` and `specs/README.md` (no `community-config/`, no `scripts/`, no built outputs, no `cli-matrix.md`).

## Detailed description (for agents)

Section-by-section walkthrough:

- **`AGENTS.md` +76 / -0** — six subsections under the new `## Spec-PR workflow` heading:
  - *Branch naming* — `spec/<id>-<slug>` vs `feat|fix|docs/<id>-<slug>`.
  - *One-file rule* — spec-PR touches exactly one `specs/<id>-*.md` file.
  - *Ordering rule* — spec-PR MUST merge before its impl-PR opens.
  - *Independence rule* — impl-PR carries no spec edits; spec amendments land via a delta-spec PR.
  - *Delta-spec cumulative rule* — successive delta-specs accrete on `main`; the original is immutable.
  - *Worktree pointer* — both PRs use the standard `.worktrees/<ticket-id>(-impl)/` convention.
  - Plus a bullet under *Branching Strategy* anchoring `spec/` as a first-class prefix, and a class:tech bullet under *Retroactive review loop* anchoring spec 0003's *Failure path* (an impl-PR that drifts from its spec is a `tech` finding routed back to DEV, not a SPECS reopening).

- **`specs/README.md` +14 / -7** — *Two-PR flow* rewritten as a short contributor-facing summary deep-linking `AGENTS.md#spec-pr-workflow` (the canonical contract). *Creating a new spec* step 4 updated to reflect the merged-spec-first ordering. No drift from the new `AGENTS.md` section — `AGENTS.md` is authoritative, `specs/README.md` is the discovery surface.

Explicit notes:

- This is the **first live use** of the spec-PR / impl-PR split — spec-PR #180 already merged, this is the impl-PR. Recursion proof: #170 was processed end-to-end through its own about-to-be-defined workflow.
- **R9 helper script DEFERRED** per plan Alternative #3. Rationale: the spec says R9 MAY ship the helper; hand-cutting a spec-PR is two `git` commands; `spec-author` already scaffolds the file. Revisit if friction surfaces after three real spec-PRs.
- **No build run** — no `community-config/` touched, so `scripts/build-components.sh` is a no-op.
- **No CLI matrix edit** — no `.claude/`, `.gemini/`, `community-config/`, `hooks/`, `scripts/build-*` or `Taskfile.yml` trigger surface touched.
- **No version bump** — no skill or agent source modified.

Closes #170