### PR TITLE
✨ spec-author: prose discipline for interactive question batches (#193)

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.1.0"
 ---
 
 
@@ -108,6 +108,57 @@ After drafting each of the five mandatory body sections, the skill SHALL
 present the drafted section verbatim and request explicit sign-off
 ("approve / revise / reject") before moving on. The user gates exit on
 the same Open-questions discipline as INTERMEDIATE.
+
+### Prose discipline for interactive batches
+
+The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
+FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt). AUTO is out of scope: it asks no
+questions. The rules realise R15 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+and exist because the framework's interview text frequently renders
+through a side panel that strips prior chat context — the user sees the
+question and option descriptions in isolation. Treat each batch as if
+it were the first thing the user reads in this session.
+
+- **Preface anchors.** Before every interactive batch, emit a short
+  one-paragraph preface that names, in this order: (1) the originating
+  ticket identifier (issue number or spec id), (2) the current
+  lifecycle stage and the artefact being authored, (3) the
+  interview-pass position as "Question N of M — &lt;short label&gt;",
+  and (4) a one-or-two-clause recap of the decisions already taken in
+  this session. The preface compensates for the side-panel rendering;
+  it is not a re-introduction of the skill. Concrete example for a
+  MINIMAL pass at its third question: *"Issue #193 — SPECS stage,
+  authoring `specs/0002-…-delta-03.md`. Question 3 of 3 (acceptance
+  signal). So far: intent confirmed as the prose-discipline edit, and
+  the `harness-report` skill is out of scope."*
+- **Acronym discipline.** Non-standard software-engineering vocabulary
+  SHALL be spelled out at first use within the batch, including inside
+  every option `description`. Treat the following as **illustrative**,
+  not exhaustive. Spell out at first use: `OQ` (*Open Question*), `R1`
+  / `R2` / … (*Requirement N*), `NNNN` (the four-digit spec id),
+  `delta-NN` (the two-digit delta sequence number). Leave bare: `PR`,
+  `CI`, `URL`, `ADR`, `CLI`. When in doubt, spell out — the cost of
+  redundancy is negligible against the cost of an opaque question.
+- **Description self-sufficiency.** Each option's `description` field
+  renders in a side panel disconnected from the question text and from
+  prior chat history; the user must be able to decide from the
+  description alone. Every `description` SHALL carry enough rationale
+  to support the decision without re-reading earlier turns.
+  Non-self-sufficient (bad): *"Use the same approach as before."*
+  Self-sufficient (good): *"Reuse the `INTERMEDIATE` interview path
+  (six questions, user-gated) — same gating model already chosen for
+  spec 0002's parent ticket; lets the user audit each draft section
+  before commit."*
+
+Reviewer enforcement: the three failure-path scenarios added by spec
+0002 delta-02 in
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+→ `## Scenarios` codify the contract. A spec-PR that ships an
+interview batch without a preface, or with an opaque option
+`description`, or with an undefined acronym, is a `class: spec`
+finding in the retroactive review loop.
 
 ## Output contract
 

