### PR TITLE
✨ Retroactive routing engine — docs + AGENTS.md + 5 skills (#172)

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -142,6 +142,22 @@ does this trace to a file path, a command output, or a sentence in my
 brief? If no, delete it or downgrade it to "assumption — verify
 before relying on this". The self-check is cheap; an ADR that
 recommends a design around a non-existent surface is not.
+
+## Finding class taxonomy
+
+When this skill acts as plan reviewer (per `AGENTS.md` →
+*Plan review protocol* — *Review rule*) or as spec reviewer in the
+SPECS stage, every finding it emits SHALL carry exactly one `class:`
+field whose value is `tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2 and `docs/plan-format.md` → *Finding tag schema*). The tag is the
+only signal the routing engine reads to pick the loop target; a
+finding without it is malformed and SHALL be retagged before the
+orchestrator consumes the verdict (see
+[`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md) →
+*Class tagging discipline*). Do not default to `tech` when the class
+is ambiguous — escalate upstream per ADR-0010 →
+*Finding classification taxonomy*.
 
 ## Friction reporting
 

--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -123,6 +123,21 @@ independent — serialise them.
   asks. The diff is the summary.
 - Comments only where the *why* is non-obvious. Do not narrate *what*
   the code does — the code already does that.
+
+## Finding class taxonomy
+
+When re-spawned as the DEV target of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the brief carries reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and SHALL surface a violation back to the
+orchestrator if any incoming finding it is asked to address omits
+the tag — a missing tag is a reviewer protocol error, not a hint to
+guess at the loop target. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -144,6 +144,21 @@ returns exit 0 (clean) or exit 1 (findings).
 All five scripts use `command -v <tool>` before invoking optional
 tools and print a one-line note when degrading, so a missing tool
 never aborts the review.
+
+## Finding class taxonomy
+
+Every finding emitted by this skill — blocking and non-blocking
+alike — SHALL carry exactly one `class:` field whose value is
+`tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2). The tag drives the retroactive routing engine's loop target
+(see [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md));
+findings without it are malformed and trigger a retag round-trip
+that does NOT count against the max-iteration guardrail. Tag every
+finding individually — a single section header above multiple
+findings is not sufficient. Non-blocking findings still need the
+tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
+through the matrix as if blocking.
 
 ## Grounding discipline
 

--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 
@@ -209,6 +209,26 @@ iteration.
 In **AUTO** mode the same discipline applies with no user round-trip:
 unresolved items land under the prefix `[AUTO-PARKED]` and the user
 audits after the fact via the spec PR.
+
+## Finding class taxonomy
+
+This skill participates in the retroactive review loop on both ends
+(per [`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2, R6 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*):
+
+- **As reviewer.** When the skill reviews a spec-PR (originating or
+  delta), every finding it emits SHALL carry exactly one `class:`
+  field whose value is `tech`, `arch`, or `spec`. Untagged findings
+  are malformed and trigger a retag round-trip that does NOT
+  increment the iteration counter.
+- **As re-spawn target.** When invoked on a `class: spec` REVIEW
+  finding (activation trigger 3 above), the skill operates in
+  **delta-spec mode only** — the original spec on `main` is
+  immutable per ADR-0010 and spec 0003. The `superseded` transition
+  is a new-ticket path outside the loop. The skill SHALL surface a
+  violation if the incoming routing request omits the `class:` tag
+  or asks for a non-delta re-author of an existing spec.
 
 ## Harness friction tagging
 

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.2.1"
 ---
 
 
@@ -143,6 +143,21 @@ to be re-attempted.
 - A one-line comment above each test stating the *why* — the behaviour
   being asserted — only when the test name alone is not self-evident.
 - Test data inline when small; in fixtures when reused or large.
+
+## Finding class taxonomy
+
+When re-spawned as part of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the skill consumes reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and that touch the test surface, and SHALL
+surface a violation back to the orchestrator if any incoming
+finding it is asked to address omits the tag — a missing tag is a
+reviewer protocol error. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -136,6 +136,22 @@ does this trace to a file path, a command output, or a sentence in my
 brief? If no, delete it or downgrade it to "assumption — verify
 before relying on this". The self-check is cheap; an ADR that
 recommends a design around a non-existent surface is not.
+
+## Finding class taxonomy
+
+When this skill acts as plan reviewer (per `AGENTS.md` →
+*Plan review protocol* — *Review rule*) or as spec reviewer in the
+SPECS stage, every finding it emits SHALL carry exactly one `class:`
+field whose value is `tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2 and `docs/plan-format.md` → *Finding tag schema*). The tag is the
+only signal the routing engine reads to pick the loop target; a
+finding without it is malformed and SHALL be retagged before the
+orchestrator consumes the verdict (see
+[`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md) →
+*Class tagging discipline*). Do not default to `tech` when the class
+is ambiguous — escalate upstream per ADR-0010 →
+*Finding classification taxonomy*.
 
 ## Friction reporting
 

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -115,6 +115,21 @@ independent — serialise them.
   asks. The diff is the summary.
 - Comments only where the *why* is non-obvious. Do not narrate *what*
   the code does — the code already does that.
