### PR TITLE
📝 [spec-PR] 0001 delta-01 — promote delta-section headings to H2 (#195)

### DIFF
--- a/specs/0001-spec-format-self.delta-01.md
+++ b/specs/0001-spec-format-self.delta-01.md
@@ -1,0 +1,137 @@
+---
+id: "0001"
+slug: spec-format-self
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 195
+version: 1.1.0
+---
+
+# 0001 — spec-format-self (delta-01)
+
+This delta amends the *Delta-spec body sections* convention defined in
+`docs/spec-format.md` so that a delta-spec authored from scratch passes
+`markdownlint` with the project's default rules. The current convention
+places three `### ADDED` / `### MODIFIED` / `### REMOVED` sub-sections
+directly under the file's H1 title, which violates MD001
+(heading-increment). Every delta-spec is structurally identical, so the
+defect is in the format itself, not in any individual author's diff.
+
+## ADDED
+
+1. The repository SHALL include a regression scenario in spec 0001 →
+   `## Scenarios` that exercises a delta-spec failing `markdownlint`
+   when its body uses three H3 sub-sections directly under the H1 title.
+   The scenario name is *"Reviewer rejects a delta-spec that violates
+   MD001"* (see `## MODIFIED` below for the inserted Given/When/Then
+   block).
+2. The implementation-PR for related-issue 195 SHALL realign the
+   already-merged delta-spec
+   `specs/0007-build-install-spec-author.delta-01.md` to the new
+   convention: remove the `## Body` wrapper introduced as a workaround
+   in PR #189 and promote `### ADDED` / `### MODIFIED` / `### REMOVED`
+   to H2. This migration is part of #195's DEV stage; no follow-up
+   ticket is opened.
+
+## MODIFIED
+
+1. **`docs/spec-format.md` → *Delta-spec body sections* (the fenced
+   code block at lines 142–155).**
+
+   Original:
+
+   ````markdown
+   ```markdown
+   ### ADDED
+
+   <requirements, scenarios, or out-of-scope items that the delta introduces>
+
+   ### MODIFIED
+
+   <requirements, scenarios, or out-of-scope items the delta changes; quote the
+   original line, then show the replacement>
+
+   ### REMOVED
+
+   <items the delta deletes; quote the original line>
+   ```
+   ````
+
+   Replacement:
+
+   ````markdown
+   ```markdown
+   ## ADDED
+
+   <requirements, scenarios, or out-of-scope items that the delta introduces>
+
+   ## MODIFIED
+
+   <requirements, scenarios, or out-of-scope items the delta changes; quote the
+   original line, then show the replacement>
+
+   ## REMOVED
+
+   <items the delta deletes; quote the original line>
+   ```
+   ````
+
+   The three delta sections SHALL be authored at H2 level. The H1 of a
+   delta-spec file remains the spec's title; no intermediate H2 wrapper
+   (`## Body`, `## Delta sections`, or any other) SHALL be introduced.
+
+2. **`docs/spec-format.md` → *Linting hints* (the bullet at lines 232–233).**
+
+   Original:
+
+   > For a delta-spec, the three delta section headings (`### ADDED`,
+   > `### MODIFIED`, `### REMOVED`) SHALL be present in that order.
+
+   Replacement:
+
+   > For a delta-spec, the three delta section headings (`## ADDED`,
+   > `## MODIFIED`, `## REMOVED`) SHALL be present in that order, at H2
+   > level. The H1 of a delta-spec file is the spec title; no
+   > intermediate H2 wrapper is allowed.
+
+3. **`specs/0001-spec-format-self.md` → `## Scenarios` (after the
+   existing *"Author writes a delta-spec for a `spec`-class finding"*
+   scenario).** A new scenario SHALL be inserted, recording the
+   MD001-rejection contract that the linting hints now imply:
+
+   ```text
+   **Scenario:** Reviewer rejects a delta-spec that violates MD001
+
+   Given a delta-spec PR is opened with `### ADDED`, `### MODIFIED`,
+         `### REMOVED` sub-sections placed directly under the file's
+         `# <title>` H1 heading
+   When  `markdownlint` runs on the file with the project's default
+         configuration
+   Then  the linter rejects the file with MD001 (heading-increment)
+   and   the reviewer asks the author to promote the three headings
+         to H2 per `docs/spec-format.md` → *Delta-spec body sections*.
+   ```
+
+4. **`specs/0001-spec-format-self.md` → `## Scenarios` → existing
+   scenario *"Author writes a delta-spec for a `spec`-class finding"*
+   (the Then-clause that names the three sub-sections).**
+
+   Original:
+
+   ```text
+   and   the delta file contains the `### ADDED`, `### MODIFIED`, and
+         `### REMOVED` sub-sections
+   ```
+
+   Replacement:
+
+   ```text
+   and   the delta file contains the `## ADDED`, `## MODIFIED`, and
+         `## REMOVED` sections at H2 level
+   ```
+
+## REMOVED
+
+(None. The convention is amended, not retracted; no requirement of
+spec 0001 is deleted.)


### PR DESCRIPTION
Promotes the three delta-spec sections (`ADDED` / `MODIFIED` / `REMOVED`) from H3 to H2 so a delta-spec body conforms to `markdownlint` MD001 (heading-increment) out of the box. Self-demonstrating: this delta-spec file itself uses the new convention.

## How to read this PR?

Read `specs/0001-spec-format-self.delta-01.md` end-to-end. Single new file, three H2 sub-sections (ADDED / MODIFIED / REMOVED) per the convention this very delta introduces.

Key normative pieces in order:

1. `## ADDED` — two new requirements: (1) add a regression scenario to spec 0001 covering MD001 rejection, (2) realign the existing `0007-...delta-01.md` to the new convention as part of the impl-PR for #195.
2. `## MODIFIED` bullet 1 — the exact diff to apply to `docs/spec-format.md` → *Delta-spec body sections* (lines 142–155 in the fenced code block).
3. `## MODIFIED` bullet 2 — the exact diff to apply to `docs/spec-format.md` → *Linting hints* (lines 232–233).
4. `## MODIFIED` bullets 3 & 4 — additions / updates to `specs/0001-spec-format-self.md` → `## Scenarios`.
5. `## REMOVED` — empty (no requirement of the parent spec is retracted).