--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -157,8 +157,9 @@ Reviewer enforcement: the three failure-path scenarios added by spec
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
 → `## Scenarios` codify the contract. A spec-PR that ships an
 interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: spec`
-finding in the retroactive review loop.
+`description`, or with an undefined acronym, is a `class: tech`
+finding in the retroactive review loop (per the three failure-path
+scenarios codified in spec 0002 delta-02 R15).
 
 ## Output contract
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.1.0"
 ---
 
 
@@ -102,6 +102,57 @@ After drafting each of the five mandatory body sections, the skill SHALL
 present the drafted section verbatim and request explicit sign-off
 ("approve / revise / reject") before moving on. The user gates exit on
 the same Open-questions discipline as INTERMEDIATE.
+
+### Prose discipline for interactive batches
+
+The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
+FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt). AUTO is out of scope: it asks no
+questions. The rules realise R15 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+and exist because the framework's interview text frequently renders
+through a side panel that strips prior chat context — the user sees the
+question and option descriptions in isolation. Treat each batch as if
+it were the first thing the user reads in this session.
+
+- **Preface anchors.** Before every interactive batch, emit a short
+  one-paragraph preface that names, in this order: (1) the originating
+  ticket identifier (issue number or spec id), (2) the current
+  lifecycle stage and the artefact being authored, (3) the
+  interview-pass position as "Question N of M — &lt;short label&gt;",
+  and (4) a one-or-two-clause recap of the decisions already taken in
+  this session. The preface compensates for the side-panel rendering;
+  it is not a re-introduction of the skill. Concrete example for a
+  MINIMAL pass at its third question: *"Issue #193 — SPECS stage,
+  authoring `specs/0002-…-delta-03.md`. Question 3 of 3 (acceptance
+  signal). So far: intent confirmed as the prose-discipline edit, and
+  the `harness-report` skill is out of scope."*
+- **Acronym discipline.** Non-standard software-engineering vocabulary
+  SHALL be spelled out at first use within the batch, including inside
+  every option `description`. Treat the following as **illustrative**,
+  not exhaustive. Spell out at first use: `OQ` (*Open Question*), `R1`
+  / `R2` / … (*Requirement N*), `NNNN` (the four-digit spec id),
+  `delta-NN` (the two-digit delta sequence number). Leave bare: `PR`,
+  `CI`, `URL`, `ADR`, `CLI`. When in doubt, spell out — the cost of
+  redundancy is negligible against the cost of an opaque question.
+- **Description self-sufficiency.** Each option's `description` field
+  renders in a side panel disconnected from the question text and from
+  prior chat history; the user must be able to decide from the
+  description alone. Every `description` SHALL carry enough rationale
+  to support the decision without re-reading earlier turns.
+  Non-self-sufficient (bad): *"Use the same approach as before."*
+  Self-sufficient (good): *"Reuse the `INTERMEDIATE` interview path
+  (six questions, user-gated) — same gating model already chosen for
+  spec 0002's parent ticket; lets the user audit each draft section
+  before commit."*
+
+Reviewer enforcement: the three failure-path scenarios added by spec
+0002 delta-02 in
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+→ `## Scenarios` codify the contract. A spec-PR that ships an
+interview batch without a preface, or with an opaque option
+`description`, or with an undefined acronym, is a `class: spec`
+finding in the retroactive review loop.
 
 ## Output contract
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -151,8 +151,9 @@ Reviewer enforcement: the three failure-path scenarios added by spec
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
 → `## Scenarios` codify the contract. A spec-PR that ships an
 interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: spec`
-finding in the retroactive review loop.
+`description`, or with an undefined acronym, is a `class: tech`
+finding in the retroactive review loop (per the three failure-path
+scenarios codified in spec 0002 delta-02 R15).
 
 ## Output contract
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.1.0"
 ---
 
 
@@ -102,6 +102,57 @@ After drafting each of the five mandatory body sections, the skill SHALL
 present the drafted section verbatim and request explicit sign-off
 ("approve / revise / reject") before moving on. The user gates exit on
 the same Open-questions discipline as INTERMEDIATE.
+
+### Prose discipline for interactive batches
+
+The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
+FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt). AUTO is out of scope: it asks no
+questions. The rules realise R15 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+and exist because the framework's interview text frequently renders
+through a side panel that strips prior chat context — the user sees the
+question and option descriptions in isolation. Treat each batch as if
+it were the first thing the user reads in this session.
+
+- **Preface anchors.** Before every interactive batch, emit a short
+  one-paragraph preface that names, in this order: (1) the originating
+  ticket identifier (issue number or spec id), (2) the current
+  lifecycle stage and the artefact being authored, (3) the
+  interview-pass position as "Question N of M — &lt;short label&gt;",
+  and (4) a one-or-two-clause recap of the decisions already taken in
+  this session. The preface compensates for the side-panel rendering;
+  it is not a re-introduction of the skill. Concrete example for a
+  MINIMAL pass at its third question: *"Issue #193 — SPECS stage,
+  authoring `specs/0002-…-delta-03.md`. Question 3 of 3 (acceptance
+  signal). So far: intent confirmed as the prose-discipline edit, and
+  the `harness-report` skill is out of scope."*
+- **Acronym discipline.** Non-standard software-engineering vocabulary
+  SHALL be spelled out at first use within the batch, including inside
+  every option `description`. Treat the following as **illustrative**,
+  not exhaustive. Spell out at first use: `OQ` (*Open Question*), `R1`
+  / `R2` / … (*Requirement N*), `NNNN` (the four-digit spec id),
+  `delta-NN` (the two-digit delta sequence number). Leave bare: `PR`,
+  `CI`, `URL`, `ADR`, `CLI`. When in doubt, spell out — the cost of
+  redundancy is negligible against the cost of an opaque question.
+- **Description self-sufficiency.** Each option's `description` field
+  renders in a side panel disconnected from the question text and from
+  prior chat history; the user must be able to decide from the
+  description alone. Every `description` SHALL carry enough rationale
+  to support the decision without re-reading earlier turns.
+  Non-self-sufficient (bad): *"Use the same approach as before."*
+  Self-sufficient (good): *"Reuse the `INTERMEDIATE` interview path
+  (six questions, user-gated) — same gating model already chosen for
+  spec 0002's parent ticket; lets the user audit each draft section
+  before commit."*
+
+Reviewer enforcement: the three failure-path scenarios added by spec
+0002 delta-02 in
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+→ `## Scenarios` codify the contract. A spec-PR that ships an
+interview batch without a preface, or with an opaque option
+`description`, or with an undefined acronym, is a `class: spec`
+finding in the retroactive review loop.
 
 ## Output contract
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -151,8 +151,9 @@ Reviewer enforcement: the three failure-path scenarios added by spec
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
 → `## Scenarios` codify the contract. A spec-PR that ships an
 interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: spec`
-finding in the retroactive review loop.
+`description`, or with an undefined acronym, is a `class: tech`
+finding in the retroactive review loop (per the three failure-path
+scenarios codified in spec 0002 delta-02 R15).
 
 ## Output contract
 

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -163,8 +163,9 @@ Reviewer enforcement: the three failure-path scenarios added by spec
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
 → `## Scenarios` codify the contract. A spec-PR that ships an
 interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: spec`
-finding in the retroactive review loop.
+`description`, or with an undefined acronym, is a `class: tech`
+finding in the retroactive review loop (per the three failure-path
+scenarios codified in spec 0002 delta-02 R15).
 
 ## Output contract
 

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.0.2"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read
@@ -114,6 +114,57 @@ After drafting each of the five mandatory body sections, the skill SHALL
 present the drafted section verbatim and request explicit sign-off
 ("approve / revise / reject") before moving on. The user gates exit on
 the same Open-questions discipline as INTERMEDIATE.
+
+### Prose discipline for interactive batches
+
+The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
+FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt). AUTO is out of scope: it asks no
+questions. The rules realise R15 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+and exist because the framework's interview text frequently renders
+through a side panel that strips prior chat context — the user sees the
+question and option descriptions in isolation. Treat each batch as if
+it were the first thing the user reads in this session.
+
+- **Preface anchors.** Before every interactive batch, emit a short
+  one-paragraph preface that names, in this order: (1) the originating
+  ticket identifier (issue number or spec id), (2) the current
+  lifecycle stage and the artefact being authored, (3) the
+  interview-pass position as "Question N of M — &lt;short label&gt;",
+  and (4) a one-or-two-clause recap of the decisions already taken in
+  this session. The preface compensates for the side-panel rendering;
+  it is not a re-introduction of the skill. Concrete example for a
+  MINIMAL pass at its third question: *"Issue #193 — SPECS stage,
+  authoring `specs/0002-…-delta-03.md`. Question 3 of 3 (acceptance
+  signal). So far: intent confirmed as the prose-discipline edit, and
+  the `harness-report` skill is out of scope."*
+- **Acronym discipline.** Non-standard software-engineering vocabulary
+  SHALL be spelled out at first use within the batch, including inside
+  every option `description`. Treat the following as **illustrative**,
+  not exhaustive. Spell out at first use: `OQ` (*Open Question*), `R1`
+  / `R2` / … (*Requirement N*), `NNNN` (the four-digit spec id),
+  `delta-NN` (the two-digit delta sequence number). Leave bare: `PR`,
+  `CI`, `URL`, `ADR`, `CLI`. When in doubt, spell out — the cost of
+  redundancy is negligible against the cost of an opaque question.
+- **Description self-sufficiency.** Each option's `description` field
+  renders in a side panel disconnected from the question text and from
+  prior chat history; the user must be able to decide from the
+  description alone. Every `description` SHALL carry enough rationale
+  to support the decision without re-reading earlier turns.
+  Non-self-sufficient (bad): *"Use the same approach as before."*
+  Self-sufficient (good): *"Reuse the `INTERMEDIATE` interview path
+  (six questions, user-gated) — same gating model already chosen for
+  spec 0002's parent ticket; lets the user audit each draft section
+  before commit."*
+
+Reviewer enforcement: the three failure-path scenarios added by spec
+0002 delta-02 in
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+→ `## Scenarios` codify the contract. A spec-PR that ships an
+interview batch without a preface, or with an opaque option
+`description`, or with an undefined acronym, is a `class: spec`
+finding in the retroactive review loop.
 
 ## Output contract
 