+
+## Finding class taxonomy
+
+When re-spawned as the DEV target of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the brief carries reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and SHALL surface a violation back to the
+orchestrator if any incoming finding it is asked to address omits
+the tag — a missing tag is a reviewer protocol error, not a hint to
+guess at the loop target. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -139,6 +139,21 @@ returns exit 0 (clean) or exit 1 (findings).
 All five scripts use `command -v <tool>` before invoking optional
 tools and print a one-line note when degrading, so a missing tool
 never aborts the review.
+
+## Finding class taxonomy
+
+Every finding emitted by this skill — blocking and non-blocking
+alike — SHALL carry exactly one `class:` field whose value is
+`tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2). The tag drives the retroactive routing engine's loop target
+(see [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md));
+findings without it are malformed and trigger a retag round-trip
+that does NOT count against the max-iteration guardrail. Tag every
+finding individually — a single section header above multiple
+findings is not sufficient. Non-blocking findings still need the
+tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
+through the matrix as if blocking.
 
 ## Grounding discipline
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 
@@ -203,6 +203,26 @@ iteration.
 In **AUTO** mode the same discipline applies with no user round-trip:
 unresolved items land under the prefix `[AUTO-PARKED]` and the user
 audits after the fact via the spec PR.
+
+## Finding class taxonomy
+
+This skill participates in the retroactive review loop on both ends
+(per [`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2, R6 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*):
+
+- **As reviewer.** When the skill reviews a spec-PR (originating or
+  delta), every finding it emits SHALL carry exactly one `class:`
+  field whose value is `tech`, `arch`, or `spec`. Untagged findings
+  are malformed and trigger a retag round-trip that does NOT
+  increment the iteration counter.
+- **As re-spawn target.** When invoked on a `class: spec` REVIEW
+  finding (activation trigger 3 above), the skill operates in
+  **delta-spec mode only** — the original spec on `main` is
+  immutable per ADR-0010 and spec 0003. The `superseded` transition
+  is a new-ticket path outside the loop. The skill SHALL surface a
+  violation if the incoming routing request omits the `class:` tag
+  or asks for a non-delta re-author of an existing spec.
 
 ## Harness friction tagging
 

--- a/.gemini/skills/tester/SKILL.md
+++ b/.gemini/skills/tester/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.2.1"
 ---
 
 
@@ -135,6 +135,21 @@ to be re-attempted.
 - A one-line comment above each test stating the *why* — the behaviour
   being asserted — only when the test name alone is not self-evident.
 - Test data inline when small; in fixtures when reused or large.
+
+## Finding class taxonomy
+
+When re-spawned as part of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the skill consumes reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and that touch the test surface, and SHALL
+surface a violation back to the orchestrator if any incoming
+finding it is asked to address omits the tag — a missing tag is a
+reviewer protocol error. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/.github/skills/architect/SKILL.md
+++ b/.github/skills/architect/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -136,6 +136,22 @@ does this trace to a file path, a command output, or a sentence in my
 brief? If no, delete it or downgrade it to "assumption — verify
 before relying on this". The self-check is cheap; an ADR that
 recommends a design around a non-existent surface is not.
+
+## Finding class taxonomy
+
+When this skill acts as plan reviewer (per `AGENTS.md` →
+*Plan review protocol* — *Review rule*) or as spec reviewer in the
+SPECS stage, every finding it emits SHALL carry exactly one `class:`
+field whose value is `tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2 and `docs/plan-format.md` → *Finding tag schema*). The tag is the
+only signal the routing engine reads to pick the loop target; a
+finding without it is malformed and SHALL be retagged before the
+orchestrator consumes the verdict (see
+[`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md) →
+*Class tagging discipline*). Do not default to `tech` when the class
+is ambiguous — escalate upstream per ADR-0010 →
+*Finding classification taxonomy*.
 
 ## Friction reporting
 

--- a/.github/skills/developer/SKILL.md
+++ b/.github/skills/developer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -115,6 +115,21 @@ independent — serialise them.
   asks. The diff is the summary.
 - Comments only where the *why* is non-obvious. Do not narrate *what*
   the code does — the code already does that.
+
+## Finding class taxonomy
+
+When re-spawned as the DEV target of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the brief carries reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and SHALL surface a violation back to the
+orchestrator if any incoming finding it is asked to address omits
+the tag — a missing tag is a reviewer protocol error, not a hint to
+guess at the loop target. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -139,6 +139,21 @@ returns exit 0 (clean) or exit 1 (findings).
 All five scripts use `command -v <tool>` before invoking optional
 tools and print a one-line note when degrading, so a missing tool
 never aborts the review.
