### PR TITLE
✨ spec-author: idiomatic language quality (#209)

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -111,15 +111,19 @@ the same Open-questions discipline as INTERMEDIATE.
 
 ### Prose discipline for interactive batches
 
-The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
-FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
-equivalent interactive prompt). AUTO is out of scope: it asks no
-questions. The rules realise R15 of
-[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-and exist because the framework's interview text frequently renders
-through a side panel that strips prior chat context — the user sees the
-question and option descriptions in isolation. Treat each batch as if
-it were the first thing the user reads in this session.
+The four sub-rules below realise R15 and R17 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md).
+The first three (preface anchors, acronym discipline, description
+self-sufficiency) apply uniformly to MINIMAL, INTERMEDIATE, and FULL —
+wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt) — and exist because the framework's
+interview text frequently renders through a side panel that strips
+prior chat context; the user sees the question and option descriptions
+in isolation. Treat each batch as if it were the first thing the user
+reads in this session. The fourth sub-rule (idiomatic language quality)
+extends to AUTO whenever AUTO emits any user-visible artefact in a
+language other than English — AUTO is not exempt simply because no
+interactive question batch is emitted.
 
 - **Preface anchors.** Before every interactive batch, emit a short
   one-paragraph preface that names, in this order: (1) the originating
@@ -151,15 +155,36 @@ it were the first thing the user reads in this session.
   (six questions, user-gated) — same gating model already chosen for
   spec 0002's parent ticket; lets the user audit each draft section
   before commit."*
+- **Idiomatic language quality.** When the user's preferred language
+  is not English (declared explicitly via a memory record or a direct
+  *"écris-moi en français"*-style instruction, inferred from the
+  last three messages, or inherited from prior session prose without
+  correction), produce the preface, the question text, the option
+  `label` fields, the option `description` fields, inline progress
+  messages, and any AUTO-mode user-visible artefact in **idiomatic**
+  prose in that language. Direct calques of English software-
+  engineering jargon — verb forms in `-er` derived from English
+  verbs (`spawner`, `shipper`, `merger` as a verb, `amender` in the
+  English sense), unprefixed `cold reviewer` instead of *"contrôle
+  indépendant"*, `verdicter` instead of *"rendre un verdict"* or
+  *"trancher"*, `en-branche` instead of *"directement sur la
+  branche"*, bare `PR` without first-use expansion to
+  *"pull-request"* — SHALL be avoided. The reference catalogue is
+  in spec 0002 R17 (sub-clause 2). The catalogue is non-exhaustive;
+  extrapolate from the listed patterns. When in doubt, prefer the
+  longer idiomatic phrasing over the calque — verbosity in the
+  target language is a smaller cost than the cognitive friction of
+  parsing franglais.
 
 Reviewer enforcement: the three failure-path scenarios added by spec
 0002 delta-02 in
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-→ `## Scenarios` codify the contract. A spec-PR that ships an
-interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: tech`
-finding in the retroactive review loop (per the three failure-path
-scenarios codified in spec 0002 delta-02 R15).
+→ `## Scenarios` codify the R15 contract; the two scenarios added by
+delta-04 codify the R17 contract. A spec-PR that ships an interview
+batch without a preface, with an opaque option `description`, with
+an undefined acronym, or with a non-English-language calque from the
+R17 catalogue, is a `class: tech` finding in the retroactive review
+loop.
 
 ## Pre-write grounding
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -105,15 +105,19 @@ the same Open-questions discipline as INTERMEDIATE.
 
 ### Prose discipline for interactive batches
 
