### PR TITLE
📝 [spec-PR] 0002 delta-04 — idiomatic language quality (#209)

### DIFF
--- a/specs/0002-spec-author-skill.delta-04.md
+++ b/specs/0002-spec-author-skill.delta-04.md
@@ -1,0 +1,132 @@
+---
+id: "0002"
+slug: spec-author-skill
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 209
+version: 1.4.0
+---
+
+# 0002 — spec-author-skill (delta-04)
+
+This delta adds one requirement (R17) to spec 0002 mandating that the
+`spec-author` skill, when conversing with a user whose preferred
+language is not English, produces idiomatic prose in that language —
+not direct calques of English software-engineering jargon. The
+friction surfaced live in #209: during the same session that
+introduced R15 (delta-02, prose discipline for interactive question
+batches), the skill emitted phrases like *« le cold reviewer a
+verdicté »*, *« amender en-branche »*, and *« merger »* used as a verb
+— franglais that the user explicitly pushed back on with "ça me coûte
+de l'énergie à lire".
+
+R15 already covered three prose-quality axes — contextualizing
+preface, acronym discipline, and option-description self-sufficiency
+— but said nothing about idiomatic language quality. R17 closes that
+gap. It applies to the same modes as R15 (MINIMAL / INTERMEDIATE /
+FULL) plus AUTO when AUTO emits user-visible artefacts.
+
+## ADDED
+
+1. **New requirement (R17) — idiomatic language quality in
+   user-facing prose.** When the user's preferred language is not
+   English (as declared by the user or inferred from the conversation
+   register), the `spec-author` skill SHALL produce its
+   user-facing prose — the contextualizing preface mandated by R15,
+   the question text itself, the option `label` and `description`
+   fields, and any inline progress messages — in **idiomatic** form
+   in that language. Direct calques of English software-engineering
+   jargon SHALL be avoided.
+
+2. **Calque catalogue.** The skill MAINTAINS the following
+   non-exhaustive correspondence list, against which it self-checks
+   before emitting any batch in French. Equivalent catalogues for
+   other supported languages MAY be added in future deltas; the
+   French list is the seed.
+
+   | English source | Calque to avoid (French) | Idiomatic French |
+   |---|---|---|
+   | `cold reviewer` (noun) | `cold reviewer` / `reviewer froid` | `contrôle indépendant` / `contrôleur indépendant` |
+   | `verdict` (verb form *"to verdict"*) | `verdicter` / `a verdicté` | `rendre un verdict` / `trancher` / `prononcer un verdict` |
+   | `to merge` (verb) | `merger` (calque) | `fusionner` |
+   | `merge` (noun) | `un merge` | `une fusion` |
+   | `to amend` (in the Git sense) | `amender` used as English `amend` | `modifier` / `rectifier` / *(for commits)* `corriger le commit` |
+   | `in-branch` (adjective) | `en-branche` (calque) | `directement sur la branche` |
+   | `pull request` (noun) | `PR` *(without first-use expansion)* | `pull-request` *(spelled out at first use)* |
+   | `to spawn` (an agent) | `spawner` | `lancer` / `démarrer` |
+   | `to push back` (idiomatic) | `pousser en arrière` | `contester` / `s'opposer à` |
+   | `to ship` (a feature) | `shipper` | `livrer` / `publier` |
+
+   The catalogue is informational, not exhaustive. The skill is
+   expected to extrapolate from the listed patterns to unlisted ones
+   — a verb-form anglicism in `-er` derived from an English verb is
+   the canonical red flag.
+
+3. **Trigger detection.** The skill SHALL classify a session as
+   "non-English preferred language" when ANY of the following holds:
+
+   1. The user has explicitly declared a preferred language other
+      than English (a configuration file, a memory record, or a
+      direct conversational statement *"écris-moi en français"*,
+      *"escríbeme en español"*, etc.).
+   2. The user's last three messages were predominantly written in
+      a language other than English.
+   3. The session has previously emitted user-facing prose in a
+      language other than English without correction.
+
+   When in doubt, the skill SHALL default to producing the prose in
+   the user's last-message language and apply R17 accordingly.
+
+4. **AUTO mode applicability.** R17 applies in AUTO mode whenever
+   AUTO emits any user-visible artefact in a language other than
+   English — for example, a `[AUTO-PARKED]` open-question bullet
+   addressing the user, a progress message logged for user review,
+   or a logbook comment intended to be read by the user. AUTO is
+   not exempt simply because no interactive question batch is
+   emitted.
+
+## MODIFIED
+
+1. **`specs/0002-spec-author-skill.md` → `## Scenarios` (after the
+   three failure-path scenarios from delta-02 R15 and the two from
+   delta-03 R16).** Two new scenarios SHALL be inserted, one
+   happy-path and one failure-path, recording the contract R17
+   imposes:
+
+   ```text
+   **Scenario:** Skill produces an idiomatic French interview prose
+   in INTERMEDIATE mode
+
+   Given the skill is running in `INTERMEDIATE` mode and the user's
+         preferred language is French (declared explicitly via memory
+         record or inferred from the session's last messages)
+   When  the skill emits an interactive question batch
+   Then  the contextualizing preface, question text, option labels,
+         and option descriptions SHALL be written in idiomatic French
+   and   no calque from the catalogue under R17 sub-clause 2 SHALL
+         appear in the prose
+   and   the cold spec-reviewer audits the prose for idiomatic
+         correctness and emits no `class: tech` finding.
+   ```
+
+   ```text
+   **Scenario:** Reviewer rejects a French interview batch emitted
+   with English-software-jargon calques
+
+   Given the skill is running in `INTERMEDIATE` mode with French as
+         the user's preferred language
+   When  the emitted batch contains a calque listed in the R17
+         catalogue (for example *"le cold reviewer a verdicté"*,
+         *"amender en-branche"*, *"merger"* as a verb) anywhere in
+         the preface, question text, option labels, or option
+         descriptions
+   Then  the cold spec-reviewer SHALL reject the resulting spec PR
+   and   the finding SHALL carry `class: tech` per the retroactive
+         routing matrix.
+   ```
+
+## REMOVED
+
+(None. The delta is purely additive; R17 strengthens R15 without
+removing or relaxing any existing requirement.)


### PR DESCRIPTION
Adds R17 to spec 0002 mandating that the `spec-author` skill, when conversing in a non-English preferred language, produces idiomatic prose rather than direct calques of English software-engineering jargon. Closes the friction surfaced live during the same session that introduced R15 (the orchestrator emitted *"le cold reviewer a verdicté"*, *"amender en-branche"*, *"merger"* used as a verb — see #209).

## How to read this PR?

Single new file: `specs/0002-spec-author-skill.delta-04.md`. Read end-to-end. Highlights:

1. `## ADDED` sub-clause 1 — R17 itself (mode applicability + scope of user-facing prose covered).
2. `## ADDED` sub-clause 2 — the seed *calque catalogue* (10 English → French correspondences), explicitly non-exhaustive, with the `-er` verb-anglicism extrapolation rule.
3. `## ADDED` sub-clause 3 — trigger detection: when does the skill classify a session as "non-English preferred language".
4. `## ADDED` sub-clause 4 — AUTO-mode applicability: R17 fires whenever AUTO emits user-visible artefacts in a non-English language.
5. `## MODIFIED` — two new scenarios (one happy-path, one failure-path) appended to spec 0002 → `## Scenarios`.

## How to test this PR?

1. Confirm filename: `specs/0002-spec-author-skill.delta-04.md`.
2. Confirm frontmatter `id: \"0002\"`, `version: 1.4.0` (MINOR bump from 1.3.0 after delta-03 merged via PR #206).
3. Confirm the three delta sections (`## ADDED` / `## MODIFIED` / `## REMOVED`) at H2 level.
4. `markdownlint specs/0002-spec-author-skill.delta-04.md` → zero errors.
5. Verify the calque catalogue table renders correctly and the 10 rows are consistent (verb form on the left, calque to avoid in the middle, idiomatic French on the right).

## Detailed description (for agents)

**Why this delta exists.** Live during the session that introduced R15 (delta-02, prose discipline), the user pushed back on the orchestrator's question prose with *« Il y a trop d'anglicismes, je ne comprends RIEN à ce que tu dis »*. R15 codified three axes — contextualizing preface, acronym discipline, description self-sufficiency — but said nothing about idiomatic language quality. The orchestrator could (and did) comply with R15 to the letter while emitting franglais at the sentence level. R17 closes that gap.

**Scope alignment with R15.** R17 names the same prose surface as R15: contextualizing preface + question text + option labels + option descriptions. It adds two extra surfaces: inline progress messages and AUTO-mode user-visible artefacts (because AUTO can still produce text the user reads, even without an interactive question round-trip).

**Mode applicability.** R17 applies to all four modes (MINIMAL / INTERMEDIATE / FULL / AUTO), but the AUTO clause (sub-clause 4) makes the AUTO-specific surface explicit so a future cold reviewer does not argue AUTO is exempt.

**Trigger detection (sub-clause 3).** Three signals classify a session as non-English: explicit user declaration (memory record or direct conversational instruction), inferred from the last three messages, or inherited from prior session prose without correction. The default in ambiguity is to follow the user's last-message language.

**Calque catalogue (sub-clause 2).** A seed table of 10 English → calque-to-avoid → idiomatic-French correspondences. Explicitly non-exhaustive. Carries an extrapolation rule (verb-form anglicisms in `-er` derived from English verbs — *spawner*, *shipper*, *amender* — are the canonical red flag). Future deltas may add catalogues for other supported languages.

**MINOR bump rationale.** Per `docs/spec-format.md` → *Versioning*: additive normative change constraining a previously unspecified case. `1.3.0` → `1.4.0`.

**No AGENTS.md edit.** The `## Language` section of `AGENTS.md` already documents the *User Preferred Language* exception for ephemeral dialogue but does not mandate idiomatic correctness. Adding that mandate to AGENTS.md would (a) touch the CLI-matrix trigger surface (entry-point file), and (b) duplicate what the spec / skill now own. Keeping R17 scoped to the spec is cleaner.

**Self-applying.** This delta-spec PR body is itself in English (project content), so R17 does not gate it. Once R17 lands and the impl-PR realises it, the next interview session in French will be audited cold by the spec-reviewer per the failure-path scenario.

Per Spec-PR workflow → Independence rule, this PR does NOT `Closes #209`. The implementation PR will close the logbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)