+
+## Finding class taxonomy
+
+Every finding emitted by this skill — blocking and non-blocking
+alike — SHALL carry exactly one `class:` field whose value is
+`tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2). The tag drives the retroactive routing engine's loop target
+(see [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md));
+findings without it are malformed and trigger a retag round-trip
+that does NOT count against the max-iteration guardrail. Tag every
+finding individually — a single section header above multiple
+findings is not sufficient. Non-blocking findings still need the
+tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
+through the matrix as if blocking.
 
 ## Grounding discipline
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 
@@ -203,6 +203,26 @@ iteration.
 In **AUTO** mode the same discipline applies with no user round-trip:
 unresolved items land under the prefix `[AUTO-PARKED]` and the user
 audits after the fact via the spec PR.
+
+## Finding class taxonomy
+
+This skill participates in the retroactive review loop on both ends
+(per [`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2, R6 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*):
+
+- **As reviewer.** When the skill reviews a spec-PR (originating or
+  delta), every finding it emits SHALL carry exactly one `class:`
+  field whose value is `tech`, `arch`, or `spec`. Untagged findings
+  are malformed and trigger a retag round-trip that does NOT
+  increment the iteration counter.
+- **As re-spawn target.** When invoked on a `class: spec` REVIEW
+  finding (activation trigger 3 above), the skill operates in
+  **delta-spec mode only** — the original spec on `main` is
+  immutable per ADR-0010 and spec 0003. The `superseded` transition
+  is a new-ticket path outside the loop. The skill SHALL surface a
+  violation if the incoming routing request omits the `class:` tag
+  or asks for a non-delta re-author of an existing spec.
 
 ## Harness friction tagging
 

--- a/.github/skills/tester/SKILL.md
+++ b/.github/skills/tester/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.2.1"
 ---
 
 
@@ -135,6 +135,21 @@ to be re-attempted.
 - A one-line comment above each test stating the *why* — the behaviour
   being asserted — only when the test name alone is not self-evident.
 - Test data inline when small; in fixtures when reused or large.
+
+## Finding class taxonomy
+
+When re-spawned as part of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the skill consumes reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and that touch the test surface, and SHALL
+surface a violation back to the orchestrator if any incoming
+finding it is asked to address omits the tag — a missing tag is a
+reviewer protocol error. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,6 +499,8 @@ user.
 | 4 | `pr-logbook` | Draft PR title, body, and logbook entry |
 | 5 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
 
+**REVIEW is a looping stage**, not terminal — the orchestrator follows the routing engine documented in [`docs/retroactive-loop.md`](docs/retroactive-loop.md) until the termination criterion is met.
+
 **Ordering constraint:** `pr-logbook` MUST open the PR (or hand the complete
 draft to `team-lead` for opening) before `pr-reviewer` is spawned. The
 orchestrator MUST NOT parallelise these two roles — `pr-reviewer` cannot
@@ -523,6 +525,8 @@ Lighter pipeline — no code, no tests.
 | 2 | `pr-logbook` | Draft PR title, body, and logbook entry |
 | 3 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
 
+**REVIEW is a looping stage**, not terminal — the orchestrator follows the routing engine documented in [`docs/retroactive-loop.md`](docs/retroactive-loop.md) until the termination criterion is met.
+
 **Ordering constraint:** `pr-logbook` MUST open the PR (or hand the complete
 draft to `team-lead` for opening) before `pr-reviewer` is spawned. The
 orchestrator MUST NOT parallelise these two roles — `pr-reviewer` cannot
@@ -546,6 +550,8 @@ to lock in reproduction.
 | 2 | `developer` | Implement the fix until the regression test passes |
 | 3 | `pr-logbook` | Draft PR title, body, and logbook entry |
 | 4 | `pr-reviewer` | Independent cold review of the diff; verifies CI checks pass before posting verdict |
+
+**REVIEW is a looping stage**, not terminal — the orchestrator follows the routing engine documented in [`docs/retroactive-loop.md`](docs/retroactive-loop.md) until the termination criterion is met.
 
 **Ordering constraint:** `pr-logbook` MUST open the PR (or hand the complete
 draft to `team-lead` for opening) before `pr-reviewer` is spawned. The
@@ -734,6 +740,19 @@ comment break the retroactive review loop's audit trail and are
 prohibited.
 
 ## Retroactive review loop
+
+This section operationalises the REVIEW stage of the lifecycle (per
+ADR-0010 → *Stage definitions → REVIEW*) and the routing contract
+mandated by [`specs/0005-retroactive-routing-engine.md`](specs/0005-retroactive-routing-engine.md).
+The engine is **doc-only**: the orchestrator (the `team-lead` role)
+follows the procedure documented in
+[`docs/retroactive-loop.md`](docs/retroactive-loop.md), which is the
+reference home for the routing precedence, the iteration mechanics,
+the termination check, the max-iteration guardrail, and the
+mode-conditional handling of non-blocking findings. The iteration
+counter SHALL be persisted as a GitHub label `iter:N` on the PR whose
+content the iteration is reshaping (implementation-PR for `tech` /
+`arch`; the active delta spec-PR for `spec`).
 
 Every REVIEW finding SHALL be tagged with exactly one class. Class
 drives the loop target.

