### PR TITLE
✨ Interaction modes matrix + tier sizing + pr-reviewer tier-challenge (#173)

### DIFF
--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -159,6 +159,17 @@ finding individually — a single section header above multiple
 findings is not sufficient. Non-blocking findings still need the
 tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
 through the matrix as if blocking.
+
+## Spec-review obligation — tier challenge
+
+When acting as a spec-reviewer (cold-spawned to review a spec-PR), the
+role MUST challenge a complexity tier that appears under-stated
+relative to the spec's declared blast radius. Emit a `class: spec`
+finding citing `AGENTS.md → Team sizing by complexity`. Under-statement
+is detected when the spec's `## Requirements` or `## Out of scope`
+enumerate a surface broader than the declared tier admits (per the
+tier table). Over-statement is a non-blocking observation, not a
+blocking finding.
 
 ## Grounding discipline
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -154,6 +154,17 @@ finding individually — a single section header above multiple
 findings is not sufficient. Non-blocking findings still need the
 tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
 through the matrix as if blocking.
+
+## Spec-review obligation — tier challenge
+
+When acting as a spec-reviewer (cold-spawned to review a spec-PR), the
+role MUST challenge a complexity tier that appears under-stated
+relative to the spec's declared blast radius. Emit a `class: spec`
+finding citing `AGENTS.md → Team sizing by complexity`. Under-statement
+is detected when the spec's `## Requirements` or `## Out of scope`
+enumerate a surface broader than the declared tier admits (per the
+tier table). Over-statement is a non-blocking observation, not a
+blocking finding.
 
 ## Grounding discipline
 

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -154,6 +154,17 @@ finding individually — a single section header above multiple
 findings is not sufficient. Non-blocking findings still need the
 tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
 through the matrix as if blocking.
+
+## Spec-review obligation — tier challenge
+
+When acting as a spec-reviewer (cold-spawned to review a spec-PR), the
+role MUST challenge a complexity tier that appears under-stated
+relative to the spec's declared blast radius. Emit a `class: spec`
+finding citing `AGENTS.md → Team sizing by complexity`. Under-statement
+is detected when the spec's `## Requirements` or `## Out of scope`
+enumerate a surface broader than the declared tier admits (per the
+tier table). Over-statement is a non-blocking observation, not a
+blocking finding.
 
 ## Grounding discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,6 +461,11 @@ trigger surface (e.g. `security`, `architect`). Either adjustment requires a
 one-line rationale in the task handoff comment. Ad-hoc partial crews —
 omitting roles without justification — are prohibited.
 
+The templates below describe the **`standard`**-tier composition.
+Trivial / small / large tickets follow the tier-specific rules in
+*Team sizing by complexity* below; consult that section before
+spawning a team.
+
 **Security rule (applies to all templates):** When a change touches the
 security skill's trigger surface (authentication, authorization, secrets,
 cryptography, input parsing, deserialization, network calls, or dependency
@@ -562,6 +567,47 @@ Communication → Rule 1*).
 
 `architect` is optional: include it only when the root cause exposes a
 design flaw rather than a localized defect.