### PR DESCRIPTION
Teach the `spec-author` skill to preface every interactive question batch with the four context anchors that the side-panel rendering otherwise strips. Realises requirement R15 of `specs/0002-spec-author-skill.md` (introduced by the merged delta-02) and closes the friction cluster surfaced live during the morning's SPECS interview for issue #173.

## How to read this PR?

Suggested order:

1. Read the merged delta-spec `specs/0002-spec-author-skill.delta-02.md` on `main` first — it defines requirement R15 (preface anchors, acronym discipline, description self-sufficiency) and the three failure-path scenarios that the skill text must cover.
2. Read the diff on `community-config/skills/spec-author/SKILL.md` — the only source change. A new subsection `### Prose discipline for interactive batches` lands at the tail of `## Interview script`, plus the `metadata.provenance.version` bump from `1.0.2` to `1.1.0`.
3. Skim the three regenerated bundles (`.claude/skills/spec-author/SKILL.md`, `.gemini/skills/spec-author/SKILL.md`, `.github/skills/spec-author/SKILL.md`) — each is a verbatim mirror of the source produced by `scripts/build-components.sh`. Same `+52 / -1` shape, no semantic divergence.

**Dogfooding angle.** R15 was applied retroactively to this PR's own session and to the preceding spec-PR #204 session — every `AskUserQuestion` posed to the user during the SPECS interview (for delta-02) and the PLAN interview (for issue #193) already followed the four-anchor preface template the skill is now teaching. The user can audit the practice in the GitHub comment history on issue #193 and on the merged spec-PR #204 before the skill itself shipped the rule.

