### PR TITLE
🔧 mempalace-transcript hook: portable timeout detection (#210)

### DIFF
--- a/hooks/mempalace-transcript.sh
+++ b/hooks/mempalace-transcript.sh
@@ -28,6 +28,20 @@ fi
 # --- Dependencies ---
 command -v jq >/dev/null 2>&1 || { echo "mempalace-transcript: jq required" >&2; exit 0; }
 
+# Detect a portable `timeout` binary. GNU coreutils ships `timeout(1)` on
+# Linux out of the box; macOS does not. Homebrew's `coreutils` package
+# provides `gtimeout`. Fall back to no timeout protection when neither is
+# present — the issue-94 Stop-hook-loop risk returns, but rc=127 on every
+# event (issue #210) is a worse failure mode than the rare hung-Python case.
+if command -v timeout >/dev/null 2>&1; then
+  _HOOK_TIMEOUT="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  _HOOK_TIMEOUT="gtimeout"
+else
+  _HOOK_TIMEOUT=""
+  echo "mempalace-transcript: neither 'timeout' nor 'gtimeout' on PATH; persistence runs without timeout protection (install coreutils to restore it, e.g. 'brew install coreutils' on macOS)" >&2
+fi
+
 MEMPALACE_PYTHON="${MEMPALACE_PYTHON:-python3}"
 
 # --- Read input ---
@@ -121,10 +135,12 @@ if [ -n "$CONTENT" ]; then
 
   # Capture Python stderr to a dedicated file so import/runtime errors are
   # visible instead of being swallowed into $STATUS (issue #93). The
-  # `timeout 5` wrapper kills a hung Python after 5 seconds so a MemPalace
-  # lock cannot stall the calling CLI (issues #90, #94). `set +e`/`set -e`
-  # brackets the call so a non-zero Python exit does not abort the hook —
-  # STATUS_RC carries the actual outcome.
+  # `$_HOOK_TIMEOUT 5` wrapper (resolved at script init to `timeout` or
+  # `gtimeout` per portability detection — issue #210) kills a hung Python
+  # after 5 seconds so a MemPalace lock cannot stall the calling CLI
+  # (issues #90, #94). `set +e`/`set -e` brackets the call so a non-zero
+  # Python exit does not abort the hook — STATUS_RC carries the actual
+  # outcome.
   _HOOK_ERR="${TMPDIR:-/tmp}/mempalace-hook-$$.err"
   trap 'rm -f "$_HOOK_ERR"' EXIT
 
@@ -135,7 +151,7 @@ if [ -n "$CONTENT" ]; then
     TRANSCRIPT_CONTENT="$TRANSCRIPT_CONTENT" \
     TRANSCRIPT_ROOM="$TRANSCRIPT_ROOM" \
     TRANSCRIPT_AGENT="$TRANSCRIPT_AGENT" \
-    timeout 5 "$MEMPALACE_PYTHON" - 2>"$_HOOK_ERR" <<'PYEOF'
+    ${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5} "$MEMPALACE_PYTHON" - 2>"$_HOOK_ERR" <<'PYEOF'
 import os, sys
 try:
     from mempalace.mcp_server import tool_add_drawer


### PR DESCRIPTION
Replaces the hardcoded `timeout 5` invocation in `hooks/mempalace-transcript.sh` with a runtime detection that picks GNU `timeout`, Homebrew's `gtimeout`, or a no-timeout fallback — fixing the rc=127 silent-drop of every transcript event on macOS without coreutils.

## How to read this PR?

Single file changed: `hooks/mempalace-transcript.sh` (+21 / −5). Three logical hunks:

1. **Lines 35–43 (new)** — detection block right after the existing `jq` dependency check. Binds `_HOOK_TIMEOUT` to `timeout` / `gtimeout` / empty string depending on PATH availability.
2. **Lines 138–146 (rewording)** — the comment block above the Python invocation, updated to cite `$_HOOK_TIMEOUT 5` and reference #210 alongside the existing #90 / #93 / #94 references.
3. **Line 154 (the actual call)** — `timeout 5 "$MEMPALACE_PYTHON"…` becomes `${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5} "$MEMPALACE_PYTHON"…`. The `${VAR:+VAR …}` parameter-expansion idiom emits nothing when `_HOOK_TIMEOUT` is empty, leaving a bare Python call on systems lacking both binaries.

## How to test this PR?

1. **Syntax check** — `bash -n hooks/mempalace-transcript.sh` → exit 0.
2. **Linux happy path** — on any system where `timeout(1)` is on PATH, run a Gemini CLI or Claude Code session with `MEMPALACE_TRANSCRIPT_ENABLED=1`; transcripts persist as before. Sanity-check stderr for `mempalace-transcript: persisted ... to transcripts/...`.
3. **macOS happy path (with coreutils)** — `brew install coreutils` provides `gtimeout`. Run the same hook invocation; stderr should show successful persistence (no warning).
4. **macOS fallback path (without coreutils)** — uninstall coreutils (or simulate by hiding `timeout`/`gtimeout` from PATH). The hook should emit one warning at init (`neither 'timeout' nor 'gtimeout' on PATH; persistence runs without timeout protection…`) and then proceed without rc=127.
5. **Reproduction confirmation** — before this PR, the user reported `mempalace-transcript: FAILED to persist tool-use (rc=127): … timeout: commande introuvable` on every event from a macOS Gemini CLI session. After merge + redeployment of `~/.gemini/hooks/mempalace-transcript.sh`, that error should disappear (or be replaced by the one-time init warning if coreutils is not installed).

## Detailed description (for agents)

**Why this PR exists.** Issue #210 reports that `hooks/mempalace-transcript.sh` line 138 hardcodes GNU `timeout(1)`, which is not present on macOS by default. macOS users without Homebrew's `coreutils` installed hit `command not found`, the hook returns rc=127, and every transcript event is silently dropped. The fix that introduced the `timeout 5` wrapper (PR closing issue #94) addressed a hung-Python Stop-hook loop on Linux; it did not consider Darwin portability. Issue #210 is the resulting portability gap.

**Detection logic.** Three-step priority:

```sh
if command -v timeout >/dev/null 2>&1; then
  _HOOK_TIMEOUT="timeout"
elif command -v gtimeout >/dev/null 2>&1; then
  _HOOK_TIMEOUT="gtimeout"
else
  _HOOK_TIMEOUT=""
  echo "<one-time warning at init>" >&2
fi
```

The detection runs once at script init, after the opt-in guard and the `jq` check (so the cost is paid only when the hook actually runs). The chosen binary name is captured in `_HOOK_TIMEOUT` and reused at the call site via `${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5}` — a POSIX-portable parameter expansion that emits the full `<binary> 5` token only when `_HOOK_TIMEOUT` is non-empty, and emits nothing otherwise. The Python call then runs unwrapped on systems without either binary.

**Tradeoff on the third fallback.** When neither `timeout` nor `gtimeout` is present, the script logs a one-time warning and proceeds without timeout protection. This intentionally re-opens the issue-94 hung-Python failure mode on those systems. The tradeoff is sound: rc=127 on every event (current state on macOS without coreutils) silently drops every transcript — a 100% failure rate; the hung-Python case is rare and only manifests when MemPalace itself stalls. The warning gives the user a clear migration path (`brew install coreutils`) to restore protection.

**CLI-matrix impact.** `hooks/mempalace-transcript.sh` is invoked by all three supported CLIs (Claude / Gemini / Copilot). The fix is uniform across CLIs — same binary detection, same fallback — so no CLI-specific behaviour is introduced. The trigger surface in *AGENTS.md → CLI Matrix Maintenance* lists `hooks/*-transcript-hooks.json` (the registration JSONs) but not the shared hook script itself; `docs/cli-matrix.md` therefore needs no update for this PR.

**No version bump.** The file is not under `community-config/skills/*/SKILL.md` nor `community-config/agents/*/AGENT.md` — the *Version Bump Convention* rule does not apply. The hook has no provenance frontmatter.

**No spec, no plan.** Treated as **trivial tier** + **AUTO** mode per user direction. The change is mechanical (binary detection + parameter-expansion wrap), bounded to a single file with no conceptual surface beyond portability, and would not benefit from a spec-PR + plan-comment cycle. The orchestrator handled the edit inline; a cold pr-reviewer pass confirms the change before merge.

**Build / test surface.** No CI tests cover this hook directly. The repo's `lint-markdown` and `check-components` jobs are unaffected. The change will surface in CI only via the absence of regression on the existing checks.

Closes #210