+
+### Team sizing by complexity
+
+The complexity tier declared in a spec's frontmatter (per ADR-0010 →
+*Complexity tiers and team sizing* and
+[`specs/0006-interaction-modes-and-sizing.md`](specs/0006-interaction-modes-and-sizing.md)
+R4) determines the DEV-stage team composition. The orchestrator reads
+the tier once at ticket pickup and spawns the matching team. The four
+tiers and their exact compositions:
+
+| Tier | DEV-stage team | Notes |
+|---|---|---|
+| `trivial` | No team — orchestrator handles the work inline in a single turn. | Bypasses `spec-author` per *Standard Team Templates → Step 0*. The `AskUserQuestion` and merge-authorization gates of the declared interaction mode still apply to inline work. |
+| `small` | `developer` + `pr-logbook` + `pr-reviewer`. | No `architect` (the spec is its own architectural input). No `tester` unless the change carries a test surface; when added, slot `tester` between `developer` and `pr-logbook`. The *Security rule* still applies. |
+| `standard` | The matching Template (1 / 2 / 3) from *Standard Team Templates* above, unchanged. | Default tier when the frontmatter is silent. |
+| `large` | `architect`-led decomposition into one or more sub-specs **before** any `developer` spawn. | Each sub-spec is a separate ticket with its own SPECS-stage entry (a new spec file under `/specs/`, a new spec-PR, a new implementation-PR). The parent ticket coordinates; it does not implement. |
+
+**Selection rule.** The orchestrator SHALL read the `complexity`
+field from the merged spec's frontmatter at ticket pickup and SHALL
+NOT re-evaluate it mid-lifecycle. Per ADR-0010, the tier — like the
+interaction mode — is immutable once SPECS merges; correcting a
+mis-tagged tier requires a delta-spec PR routed through the
+retroactive review loop (`class: spec`).
+
+**Independence from interaction mode.** The tier and the interaction
+mode are orthogonal axes. Any combination is legitimate
+(e.g. `trivial` + `FULL`, `large` + `AUTO`) and the orchestrator
+SHALL NOT reject a spec on the basis of an unusual combination
+(spec 0006 R1). The mode governs user gating per *Interaction modes →
+Behavioural contract per (mode × stage) cell*; the tier governs team
+composition per the table above.
+
+**Spec-reviewer obligation.** When a spec-PR is cold-reviewed, the
+reviewer MUST challenge a tier that appears under-stated relative
+to the spec's declared blast radius (the union of
+`## Requirements` and the file paths the spec touches). The
+challenge is emitted as a `class: spec` finding citing this
+section — see
+[`community-config/skills/pr-reviewer/SKILL.md`](community-config/skills/pr-reviewer/SKILL.md)
+→ *Spec-review obligation — tier challenge*. Over-statement is a
+non-blocking observation, not a blocking finding.
 
 ### Team Communication
 
@@ -683,6 +729,63 @@ Rules:
 The mode-driven engine — argument parsing, gate enforcement, user
 notification surface — lands in #173. This section states the
 contract.
+
+### User-gate definition
+
+A **user gate** is defined narrowly as one of two actions:
+
+1. A call to `AskUserQuestion` (or the equivalent interactive prompt
+   exposed by the host CLI).
+2. The pre-merge authorization request mandated by *Branching
+   Strategy* — the explicit "may I merge?" question the agent MUST
+   ask JUST BEFORE every `gh pr merge` invocation.
+
+Both gates **block** agent execution until the user responds. Nothing
+else does. The following outputs are explicitly **NOT** user gates and
+SHALL NOT pause the agent:
+
+- Logbook comments (per *Logbook Issues → Rule B*) — informational.
+- Progress messages and intermediate `SendMessage` traffic between
+  teammates — coordination, not consent.
+- Idle notifications, status pings, and harness-level events —
+  observational.
+- ADR drafts, plan comments, review verdicts posted to a PR or issue
+  — artefacts of stage execution, audited asynchronously.
+
+The mode table above governs only the two gating actions. Whether the
+agent posts ADRs, plan comments, or REVIEW iteration notices in a
+given mode is fixed by the lifecycle contract (ADR-0010), independent
+of mode.
+
+### Behavioural contract per (mode × stage) cell
+
+Each cell below names precisely the user gates the orchestrator SHALL
+fire while running that stage in that mode. "—" means no gate; the
+stage runs autonomously and the user is informed (if at all) only via
+non-blocking artefacts (logbook comments, PR/spec-PR diffs to audit
+post hoc).
+
+| Stage \ Mode | FULL | INTERMEDIATE | MINIMAL | AUTO |
+|---|---|---|---|---|
+| **SPECS** | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | No interview gate (spec authored autonomously); merge-authorization gate before merging the spec-PR. |
+| **PLAN** | `AskUserQuestion` to validate the plan comment before DEV starts; second `architect` cold-review remains autonomous. | `AskUserQuestion` to validate the plan comment before DEV starts; second `architect` cold-review remains autonomous. | — (plan authored and cold-reviewed autonomously; DEV starts on APPROVE without user prompt). | — (plan authored and cold-reviewed autonomously). |
+| **DEV** | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). |
+| **REVIEW** | Non-blocking notification posted on the logbook issue at the start and end of every iteration (per the FULL-mode rule above). No `AskUserQuestion`. | — (loop runs autonomously; iteration count visible via the `iter:N` PR label). | — (loop runs autonomously). | — (loop runs autonomously; halt at max-iteration guardrail pages the user per *Retroactive review loop*). |
+
+Notes on the matrix:
+
+- The merge-authorization gate is **invariant across modes**: every
+  mode, including AUTO, MUST ask the user before any `gh pr merge`.
+  *Branching Strategy* is not waivable.
+- FULL-mode REVIEW notifications are non-blocking — posting them does
+  not pause the loop. They are listed under "REVIEW" only because
+  they are the FULL-mode-specific surface the orchestrator must
+  produce; they are not gates.
+- The max-iteration guardrail (*Retroactive review loop*) pages the
+  user in **every** mode, including AUTO. That paging is a gate by
+  exception — the loop has halted and the user must decide whether
+  to relax the iteration cap, accept the partial work, or close the
+  ticket. It is not part of the steady-state matrix above.
 
 ## Plan review protocol
 

