### PR TITLE
📝 [spec-PR] 0002 delta-02 — prose discipline for interview question batches (#193)

### DIFF
--- a/specs/0002-spec-author-skill.delta-02.md
+++ b/specs/0002-spec-author-skill.delta-02.md
@@ -1,0 +1,84 @@
+---
+id: "0002"
+slug: spec-author-skill
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 193
+version: 1.2.0
+---
+
+# 0002 — spec-author-skill (delta-02)
+
+This delta adds one requirement on the **prose discipline** the
+`spec-author` skill SHALL apply to every batch of interview questions
+posed to the user. The friction reported in #193 (rephrased: terse
+question labels and unexplained shorthand made the user unable to
+ground decisions during the spec interview for a prior ticket) is a
+prompt-quality defect, not a structural one — the skill already
+selects the right number of questions per mode; it merely fails to
+frame them. This delta closes the framing gap.
+
+## ADDED
+
+1. **New requirement (R15) — contextualizing prose around interactive
+   question batches.** In `MINIMAL`, `INTERMEDIATE`, and `FULL` modes,
+   every batch of questions the skill emits to the user via
+   `AskUserQuestion` (or the host CLI's equivalent interactive
+   primitive) SHALL be preceded by a short prose paragraph that recalls
+   the following four anchors, in this order:
+
+   1. The originating ticket identifier (GitHub issue number or
+      equivalent).
+   2. The current lifecycle stage (here always `SPECS`) and the
+      artefact being authored (e.g. *"delta-spec on parent spec 0002"*).
+   3. The current interview-pass position — which question of which
+      mode (e.g. *"Question 4 of 6 — failure-path scenario"*).
+   4. The decisions already taken in this session, summarised in one
+      or two clauses (e.g. *"complexity tier already set to `small`,
+      interaction mode to `INTERMEDIATE`"*).
+
+   In addition:
+
+   - **Acronym discipline.** Any acronym that is not part of the
+     widely-used software-engineering vocabulary (examples of
+     acronyms that DO need explanation at first use within the batch:
+     `OQ` for *Open Question*, `R1` for *Requirement 1*, `NNNN` for
+     the four-digit spec id; examples that do NOT need explanation:
+     `PR`, `CI`, `URL`) SHALL be spelled out the first time it appears
+     in a question, including the prose preface and every option
+     `description` field.
+   - **Description self-sufficiency.** The `description` field of each
+     option in an `AskUserQuestion` call SHALL carry enough rationale
+     for the user to make a decision without re-reading prior turns of
+     the conversation. This is mandatory because the option
+     `description` renders in a side panel disconnected from the
+     question text and from any preceding chat history.
+
+   The `AUTO` mode poses no questions and is therefore not in scope.
+
+## MODIFIED
+
+1. **`specs/0002-spec-author-skill.md` → `## Scenarios` (after the
+   existing *"Delta mode on a `spec`-class REVIEW finding"* scenario).**
+   A new failure-path scenario SHALL be inserted, recording the
+   contract that the cold spec-reviewer enforces on prose discipline:
+
+   ```text
+   **Scenario:** Reviewer rejects an interview question batch with no
+   contextualizing preface
+
+   Given the skill is running in `INTERMEDIATE` mode and is about to
+         emit a question batch to the user
+   When  the batch is emitted without a prose preface recalling the
+         ticket, the lifecycle stage, the interview-pass position, and
+         the decisions already taken
+   Then  the cold spec-reviewer SHALL reject the resulting spec PR
+   and   the finding SHALL carry `class: tech` per the retroactive
+         routing matrix
+   ```
+
+## REMOVED
+
+(None. The delta adds discipline; no existing requirement is removed
+or relaxed.)

--- a/specs/0002-spec-author-skill.delta-02.md
+++ b/specs/0002-spec-author-skill.delta-02.md
@@ -19,6 +19,14 @@ prompt-quality defect, not a structural one — the skill already
 selects the right number of questions per mode; it merely fails to
 frame them. This delta closes the framing gap.
 
+The friction's `suggestion:` field cited four preface anchors —
+*EPIC*, *ticket*, *interview-pass position*, and *decisions already
+taken*. R15 collapses the first two into a single *originating ticket
+identifier* anchor because the concept *EPIC* is not first-class in
+`AGENTS.md`: the repository's lifecycle (per ADR-0010) tracks logbook
+issues, not multi-ticket epics. Re-introducing EPIC as a mandatory
+anchor would import a concept the framework does not otherwise carry.
+
 ## ADDED
 
 1. **New requirement (R15) — contextualizing prose around interactive
@@ -61,8 +69,9 @@ frame them. This delta closes the framing gap.
 
 1. **`specs/0002-spec-author-skill.md` → `## Scenarios` (after the
    existing *"Delta mode on a `spec`-class REVIEW finding"* scenario).**
-   A new failure-path scenario SHALL be inserted, recording the
-   contract that the cold spec-reviewer enforces on prose discipline:
+   Three new failure-path scenarios SHALL be inserted, one per R15
+   sub-rule, recording the contracts the cold spec-reviewer enforces
+   on prose discipline:
 
    ```text
    **Scenario:** Reviewer rejects an interview question batch with no
@@ -73,6 +82,37 @@ frame them. This delta closes the framing gap.
    When  the batch is emitted without a prose preface recalling the
          ticket, the lifecycle stage, the interview-pass position, and
          the decisions already taken
+   Then  the cold spec-reviewer SHALL reject the resulting spec PR
+   and   the finding SHALL carry `class: tech` per the retroactive
+         routing matrix
+   ```
+
+   ```text
+   **Scenario:** Reviewer rejects an interview question batch with
+   unexplained non-standard acronyms
+
+   Given the skill is running in `INTERMEDIATE` mode and is about to
+         emit a question batch containing a non-standard
+         software-engineering acronym at its first use within the
+         batch (for example `OQ`, `R1`, `NNNN`)
+   When  the batch is emitted without spelling out the acronym at
+         that first use, either in the question prose, in the option
+         labels, or in the option `description` fields
+   Then  the cold spec-reviewer SHALL reject the resulting spec PR
+   and   the finding SHALL carry `class: tech` per the retroactive
+         routing matrix
+   ```
+
+   ```text
+   **Scenario:** Reviewer rejects an interview question batch whose
+   option descriptions require prior-turn context to be understood
+
+   Given the skill is running in `INTERMEDIATE` mode and is about to
+         emit a question batch whose options each have a `description`
+         field
+   When  any option's `description` field references a decision,
+         identifier, or concept introduced in an earlier conversation
+         turn without restating it inline
    Then  the cold spec-reviewer SHALL reject the resulting spec PR
    and   the finding SHALL carry `class: tech` per the retroactive
          routing matrix


### PR DESCRIPTION
Adds one requirement (R15) to spec 0002 mandating that the `spec-author` skill preface every interactive question batch with a contextualizing paragraph (ticket / lifecycle stage / interview-pass position / decisions already taken), spell out non-standard acronyms at first use, and put enough rationale in each option `description` for the user to decide without re-reading prior conversation turns.

Closes the friction reported in issue #193 (logbook): the previous session's spec-author interview emitted terse question labels and unexplained shorthand, leaving the user unable to ground decisions without scrolling back through the chat history.

## How to read this PR?

Single new file: `specs/0002-spec-author-skill.delta-02.md`. Read end-to-end — the file is short and self-contained.

Key normative pieces:

1. `## ADDED` R15 — the new requirement, in four sub-clauses (preface anchors, acronym discipline, description self-sufficiency, AUTO-mode exemption).
2. `## MODIFIED` — one new failure-path scenario inserted into spec 0002 → `## Scenarios`, codifying the contract the cold spec-reviewer applies (a missing preface ⇒ `class: tech` finding).
3. `## REMOVED` — empty (with explanatory parenthetical).

## How to test this PR?

1. Confirm delta filename: `specs/0002-spec-author-skill.delta-02.md` (parent id `0002`, delta `02`, since `delta-01` was already merged via PR #199).
2. Confirm frontmatter `id: \"0002\"`, `version: 1.2.0` (MINOR bump per *Versioning* — additive normative change constraining a previously unspecified case: prose framing of question batches).
3. Confirm the three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`) are present at H2 level, directly under the file's H1 — the convention introduced by PR #197 and confirmed by PR #199.
4. `markdownlint specs/0002-spec-author-skill.delta-02.md` → zero errors.
5. Inspect the cross-file claim: `specs/0002-spec-author-skill.md` → `## Scenarios` currently contains *"Delta mode on a `spec`-class REVIEW finding"* (around line 121); the new scenario *"Reviewer rejects an interview question batch with no contextualizing preface"* is to be inserted after it.

## Detailed description (for agents)

**Why this delta exists.** The harness-curator's V0 run earlier today opened logbook issue #193 from a friction tagged during the SPECS interview of a prior ticket. The user explicitly told the orchestrator that terse question labels (e.g. *\"OQ unresolved?\"* without spelling out *Open Question*) and unframed batches (no recall of which ticket, which stage, which question of how many) made the interview hard to ground. The friction is a **prompt-quality defect**, not a structural one: the skill already selects the right number of questions per mode; it just fails to frame them.

**Scope decision (interview Q1).** R15 applies to all three interactive modes: `MINIMAL`, `INTERMEDIATE`, and `FULL`. `AUTO` mode poses no questions and is exempt naturally. The user rejected the narrower scope of \"INTERMEDIATE + FULL only\" (the literal wording of the friction's `suggestion:` field) because the same prose discipline should hold the moment any question is posed.

**Normative strength (interview Q2).** R15 uses `SHALL`, not `SHOULD`. Rationale: a `SHOULD`-level rule would allow the skill to skip the preface in \"trivially evident\" cases, but those are exactly the cases where the discipline matters least and where deviation accumulates into the failure mode #193 reports. The cold spec-reviewer is empowered to reject a spec PR that violates R15 with a `class: tech` finding.

**Acronym discipline (interview Q3).** The rule is a **general open rule**, not a closed list. Acronyms not part of widely-used software-engineering vocabulary (examples needing explanation: `OQ`, `R1`, `NNNN`; examples that do not: `PR`, `CI`, `URL`) must be spelled out at first use. A closed list would age badly; the general rule survives vocabulary drift.

**MINOR bump rationale.** Per `docs/spec-format.md` → *Versioning*: an additive normative change that constrains a previously unspecified case is MINOR. The new R15 constrains prose framing, which the parent spec on `main` left unspecified. `1.1.0` → `1.2.0`.

**Dogfooding.** This PR's own session is the first to apply R15 retroactively — every question posed to the user during this SPECS interview followed the contextualization template R15 mandates. The user signalled (in earlier turns of the same session) that the previous question style was opaque, then directly experienced the new style for this very ticket's qualification.

Per Spec-PR workflow → Independence rule, this PR does NOT `Closes #193`. The implementation PR that lands R15 in `community-config/skills/spec-author/SKILL.md` and regenerates the bundles will close the logbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)