### PR TITLE
✨ spec-author: pre-write grounding for verification specs (#194)

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -160,6 +160,171 @@ interview batch without a preface, or with an opaque option
 `description`, or with an undefined acronym, is a `class: tech`
 finding in the retroactive review loop (per the three failure-path
 scenarios codified in spec 0002 delta-02 R15).
+
+## Pre-write grounding
+
+Before writing the `## Requirements` section of a spec that qualifies
+a **verification, audit, or sanity-check tool** whose acceptance is
+file-level, run a short grounding pass against the codebase. The pass
+realises R16 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+(introduced by delta-03) and exists because the friction reported in
+issue #194 — spec 0007 mandated a `type` field that no built artefact
+ever exhibited, discovered only at DEV time — proves that a WHAT
+qualified in isolation from the actual code drifts. The grounding
+step is the cheap safety net that catches the drift at qualification
+time.
+
+**Mode applicability.** The grounding step runs in all four
+interaction modes — `MINIMAL`, `INTERMEDIATE`, `FULL`, and `AUTO`.
+In `AUTO` the user has no interactive surface to challenge the
+requirements list before the spec PR opens, so grounding is the only
+catcher; any anomaly bullet emitted in `AUTO` carries the
+`[AUTO-PARKED]` discipline of R10 and is audited post hoc via the PR
+diff. A residual risk remains in `AUTO` — a missed-in-scope
+classification produces no bullet at all and no `[AUTO-PARKED]`
+entry to audit — acknowledged in spec 0002 delta-03's `### Risks`
+section.
+
+### Detection
+
+Classify the spec as in-scope for grounding when ANY of the four
+conditions below holds for any drafted requirement. Use the
+disjunction, not a conjunction — a single match flips the spec
+in-scope.
+
+- **a. Quantifier pattern.** The requirement contains *"every"* or
+  *"each"* followed by a noun naming a built artefact class.
+  Example: *"every built `SKILL.md` frontmatter SHALL contain a
+  `type` field"* — `every` + `SKILL.md frontmatter` triggers.
+- **b. File-level assertion.** The requirement asserts a property at
+  the file level: an `exit zero`-style claim, a field-presence claim,
+  a layout claim, or a content-shape claim. Example: *"the linter
+  SHALL exit zero on a clean checkout"* — file-level outcome triggers.
+- **c. Validation-verb on existing class.** The requirement uses a
+  validation, rejection, refusal, or enforcement verb (*refuse*,
+  *reject*, *validate*, *require*, *mandate*, *disallow*, *enforce*,
+  *forbid*) acting on a property of an artefact class the codebase
+  already produces. Example (the iter:1 reviewer counter-example
+  that motivated this clause): *"the build script SHALL refuse to
+  publish bundles whose `provenance` block is missing the `version`
+  field"* — `refuse` + property of `bundles` (an existing class)
+  triggers via condition c. Note that condition a does NOT fire here
+  (no `every` / `each`); condition c is the catcher.
+- **d. Semantic catch-all.** The drafted requirement describes the
+  shape, structure, or content of a class of artefacts the codebase
+  already produces, regardless of surface wording. Example: *"the
+  ADR header MUST carry the status badge in the second line"* — no
+  quantifier, no validation verb, but the requirement targets the
+  shape of an existing class.
+
+**False-positive preference.** When uncertain whether a requirement
+triggers any of the four conditions, treat it as in-scope and run the
+grounding step. Grounding ceremony in an out-of-scope case costs one
+extra file read; grounding skipped in an in-scope case re-introduces
+the original #194 friction. Bias accordingly.
+
+### Inspection
+
+When the spec is in-scope:
+
+1. **Pick the artefact class.** Read the noun in the drafted
+   requirement (e.g. *"every built SKILL.md frontmatter"* →
+   `community-config/skills/*/SKILL.md`). When the requirement names
+   multiple classes, pick one per class.
+2. **Pick at least one real instance.** A safe default is the
+   most-recently-modified file under the class's canonical path
+   (`git log -1 --name-only` scoped to the path). Choose more
+   instances when the class is heterogeneous (e.g. skills and
+   agents both ship `metadata.provenance` — inspect one of each).
+3. **Read the instance end-to-end** when the file is short, or read
+   the relevant section (frontmatter, header block, target field)
+   when the file is long. Use the same `Read` / equivalent tool the
+   skill already uses for repository content; no new tooling
+   required.
+
+### Comparison
+
+Cross-check the observed shape against the drafted requirement. Look
+specifically for:
+
+- **Missing fields.** The requirement mandates a field that the
+  observed instance does not exhibit. (The #194 origin case — spec
+  0007's `type` field.) Distinguish "absent from this instance" from
+  "absent from every instance" — the latter is the *New field on
+  existing class* path below.
+- **Layout divergence.** The requirement implies a structural layout
+  (field nesting, section ordering, header level) the observed
+  instance does not match.
+- **Path mismatch.** The requirement assumes a canonical path
+  (`community-config/skills/<name>/SKILL.md`) that does not match
+  where the class actually lives in the codebase.
+
+The comparison is informational — the skill is checking that the
+WHAT it is about to qualify matches the WHAT already in the codebase,
+not refactoring the codebase to match the spec.
+
+### Anomaly emission
+
+When the comparison surfaces an anomaly, emit a single bullet under
+`## Open questions` prefixed `[GROUNDING:]`. The bullet blocks skill
+exit per R10's open-question discipline (`MINIMAL` / `INTERMEDIATE` /
+`FULL`) or lands as `[AUTO-PARKED]` (`AUTO`). One bullet per anomaly,
+each one one line, naming the observed shape, the drafted requirement,
+and the reconciliation that the user (or AUTO-mode audit reader) must
+take.
+
+Worked example:
+
+```text
+- [GROUNDING:] community-config/skills/spec-author/SKILL.md frontmatter
+  has no 'type' field; the drafted R8 mandates it. Reconcile before exit
+  — either drop R8, retarget the requirement at a different artefact
+  class, or scope the back-fill in `## Out of scope`.
+```
+
+The bullet names enough context for the reader to act without
+re-reading the inspection trail: which file was inspected, what the
+delta is, what the next decision is.
+
+### Conforming-case silence
+
+When the inspection confirms the observed shape matches the drafted
+requirements, emit **nothing**. No `[GROUNDING:]` bullet, no
+"grounding confirmed" line, no audit trail in the spec body. The
+absence of pushback is the only signal. This keeps the spec lean —
+the spec body documents the WHAT, not the qualification ceremony —
+and the grounding step is auditable from the absence of an open
+question, not from a manufactured marker.
+
+### New field on existing class
+
+When the spec mandates a field, attribute, or property that no
+instance of the artefact class currently exhibits on `main` (the
+PR-189 scenario that originated this discipline), still run the
+inspection. The purpose is no longer to confirm field presence
+(absent by definition) but to confirm two adjacent facts:
+
+- The artefact class genuinely exists in the codebase under the
+  path the spec assumes — no typo, no stale path.
+- The existing instances have a coherent shape into which the new
+  field can be added without breaking the structure.
+
+Emit a `[GROUNDING:]` bullet under `## Open questions` stating
+explicitly that the field is absent from every existing instance and
+naming who is responsible for the back-fill: the implementation PR
+that realises this spec, a migration PR scoped under `## Out of
+scope`, or a separate follow-up ticket. This forces the back-fill
+scope decision into the spec PR rather than deferring it to DEV time.
+
+Worked example:
+
+```text
+- [GROUNDING:] No `community-config/skills/*/SKILL.md` on main carries
+  a `type: skill` frontmatter field; the drafted R8 mandates it.
+  Back-fill responsibility: the implementation PR for this spec SHALL
+  add `type:` to every existing skill source in the same diff.
+```
 
 ## Output contract
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -154,6 +154,171 @@ interview batch without a preface, or with an opaque option
 `description`, or with an undefined acronym, is a `class: tech`
 finding in the retroactive review loop (per the three failure-path
 scenarios codified in spec 0002 delta-02 R15).
+
+## Pre-write grounding
+
+Before writing the `## Requirements` section of a spec that qualifies
+a **verification, audit, or sanity-check tool** whose acceptance is
+file-level, run a short grounding pass against the codebase. The pass
+realises R16 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+(introduced by delta-03) and exists because the friction reported in
+issue #194 — spec 0007 mandated a `type` field that no built artefact
+ever exhibited, discovered only at DEV time — proves that a WHAT
+qualified in isolation from the actual code drifts. The grounding
+step is the cheap safety net that catches the drift at qualification
+time.
+
+**Mode applicability.** The grounding step runs in all four
+interaction modes — `MINIMAL`, `INTERMEDIATE`, `FULL`, and `AUTO`.
+In `AUTO` the user has no interactive surface to challenge the
+requirements list before the spec PR opens, so grounding is the only
+catcher; any anomaly bullet emitted in `AUTO` carries the
+`[AUTO-PARKED]` discipline of R10 and is audited post hoc via the PR
+diff. A residual risk remains in `AUTO` — a missed-in-scope
+classification produces no bullet at all and no `[AUTO-PARKED]`
+entry to audit — acknowledged in spec 0002 delta-03's `### Risks`
+section.
+
+### Detection
+
+Classify the spec as in-scope for grounding when ANY of the four
+conditions below holds for any drafted requirement. Use the
+disjunction, not a conjunction — a single match flips the spec
+in-scope.
+
+- **a. Quantifier pattern.** The requirement contains *"every"* or
+  *"each"* followed by a noun naming a built artefact class.
+  Example: *"every built `SKILL.md` frontmatter SHALL contain a
+  `type` field"* — `every` + `SKILL.md frontmatter` triggers.
+- **b. File-level assertion.** The requirement asserts a property at
+  the file level: an `exit zero`-style claim, a field-presence claim,
+  a layout claim, or a content-shape claim. Example: *"the linter
+  SHALL exit zero on a clean checkout"* — file-level outcome triggers.
+- **c. Validation-verb on existing class.** The requirement uses a
+  validation, rejection, refusal, or enforcement verb (*refuse*,
+  *reject*, *validate*, *require*, *mandate*, *disallow*, *enforce*,
+  *forbid*) acting on a property of an artefact class the codebase
+  already produces. Example (the iter:1 reviewer counter-example
+  that motivated this clause): *"the build script SHALL refuse to
+  publish bundles whose `provenance` block is missing the `version`
+  field"* — `refuse` + property of `bundles` (an existing class)
+  triggers via condition c. Note that condition a does NOT fire here
+  (no `every` / `each`); condition c is the catcher.
+- **d. Semantic catch-all.** The drafted requirement describes the
+  shape, structure, or content of a class of artefacts the codebase
+  already produces, regardless of surface wording. Example: *"the
+  ADR header MUST carry the status badge in the second line"* — no
+  quantifier, no validation verb, but the requirement targets the
+  shape of an existing class.
+
+**False-positive preference.** When uncertain whether a requirement
+triggers any of the four conditions, treat it as in-scope and run the
+grounding step. Grounding ceremony in an out-of-scope case costs one
+extra file read; grounding skipped in an in-scope case re-introduces
+the original #194 friction. Bias accordingly.
+
+### Inspection
+
+When the spec is in-scope:
+
+1. **Pick the artefact class.** Read the noun in the drafted
+   requirement (e.g. *"every built SKILL.md frontmatter"* →
+   `community-config/skills/*/SKILL.md`). When the requirement names
+   multiple classes, pick one per class.
+2. **Pick at least one real instance.** A safe default is the
+   most-recently-modified file under the class's canonical path
+   (`git log -1 --name-only` scoped to the path). Choose more
+   instances when the class is heterogeneous (e.g. skills and
+   agents both ship `metadata.provenance` — inspect one of each).
+3. **Read the instance end-to-end** when the file is short, or read
+   the relevant section (frontmatter, header block, target field)
+   when the file is long. Use the same `Read` / equivalent tool the
+   skill already uses for repository content; no new tooling
+   required.
+
+### Comparison
+
+Cross-check the observed shape against the drafted requirement. Look
+specifically for:
+
+- **Missing fields.** The requirement mandates a field that the
+  observed instance does not exhibit. (The #194 origin case — spec
+  0007's `type` field.) Distinguish "absent from this instance" from
+  "absent from every instance" — the latter is the *New field on
+  existing class* path below.
+- **Layout divergence.** The requirement implies a structural layout
+  (field nesting, section ordering, header level) the observed
+  instance does not match.
+- **Path mismatch.** The requirement assumes a canonical path
+  (`community-config/skills/<name>/SKILL.md`) that does not match
+  where the class actually lives in the codebase.
+
+The comparison is informational — the skill is checking that the
+WHAT it is about to qualify matches the WHAT already in the codebase,
+not refactoring the codebase to match the spec.
+
+### Anomaly emission
+
+When the comparison surfaces an anomaly, emit a single bullet under
+`## Open questions` prefixed `[GROUNDING:]`. The bullet blocks skill
+exit per R10's open-question discipline (`MINIMAL` / `INTERMEDIATE` /
+`FULL`) or lands as `[AUTO-PARKED]` (`AUTO`). One bullet per anomaly,
+each one one line, naming the observed shape, the drafted requirement,
+and the reconciliation that the user (or AUTO-mode audit reader) must
+take.
+
+Worked example:
+
+```text
+- [GROUNDING:] community-config/skills/spec-author/SKILL.md frontmatter
+  has no 'type' field; the drafted R8 mandates it. Reconcile before exit
+  — either drop R8, retarget the requirement at a different artefact
+  class, or scope the back-fill in `## Out of scope`.
+```
+
+The bullet names enough context for the reader to act without
+re-reading the inspection trail: which file was inspected, what the
+delta is, what the next decision is.
+
+### Conforming-case silence
+
+When the inspection confirms the observed shape matches the drafted
+requirements, emit **nothing**. No `[GROUNDING:]` bullet, no
+"grounding confirmed" line, no audit trail in the spec body. The
+absence of pushback is the only signal. This keeps the spec lean —
+the spec body documents the WHAT, not the qualification ceremony —
+and the grounding step is auditable from the absence of an open
+question, not from a manufactured marker.
+
+### New field on existing class
+
+When the spec mandates a field, attribute, or property that no
+instance of the artefact class currently exhibits on `main` (the
+PR-189 scenario that originated this discipline), still run the
+inspection. The purpose is no longer to confirm field presence
+(absent by definition) but to confirm two adjacent facts:
+
+- The artefact class genuinely exists in the codebase under the
+  path the spec assumes — no typo, no stale path.
+- The existing instances have a coherent shape into which the new
+  field can be added without breaking the structure.
+
+Emit a `[GROUNDING:]` bullet under `## Open questions` stating
+explicitly that the field is absent from every existing instance and
+naming who is responsible for the back-fill: the implementation PR
+that realises this spec, a migration PR scoped under `## Out of
+scope`, or a separate follow-up ticket. This forces the back-fill
+scope decision into the spec PR rather than deferring it to DEV time.
+
+Worked example:
+
+```text
+- [GROUNDING:] No `community-config/skills/*/SKILL.md` on main carries
+  a `type: skill` frontmatter field; the drafted R8 mandates it.
+  Back-fill responsibility: the implementation PR for this spec SHALL
+  add `type:` to every existing skill source in the same diff.
+```
 
 ## Output contract
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.2.0"
 ---
 
 
@@ -154,6 +154,171 @@ interview batch without a preface, or with an opaque option
 `description`, or with an undefined acronym, is a `class: tech`
 finding in the retroactive review loop (per the three failure-path
 scenarios codified in spec 0002 delta-02 R15).
+
+## Pre-write grounding
+
+Before writing the `## Requirements` section of a spec that qualifies
+a **verification, audit, or sanity-check tool** whose acceptance is
+file-level, run a short grounding pass against the codebase. The pass
+realises R16 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+(introduced by delta-03) and exists because the friction reported in
+issue #194 — spec 0007 mandated a `type` field that no built artefact
+ever exhibited, discovered only at DEV time — proves that a WHAT
+qualified in isolation from the actual code drifts. The grounding
+step is the cheap safety net that catches the drift at qualification
+time.
+
+**Mode applicability.** The grounding step runs in all four
+interaction modes — `MINIMAL`, `INTERMEDIATE`, `FULL`, and `AUTO`.
+In `AUTO` the user has no interactive surface to challenge the
+requirements list before the spec PR opens, so grounding is the only
+catcher; any anomaly bullet emitted in `AUTO` carries the
+`[AUTO-PARKED]` discipline of R10 and is audited post hoc via the PR
+diff. A residual risk remains in `AUTO` — a missed-in-scope
+classification produces no bullet at all and no `[AUTO-PARKED]`
+entry to audit — acknowledged in spec 0002 delta-03's `### Risks`
+section.
+
+### Detection
+
+Classify the spec as in-scope for grounding when ANY of the four
+conditions below holds for any drafted requirement. Use the
+disjunction, not a conjunction — a single match flips the spec
+in-scope.
+
+- **a. Quantifier pattern.** The requirement contains *"every"* or
+  *"each"* followed by a noun naming a built artefact class.
+  Example: *"every built `SKILL.md` frontmatter SHALL contain a
+  `type` field"* — `every` + `SKILL.md frontmatter` triggers.
+- **b. File-level assertion.** The requirement asserts a property at
+  the file level: an `exit zero`-style claim, a field-presence claim,
+  a layout claim, or a content-shape claim. Example: *"the linter
+  SHALL exit zero on a clean checkout"* — file-level outcome triggers.
+- **c. Validation-verb on existing class.** The requirement uses a
+  validation, rejection, refusal, or enforcement verb (*refuse*,
+  *reject*, *validate*, *require*, *mandate*, *disallow*, *enforce*,
+  *forbid*) acting on a property of an artefact class the codebase
+  already produces. Example (the iter:1 reviewer counter-example
+  that motivated this clause): *"the build script SHALL refuse to
+  publish bundles whose `provenance` block is missing the `version`
+  field"* — `refuse` + property of `bundles` (an existing class)
+  triggers via condition c. Note that condition a does NOT fire here
+  (no `every` / `each`); condition c is the catcher.
+- **d. Semantic catch-all.** The drafted requirement describes the
+  shape, structure, or content of a class of artefacts the codebase
+  already produces, regardless of surface wording. Example: *"the
+  ADR header MUST carry the status badge in the second line"* — no
+  quantifier, no validation verb, but the requirement targets the
+  shape of an existing class.
+
+**False-positive preference.** When uncertain whether a requirement
+triggers any of the four conditions, treat it as in-scope and run the
+grounding step. Grounding ceremony in an out-of-scope case costs one
+extra file read; grounding skipped in an in-scope case re-introduces
+the original #194 friction. Bias accordingly.
+
+### Inspection
+
+When the spec is in-scope:
+
+1. **Pick the artefact class.** Read the noun in the drafted
+   requirement (e.g. *"every built SKILL.md frontmatter"* →
+   `community-config/skills/*/SKILL.md`). When the requirement names
+   multiple classes, pick one per class.
+2. **Pick at least one real instance.** A safe default is the
+   most-recently-modified file under the class's canonical path
+   (`git log -1 --name-only` scoped to the path). Choose more
+   instances when the class is heterogeneous (e.g. skills and
+   agents both ship `metadata.provenance` — inspect one of each).
+3. **Read the instance end-to-end** when the file is short, or read
+   the relevant section (frontmatter, header block, target field)
+   when the file is long. Use the same `Read` / equivalent tool the
+   skill already uses for repository content; no new tooling
+   required.
+
+### Comparison
+
+Cross-check the observed shape against the drafted requirement. Look
+specifically for:
+
+- **Missing fields.** The requirement mandates a field that the
+  observed instance does not exhibit. (The #194 origin case — spec
+  0007's `type` field.) Distinguish "absent from this instance" from
+  "absent from every instance" — the latter is the *New field on
+  existing class* path below.
+- **Layout divergence.** The requirement implies a structural layout
+  (field nesting, section ordering, header level) the observed
+  instance does not match.
+- **Path mismatch.** The requirement assumes a canonical path
+  (`community-config/skills/<name>/SKILL.md`) that does not match
+  where the class actually lives in the codebase.
+
+The comparison is informational — the skill is checking that the
+WHAT it is about to qualify matches the WHAT already in the codebase,
+not refactoring the codebase to match the spec.
+
+### Anomaly emission
+
+When the comparison surfaces an anomaly, emit a single bullet under
+`## Open questions` prefixed `[GROUNDING:]`. The bullet blocks skill
+exit per R10's open-question discipline (`MINIMAL` / `INTERMEDIATE` /
+`FULL`) or lands as `[AUTO-PARKED]` (`AUTO`). One bullet per anomaly,
+each one one line, naming the observed shape, the drafted requirement,
+and the reconciliation that the user (or AUTO-mode audit reader) must
+take.
+
+Worked example:
+
+```text
+- [GROUNDING:] community-config/skills/spec-author/SKILL.md frontmatter
+  has no 'type' field; the drafted R8 mandates it. Reconcile before exit
+  — either drop R8, retarget the requirement at a different artefact
+  class, or scope the back-fill in `## Out of scope`.
+```
+
+The bullet names enough context for the reader to act without
+re-reading the inspection trail: which file was inspected, what the
+delta is, what the next decision is.
+
+### Conforming-case silence
+
+When the inspection confirms the observed shape matches the drafted
+requirements, emit **nothing**. No `[GROUNDING:]` bullet, no
+"grounding confirmed" line, no audit trail in the spec body. The
+absence of pushback is the only signal. This keeps the spec lean —
+the spec body documents the WHAT, not the qualification ceremony —
+and the grounding step is auditable from the absence of an open
+question, not from a manufactured marker.
+
+### New field on existing class
+
+When the spec mandates a field, attribute, or property that no
+instance of the artefact class currently exhibits on `main` (the
+PR-189 scenario that originated this discipline), still run the
+inspection. The purpose is no longer to confirm field presence
+(absent by definition) but to confirm two adjacent facts:
+
+- The artefact class genuinely exists in the codebase under the
+  path the spec assumes — no typo, no stale path.
+- The existing instances have a coherent shape into which the new
+  field can be added without breaking the structure.
+
+Emit a `[GROUNDING:]` bullet under `## Open questions` stating
+explicitly that the field is absent from every existing instance and
+naming who is responsible for the back-fill: the implementation PR
+that realises this spec, a migration PR scoped under `## Out of
+scope`, or a separate follow-up ticket. This forces the back-fill
+scope decision into the spec PR rather than deferring it to DEV time.
+
+Worked example:
+
+```text
+- [GROUNDING:] No `community-config/skills/*/SKILL.md` on main carries
+  a `type: skill` frontmatter field; the drafted R8 mandates it.
+  Back-fill responsibility: the implementation PR for this spec SHALL
+  add `type:` to every existing skill source in the same diff.
+```
 
 ## Output contract
 

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read
@@ -166,6 +166,171 @@ interview batch without a preface, or with an opaque option
 `description`, or with an undefined acronym, is a `class: tech`
 finding in the retroactive review loop (per the three failure-path
 scenarios codified in spec 0002 delta-02 R15).
+
+## Pre-write grounding
+
+Before writing the `## Requirements` section of a spec that qualifies
+a **verification, audit, or sanity-check tool** whose acceptance is
+file-level, run a short grounding pass against the codebase. The pass
+realises R16 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
+(introduced by delta-03) and exists because the friction reported in
+issue #194 — spec 0007 mandated a `type` field that no built artefact
+ever exhibited, discovered only at DEV time — proves that a WHAT
+qualified in isolation from the actual code drifts. The grounding
+step is the cheap safety net that catches the drift at qualification
+time.
+
+**Mode applicability.** The grounding step runs in all four
+interaction modes — `MINIMAL`, `INTERMEDIATE`, `FULL`, and `AUTO`.
+In `AUTO` the user has no interactive surface to challenge the
+requirements list before the spec PR opens, so grounding is the only
+catcher; any anomaly bullet emitted in `AUTO` carries the
+`[AUTO-PARKED]` discipline of R10 and is audited post hoc via the PR
+diff. A residual risk remains in `AUTO` — a missed-in-scope
+classification produces no bullet at all and no `[AUTO-PARKED]`
+entry to audit — acknowledged in spec 0002 delta-03's `### Risks`
+section.
+
+### Detection
+
+Classify the spec as in-scope for grounding when ANY of the four
+conditions below holds for any drafted requirement. Use the
+disjunction, not a conjunction — a single match flips the spec
+in-scope.
+
+- **a. Quantifier pattern.** The requirement contains *"every"* or
+  *"each"* followed by a noun naming a built artefact class.
+  Example: *"every built `SKILL.md` frontmatter SHALL contain a
+  `type` field"* — `every` + `SKILL.md frontmatter` triggers.
+- **b. File-level assertion.** The requirement asserts a property at
+  the file level: an `exit zero`-style claim, a field-presence claim,
+  a layout claim, or a content-shape claim. Example: *"the linter
+  SHALL exit zero on a clean checkout"* — file-level outcome triggers.
+- **c. Validation-verb on existing class.** The requirement uses a
+  validation, rejection, refusal, or enforcement verb (*refuse*,
+  *reject*, *validate*, *require*, *mandate*, *disallow*, *enforce*,
+  *forbid*) acting on a property of an artefact class the codebase
+  already produces. Example (the iter:1 reviewer counter-example
+  that motivated this clause): *"the build script SHALL refuse to
+  publish bundles whose `provenance` block is missing the `version`
+  field"* — `refuse` + property of `bundles` (an existing class)
+  triggers via condition c. Note that condition a does NOT fire here
+  (no `every` / `each`); condition c is the catcher.
+- **d. Semantic catch-all.** The drafted requirement describes the
+  shape, structure, or content of a class of artefacts the codebase
+  already produces, regardless of surface wording. Example: *"the
+  ADR header MUST carry the status badge in the second line"* — no
+  quantifier, no validation verb, but the requirement targets the
+  shape of an existing class.
+
+**False-positive preference.** When uncertain whether a requirement
+triggers any of the four conditions, treat it as in-scope and run the
+grounding step. Grounding ceremony in an out-of-scope case costs one
+extra file read; grounding skipped in an in-scope case re-introduces
+the original #194 friction. Bias accordingly.
+
+### Inspection
+
+When the spec is in-scope:
+
+1. **Pick the artefact class.** Read the noun in the drafted
+   requirement (e.g. *"every built SKILL.md frontmatter"* →
+   `community-config/skills/*/SKILL.md`). When the requirement names
+   multiple classes, pick one per class.
+2. **Pick at least one real instance.** A safe default is the
+   most-recently-modified file under the class's canonical path
+   (`git log -1 --name-only` scoped to the path). Choose more
+   instances when the class is heterogeneous (e.g. skills and
+   agents both ship `metadata.provenance` — inspect one of each).
+3. **Read the instance end-to-end** when the file is short, or read
+   the relevant section (frontmatter, header block, target field)
+   when the file is long. Use the same `Read` / equivalent tool the
+   skill already uses for repository content; no new tooling
+   required.
+
+### Comparison
+
+Cross-check the observed shape against the drafted requirement. Look
+specifically for:
+
+- **Missing fields.** The requirement mandates a field that the
+  observed instance does not exhibit. (The #194 origin case — spec
+  0007's `type` field.) Distinguish "absent from this instance" from
+  "absent from every instance" — the latter is the *New field on
+  existing class* path below.
+- **Layout divergence.** The requirement implies a structural layout
+  (field nesting, section ordering, header level) the observed
+  instance does not match.
+- **Path mismatch.** The requirement assumes a canonical path
+  (`community-config/skills/<name>/SKILL.md`) that does not match
+  where the class actually lives in the codebase.
+
+The comparison is informational — the skill is checking that the
+WHAT it is about to qualify matches the WHAT already in the codebase,
+not refactoring the codebase to match the spec.
+
+### Anomaly emission
+
+When the comparison surfaces an anomaly, emit a single bullet under
+`## Open questions` prefixed `[GROUNDING:]`. The bullet blocks skill
+exit per R10's open-question discipline (`MINIMAL` / `INTERMEDIATE` /
+`FULL`) or lands as `[AUTO-PARKED]` (`AUTO`). One bullet per anomaly,
+each one one line, naming the observed shape, the drafted requirement,
+and the reconciliation that the user (or AUTO-mode audit reader) must
+take.
+
+Worked example:
+
+```text
+- [GROUNDING:] community-config/skills/spec-author/SKILL.md frontmatter
+  has no 'type' field; the drafted R8 mandates it. Reconcile before exit
+  — either drop R8, retarget the requirement at a different artefact
+  class, or scope the back-fill in `## Out of scope`.
+```
+
+The bullet names enough context for the reader to act without
+re-reading the inspection trail: which file was inspected, what the
+delta is, what the next decision is.
+
+### Conforming-case silence
+
+When the inspection confirms the observed shape matches the drafted
+requirements, emit **nothing**. No `[GROUNDING:]` bullet, no
+"grounding confirmed" line, no audit trail in the spec body. The
+absence of pushback is the only signal. This keeps the spec lean —
+the spec body documents the WHAT, not the qualification ceremony —
+and the grounding step is auditable from the absence of an open
+question, not from a manufactured marker.
+
+### New field on existing class
+
+When the spec mandates a field, attribute, or property that no
+instance of the artefact class currently exhibits on `main` (the
+PR-189 scenario that originated this discipline), still run the
+inspection. The purpose is no longer to confirm field presence
+(absent by definition) but to confirm two adjacent facts:
+
+- The artefact class genuinely exists in the codebase under the
+  path the spec assumes — no typo, no stale path.
+- The existing instances have a coherent shape into which the new
+  field can be added without breaking the structure.
+
+Emit a `[GROUNDING:]` bullet under `## Open questions` stating
+explicitly that the field is absent from every existing instance and
+naming who is responsible for the back-fill: the implementation PR
+that realises this spec, a migration PR scoped under `## Out of
+scope`, or a separate follow-up ticket. This forces the back-fill
+scope decision into the spec PR rather than deferring it to DEV time.
+
+Worked example:
+
+```text
+- [GROUNDING:] No `community-config/skills/*/SKILL.md` on main carries
+  a `type: skill` frontmatter field; the drafted R8 mandates it.
+  Back-fill responsibility: the implementation PR for this spec SHALL
+  add `type:` to every existing skill source in the same diff.
+```
 
 ## Output contract
 


### PR DESCRIPTION
Realises R16 of `specs/0002-spec-author-skill.md` (delta-03, merged via #206) by adding a `## Pre-write grounding` operational section to the `spec-author` skill. Closes the friction reported in #194 where spec 0007 mandated a `type` field absent from every built artefact — a drift the new grounding pass would have caught at SPECS time rather than DEV time.

## How to read this PR?

Read in this order to follow the qualification → realisation chain:

1. **The merged WHAT** — `specs/0002-spec-author-skill.delta-03.md` on `main` (R16's seven sub-clauses plus sub-clause 7 *"new field on existing class"*). That is the normative contract this PR realises.
2. **The skill diff** — `community-config/skills/spec-author/SKILL.md`, +163 lines inserting a new `## Pre-write grounding` top-level section between `## Interview script` (line 71) and `## Output contract` (now at line 335). Six operational sub-sections — *Detection*, *Inspection*, *Comparison*, *Anomaly emission*, *Conforming-case silence*, *New field on existing class* — plus a one-line *Mode applicability* note covering all four interaction modes including AUTO.
3. **The walk-through under *Detection*** — condition c of the four-condition trigger heuristic is illustrated with the iter:1 reviewer's counter-example (*"build script SHALL refuse to publish bundles whose `provenance` block is missing the `version` field"*). The walk-through confirms the false-positive preference: a borderline case flips the spec in-scope rather than out.
4. **The three regenerated mirrors** — `.claude/`, `.gemini/`, `.github/skills/spec-author/SKILL.md`. Skim only to confirm parity; the source is the normative artefact.

## How to test this PR?

- `git checkout fix/194-pre-write-grounding`
- Confirm the new section exists and covers the mandated sub-sections: `grep -A 5 \"^## Pre-write grounding\" community-config/skills/spec-author/SKILL.md` — expect content covering *Detection / Inspection / Comparison / Anomaly emission / Conforming-case silence / New field on existing class* plus the *Mode applicability* note.
- Confirm the version bump: `grep \"version:\" community-config/skills/spec-author/SKILL.md | head -1` → `1.2.0`.
- Confirm bundle parity: `diff <(grep -A 200 \"Pre-write grounding\" community-config/skills/spec-author/SKILL.md) <(grep -A 200 \"Pre-write grounding\" .claude/skills/spec-author/SKILL.md)` → empty modulo the provenance header lines stripped by the build script.
- Run `markdownlint community-config/skills/spec-author/SKILL.md .claude/skills/spec-author/SKILL.md .gemini/skills/spec-author/SKILL.md .github/skills/spec-author/SKILL.md` → zero errors.
- Verify the five required CI checks are green on head `935977c`.

## Detailed description (for agents)

**Why this PR exists.** Issue #194 reported the friction: spec 0007 (PR #189) required built `SKILL.md` artefacts to carry a `type` frontmatter field — a field no built artefact actually exhibits. The drift was discovered at DEV time only because no qualification-time mechanism cross-checked the WHAT against the codebase. Spec 0002 delta-03 added R16 to mandate the cross-check; this PR is its operational realisation inside the `spec-author` skill.

**R16 sub-clause mapping.** Each of R16's normative sub-clauses lands in a named sub-section of the new `## Pre-write grounding` block:

- Sub-clauses 1–2 (detection trigger, false-positive preference) → `### Detection`. Four-condition disjunction (quantifier pattern, file-level assertion, validation-verb on existing class, *"all built X SHALL …"* surface form) with the explicit *"a single match flips the spec in-scope"* rule and the iter:1 counter-example walk-through.
- Sub-clause 3 (artefact inspection) → `### Inspection`. Identifies which built artefacts to read (e.g. for a `SKILL.md` claim, sample at least three real bundles under `.claude/skills/*/`, `.gemini/skills/*/`, `.github/skills/*/`).
- Sub-clause 4 (drafted-requirement vs reality comparison) → `### Comparison`. Side-by-side check; if the requirement names a field, layout, or shape, confirm at least one inspected artefact already exhibits it OR the requirement explicitly mandates a *change* to introduce it.
- Sub-clause 5 (anomaly emission as a `[GROUNDING:]` open question) → `### Anomaly emission`. Anomalies are surfaced as `[GROUNDING:]` bullets under `## Open questions`, not silently rewritten — preserves the user's ability to choose between *"fix the artefacts"* and *"relax the requirement"*.
- Conforming-case silence → `### Conforming-case silence`. When inspection confirms reality matches the draft, no bullet is emitted; the grounding pass leaves no trace beyond the absence of a `[GROUNDING:]` entry.
- Sub-clause 7 (new field on existing class) → `### New field on existing class`. Explicit handling of the *additive* case: a requirement mandating a new field on an existing artefact class is in-scope (no existing artefact will exhibit it by definition), but the comparison's purpose shifts from *"does reality match?"* to *"does the migration path reach every existing instance?"*.
- Sub-clause 6 (mode applicability) → opening *Mode applicability* paragraph. Grounding runs in all four interaction modes including AUTO; in AUTO the absence of an interactive surface makes the grounding bullet the only catcher, and any emitted bullet inherits R10's `[AUTO-PARKED]` discipline.