--- a/community-config/skills/pr-reviewer/SKILL.md
+++ b/community-config/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.1"
+    version: "1.1.2"
 claude:
   allowed-tools:
     - Read
@@ -165,6 +165,17 @@ finding individually — a single section header above multiple
 findings is not sufficient. Non-blocking findings still need the
 tag: in autonomous modes (MINIMAL / AUTO) the engine routes them
 through the matrix as if blocking.
+
+## Spec-review obligation — tier challenge
+
+When acting as a spec-reviewer (cold-spawned to review a spec-PR), the
+role MUST challenge a complexity tier that appears under-stated
+relative to the spec's declared blast radius. Emit a `class: spec`
+finding citing `AGENTS.md → Team sizing by complexity`. Under-statement
+is detected when the spec's `## Requirements` or `## Out of scope`
+enumerate a surface broader than the declared tier admits (per the
+tier table). Over-statement is a non-blocking observation, not a
+blocking finding.
 
 ## Grounding discipline
 


### PR DESCRIPTION
Realise spec 0006 — expand the interaction-modes contract into a 16-cell behavioural matrix with a narrow user-gate definition, add a 4-tier complexity sizing table, and extend `pr-reviewer` with a spec-tier challenge obligation. This is the implementation leg of the spec-PR workflow (spec PR #186 already merged on `main`).

## How to read this PR?

1. **`specs/0006-interaction-modes-and-sizing.md` on `main`** — the WHAT (requirements R1..R9).
2. **Validated PLAN comment on issue #173** — the HOW (6 plan steps, plus the explicit decisions to skip a `docs/cli-matrix.md` edit and to defer audit corrections to delta-spec PRs).
3. **`AGENTS.md` diff** — three surgical edits: *Interaction modes* expanded with the user-gate definition + 16-cell behavioural contract (R1/R2/R3); new *Team sizing by complexity* section between *Standard Team Templates* and *Team Communication*, carrying the 4-tier table (R4); one-line cross-reference inserted into *Standard Team Templates* (R5).
4. **`community-config/skills/pr-reviewer/SKILL.md` diff** — new *Spec-review obligation — tier challenge* subsection (R6) + PATCH bump `1.1.1 → 1.1.2` per the *Version Bump Convention*.
5. **Build outputs** — three regenerated mirrors of `pr-reviewer/SKILL.md` under `.claude/`, `.gemini/`, `.github/` via `scripts/build-components.sh`.
6. **Audit logbook comment on #173** — DEV-time R8 sweep of the 5 merged specs, posted at https://github.com/crewrig/crewrig/issues/173#issuecomment-4590438953.

## How to test this PR?

1. `npx markdownlint-cli AGENTS.md community-config/skills/pr-reviewer/SKILL.md` → 0 errors.
2. `bash scripts/build-components.sh` then `git status --porcelain` → empty (no drift).
3. Confirm *Interaction modes* now carries the narrow user-gate definition + the 16-cell behavioural contract.
4. Confirm a new *Team sizing by complexity* section sits between *Standard Team Templates* and *Team Communication* with the 4-tier table.
5. Confirm `community-config/skills/pr-reviewer/SKILL.md` version bumped `1.1.1 → 1.1.2` and the tier-challenge subsection is present.
6. Confirm 5/5 audit verdicts posted as a logbook comment on #173, and that no merged spec file was edited.
7. Confirm no edit to `docs/cli-matrix.md` (intentional per validated PLAN — no per-CLI behaviour introduced).

## Detailed description (for agents)

This is the **fourth lifecycle ticket** processed end-to-end under ADR-0010 (after #170, #169, #172). It is the **second leg of the spec-PR workflow** for #173 — spec-PR #186 merged to `main` first, this implementation-PR realises that spec.

### `AGENTS.md` (+103 / -0)

Three surgical, additive edits — no rewording of pre-existing prose:

- **R1/R2/R3 — *Interaction modes* expansion.** Adds a narrow definition of *user gate* (a synchronous stop where the orchestrator must hand control back and await user input — distinct from a notification, which is fire-and-forget). Adds the 16-cell behavioural contract table cross-cutting the 4 modes (FULL / INTERMEDIATE / MINIMAL / AUTO) against the 4 user-touchpoint axes (SPECS gate, PLAN gate, REVIEW iteration notification, max-iter halt page).
- **R4 — *Team sizing by complexity* section.** New top-level section inserted between *Standard Team Templates* and *Team Communication*. Carries the 4-tier table (`trivial` / `small` / `standard` / `large`) mapping each tier to its team composition deltas relative to the standard templates. Mirrors ADR-0010 → *Complexity tiers and team sizing* without duplicating the rationale.
- **R5 — *Standard Team Templates* cross-reference.** One-line pointer added at the top of *Standard Team Templates* directing the reader to the new sizing section for non-standard tiers.
- **R7 — wording consistency.** Existing references to *Standard Team Templates → \\<role\\> rule* preserved verbatim; no incidental rewording.

### `community-config/skills/pr-reviewer/SKILL.md` (+12 / -1)

- **R6 — *Spec-review obligation — tier challenge*.** New subsection added under the existing review checklist. Mandates that during a spec-PR review, the reviewer SHALL challenge the declared complexity tier against the spec body (file count, surface touched, cross-cutting impact) and emit a `class: spec` finding when the declared tier under- or over-states the actual complexity. Cross-references ADR-0010 → *Complexity tiers and team sizing* for the canonical thresholds.
- **PATCH bump** — `metadata.provenance.version: 1.1.1 → 1.1.2` per *Version Bump Convention* (additive contract change to a shipped skill).

### Build outputs (3 mirrors regenerated)

`scripts/build-components.sh` regenerated the three CLI mirrors of `pr-reviewer/SKILL.md` under `.claude/skills/`, `.gemini/skills/`, and `.github/skills/`. Each mirror carries the identical +12/-1 diff. `git status --porcelain` after the build is empty.

### DEV-time audit (R8) — 5 specs reviewed, 0 corrected

R8 mandates a DEV-time sweep of the merged specs to detect tier discordances. Result, posted as a logbook comment on #173:

- **5/5 specs audited.**
- **3 coherent** — tier declared matches the realised scope.
- **2 over-stated non-blocking** — spec 0003 (Spec-PR workflow) and spec 0004 (Plan format and review) were each declared `standard` tier but realised with only **2 files modified each**, which sits in the `small` tier per ADR-0010 thresholds.
- **No spec file was edited** — ADR-0010 mandates merged-spec immutability. The audit identifies discordances; it does not correct them in place.
- **Corrections deferred per R9** — out of scope for #173. Each correction is a delta-spec PR in its own ticket (`spec/<id>-<slug>-delta-01`), per spec 0006 R9.

### CLI matrix decision — no edit

The validated PLAN comment on #173 argues this PR's trigger surface (AGENTS.md additions + a skill version bump + regenerated mirrors) introduces **no per-CLI behaviour** — every change applies symmetrically to every CLI. Per *CLI Matrix Maintenance → Protocol-only exemption*, no `docs/cli-matrix.md` edit is required. The decision is recorded in the PLAN for audit.

Closes #173