-The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
-FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
-equivalent interactive prompt). AUTO is out of scope: it asks no
-questions. The rules realise R15 of
-[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-and exist because the framework's interview text frequently renders
-through a side panel that strips prior chat context — the user sees the
-question and option descriptions in isolation. Treat each batch as if
-it were the first thing the user reads in this session.
+The four sub-rules below realise R15 and R17 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md).
+The first three (preface anchors, acronym discipline, description
+self-sufficiency) apply uniformly to MINIMAL, INTERMEDIATE, and FULL —
+wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt) — and exist because the framework's
+interview text frequently renders through a side panel that strips
+prior chat context; the user sees the question and option descriptions
+in isolation. Treat each batch as if it were the first thing the user
+reads in this session. The fourth sub-rule (idiomatic language quality)
+extends to AUTO whenever AUTO emits any user-visible artefact in a
+language other than English — AUTO is not exempt simply because no
+interactive question batch is emitted.
 
 - **Preface anchors.** Before every interactive batch, emit a short
   one-paragraph preface that names, in this order: (1) the originating
@@ -145,15 +149,36 @@ it were the first thing the user reads in this session.
   (six questions, user-gated) — same gating model already chosen for
   spec 0002's parent ticket; lets the user audit each draft section
   before commit."*
+- **Idiomatic language quality.** When the user's preferred language
+  is not English (declared explicitly via a memory record or a direct
+  *"écris-moi en français"*-style instruction, inferred from the
+  last three messages, or inherited from prior session prose without
+  correction), produce the preface, the question text, the option
+  `label` fields, the option `description` fields, inline progress
+  messages, and any AUTO-mode user-visible artefact in **idiomatic**
+  prose in that language. Direct calques of English software-
+  engineering jargon — verb forms in `-er` derived from English
+  verbs (`spawner`, `shipper`, `merger` as a verb, `amender` in the
+  English sense), unprefixed `cold reviewer` instead of *"contrôle
+  indépendant"*, `verdicter` instead of *"rendre un verdict"* or
+  *"trancher"*, `en-branche` instead of *"directement sur la
+  branche"*, bare `PR` without first-use expansion to
+  *"pull-request"* — SHALL be avoided. The reference catalogue is
+  in spec 0002 R17 (sub-clause 2). The catalogue is non-exhaustive;
+  extrapolate from the listed patterns. When in doubt, prefer the
+  longer idiomatic phrasing over the calque — verbosity in the
+  target language is a smaller cost than the cognitive friction of
+  parsing franglais.
 
 Reviewer enforcement: the three failure-path scenarios added by spec
 0002 delta-02 in
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-→ `## Scenarios` codify the contract. A spec-PR that ships an
-interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: tech`
-finding in the retroactive review loop (per the three failure-path
-scenarios codified in spec 0002 delta-02 R15).
+→ `## Scenarios` codify the R15 contract; the two scenarios added by
+delta-04 codify the R17 contract. A spec-PR that ships an interview
+batch without a preface, with an opaque option `description`, with
+an undefined acronym, or with a non-English-language calque from the
+R17 catalogue, is a `class: tech` finding in the retroactive review
+loop.
 
 ## Pre-write grounding
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -105,15 +105,19 @@ the same Open-questions discipline as INTERMEDIATE.
 
 ### Prose discipline for interactive batches
 
-The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
-FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
-equivalent interactive prompt). AUTO is out of scope: it asks no
-questions. The rules realise R15 of
-[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-and exist because the framework's interview text frequently renders
-through a side panel that strips prior chat context — the user sees the
-question and option descriptions in isolation. Treat each batch as if
-it were the first thing the user reads in this session.
+The four sub-rules below realise R15 and R17 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md).
+The first three (preface anchors, acronym discipline, description
+self-sufficiency) apply uniformly to MINIMAL, INTERMEDIATE, and FULL —
+wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt) — and exist because the framework's
+interview text frequently renders through a side panel that strips
+prior chat context; the user sees the question and option descriptions
+in isolation. Treat each batch as if it were the first thing the user
+reads in this session. The fourth sub-rule (idiomatic language quality)
+extends to AUTO whenever AUTO emits any user-visible artefact in a
+language other than English — AUTO is not exempt simply because no
+interactive question batch is emitted.
 
 - **Preface anchors.** Before every interactive batch, emit a short
   one-paragraph preface that names, in this order: (1) the originating