--- a/community-config/skills/architect/SKILL.md
+++ b/community-config/skills/architect/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 claude:
   allowed-tools:
     - Read
@@ -146,6 +146,22 @@ does this trace to a file path, a command output, or a sentence in my
 brief? If no, delete it or downgrade it to "assumption — verify
 before relying on this". The self-check is cheap; an ADR that
 recommends a design around a non-existent surface is not.
+
+## Finding class taxonomy
+
+When this skill acts as plan reviewer (per `AGENTS.md` →
+*Plan review protocol* — *Review rule*) or as spec reviewer in the
+SPECS stage, every finding it emits SHALL carry exactly one `class:`
+field whose value is `tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2 and `docs/plan-format.md` → *Finding tag schema*). The tag is the
+only signal the routing engine reads to pick the loop target; a
+finding without it is malformed and SHALL be retagged before the
+orchestrator consumes the verdict (see
+[`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md) →
+*Class tagging discipline*). Do not default to `tech` when the class
+is ambiguous — escalate upstream per ADR-0010 →
+*Finding classification taxonomy*.
 
 ## Friction reporting
 

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 claude:
   allowed-tools:
     - Read
@@ -127,6 +127,21 @@ independent — serialise them.
   asks. The diff is the summary.
 - Comments only where the *why* is non-obvious. Do not narrate *what*
   the code does — the code already does that.
+
+## Finding class taxonomy
+
+When re-spawned as the DEV target of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the brief carries reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and SHALL surface a violation back to the
+orchestrator if any incoming finding it is asked to address omits
+the tag — a missing tag is a reviewer protocol error, not a hint to
+guess at the loop target. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/community-config/skills/pr-reviewer/SKILL.md
+++ b/community-config/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 claude:
   allowed-tools:
     - Read
@@ -150,6 +150,21 @@ returns exit 0 (clean) or exit 1 (findings).
 All five scripts use `command -v <tool>` before invoking optional
 tools and print a one-line note when degrading, so a missing tool
 never aborts the review.
+
+## Finding class taxonomy
+
+Every finding emitted by this skill — blocking and non-blocking
+alike — SHALL carry exactly one `class:` field whose value is
+`tech`, `arch`, or `spec` (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2). The tag drives the retroactive routing engine's loop target
+(see [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md));
+findings without it are malformed and trigger a retag round-trip
+that does NOT count against the max-iteration guardrail. Tag every
+finding individually — a single section header above multiple
+findings is not sufficient. Non-blocking findings still need the
+tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
+through the matrix as if blocking.
 
 ## Grounding discipline
 

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.0.0"
+    version: "1.0.1"
 claude:
   allowed-tools:
     - Read
@@ -215,6 +215,26 @@ iteration.
 In **AUTO** mode the same discipline applies with no user round-trip:
 unresolved items land under the prefix `[AUTO-PARKED]` and the user
 audits after the fact via the spec PR.
