### PR TITLE
🔧 Promote delta-spec section headings to H2 (#195)

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 
@@ -44,7 +44,7 @@ escalate user gating.
    delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
    → *Delta-spec convention*. The skill detects delta mode by the presence
    of a parent spec for the ticket and switches its output template to the
-   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+   three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`).
 
 ## Inputs
 
@@ -181,8 +181,8 @@ When the skill is invoked on a ticket that already has a parent spec
 `/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
 two-digit delta number for the parent. The body replaces the five
 mandatory sections with the three delta sections defined in
-`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
-`### MODIFIED`, `### REMOVED`), all three present even when empty.
+`docs/spec-format.md` → *Delta-spec convention* (`## ADDED`,
+`## MODIFIED`, `## REMOVED`), all three present even when empty.
 
 ### Self-validation (best-effort)
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 
@@ -38,7 +38,7 @@ escalate user gating.
    delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
    → *Delta-spec convention*. The skill detects delta mode by the presence
    of a parent spec for the ticket and switches its output template to the
-   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+   three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`).
 
 ## Inputs
 
@@ -175,8 +175,8 @@ When the skill is invoked on a ticket that already has a parent spec
 `/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
 two-digit delta number for the parent. The body replaces the five
 mandatory sections with the three delta sections defined in
-`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
-`### MODIFIED`, `### REMOVED`), all three present even when empty.
+`docs/spec-format.md` → *Delta-spec convention* (`## ADDED`,
+`## MODIFIED`, `## REMOVED`), all three present even when empty.
 
 ### Self-validation (best-effort)
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 
@@ -38,7 +38,7 @@ escalate user gating.
    delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
    → *Delta-spec convention*. The skill detects delta mode by the presence
    of a parent spec for the ticket and switches its output template to the
-   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+   three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`).
 
 ## Inputs
 
@@ -175,8 +175,8 @@ When the skill is invoked on a ticket that already has a parent spec
 `/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
 two-digit delta number for the parent. The body replaces the five
 mandatory sections with the three delta sections defined in
-`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
-`### MODIFIED`, `### REMOVED`), all three present even when empty.
+`docs/spec-format.md` → *Delta-spec convention* (`## ADDED`,
+`## MODIFIED`, `## REMOVED`), all three present even when empty.
 
 ### Self-validation (best-effort)
 

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.0.1"
+    version: "1.0.2"
 claude:
   allowed-tools:
     - Read
@@ -50,7 +50,7 @@ escalate user gating.
    delta-spec (`/specs/<NNNN>-<slug>.delta-<NN>.md`) per `docs/spec-format.md`
    → *Delta-spec convention*. The skill detects delta mode by the presence
    of a parent spec for the ticket and switches its output template to the
-   three delta sections (`### ADDED` / `### MODIFIED` / `### REMOVED`).
+   three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`).
 
 ## Inputs
 
@@ -187,8 +187,8 @@ When the skill is invoked on a ticket that already has a parent spec
 `/specs/<NNNN>-<slug>.delta-<NN>.md` where `<NN>` is the next free
 two-digit delta number for the parent. The body replaces the five
 mandatory sections with the three delta sections defined in
-`docs/spec-format.md` → *Delta-spec convention* (`### ADDED`,
-`### MODIFIED`, `### REMOVED`), all three present even when empty.
+`docs/spec-format.md` → *Delta-spec convention* (`## ADDED`,
+`## MODIFIED`, `## REMOVED`), all three present even when empty.
 
 ### Self-validation (best-effort)
 

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -140,19 +140,23 @@ two additional constraints:
 ### Delta-spec body sections
 
 ```markdown
-### ADDED
+## ADDED
 
 <requirements, scenarios, or out-of-scope items that the delta introduces>
 
-### MODIFIED
+## MODIFIED
 
 <requirements, scenarios, or out-of-scope items the delta changes; quote the
 original line, then show the replacement>
 
-### REMOVED
+## REMOVED
 
 <items the delta deletes; quote the original line>
 ```
+
+The three delta sections SHALL be authored at H2 level. The H1 of a
+delta-spec file remains the spec's title; no intermediate H2 wrapper
+(`## Body`, `## Delta sections`, or any other) SHALL be introduced.
 
 All three sections MUST be present (empty is allowed); the linter will
 check for presence, not content. This mirrors the OpenSpec delta