@@ -145,15 +149,36 @@ it were the first thing the user reads in this session.
   (six questions, user-gated) — same gating model already chosen for
   spec 0002's parent ticket; lets the user audit each draft section
   before commit."*
+- **Idiomatic language quality.** When the user's preferred language
+  is not English (declared explicitly via a memory record or a direct
+  *"écris-moi en français"*-style instruction, inferred from the
+  last three messages, or inherited from prior session prose without
+  correction), produce the preface, the question text, the option
+  `label` fields, the option `description` fields, inline progress
+  messages, and any AUTO-mode user-visible artefact in **idiomatic**
+  prose in that language. Direct calques of English software-
+  engineering jargon — verb forms in `-er` derived from English
+  verbs (`spawner`, `shipper`, `merger` as a verb, `amender` in the
+  English sense), unprefixed `cold reviewer` instead of *"contrôle
+  indépendant"*, `verdicter` instead of *"rendre un verdict"* or
+  *"trancher"*, `en-branche` instead of *"directement sur la
+  branche"*, bare `PR` without first-use expansion to
+  *"pull-request"* — SHALL be avoided. The reference catalogue is
+  in spec 0002 R17 (sub-clause 2). The catalogue is non-exhaustive;
+  extrapolate from the listed patterns. When in doubt, prefer the
+  longer idiomatic phrasing over the calque — verbosity in the
+  target language is a smaller cost than the cognitive friction of
+  parsing franglais.
 
 Reviewer enforcement: the three failure-path scenarios added by spec
 0002 delta-02 in
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-→ `## Scenarios` codify the contract. A spec-PR that ships an
-interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: tech`
-finding in the retroactive review loop (per the three failure-path
-scenarios codified in spec 0002 delta-02 R15).
+→ `## Scenarios` codify the R15 contract; the two scenarios added by
+delta-04 codify the R17 contract. A spec-PR that ships an interview
+batch without a preface, with an opaque option `description`, with
+an undefined acronym, or with a non-English-language calque from the
+R17 catalogue, is a `class: tech` finding in the retroactive review
+loop.
 
 ## Pre-write grounding
 

--- a/community-config/skills/spec-author/SKILL.md
+++ b/community-config/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.2.0"
+    version: "1.3.0"
 claude:
   allowed-tools:
     - Read
@@ -117,15 +117,19 @@ the same Open-questions discipline as INTERMEDIATE.
 
 ### Prose discipline for interactive batches
 