+
+## Finding class taxonomy
+
+This skill participates in the retroactive review loop on both ends
+(per [`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R2, R6 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*):
+
+- **As reviewer.** When the skill reviews a spec-PR (originating or
+  delta), every finding it emits SHALL carry exactly one `class:`
+  field whose value is `tech`, `arch`, or `spec`. Untagged findings
+  are malformed and trigger a retag round-trip that does NOT
+  increment the iteration counter.
+- **As re-spawn target.** When invoked on a `class: spec` REVIEW
+  finding (activation trigger 3 above), the skill operates in
+  **delta-spec mode only** — the original spec on `main` is
+  immutable per ADR-0010 and spec 0003. The `superseded` transition
+  is a new-ticket path outside the loop. The skill SHALL surface a
+  violation if the incoming routing request omits the `class:` tag
+  or asks for a non-delta re-author of an existing spec.
 
 ## Harness friction tagging
 

--- a/community-config/skills/tester/SKILL.md
+++ b/community-config/skills/tester/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.2.0"
+    version: "1.2.1"
 claude:
   allowed-tools:
     - Read
@@ -147,6 +147,21 @@ to be re-attempted.
 - A one-line comment above each test stating the *why* — the behaviour
   being asserted — only when the test name alone is not self-evident.
 - Test data inline when small; in fixtures when reused or large.
+
+## Finding class taxonomy
+
+When re-spawned as part of a `tech`-class iteration of the
+retroactive review loop (per
+[`specs/0005-retroactive-routing-engine.md`](../../../specs/0005-retroactive-routing-engine.md)
+R4 and [`docs/retroactive-loop.md`](../../../docs/retroactive-loop.md)
+→ *Routing matrix*), the skill consumes reviewer findings each
+tagged with a `class:` field. The skill SHALL act on findings whose
+`class:` is `tech` and that touch the test surface, and SHALL
+surface a violation back to the orchestrator if any incoming
+finding it is asked to address omits the tag — a missing tag is a
+reviewer protocol error. Findings tagged `arch` or `spec` are
+out-of-scope for this skill and indicate misrouting; flag and
+return.
 
 ## Friction reporting
 

--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -1,0 +1,247 @@
+# Retroactive review loop
+
+This document is the normative reference for the **retroactive routing
+engine** that closes the REVIEW stage of the lifecycle introduced in
+[ADR-0010](adr/0010-spec-plan-review-lifecycle.md) — specifically
+*Stage definitions → REVIEW*. It operationalises the requirements of
+[`specs/0005-retroactive-routing-engine.md`](../specs/0005-retroactive-routing-engine.md)
+and the contract layered on top by `AGENTS.md` → *Retroactive review
+loop*. Every section below traces back to one of spec 0005's
+requirements R1..R14.
+
+## Doc-only engine
+
+The engine is **a documented procedure the orchestrator (the
+`team-lead` role) follows**, not an executable script (spec 0005 R1).
+Until friction on the first ten real REVIEW loops justifies otherwise,
+no helper binary, no parser, no review-comment crawler ships with this
+spec — the orchestrator reads the verdict, applies the rules below,
+and acts. A scripted variant is a candidate follow-up tracked in
+`specs/0005-retroactive-routing-engine.md` → *Out of scope*; pre-empting
+it would encode guesses about a routing surface no live run has
+exercised end-to-end.
+
+The reading audience is the orchestrator. Reviewers (`architect`,
+`pr-reviewer`, `spec-author` when acting as spec reviewer) need only
+the *Class tagging discipline* section below; downstream skills
+(`developer`, `tester`, `spec-author` in delta mode) need only the
+*Routing matrix* row that names them.
+
+## Routing matrix
+
+The matrix below is the engine's authoritative reference. It is also
+restated in condensed form in `AGENTS.md` → *Retroactive review loop*
+for cross-section navigability; the duplication is intentional, and
+the two surfaces SHALL stay in lockstep when either is amended.
+
+| Class | Loop target | Re-spawn sequence | Spec-PR impact |
+|---|---|---|---|
+| `tech` | DEV | `developer` (+ `tester` if the touched surface includes test code) | none |
+| `arch` | PLAN | `architect` (PLAN-author) → on revalidation, DEV team re-runs from start of the matching template (per `AGENTS.md` → *Standard Team Templates*) | none |
+| `spec` | SPECS | `spec-author` in delta-spec mode → spec-PR review → on merge, PLAN re-runs (fresh `architect`), then DEV team re-runs | new delta-spec PR (per spec 0003 → *Delta-spec cumulative rule*) |
+
+The re-spawn columns are minimums. Every re-spawn SHALL apply the
+`security` rule from `AGENTS.md` → *Standard Team Templates →
+Security rule* if the touched surface qualifies; the engine does not
+override the rule, it inherits it.
+
+## Class tagging discipline
+
+Every reviewer finding SHALL carry exactly one `class:` field whose
+value is one of `tech`, `arch`, or `spec` (spec 0005 R2). The tag is
+the only signal the engine reads — without it, routing is undefined.
+
+**Untagged-finding round-trip.** A REVIEW verdict that contains at
+least one finding without a `class:` field is *malformed*. The
+orchestrator SHALL NOT consume it. Instead (spec 0005 R3):
+
+1. Post a comment on the relevant PR (implementation-PR for `tech` /
+   `arch` candidates, spec-PR for `spec` candidates) explicitly
+   requesting retagging, naming each unlabeled finding by its index.
+2. Re-spawn the reviewer cold (same role, fresh agent) with the retag
+   instruction.
+3. **Do NOT increment the iteration counter for this pass.** A
+   malformed verdict does not count as an iteration consumed against
+   the max-iteration guardrail (R9). The engine refuses to penalise
+   the implementation team for the reviewer's protocol violation.
+
+The orchestrator SHALL NOT default an untagged finding to `tech` — a
+silent default would conceal a reviewer defect and would drift the
+loop target away from the most upstream class present.
+
+## Routing precedence
+
+A single REVIEW pass MAY surface findings of multiple classes. The
+engine SHALL pick the **most upstream class present** and route the
+entire iteration to the corresponding stage (spec 0005 R4):
+
+```text
+precedence:  spec  >  arch  >  tech
+```
+
+Findings of lower-precedence classes from the same pass SHALL NOT be
+silently dropped — they SHALL be re-tagged onto the next iteration's
+verdict by the next reviewer spawned cold (spec 0005 R5). The engine
+does not parallelise multi-class routing within a single iteration;
+parallelising would fan out the team and require synchronising N
+upstream re-spawns against a single PR, which the spec-PR workflow
+(spec 0003) and the plan-review protocol (spec 0004) explicitly
+forbid by their one-artefact-per-stage discipline.
+
+The disambiguation rule on a tie at SPECS time (`arch` vs `spec`,
+`tech` vs `arch`) — escalate upstream — lives in ADR-0010 →
+*Finding classification taxonomy*. The engine inherits it; it does
+not redefine it.
+
+## Spec-class loop — delta mode only
+
+A `spec`-class iteration SHALL invoke `spec-author` in **delta-spec
+mode** (spec 0005 R6). The original spec on `main` is immutable per
+ADR-0010 and spec 0003 — the delta-spec accumulates as a new file
+`/specs/<NNNN>-<slug>.delta-<NN>.md` on a fresh branch
+`spec/<NNNN>-<slug>-delta-<NN>` cut from `main`, reviewed as its own
+spec-PR, and merged independently. The implementation-PR then
+absorbs the delta on the next iteration per spec 0003 →
+*Delta-spec cumulative rule*.
+
+Re-authoring a fundamentally broken spec — status transition to
+`superseded` — is **out of the loop**. It is a new-ticket path:
+abandon the implementation-PR, open a fresh ticket whose SPECS stage
+authors a replacement spec (frontmatter `superseded-by: <new-id>` on
+the old, `superseded` on its status line). The loop owns deltas;
+it does not own full re-authoring.
+
+## Iteration counter — GitHub label
+
+The iteration counter SHALL be persisted as a GitHub label `iter:N`
+on the PR (spec 0005 R7). The label is the engine's source of truth
+for "what iteration are we on" — no shadow counter in memory, no
+parsing of comment timestamps, no spreadsheet.
+
+**Which PR carries the label.** The label lives on the PR whose
+content the iteration is reshaping:
+
+- `tech` and `arch` iterations → label on the **implementation-PR**
+  (`feat/<NNNN>-<slug>` or sibling).
+- `spec` iterations → label on the **spec-PR** for the active delta
+  (`spec/<NNNN>-<slug>-delta-<NN>`). Once the delta-spec merges and
+  the implementation-PR resumes its loop, the implementation-PR's
+  `iter:N` label increments on the next pass; the spec-PR's label
+  becomes a permanent record of how many spec-class passes the
+  ticket required.
+
+**Increment mechanism.** Atomic via the GitHub label API:
+
+```sh
+gh pr edit <pr-number> --add-label "iter:<N>" --remove-label "iter:<N-1>"
+```
+
+Run the command at the **start of every new iteration**, after a
+verdict has been validated as well-formed (untagged-finding round-
+trips do NOT increment, see *Class tagging discipline* above). The
+command is idempotent against repeated invocation on the same N and
+cross-session-safe by virtue of being a GitHub primitive — two
+sibling orchestrators racing the same PR converge on the same label
+state without coordinating through MemPalace.
+
+**Initial label.** The first REVIEW pass on a freshly opened PR
+implies `iter:1`; the engine SHALL apply the `iter:1` label at the
+moment the first verdict is consumed, not at PR open time. PRs that
+never need a second pass therefore carry exactly one `iter:N` label
+on merge — a useful searchable signal for ticket-difficulty
+retrospectives.
+
+## Termination
+
+The lifecycle terminates at MERGE iff all three conditions hold on
+the same REVIEW pass (spec 0005 R8):
+
+1. The verdict line is `### Verdict: APPROVE`.
+2. The pass surfaces **zero** findings of any class (blocking or
+   non-blocking — see *Non-blocking conditional routing* for the
+   non-blocking distinction).
+3. CI is **green** on the head commit reviewed. The engine SHALL
+   query `gh pr checks <pr-number>` and confirm every required
+   check is `pass`; pending or failing checks block termination
+   regardless of the verdict text.
+
+All three are necessary. An APPROVE with one nit is one finding away
+from termination. An APPROVE with zero findings and red CI is a
+reviewer who skipped the CI-status section of `pr-reviewer` →
+*Preflight*; the engine SHALL flag this as a protocol violation and
+re-spawn the reviewer cold.
+
+## Max-iteration guardrail
+
+The loop SHALL halt after **5 iterations** without termination (spec
+0005 R9). The default is configurable per ticket via the spec
+frontmatter `max-iterations` field (`docs/spec-format.md` →
+*Frontmatter schema*); the engine reads the value at SPECS time and
+caches it for the duration of the lifecycle.
+
+On halt, the orchestrator SHALL:
+
+1. Post a structured summary comment on the logbook issue. The
+   summary lists, per iteration: the class routed, the role(s)
+   re-spawned, the verdict outcome, and the carry-over findings (if
+   any).
+2. **Page the user regardless of mode** — including AUTO. The
+   guardrail is the one place where AUTO breaks its
+   no-user-round-trip contract: five autonomous iterations without
+   convergence is the engine's signal that the ticket has crossed
+   from "automation-tractable" to "needs human judgment", and the
+   user is the only role that can decide the next move (abandon,
+   re-scope, lift the cap, etc.).
+
+The guardrail SHALL NOT auto-increment past the cap. The orchestrator
+stops the loop; the user resumes it (or terminates it) explicitly.
+
+## Non-blocking conditional routing
+
+Reviewer findings carry an implicit *blocking* / *non-blocking*
+classification: blocking findings prevent merge, non-blocking
+findings are observations the reviewer surfaces without gating the
+verdict. The engine routes non-blocking findings conditionally on
+the lifecycle's interaction mode (spec 0005 R10):
+
+| Mode | Non-blocking finding handling |
+|---|---|
+| **FULL** | Apply `AGENTS.md` → *Team Communication → Rule 4*: the orchestrator presents every non-blocking finding to the user and routes only those the user accepts into the loop. Findings the user defers are journalled in the logbook and left unactioned. |
+| **INTERMEDIATE** | Same as FULL — Rule 4 applies; the user decides. |
+| **MINIMAL** | The orchestrator SHALL route every non-blocking finding into the loop using the same precedence matrix as blocking findings. In autonomous modes there is no user to defer to. |
+| **AUTO** | Same as MINIMAL — non-blocking becomes effectively blocking, routed via the matrix. |
+
+The asymmetry reflects the lifecycle's gating philosophy: modes that
+keep the user in the loop give the user the last word on scope; modes
+that explicitly delegate scope to the engine route every signal
+through the matrix so that termination genuinely means "no work
+left", not "no work the engine bothered to do".
+
+## Worked example — PR #183 iteration 2
+
+The closest live fixture is the second iteration of PR #183 (the
+plan-format ticket, issue #169), where the cold review surfaced three
+non-blocking findings under `INTERMEDIATE` mode. Per the table above,
+the orchestrator applied Rule 4: each finding was presented to the
+user, who decided which to absorb in-session and which to journal.
+The PR merged after the user-accepted findings landed.
+
+The fixture predates this spec's `iter:N` label convention — the
+label was not applied retroactively — so readers should treat the
+example as a *retrofit* ("had the engine existed, here is how it
+would have routed") rather than a literal record of label state.
+The substantive routing decision the example demonstrates — three
+non-blocking findings, INTERMEDIATE mode, Rule 4 deciding which
+absorb and which defer — is the engine's intended behaviour
+unchanged.
+
+- <https://github.com/crewrig/crewrig/pull/183>
+
+## Cross-references
+
+- Spec 0005 — [`specs/0005-retroactive-routing-engine.md`](../specs/0005-retroactive-routing-engine.md).
+- ADR-0010 — [`docs/adr/0010-spec-plan-review-lifecycle.md`](adr/0010-spec-plan-review-lifecycle.md), specifically *Stage definitions → REVIEW* and *Finding classification taxonomy*.
+- Plan format and review protocol — [`docs/plan-format.md`](plan-format.md) and `AGENTS.md` → *Plan review protocol*.
+- Spec format and delta-spec convention — [`docs/spec-format.md`](spec-format.md).
+- Spec-PR workflow — [`specs/0003-spec-pr-workflow.md`](../specs/0003-spec-pr-workflow.md) and `AGENTS.md` → *Spec-PR workflow*.
+- Team Communication Rule 4 — `AGENTS.md` → *Agent Team Protocol → Team Communication*.


### PR DESCRIPTION
Implements the **Retroactive review loop engine** mandated by spec 0005 — the normative reference that documents how REVIEW findings are routed back into SPECS / PLAN / DEV and how the loop terminates. Doc-only by design (R1): five skills gain a `Finding class taxonomy` paragraph pointing to `docs/retroactive-loop.md`, AGENTS.md gains a short preamble, and the built outputs are regenerated.

## How to read this PR?

1. **`specs/0005-retroactive-routing-engine.md`** (already on `main` via #184) — the WHAT (R1..R14).
2. **Validated PLAN comment on #172** — the HOW (user-validated, INTERMEDIATE mode).
3. **`docs/retroactive-loop.md`** (new, 247 lines) — the normative engine reference. Covers the routing matrix, `iter:N` label semantics, the termination triple, the max-iteration halt, the untagged-finding round-trip, mode-conditional non-blocking, and a worked example traced to PR #183.
4. **`AGENTS.md` diff** (+19/-0) — preamble at the top of the *Retroactive review loop* section + one-line looping-stage notes under Templates 1/2/3 in *Standard Team Templates*. No duplication of the routing matrix.
5. **Five skill `SKILL.md` source diffs** — `architect`, `pr-reviewer`, `developer`, `tester`, `spec-author` each gain a 3–6 line *Finding class taxonomy* paragraph and bump PATCH per *Version Bump Convention*.
6. **Built outputs under `.claude/`, `.gemini/`, `.github/`** — regenerated from sources via `scripts/build-components.sh`; included in the same commit per *Built Components* rule.

## How to test this PR?

- [ ] `npx markdownlint-cli AGENTS.md docs/retroactive-loop.md community-config/skills/{architect,pr-reviewer,developer,tester,spec-author}/SKILL.md` → zero errors.
- [ ] `bash scripts/build-components.sh && git status --porcelain` → empty (zero drift between sources and built outputs).
- [ ] Confirm `docs/retroactive-loop.md` covers all of R1..R14 from spec 0005 (routing matrix, `iter:N` label, termination triple, max-iter halt, untagged-finding round-trip, mode-conditional non-blocking, worked example to PR #183).
- [ ] Confirm `AGENTS.md` carries the preamble at the top of *Retroactive review loop* and the one-line looping-stage note under each of Templates 1/2/3.
- [ ] Confirm the five skill sources each bumped PATCH: `architect` 1.1.0→1.1.1; `pr-reviewer` 1.1.0→1.1.1; `developer` 1.1.2→1.1.3; `tester` 1.2.0→1.2.1; `spec-author` 1.0.0→1.0.1.
- [ ] Confirm `docs/cli-matrix.md` is **not** touched (per validated PLAN — no per-CLI behaviour added; the five sources stay symmetric).

## Detailed description (for agents)

This is the **implementation PR** of the spec-PR / impl-PR split mandated by *Spec-PR workflow* (#170). The corresponding spec-PR is **#184** (merged: `dc13985` — `📝 Spec 0005 — retroactive routing engine (#172) (#184)`). This PR is the second leg and realises spec 0005 (`specs/0005-retroactive-routing-engine.md`, immutable on `main`).

It is also the **third lifecycle ticket** processed end-to-end through the ADR-0010 four-stage lifecycle (after #170 → #181 and #169 → #183). The engine documented here is precisely what the orchestrator has been doing manually for those first three iterations.

### Artefact cluster 1 — New normative doc

`docs/retroactive-loop.md` (247 lines). Each R1..R14 from spec 0005 is mapped to a section:

- The full routing matrix (finding class × loop target × re-spawn × spec-PR impact).
- `iter:N` GitHub label semantics — atomic, visible, cross-session-safe via `gh` CLI; the iteration counter lives on the impl-PR for `tech`/`arch` and on the spec-PR for `spec`.
- Termination triple: APPROVE verdict + zero findings + CI green on the head commit reviewed.
- Max-iteration guardrail: halts at 5 (configurable in spec frontmatter), posts a structured summary on the logbook issue, and pages the user regardless of mode (AUTO included).
- Untagged-finding round-trip — reviewers MUST tag every finding with a `class:`; missing tag triggers a single round-trip back to the reviewer for retagging.
- Mode-conditional non-blocking semantics per Interaction modes.
- Worked example tracing back to PR #183 (the second lifecycle ticket).

### Artefact cluster 2 — `AGENTS.md`

`AGENTS.md` (+19/-0):

- Preamble at the top of the *Retroactive review loop* section pointing at `docs/retroactive-loop.md` as the normative engine reference.
- One-line "looping-stage" note under each of Templates 1, 2, 3 in *Standard Team Templates* clarifying which roles are re-spawned for each finding class.
- No duplication of the routing matrix — the matrix lives in `docs/retroactive-loop.md` only.

### Artefact cluster 3 — Five skill sources + built outputs

`community-config/skills/{architect,pr-reviewer,developer,tester,spec-author}/SKILL.md` each gain a *Finding class taxonomy* paragraph (3–6 lines) explaining how that role participates in the loop, with a pointer to `docs/retroactive-loop.md`. Each source bumps PATCH per *Version Bump Convention*.

Built outputs under `.claude/skills/`, `.gemini/skills/`, `.github/skills/` regenerated via `bash scripts/build-components.sh` and staged in the same commit (`b17ad7d`) per *Built Components* rule.

### CLI-matrix decision

`docs/cli-matrix.md` is intentionally **not** modified, argued on the merits in the validated PLAN's *Blast radius* section. `community-config/**` is on the *Trigger surface* of the CLI-matrix obligation, so consultation is mandatory — but no per-CLI behaviour is added or modified: the five sources stay symmetric, the build emits the same artefact shape across `.claude/`, `.gemini/`, and `.github/`. No parity gap is introduced and the matrix's rows remain accurate; an edit would be noise.

### Engine is doc-only by design

R1 mandates that this iteration ships **no script and no automation** — the engine is what the orchestrator already does manually. Automating the routing engine (label flipping, re-spawn composition, untagged-finding round-trip) is deferred to a follow-up ticket and SHALL only be opened if real friction surfaces after the first 10 production REVIEW loops.

Closes #172
