### PR TITLE
📝 [spec-PR] 0007 delta-01 — align R2/R3 with reality (#174)

### DIFF
--- a/specs/0007-build-install-spec-author.delta-01.md
+++ b/specs/0007-build-install-spec-author.delta-01.md
@@ -1,0 +1,97 @@
+---
+id: "0007"
+slug: build-install-spec-author
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 174
+version: 1.0.1
+---
+
+# Delta 01 — align R2/R3 with built-artefact reality
+
+## Body
+
+### ADDED
+
+(none — this delta is corrective, not additive.)
+
+### MODIFIED
+
+**R2** — the path enumeration for matching agent files SHALL be
+corrected to reflect the actual mirror layouts produced by
+`scripts/build-components.sh`.
+
+> Original R2 (excerpt): *"the matching slim agent file when it exists,
+> at the three paths `.claude/agents/<NAME>.md`, `.gemini/agents/<NAME>.md`,
+> and `.github/agents/<NAME>.md`."*
+
+Replacement: the three agent paths SHALL be:
+
+- `.claude/agents/<NAME>/AGENT.md` (Claude uses a sub-directory layout
+  for agents, parallelling the skill layout, NOT a flat `<NAME>.md`).
+- `.gemini/agents/<NAME>.md` (flat layout, correct in the original).
+- `.github/agents/<NAME>.md` (flat layout, correct in the original).
+
+Asymmetric agent presence (some CLIs have the agent, others do not)
+remains a verification failure per the unchanged second half of R2.
+
+**R3** — the required-fields list for the file-level verification SHALL
+be corrected to match the frontmatter schema actually emitted by
+`scripts/build-components.sh`.
+
+> Original R3 (excerpt): *"For each found output file, the target SHALL
+> verify: (a) the file exists and is non-empty, (b) the YAML frontmatter
+> parses as valid YAML, and (c) the required fields `name`, `type`, and
+> `metadata.provenance.version` are present and non-empty."*
+
+Replacement: the verification SHALL check the following on each found
+output file:
+
+- (a) The file exists and is non-empty (unchanged from original).
+- (b) The YAML frontmatter parses as valid YAML (unchanged from
+  original).
+- (c) For all skill outputs (`.claude/skills/<NAME>/SKILL.md`,
+  `.gemini/skills/<NAME>/SKILL.md`, `.github/skills/<NAME>/SKILL.md`)
+  AND for Claude / GitHub-Copilot agent outputs
+  (`.claude/agents/<NAME>/AGENT.md`, `.github/agents/<NAME>.md`):
+  the field `name` SHALL be present and non-empty in the YAML
+  frontmatter, AND the field `metadata.provenance.version` SHALL be
+  present and non-empty in the YAML frontmatter.
+- (d) For the Gemini agent output (`.gemini/agents/<NAME>.md`)
+  specifically: the field `name` SHALL be present and non-empty in
+  the YAML frontmatter, AND a line of the form `<!-- crewrig-provenance:
+  version="<semver>" ... -->` SHALL be present immediately after the
+  YAML frontmatter (Gemini's agent format stores provenance in an
+  HTML comment rather than in the YAML frontmatter; this is the
+  convention emitted by the build script).
+
+The previously-required `type` field SHALL be DROPPED from the
+verification list. The field is not part of the frontmatter schema
+emitted by `scripts/build-components.sh` for any artefact (skill or
+agent, any CLI); requiring it caused the verification to fail against
+every existing built file. The original R3 wording was aspirational,
+not descriptive.
+
+### REMOVED
+
+(none — the dropped `type` field is recorded under MODIFIED above
+because R3 as a whole is restated, not deleted.)
+
+### Notes
+
+This delta is purely corrective: the original spec 0007 was written
+without inspecting the actual mirror artefacts produced by
+`scripts/build-components.sh`. The blocker surfaced at DEV time when
+the developer cross-checked the spec against the filesystem (see
+issue #174 logbook for the diagnostic detail). PATCH-bump (`1.0.0` →
+`1.0.1`) per `docs/spec-format.md` → *Versioning*: clarification /
+wording fix, no in-flight implementation invalidated (DEV had not
+started writing any code yet).
+
+After this delta-spec merges, the developer resumes DEV with the
+corrected R2 path layout and R3 field set. The Taskfile target's
+behaviour against the actual built outputs is unchanged in intent
+(file-level smoke check, no live API invocation, strict separation
+from #178); only the verification's field list and one path string
+are aligned with reality.


### PR DESCRIPTION
First live **delta-spec PR** under the ADR-0010 lifecycle. Routed via the retroactive review loop as a `class: spec` finding produced at DEV-time on impl ticket #174.

## How to read this PR?

Read `specs/0007-build-install-spec-author.delta-01.md` end-to-end. Single new file, three sub-sections (ADDED / MODIFIED / REMOVED) per `docs/spec-format.md` → *Delta-spec convention*.

## How to test this PR?

1. Confirm delta filename: `specs/0007-build-install-spec-author.delta-01.md` (parent id `0007`, delta `01`).
2. Confirm frontmatter `id: "0007"` (same as parent), `version: 1.0.1` (PATCH bump per format Versioning rules — wording fix, no in-flight implementation invalidated).
3. Confirm the three delta sub-sections (ADDED / MODIFIED / REMOVED) are present.
4. Confirm R2's MODIFIED paragraph quotes the original R2 then states the replacement (Claude `.claude/agents/<NAME>/AGENT.md` sub-directory layout).
5. Confirm R3's MODIFIED paragraph drops the non-existent `type` field and codifies Gemini's HTML-comment provenance convention.
6. `npx markdownlint-cli specs/0007-build-install-spec-author.delta-01.md` → zero errors.

## Detailed description (for agents)

**Why this delta exists.** Original spec 0007 was authored without cross-checking the actual mirror artefacts produced by `scripts/build-components.sh`. The developer on #174 hit a blocker at DEV time:

- R3 required `type` field — does not exist in any built skill or agent frontmatter.
- R2 stated `.claude/agents/<NAME>.md` (flat) — Claude actually uses `.claude/agents/<NAME>/AGENT.md` (sub-directory).
- R3 implicitly required `metadata.provenance.version` in YAML frontmatter on the Gemini agent — but the build script stores it in an HTML comment for Gemini specifically.

**Why a delta rather than an inline workaround.** The user chose Option B (strict lifecycle) over Option A (pragmatic ship): the routing matrix says `class: spec` findings re-enter SPECS via delta. This is the first live exercise of that path.

**PATCH bump rationale.** Per `docs/spec-format.md` → *Versioning*: clarification / wording fix with no in-flight implementation invalidated (DEV had not started writing code yet). `1.0.0` → `1.0.1`.

**Side-friction noted.** Adding the H3 ADDED / MODIFIED / REMOVED directly under the H1 title triggers `MD001/heading-increment`. Worked around with an H2 wrapper `## Body`. Worth folding into either the spec-linter ticket (#178) or a delta on `docs/spec-format.md` itself if the pattern recurs.

After this delta-spec merges, the developer on #174 resumes DEV with R2/R3 aligned to reality. The impl-PR target remains the same: a `task skill:check NAME=<name>` Taskfile target + brief note in `docs/cli-matrix.md` row 3.

(Per spec-PR workflow: this PR does NOT `Closes #174`. The impl-PR does.)