## How to test this PR?

- `git checkout fix/193-prose-discipline`.
- Confirm the new subsection exists and covers all three sub-rules:

  ```sh
  grep -A 5 "Prose discipline for interactive batches" community-config/skills/spec-author/SKILL.md
  ```

- Confirm the MINOR version bump landed:

  ```sh
  grep "version:" community-config/skills/spec-author/SKILL.md | head -1
  # expected: version: "1.1.0"
  ```

- Confirm bundle parity for the new subsection (output should be empty modulo provenance headers):

  ```sh
  diff <(grep -A 200 "Prose discipline" community-config/skills/spec-author/SKILL.md) \
       <(grep -A 200 "Prose discipline" .claude/skills/spec-author/SKILL.md)
  diff <(grep -A 200 "Prose discipline" community-config/skills/spec-author/SKILL.md) \
       <(grep -A 200 "Prose discipline" .gemini/skills/spec-author/SKILL.md)
  diff <(grep -A 200 "Prose discipline" community-config/skills/spec-author/SKILL.md) \
       <(grep -A 200 "Prose discipline" .github/skills/spec-author/SKILL.md)
  ```

- Lint the four touched files (expect zero errors):

  ```sh
  markdownlint community-config/skills/spec-author/SKILL.md \
               .claude/skills/spec-author/SKILL.md \
               .gemini/skills/spec-author/SKILL.md \
               .github/skills/spec-author/SKILL.md
  ```

- Verify CI on head `6b626fb`: `build`, `check-components`, `check-skill-versions`, `lint-markdown`, `test-harness-curate` — all green.

## Detailed description (for agents)

**Why this PR exists.** Issue #193 captures a friction cluster (`spec-author-interview-prose`, room `prompt`, severity `med`) auto-curated from a `claude-code` report tagged during the morning of 2026-06-01. The user surfaced the same friction live during the SPECS interview for issue #173 (the user word for it was *"charabia"* — terse acronym-laden questions rendered through the host-CLI side panel without enough rationale to decide). The friction's evidence pointer (`community-config/skills/spec-author/SKILL.md` → Interview script section) drove the routing: the fix belongs in the skill that authors the prose, not in any consumer.