## How to test this PR?

1. Confirm delta filename: `specs/0001-spec-format-self.delta-01.md` (parent id `0001`, delta `01`).
2. Confirm frontmatter `id: \"0001\"` (same as parent), `version: 1.1.0` (MINOR bump per format Versioning rules — additive normative change on the delta-body convention; no in-flight delta-spec invalidated since `0007-...delta-01.md` is already merged and explicitly handled in scope per Q2 above).
3. Confirm the three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`) are present at **H2 level**, directly under the file's H1 — i.e. the new convention is self-applied.
4. `markdownlint specs/0001-spec-format-self.delta-01.md` → zero errors. (Critical: validates the new convention does NOT trip MD001.)
5. Confirm `## REMOVED` is intentionally empty (with the explanatory parenthetical) — the convention is amended, not retracted.

## Detailed description (for agents)

**Why this delta exists.** Harness friction cluster `spec-format-delta-h-levels` (#195) flagged that the original `docs/spec-format.md` → *Delta-spec body sections* documents three H3 sub-sections (`### ADDED`, `### MODIFIED`, `### REMOVED`) placed directly under the file's H1 title. That layout violates `markdownlint` MD001 (heading-increment) and every delta-spec inherits the defect. The first live delta-spec (`0007-...delta-01.md`, merged in PR #189) had to add an H2 wrapper `## Body` as a workaround — and that PR explicitly flagged the friction for follow-up. This delta is that follow-up.

**Option chosen.** Promote the three sections from H3 to H2 (Q1, option A). Alternatives considered and rejected during the spec-author interview:

- *H2 wrapper `## Delta sections`* — adds a redundant ceremony layer without semantic content.
- *H2 wrapper `## Body`* — aligns with the PR #189 workaround but `Body` is semantically empty (a spec is already a body); ships a workaround as canonical convention.

The H2-promotion option produces structural symmetry between original specs (5 H2 sections) and delta-specs (3 H2 sections), and the linter rules approve the layout without any wrapper.

**SemVer bump rationale (MINOR).** Per `docs/spec-format.md` → *Versioning*: the change is an additive normative change on the delta-body convention. It does not invalidate any in-flight implementation (the only existing delta-spec, `0007-...delta-01.md`, is already merged and is realigned as in-scope work in the impl-PR). `1.0.0` → `1.1.0`.

**In-scope migration.** The spec explicitly records (in `## ADDED` requirement 2) that the impl-PR realigns the existing `specs/0007-build-install-spec-author.delta-01.md` to the new convention — removing the `## Body` wrapper and promoting its three sections to H2. No follow-up ticket; the convention change and its sole existing dependent are landed together.

**Self-demonstration.** The delta file itself uses the new H2 convention. After this spec-PR merges, the convention's first canonical artefact (this very file) on `main` is already conformant.

Per Spec-PR workflow → Independence rule, this PR does NOT `Closes #195`. The implementation-PR that lands the `docs/spec-format.md` edit and realigns `specs/0007-build-install-spec-author.delta-01.md` will close the logbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)