@@ -229,8 +233,10 @@ authors and reviewers SHOULD anticipate them.
   verbatim (case-sensitive, no trailing punctuation).
 - The frontmatter SHALL parse as YAML and SHALL contain every required
   field listed in the schema table.
-- For a delta-spec, the three delta section headings (`### ADDED`,
-  `### MODIFIED`, `### REMOVED`) SHALL be present in that order.
+- For a delta-spec, the three delta section headings (`## ADDED`,
+  `## MODIFIED`, `## REMOVED`) SHALL be present in that order, at H2
+  level. The H1 of a delta-spec file is the spec title; no
+  intermediate H2 wrapper is allowed.
 - Enum-valued fields SHALL contain a value from the listed set; any
   other value is a lint error.
 

--- a/specs/0001-spec-format-self.md
+++ b/specs/0001-spec-format-self.md
@@ -61,9 +61,20 @@ and  every mandatory frontmatter field and body section is present.
 Given an approved spec `specs/0042-build-dryrun.md` exists on `main`
 When  the REVIEW loop surfaces a `spec`-class finding
 Then  the author creates `specs/0042-build-dryrun.delta-01.md`
-and   the delta file contains the `### ADDED`, `### MODIFIED`, and
-      `### REMOVED` sub-sections
+and   the delta file contains the `## ADDED`, `## MODIFIED`, and
+      `## REMOVED` sections at H2 level
 and   the original spec on `main` is left untouched.
+
+**Scenario:** Reviewer rejects a delta-spec that violates MD001
+
+Given a delta-spec PR is opened with `### ADDED`, `### MODIFIED`,
+      `### REMOVED` sub-sections placed directly under the file's
+      `# <title>` H1 heading
+When  `markdownlint` runs on the file with the project's default
+      configuration
+Then  the linter rejects the file with MD001 (heading-increment)
+and   the reviewer asks the author to promote the three headings
+      to H2 per `docs/spec-format.md` → *Delta-spec body sections*.
 
 **Scenario:** Reviewer rejects a spec with implicit scope
 

--- a/specs/0007-build-install-spec-author.delta-01.md
+++ b/specs/0007-build-install-spec-author.delta-01.md
@@ -10,13 +10,11 @@ version: 1.0.1
 
 # Delta 01 — align R2/R3 with built-artefact reality
 
-## Body
-
-### ADDED
+## ADDED
 
 (none — this delta is corrective, not additive.)
 
-### MODIFIED
+## MODIFIED
 
 **R2** — the path enumeration for matching agent files SHALL be
 corrected to reflect the actual mirror layouts produced by
@@ -73,12 +71,12 @@ agent, any CLI); requiring it caused the verification to fail against
 every existing built file. The original R3 wording was aspirational,
 not descriptive.
 
-### REMOVED
+## REMOVED
 
 (none — the dropped `type` field is recorded under MODIFIED above
 because R3 as a whole is restated, not deleted.)
 
-### Notes
+## Notes
 
 This delta is purely corrective: the original spec 0007 was written
 without inspecting the actual mirror artefacts produced by


### PR DESCRIPTION
Realise spec `0001-spec-format-self` delta-01 by promoting delta-spec section headings from H3 to H2 across the normative format doc, the parent spec's regression scenarios, the in-tree delta artefact that originally surfaced the friction, and the `spec-author` skill source that teaches the convention. The PR closes the MD001 / heading-increment loop opened by the friction cluster `spec-format-delta-h-levels`.

## How to read this PR?

The PR is the recursive payoff of a convention introduced and validated upstream: spec `0001-spec-format-self` delta-01 (version `1.0.0` → `1.1.0`) merged into `main` via spec-PR #196, and this impl-PR realises every `## ADDED` / `## MODIFIED` item it declared. Suggested reading order:

