### PR TITLE
📝 [spec-PR] 0002 delta-01 — align R9 and delta-mode scenario to H2 (#198)

### DIFF
--- a/specs/0002-spec-author-skill.delta-01.md
+++ b/specs/0002-spec-author-skill.delta-01.md
@@ -5,7 +5,7 @@ status: draft
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 198
-version: 1.0.1
+version: 1.1.0
 ---
 
 # 0002 — spec-author-skill (delta-01)

--- a/specs/0002-spec-author-skill.delta-01.md
+++ b/specs/0002-spec-author-skill.delta-01.md
@@ -1,0 +1,80 @@
+---
+id: "0002"
+slug: spec-author-skill
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 198
+version: 1.0.1
+---
+
+# 0002 — spec-author-skill (delta-01)
+
+This delta aligns the two references in spec 0002 that still teach the
+obsolete H3 placement of delta sections (`### ADDED` / `### MODIFIED` /
+`### REMOVED`) with the canonical H2 convention introduced by the
+merged spec `0001-spec-format-self.delta-01.md` (v1.1.0) and realised
+on `main` by PR #197. Without this delta, spec 0002 R9 mandates the
+exact heading level that `docs/spec-format.md` now forbids — a
+normative contradiction surfaced by the cold `pr-reviewer` finding F1
+on PR #197.
+
+## ADDED
+
+(None. The delta corrects existing wording; no new requirement or
+scenario is introduced.)
+
+## MODIFIED
+
+1. **`specs/0002-spec-author-skill.md` → `## Requirements` → R9 (the
+   single requirement covering delta-mode body emission).**
+
+   Original:
+
+   ```text
+   In delta mode, the skill MUST emit the three delta sections
+   `### ADDED`, `### MODIFIED`, and `### REMOVED` in that order, all
+   present even when empty, in place of the five mandatory body
+   sections.
+   ```
+
+   Replacement:
+
+   ```text
+   In delta mode, the skill MUST emit the three delta sections
+   `## ADDED`, `## MODIFIED`, and `## REMOVED` at H2 level, in that
+   order, all present even when empty, in place of the five mandatory
+   body sections. No intermediate H2 wrapper (`## Body`,
+   `## Delta sections`, or any other) SHALL be introduced above the
+   three sections.
+   ```
+
+2. **`specs/0002-spec-author-skill.md` → `## Scenarios` → existing
+   scenario *"Delta mode on a `spec`-class REVIEW finding"* (the
+   Then-clause that names the three sub-sections).**
+
+   Original:
+
+   ```text
+   Then  the skill detects the parent spec, switches to delta mode,
+         writes `/specs/0042-build-dryrun.delta-01.md`, and the file
+         contains the three sub-sections `### ADDED`, `### MODIFIED`, and
+         `### REMOVED` in that order with all three present even when
+         empty, while the original spec on `main` is left untouched.
+   ```
+
+   Replacement:
+
+   ```text
+   Then  the skill detects the parent spec, switches to delta mode,
+         writes `/specs/0042-build-dryrun.delta-01.md`, and the file
+         contains the three sections `## ADDED`, `## MODIFIED`, and
+         `## REMOVED` at H2 level, in that order, with all three
+         present even when empty, while the original spec on `main`
+         is left untouched.
+   ```
+
+## REMOVED
+
+(None. The convention is aligned, not retracted; no requirement of the
+parent spec is deleted.)


### PR DESCRIPTION
Realigns spec 0002 with the H2 delta-section convention introduced by `0001.delta-01` and realised on `main` by PR #197. Closes the F1 finding raised cold on #197 — without this delta, `specs/0002-spec-author-skill.md` R9 mandates the exact heading level that `docs/spec-format.md` now forbids.

## How to read this PR?

Read `specs/0002-spec-author-skill.delta-01.md` end-to-end. Single new file, three H2 sections (`## ADDED` / `## MODIFIED` / `## REMOVED`) per the convention that landed in PR #197 (commit `e99d841`). The file is self-conformant: it is itself a delta-spec, and it is authored under the new H2 convention.

Key normative pieces:

1. `## MODIFIED` bullet 1 — the exact diff to apply to spec 0002 R9, replacing H3 with H2 + adding the explicit no-intermediate-wrapper sentence (mirrors the parallel sentence added to `docs/spec-format.md` by #197).
2. `## MODIFIED` bullet 2 — the exact diff to apply to spec 0002's *Delta mode on a `spec`-class REVIEW finding* scenario, replacing the H3 references in the Then-clause with H2.
3. `## ADDED` and `## REMOVED` — empty (with explanatory parenthetical). The delta corrects existing wording, not the requirement count.

## How to test this PR?

1. Confirm delta filename: `specs/0002-spec-author-skill.delta-01.md` (parent id `0002`, delta `01`).
2. Confirm frontmatter `id: \"0002\"` (same as parent), `version: 1.0.1` (PATCH bump per *Versioning* rules — clarification / wording fix, no in-flight implementation invalidated; the `spec-author` skill source was already aligned by #197).
3. Confirm the three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`) are present at **H2 level**, directly under the file's H1 — the new convention is self-applied.
4. `markdownlint specs/0002-spec-author-skill.delta-01.md` → zero errors.
5. Inspect the cross-file claims:
   - `specs/0002-spec-author-skill.md` R9 (around line 64) contains the original wording quoted in `## MODIFIED` bullet 1.
   - `specs/0002-spec-author-skill.md` → *Delta mode on a `spec`-class REVIEW finding* scenario (around line 128) contains the original Then-clause quoted in `## MODIFIED` bullet 2.

## Detailed description (for agents)

**Why this delta exists.** Cold `pr-reviewer` audit on PR #197 surfaced finding F1 (`class: tech`, non-blocking): after #197 merges the H2 convention, `specs/0002-spec-author-skill.md` R9 (line 64) and its *Delta mode on a `spec`-class REVIEW finding* scenario (line 128) still teach the obsolete H3 placement. Two normative references on `main` would contradict `docs/spec-format.md`. Per AGENTS.md → *Team Communication → Rule 4*, the finding was surfaced to the user rather than auto-deferred; the user authorised handling it in-session as a separate spec-PR.

**Why a delta and not a direct edit.** Specs on `main` are immutable per ADR-0010 and `docs/spec-format.md` → *Lifecycle states*. The only legal correction path for a wording defect in a merged spec is a delta-spec — exactly the path this PR exercises.

**Why no impl-PR follows this spec-PR.** The spec-author skill source (`community-config/skills/spec-author/SKILL.md`) was already updated to teach H2 in PR #197 (commit `e99d841`, scope-extension authorised by user). After this delta-spec merges, every artefact on `main` — `docs/spec-format.md`, the parent spec 0001 (via its delta-01), spec 0002 (via this delta-01), spec 0007 (via its delta-01, realigned in #197), and the `spec-author` skill — speaks one voice: H2 delta sections, no wrapper. There is nothing for a `developer` to do.

**PATCH bump rationale.** Per `docs/spec-format.md` → *Versioning*: clarification / wording fix, no in-flight implementation invalidated (the skill source already speaks the new convention). `1.0.0` → `1.0.1`.

**Recursive elegance.** This is the third delta-spec authored under the new H2 convention (after `0001.delta-01.md` and the realigned `0007-...delta-01.md`). It demonstrates that the convention sustains its own audit trail.

Per Spec-PR workflow → Independence rule, this PR does NOT `Closes #198`. There is no impl-PR; the spec is the deliverable. Closing #198 will follow the merge of this spec-PR as a Rule C action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)