### PR TITLE
🐛 Fix pr-reviewer stale-base false-positive cross-references

### DIFF
--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -184,6 +184,26 @@ Before posting, self-check: walk every numeric or factual claim and
 trace it to a path or command output. If you cannot trace, rewrite
 the claim as "see diff" or remove it. Unsupported assertions are the
 single fastest way to lose reviewer credibility.
+
+### Source-of-truth for cross-references
+
+When verifying cross-references, line numbers, or any claim about the
+surrounding context of a modified file, read that file at the PR's
+`headRef` via the GitHub API — **not** from the local working tree.
+The local checkout may be behind the PR base (e.g. an earlier PR
+landed on `main` but the local clone has not pulled), silently
+anchoring cross-reference checks on a stale file and producing
+confidently-wrong blocking findings.
+
+```bash
+gh api "repos/<owner>/<repo>/contents/<path>?ref=<headRef>" \
+  --header "Accept: application/vnd.github.raw"
+```
+
+The `gh pr diff` alone is insufficient for cross-reference validation:
+it shows only the added lines, not the surrounding rule numbering they
+point to. Always cross-check claims about surrounding context against
+the file at the PR's head ref.
 
 ## Friction reporting
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -179,6 +179,26 @@ Before posting, self-check: walk every numeric or factual claim and
 trace it to a path or command output. If you cannot trace, rewrite
 the claim as "see diff" or remove it. Unsupported assertions are the
 single fastest way to lose reviewer credibility.
+
+### Source-of-truth for cross-references
+
+When verifying cross-references, line numbers, or any claim about the
+surrounding context of a modified file, read that file at the PR's
+`headRef` via the GitHub API — **not** from the local working tree.
+The local checkout may be behind the PR base (e.g. an earlier PR
+landed on `main` but the local clone has not pulled), silently
+anchoring cross-reference checks on a stale file and producing
+confidently-wrong blocking findings.
+
+```bash
+gh api "repos/<owner>/<repo>/contents/<path>?ref=<headRef>" \
+  --header "Accept: application/vnd.github.raw"
+```
+
+The `gh pr diff` alone is insufficient for cross-reference validation:
+it shows only the added lines, not the surrounding rule numbering they
+point to. Always cross-check claims about surrounding context against
+the file at the PR's head ref.
 
 ## Friction reporting
 

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -179,6 +179,26 @@ Before posting, self-check: walk every numeric or factual claim and
 trace it to a path or command output. If you cannot trace, rewrite
 the claim as "see diff" or remove it. Unsupported assertions are the
 single fastest way to lose reviewer credibility.
+
+### Source-of-truth for cross-references
+
+When verifying cross-references, line numbers, or any claim about the
+surrounding context of a modified file, read that file at the PR's
+`headRef` via the GitHub API — **not** from the local working tree.
+The local checkout may be behind the PR base (e.g. an earlier PR
+landed on `main` but the local clone has not pulled), silently
+anchoring cross-reference checks on a stale file and producing
+confidently-wrong blocking findings.
+
+```bash
+gh api "repos/<owner>/<repo>/contents/<path>?ref=<headRef>" \
+  --header "Accept: application/vnd.github.raw"
+```
+
+The `gh pr diff` alone is insufficient for cross-reference validation:
+it shows only the added lines, not the surrounding rule numbering they
+point to. Always cross-check claims about surrounding context against
+the file at the PR's head ref.
 
 ## Friction reporting
 

--- a/community-config/skills/pr-reviewer/SKILL.md
+++ b/community-config/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 claude:
   allowed-tools:
     - Read
@@ -190,6 +190,26 @@ Before posting, self-check: walk every numeric or factual claim and
 trace it to a path or command output. If you cannot trace, rewrite
 the claim as "see diff" or remove it. Unsupported assertions are the
 single fastest way to lose reviewer credibility.
+
+### Source-of-truth for cross-references
+
+When verifying cross-references, line numbers, or any claim about the
+surrounding context of a modified file, read that file at the PR's
+`headRef` via the GitHub API — **not** from the local working tree.
+The local checkout may be behind the PR base (e.g. an earlier PR
+landed on `main` but the local clone has not pulled), silently
+anchoring cross-reference checks on a stale file and producing
+confidently-wrong blocking findings.
+
+```bash
+gh api "repos/<owner>/<repo>/contents/<path>?ref=<headRef>" \
+  --header "Accept: application/vnd.github.raw"
+```
+
+The `gh pr diff` alone is insufficient for cross-reference validation:
+it shows only the added lines, not the surrounding rule numbering they
+point to. Always cross-check claims about surrounding context against
+the file at the PR's head ref.
 
 ## Friction reporting
 


### PR DESCRIPTION
The pr-reviewer skill's Grounding discipline now mandates reading files at the PR's headRef via the GitHub API when verifying cross-references, rather than relying on the local working tree which may be stale.

## How to read this PR?

1. `community-config/skills/pr-reviewer/SKILL.md` — the source change: version bump + new "Source-of-truth for cross-references" subsection under Grounding discipline.
2. `.claude/skills/pr-reviewer/SKILL.md`, `.gemini/skills/pr-reviewer/SKILL.md`, `.github/skills/pr-reviewer/SKILL.md` — regenerated built outputs from `scripts/build-components.sh`.

## How to test this PR?

1. Run `bash scripts/build-components.sh` and verify `git status --porcelain` is clean (no drift).
2. Run `bash scripts/lint-markdown.sh community-config/skills/pr-reviewer/SKILL.md` — should pass.
3. Verify the version bump: `grep 'version:' community-config/skills/pr-reviewer/SKILL.md` should show `1.1.3`.

## Detailed description (for agents)

- **Source change (`community-config/skills/pr-reviewer/SKILL.md`):** Bumped `metadata.provenance.version` from `1.1.2` to `1.1.3` (PATCH — friction fix, wording change). Added a `### Source-of-truth for cross-references` subsection to the `## Grounding discipline` section. The new subsection mandates that when verifying cross-references, line numbers, or claims about surrounding context of a modified file, the reviewer MUST read the file at the PR's `headRef` via the GitHub API (`gh api repos/<owner>/<repo>/contents/<path>?ref=<headRef> --header "Accept: application/vnd.github.raw"`), NOT from the local working tree. Includes rationale: local checkout may be behind main, silently anchoring checks on a stale file.
- **Built outputs:** Regenerated via `scripts/build-components.sh` — the three CLI-specific copies of the skill reflect the source change identically.
- **No test changes** — this is a documentation/protocol change for an agent skill, not application code.

Closes #200