**Trigger heuristic and false-positive preference.** The four conditions are deliberately framed as a disjunction — a single match suffices. The closing paragraph of `### Detection` codifies the preference for false positives: *"when uncertain, classify in-scope"*. The walk-through under condition c uses the iter:1 reviewer's counter-example (the `provenance.version` build-script requirement) to show the heuristic correctly flips a borderline spec in-scope rather than letting it slip.

**Version bump.** `metadata.provenance.version` bumped `1.1.0` → `1.2.0` per `AGENTS.md` → *Version Bump Convention*. The change introduces a new top-level section with seven operational sub-sections and a new normative obligation on the skill's authoring behaviour. This is the *"new section / new field"* shape `Version Bump Convention` classifies as MINOR; PATCH would be appropriate only for a friction-fix wording change. The friction reporter's literal suggestion in #194 of a PATCH was considered and rejected during PLAN (see `### Alternatives considered and rejected` in the PLAN v2 comment).

**Built Components rule compliance.** Per `AGENTS.md` → *Built Components*, the diff modifies `community-config/skills/spec-author/SKILL.md` and stages the three regenerated mirrors (`.claude/`, `.gemini/`, `.github/skills/spec-author/SKILL.md`) in the same commit. `bash scripts/build-components.sh` was run; `git status --porcelain` is clean on the four target paths. The CI `check-components` job is the backstop.

**CLI-matrix non-update justification.** `docs/cli-matrix.md` is NOT updated by this PR. The touched path (`community-config/skills/spec-author/SKILL.md`) is on the trigger surface per *CLI Matrix Maintenance*, but R16's behaviour is uniform across Claude Code, Gemini CLI, and GitHub Copilot CLI — the same skill source is compiled to three identical-shape mirrors, with no per-CLI hook, command, path, or configuration introduced. This is the same substantive parity argument used by PR #205 (the previous skill-source PR for `spec-author`); it is NOT the *Protocol-only exemption*, which is reserved for top-level entry-point files only.

Closes #194