**The merged spec.** `specs/0002-spec-author-skill.delta-02.md` (merged on `main` via spec-PR #204) introduces requirement R15 *Interactive batch prose discipline* and three failure-path scenarios that codify what a non-conforming question looks like. This PR realises R15 in the skill source.

**Coverage of R15's three sub-rules.** The new `### Prose discipline for interactive batches` subsection in `community-config/skills/spec-author/SKILL.md` maps one paragraph to each sub-rule:

- **Preface anchors** (first bullet) — names the four anchors in order: (1) originating ticket identifier, (2) current lifecycle stage and artefact being authored, (3) interview-pass position as `Question N of M — <short label>`, and (4) a recap of decisions already taken. The paragraph includes a concrete worked example for a MINIMAL pass at its third question.
- **Acronym discipline** (second bullet) — spells out the project's recurrent shorthand (`OQ` → *Open Question*, `R1` → *Requirement 1*, `NNNN` → four-digit spec id, `delta-NN` → two-digit delta sequence number), enumerates which acronyms remain bare (`PR`, `CI`, `URL`, `ADR`, `CLI`), and frames the list as illustrative rather than exhaustive ("when in doubt, spell out").
- **Description self-sufficiency** (third bullet) — explains the side-panel rendering rationale and contrasts a non-self-sufficient option description ("Use the same approach as before.") against a self-sufficient one. This directly answers the friction's `suggestion` field.

A closing paragraph anchors reviewer enforcement to the three failure-path scenarios in `specs/0002-spec-author-skill.md` → `## Scenarios` and routes violations through the retroactive review loop as `class: spec`.

**Mode scope.** The subsection's opening sentence makes the scope explicit: the three sub-rules apply uniformly to MINIMAL, INTERMEDIATE, and FULL; AUTO is out of scope because it asks no questions. This matches the interaction-modes matrix in `AGENTS.md` → *Interaction modes → Behavioural contract per (mode × stage) cell*.

**Version bump rationale.** `1.0.2` → `1.1.0` is MINOR per `AGENTS.md` → *Version Bump Convention*: the diff adds a new section to a shipped source on `main` without altering or removing any existing contract. SemVer guidance for the bump matches the project's documented examples ("new section, new field" → MINOR).

**Built Components compliance.** `scripts/build-components.sh` regenerated the three bundles in the same commit (`6b626fb`); the diff carries `+52 / -1` for each of `.claude/skills/spec-author/SKILL.md`, `.gemini/skills/spec-author/SKILL.md`, `.github/skills/spec-author/SKILL.md`, matching the source's `+52 / -1`. `git status --porcelain` is clean on the head commit — the `check-components` CI job is a backstop, not the first line of defence.

**CLI-matrix non-update — justification.** `community-config/skills/spec-author/SKILL.md` is on the trigger surface listed in `AGENTS.md` → *CLI Matrix Maintenance → Trigger surface*, so the default rule would require a `docs/cli-matrix.md` edit. The non-update is justified substantively, not by the *Protocol-only exemption* (which covers entry-point files only — this is not one). The added prose-discipline subsection introduces no CLI-specific behaviour: no new path, no new command, no new hook, no configuration unique to one CLI. The rule the skill teaches applies identically to every host that surfaces an `AskUserQuestion`-equivalent interactive prompt (Claude Code, Gemini CLI, GitHub Copilot CLI). The three regenerated bundles are textually identical (modulo provenance headers) — there is no surface for the matrix to track.

**Dogfooding.** R15 was applied retroactively to the two sessions that authored this very PR — the SPECS interview that produced `specs/0002-spec-author-skill.delta-02.md` (spec-PR #204) and the PLAN interview that produced the validated PLAN comment on issue #193. Every `AskUserQuestion` in those interviews carried the four-anchor preface, spelled out non-standard acronyms at first use, and provided self-sufficient option `description` fields — before the skill source itself shipped the rule. The audit trail is the GitHub comment history on issue #193 and spec-PR #204.

**Independence rule compliance.** This PR closes the logbook issue (#193) only. It does NOT auto-close spec-PR #204 (which is already merged anyway); the spec-PR's own merge took care of its independent closure path per `AGENTS.md` → *Spec-PR workflow → Independence rule*.

Closes #193