-The three sub-rules below apply uniformly to MINIMAL, INTERMEDIATE, and
-FULL — wherever the skill emits an `AskUserQuestion` (or the host CLI's
-equivalent interactive prompt). AUTO is out of scope: it asks no
-questions. The rules realise R15 of
-[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-and exist because the framework's interview text frequently renders
-through a side panel that strips prior chat context — the user sees the
-question and option descriptions in isolation. Treat each batch as if
-it were the first thing the user reads in this session.
+The four sub-rules below realise R15 and R17 of
+[`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md).
+The first three (preface anchors, acronym discipline, description
+self-sufficiency) apply uniformly to MINIMAL, INTERMEDIATE, and FULL —
+wherever the skill emits an `AskUserQuestion` (or the host CLI's
+equivalent interactive prompt) — and exist because the framework's
+interview text frequently renders through a side panel that strips
+prior chat context; the user sees the question and option descriptions
+in isolation. Treat each batch as if it were the first thing the user
+reads in this session. The fourth sub-rule (idiomatic language quality)
+extends to AUTO whenever AUTO emits any user-visible artefact in a
+language other than English — AUTO is not exempt simply because no
+interactive question batch is emitted.
 
 - **Preface anchors.** Before every interactive batch, emit a short
   one-paragraph preface that names, in this order: (1) the originating
@@ -157,15 +161,36 @@ it were the first thing the user reads in this session.
   (six questions, user-gated) — same gating model already chosen for
   spec 0002's parent ticket; lets the user audit each draft section
   before commit."*
+- **Idiomatic language quality.** When the user's preferred language
+  is not English (declared explicitly via a memory record or a direct
+  *"écris-moi en français"*-style instruction, inferred from the
+  last three messages, or inherited from prior session prose without
+  correction), produce the preface, the question text, the option
+  `label` fields, the option `description` fields, inline progress
+  messages, and any AUTO-mode user-visible artefact in **idiomatic**
+  prose in that language. Direct calques of English software-
+  engineering jargon — verb forms in `-er` derived from English
+  verbs (`spawner`, `shipper`, `merger` as a verb, `amender` in the
+  English sense), unprefixed `cold reviewer` instead of *"contrôle
+  indépendant"*, `verdicter` instead of *"rendre un verdict"* or
+  *"trancher"*, `en-branche` instead of *"directement sur la
+  branche"*, bare `PR` without first-use expansion to
+  *"pull-request"* — SHALL be avoided. The reference catalogue is
+  in spec 0002 R17 (sub-clause 2). The catalogue is non-exhaustive;
+  extrapolate from the listed patterns. When in doubt, prefer the
+  longer idiomatic phrasing over the calque — verbosity in the
+  target language is a smaller cost than the cognitive friction of
+  parsing franglais.
 
 Reviewer enforcement: the three failure-path scenarios added by spec
 0002 delta-02 in
 [`specs/0002-spec-author-skill.md`](../../../specs/0002-spec-author-skill.md)
-→ `## Scenarios` codify the contract. A spec-PR that ships an
-interview batch without a preface, or with an opaque option
-`description`, or with an undefined acronym, is a `class: tech`
-finding in the retroactive review loop (per the three failure-path
-scenarios codified in spec 0002 delta-02 R15).
+→ `## Scenarios` codify the R15 contract; the two scenarios added by
+delta-04 codify the R17 contract. A spec-PR that ships an interview
+batch without a preface, with an opaque option `description`, with
+an undefined acronym, or with a non-English-language calque from the
+R17 catalogue, is a `class: tech` finding in the retroactive review
+loop.
 
 ## Pre-write grounding
 


### PR DESCRIPTION
Realises R17 of spec `0002.delta-04.md` (merged via PR #212) in `community-config/skills/spec-author/SKILL.md` — adds a fourth sub-rule *Idiomatic language quality* to the existing *Prose discipline* section so that the skill avoids direct calques of English software-engineering jargon when conversing in a non-English preferred language.

## How to read this PR?

4 files changed (+160 / -60): the skill source plus the three regenerated mirrors. Read order:

1. `community-config/skills/spec-author/SKILL.md` — the source. Three logical hunks:
   - Frontmatter version bump `1.2.0` → `1.3.0` (line 15).
   - Section preamble rewritten to cover **four** sub-rules instead of three, with an explicit AUTO-mode applicability clause for the new rule (around line 118).
   - New fourth bullet `**Idiomatic language quality.**` inserted after `**Description self-sufficiency.**`, plus the closing reviewer-enforcement paragraph updated to name the two delta-04 scenarios.
2. `.claude/skills/spec-author/SKILL.md`, `.gemini/skills/spec-author/SKILL.md`, `.github/skills/spec-author/SKILL.md` — regenerated mirrors. Identical content to the source modulo provenance header lines.

## How to test this PR?

1. `git checkout fix/209-idiomatic-language`.
2. Confirm the new bullet exists: `grep -A 20 "Idiomatic language quality" community-config/skills/spec-author/SKILL.md`. Expect a paragraph naming the trigger conditions (preferred-language detection signals) and the catalogue of calques to avoid (`spawner`, `shipper`, `merger` as a verb, `amender` in the English sense, `cold reviewer`, `verdicter`, `en-branche`, bare `PR`).
3. Confirm the version bump: `grep "version:" community-config/skills/spec-author/SKILL.md | head -1` → `1.3.0`.
4. Confirm bundle parity: `diff <(grep -A 30 "Idiomatic language quality" community-config/skills/spec-author/SKILL.md) <(grep -A 30 "Idiomatic language quality" .claude/skills/spec-author/SKILL.md)` → empty (modulo provenance header).
5. `markdownlint community-config/skills/spec-author/SKILL.md .claude/skills/spec-author/SKILL.md .gemini/skills/spec-author/SKILL.md .github/skills/spec-author/SKILL.md` → zero errors.
6. CI checks (`build`, `check-components`, `check-skill-versions`, `lint-markdown`, `test-harness-curate`, `grep-anti-patterns`) — all green on head `13709f1`.

## Detailed description (for agents)

**Why this PR exists.** Issue #209 reports that during the same session that introduced R15 (delta-02, *Prose discipline for interactive question batches*), the orchestrator emitted French prose that complied with R15's three axes (preface anchors, acronym discipline, description self-sufficiency) at the structural level yet remained franglais at the sentence level (*« le cold reviewer a verdicté »*, *« amender en-branche »*, *« merger »* used as a verb). The user pushed back explicitly. Spec `0002.delta-04.md` introduces R17 to close this gap; this PR realises R17 in the skill source.

**Operational content of the new sub-rule.** The new `**Idiomatic language quality.**` bullet covers:

- **Trigger detection** — three signals (explicit user declaration, inferred from last three messages, inherited from prior prose) and the default-to-last-message-language tie-breaker.
- **Prose surface** — preface + question text + option `label` + option `description` + inline progress messages + AUTO-mode user-visible artefacts.
- **Canonical red flag** — verb forms in `-er` derived from English verbs (the catalogue lists `spawner`, `shipper`, `merger`, `amender` in the English sense).
- **Specific calques to avoid** — `cold reviewer` (→ *« contrôle indépendant »*), `verdicter` (→ *« rendre un verdict » / « trancher »*), `en-branche` (→ *« directement sur la branche »*), bare `PR` (→ *« pull-request »* spelled out at first use).
- **Pointer to the full catalogue** — spec 0002 R17 sub-clause 2.
- **Disambiguation rule** — prefer the longer idiomatic phrasing over the calque when in doubt.

**Section preamble changes.** The original preamble stated three sub-rules and declared *"AUTO is out of scope: it asks no questions"*. That statement is correct for R15 (which is question-batch-bound) but R17 extends to AUTO via sub-clause 4 (AUTO emits user-visible artefacts even without an interactive batch — `[AUTO-PARKED]` open-question bullets, progress messages, logbook comments addressed to the user). The new preamble names four sub-rules, keeps the first-three-apply-to-MINIMAL/INTERMEDIATE/FULL scope, and adds the fourth-rule-extends-to-AUTO clause explicitly.

**MINOR bump rationale.** Per `AGENTS.md` → *Version Bump Convention*: new sub-rule = additive change = MINOR. `1.2.0` → `1.3.0`.

**Reviewer-enforcement clause update.** The closing paragraph that previously named only the three R15 failure-path scenarios now also names the two R17 scenarios added by delta-04 (one happy-path, one failure-path) as the contract enforced by the cold spec-reviewer. The `class: tech` finding label is unchanged.

**No AGENTS.md edit.** R17 lives in the spec and the skill — keeping it scoped here avoids touching the CLI-matrix trigger surface and avoids duplicating the catalogue across two normative artefacts.

**CLI-matrix non-update justification.** `community-config/skills/spec-author/SKILL.md` is on the trigger surface, but R17 introduces no CLI-specific behaviour — the skill behaves identically across Claude / Gemini / Copilot. Same substantive justification as PRs #205, #207.

**Self-applying.** This PR body is in English (project content). The skill's new sub-rule activates on user-facing prose in non-English languages — the next French-language interview session will be audited against R17 by the cold spec-reviewer per the failure-path scenario in delta-04.

Closes #209