1. `specs/0001-spec-format-self.delta-01.md` on `main` (already merged via #196) — the normative WHAT this PR realises.
2. `docs/spec-format.md` diff — the fenced code block (delta-spec body sections example) flips from `### ADDED`/`### MODIFIED`/`### REMOVED` to H2, a "no intermediate H2 wrapper" sentence is appended, and the *Linting hints* bullet is reworded to match.
3. `specs/0001-spec-format-self.md` diff — the existing `"Author writes a delta-spec for a 'spec'-class finding"` scenario's Then-clause is updated, and a new `"Reviewer rejects a delta-spec that violates MD001"` regression scenario is inserted immediately after.
4. `specs/0007-build-install-spec-author.delta-01.md` diff — the previously-merged `## Body` wrapper (the original workaround that surfaced the friction) is removed, and `### ADDED` / `### MODIFIED` / `### REMOVED` / `### Notes` are all promoted to H2.
5. `community-config/skills/spec-author/SKILL.md` diff — two passages that taught the old H3 convention are rewritten to H2; `metadata.provenance.version` PATCH-bumps `1.0.1` → `1.0.2`.
6. The three regenerated bundle mirrors under `.claude/`, `.gemini/`, `.github/skills/spec-author/SKILL.md` — byte-identical edits to the source above, produced by `scripts/build-components.sh`.

Self-demonstrating elegance: the merged delta-spec itself was already authored under the new H2 convention, so on this PR's merge every in-tree artefact — normative doc, parent spec, prior delta, skill source — converges to the same convention with no straggler.

## How to test this PR?

1. Check out the branch and enter the worktree:

    ```sh
    git fetch crewrig && git checkout fix/195-promote-delta-h2-sections
    # or use the existing worktree: cd .worktrees/issue-195
    ```

2. Confirm zero markdownlint errors on the in-tree delta-spec authored under the new convention (untouched by this PR — proves the convention was already self-consistent):

    ```sh
    markdownlint specs/0001-spec-format-self.delta-01.md
    ```

3. Confirm zero markdownlint errors on the realigned prior delta-spec (the file that originally surfaced the friction):

    ```sh
    markdownlint specs/0007-build-install-spec-author.delta-01.md
    ```

4. Confirm zero markdownlint errors on the three other edited surfaces:

    ```sh
    markdownlint docs/spec-format.md specs/0001-spec-format-self.md community-config/skills/spec-author/SKILL.md
    ```

5. Confirm the skill version bump landed correctly:

    ```sh
    grep -n 'version:' community-config/skills/spec-author/SKILL.md
    # expect:   version: 1.0.2
    ```

6. Confirm the built mirrors match the source (no drift):

    ```sh
    bash scripts/build-components.sh
    git status --porcelain
    # expect empty output
    ```

7. Confirm CI is green on the head commit — the canonical checks are `build`, `check-components`, `check-skill-versions`, `lint-markdown`, and `test-harness-curate`.

## Detailed description (for agents)

### Origin

This PR closes the friction cluster `spec-format-delta-h-levels` reported on logbook issue #195 by the Harness Curator. The reporter (`claude-code`) hit the friction on PR #189 (the merge of `specs/0007-build-install-spec-author.delta-01.md`) where the three sub-sections `### ADDED` / `### MODIFIED` / `### REMOVED` sitting directly under the file's H1 title triggered markdownlint MD001 (`heading-increment`); the workaround at the time was an `## Body` wrapper. The convention as written in `docs/spec-format.md` was structurally incompatible with the linter, so the friction was scoped to amend the convention itself — not to relax the linter.

### Chosen approach

Promote `ADDED` / `MODIFIED` / `REMOVED` to H2 across every surface that touches the convention, and explicitly forbid any intermediate H2 wrapper. The promotion is the minimum edit that satisfies MD001 without introducing redundant ceremony. The rejected alternatives are documented in the PLAN comment on #195 and are summarised here for the diff reader's convenience:

- **H2 wrapper `## Delta sections`** — rejected as redundant ceremony; the wrapper would carry no semantic content beyond "the next three sub-sections are delta sections", which the H1 title already conveys.
- **H2 wrapper `## Body`** — same redundancy critique; this was the workaround originally applied to `0007-...delta-01.md` (PR #189) and is precisely what this PR removes.
- **`markdownlint` exception (`MD001: false`) for `specs/*.delta-*.md`** — rejected at the SPECS stage; the spec mandates promotion, not a linter relaxation.
- **Split the `0007` realignment from the convention amendment into two PRs** — rejected because the spec explicitly bundles them; splitting would leave `main` in a transient state where the format doc mandates a layout that one in-tree artefact violates.

### Coverage of every spec item

The merged delta-spec declared two `## ADDED` items and four `## MODIFIED` items. This PR realises each exhaustively:

- `## MODIFIED 1` (fenced code block in `docs/spec-format.md`): the H3 example is rewritten to H2 and the "no intermediate H2 wrapper" sentence is appended. Step 1 of the plan.
- `## MODIFIED 2` (*Linting hints* bullet in `docs/spec-format.md`): reworded to mention the MD001-compatible H2 layout. Step 2.
- `## MODIFIED 4` (existing scenario in `specs/0001-spec-format-self.md`): the Then-clause of *"Author writes a delta-spec for a `spec`-class finding"* is updated. Step 3.
- `## MODIFIED 3` + `## ADDED 1` (new MD001 regression scenario): the *"Reviewer rejects a delta-spec that violates MD001"* scenario is inserted in `## Scenarios` of the parent spec. Step 4.
- `## ADDED 2` (realignment of `0007-...delta-01.md`): the `## Body` wrapper is deleted; `### ADDED` / `### MODIFIED` / `### REMOVED` and the trailing `### Notes` section are all promoted to H2. Step 5.

### Note on the `### Notes` promotion

The spec's `## ADDED 2` clause authorised "realigning `0007-...delta-01.md` to the new convention" without exhaustively enumerating each sub-section. The trailing `### Notes` is treated as in-scope by the same closed-loop logic: an H3 directly under H1 IS the MD001 defect this delta exists to fix, so leaving `### Notes` would reintroduce the violation on a non-canonical heading. Both the PLAN comment and its cold APPROVE review on #195 endorsed this reading.

### Scope extension to the `spec-author` skill

The merged spec did not literally enumerate the skill source under its `## MODIFIED` items. The plan extends scope to `community-config/skills/spec-author/SKILL.md` by the same closed-loop argument the spec invokes for the `0007` realignment: the skill is the author-facing surface that *operationalises* the doc; if it keeps teaching `### ADDED`, the next delta-spec author will reintroduce the very MD001 violation this delta exists to eradicate. Two passages are rewritten (the section template around the original line 53 and the example around the original lines 190–191), and `metadata.provenance.version` is PATCH-bumped `1.0.1` → `1.0.2` per *AGENTS.md → Version Bump Convention* (modified shipped source). The bump is PATCH because the change is a wording clarification of teaching material: no behavioural contract is altered, no in-flight implementation is invalidated, and no public interface shifts.

### Built mirrors

`scripts/build-components.sh` was run after the skill source edit; the three bundle mirrors under `.claude/skills/spec-author/SKILL.md`, `.gemini/skills/spec-author/SKILL.md`, and `.github/skills/spec-author/SKILL.md` are regenerated and staged in the same commit per *AGENTS.md → Built Components*. The `check-components` CI job is the canonical backstop.

### CLI-matrix non-trigger

`docs/cli-matrix.md` is NOT touched in this PR. The *AGENTS.md → CLI Matrix Maintenance* trigger surface enumerates the paths that, when touched, require a matrix update. None of the files this PR edits — `docs/spec-format.md`, `specs/0001-spec-format-self.md`, `specs/0007-build-install-spec-author.delta-01.md`, `community-config/skills/spec-author/SKILL.md`, and the three regenerated mirrors — change CLI-specific behaviour. The `community-config/**` edit is a wording correction in author-facing prose that the skill teaches symmetrically across all three CLIs; no CLI-specific path, command, hook, or configuration is introduced. (The *Protocol-only exemption* clause does not apply here because no entry-point file is touched; the matrix is left alone for the more direct reason that no edited file is on the trigger surface.)

### Frozen historical residue

`docs/design-notes/168-spec-author.md` line 189 still references the old `### ADDED / ### MODIFIED / ### REMOVED` convention. The file's frontmatter declares `**Status:** Design only` — it is a frozen historical artefact already realised into the skill on `main`, not a living author-facing surface. Leaving it untouched is the correct call; the closed-loop argument used for the skill source does not apply to a frozen design note. Flagged here so that a cold pr-reviewer running `grep -rn '### ADDED' .` is not surprised by the residue.

Closes #195