### PR TITLE
🐛 Relax identity-file prereq check to presence-only

### DIFF
--- a/scripts/setup-claude-interactive.sh
+++ b/scripts/setup-claude-interactive.sh
@@ -60,24 +60,25 @@ command -v claude >/dev/null 2>&1 || {
 }
 
 # --- Prerequisites: identity files ---
-# SOUL.md and PROFILE.md must be generated BEFORE running this setup.
+# SOUL.md and PROFILE.md must exist BEFORE running this setup.
 # They are produced by the /init-soul and /init-personal-profile skills.
+# Customization is optional: accepting all defaults in those skills is a
+# valid outcome, so a presence check is the contract — not a byte-diff
+# against the template.
 MISSING_PREREQS=()
 
 check_finalized() {
-  local file="$1" template="$2" label="$3" skill="$4"
+  local file="$1" label="$2" skill="$3"
   if [ ! -f "$file" ]; then
     MISSING_PREREQS+=("$label is missing — run: claude $skill")
-  elif [ -f "$template" ] && diff -q "$file" "$template" >/dev/null 2>&1; then
-    MISSING_PREREQS+=("$label is identical to its template — run: claude $skill to customize it")
   fi
 }
 
-check_finalized "$REPO_DIR/config/SOUL.md"    "$REPO_DIR/config/SOUL.md.template"    "config/SOUL.md"    "/init-soul"
-check_finalized "$REPO_DIR/config/PROFILE.md" "$REPO_DIR/config/PROFILE.md.template" "config/PROFILE.md" "/init-personal-profile"
+check_finalized "$REPO_DIR/config/SOUL.md"    "config/SOUL.md"    "/init-soul"
+check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-personal-profile"
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
-  echo "Cannot proceed — required identity files are missing or not customized:"
+  echo "Cannot proceed — required identity files are missing:"
   for item in "${MISSING_PREREQS[@]}"; do
     echo "  - $item"
   done

--- a/scripts/setup-copilot-interactive.sh
+++ b/scripts/setup-copilot-interactive.sh
@@ -54,24 +54,25 @@ if ! gh copilot --help >/dev/null 2>&1 && ! command -v copilot >/dev/null 2>&1; 
 fi
 
 # --- Prerequisites: identity files ---
-# SOUL.md and PROFILE.md must be generated BEFORE running this setup.
+# SOUL.md and PROFILE.md must exist BEFORE running this setup.
 # They are produced by the /init-soul and /init-personal-profile skills.
+# Customization is optional: accepting all defaults in those skills is a
+# valid outcome, so a presence check is the contract — not a byte-diff
+# against the template.
 MISSING_PREREQS=()
 
 check_finalized() {
-  local file="$1" template="$2" label="$3" skill="$4"
+  local file="$1" label="$2" skill="$3"
   if [ ! -f "$file" ]; then
     MISSING_PREREQS+=("$label is missing — run: $skill")
-  elif [ -f "$template" ] && diff -q "$file" "$template" >/dev/null 2>&1; then
-    MISSING_PREREQS+=("$label is identical to its template — run: $skill to customize it")
   fi
 }
 
-check_finalized "$REPO_DIR/config/SOUL.md"    "$REPO_DIR/config/SOUL.md.template"    "config/SOUL.md"    "/init-soul"
-check_finalized "$REPO_DIR/config/PROFILE.md" "$REPO_DIR/config/PROFILE.md.template" "config/PROFILE.md" "/init-personal-profile"
+check_finalized "$REPO_DIR/config/SOUL.md"    "config/SOUL.md"    "/init-soul"
+check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-personal-profile"
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
-  echo "Cannot proceed — required identity files are missing or not customized:"
+  echo "Cannot proceed — required identity files are missing:"
   for item in "${MISSING_PREREQS[@]}"; do
     echo "  - $item"
   done

--- a/scripts/setup-gemini-interactive.sh
+++ b/scripts/setup-gemini-interactive.sh
@@ -54,23 +54,24 @@ command -v jq >/dev/null 2>&1 || {
 }
 
 # --- Prerequisites: identity files ---
-# SOUL.md and PROFILE.md must be generated BEFORE running this setup.
+# SOUL.md and PROFILE.md must exist BEFORE running this setup.
+# Customization is optional: accepting all defaults in /init-soul and
+# /init-personal-profile is a valid outcome, so a presence check is the
+# contract — not a byte-diff against the template.
 MISSING_PREREQS=()
 
 check_finalized() {
-  local file="$1" template="$2" label="$3" skill="$4"
+  local file="$1" label="$2" skill="$3"
   if [ ! -f "$file" ]; then
     MISSING_PREREQS+=("$label is missing — run: gemini $skill")
-  elif [ -f "$template" ] && diff -q "$file" "$template" >/dev/null 2>&1; then
-    MISSING_PREREQS+=("$label is identical to its template — run: gemini $skill to customize it")
   fi
 }
 
-check_finalized "$REPO_DIR/config/SOUL.md"    "$REPO_DIR/config/SOUL.md.template"    "config/SOUL.md"    "/init-soul"
-check_finalized "$REPO_DIR/config/PROFILE.md" "$REPO_DIR/config/PROFILE.md.template" "config/PROFILE.md" "/init-personal-profile"
+check_finalized "$REPO_DIR/config/SOUL.md"    "config/SOUL.md"    "/init-soul"
+check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-personal-profile"
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
-  echo "Cannot proceed — required identity files are missing or not customized:"
+  echo "Cannot proceed — required identity files are missing:"
   for item in "${MISSING_PREREQS[@]}"; do
     echo "  - $item"
   done


### PR DESCRIPTION
Fix the first-install footgun where `/init-soul` (or `/init-personal-profile`) followed by `task setup-<cli>-interactive` could legitimately fail when the user accepted all defaults. Switch the prerequisite contract from byte-equality with the template to file presence, symmetrically across the three CLI setup scripts.

## How to read this PR?

Read `scripts/setup-claude-interactive.sh` first — the diff is the canonical pattern. The two siblings (`setup-gemini-interactive.sh`, `setup-copilot-interactive.sh`) carry the identical change for parity. The `check_finalized` helper drops its `template` and `diff -q` arguments and keeps only the presence test; user-facing message updated to reflect the new contract ("missing" — no longer "missing or not customized").

The CLI matrix (`docs/cli-matrix.md` row 10) describes the setup-script capability at a granularity that does not track the prereq check; no matrix edit was required (the row already reflects symmetric `✅` across the three CLIs and stays so).

## How to test this PR?

```sh
# Reproduce the original symptom on `main` (optional, for comparison):
cp config/SOUL.md.template config/SOUL.md
cp config/PROFILE.md.template config/PROFILE.md
bash scripts/setup-claude-interactive.sh   # FAILED before this PR

# On this branch:
cp config/SOUL.md.template config/SOUL.md
cp config/PROFILE.md.template config/PROFILE.md
bash scripts/setup-claude-interactive.sh   # PASSES the prereq block

# Negative path (still enforced):
rm config/SOUL.md
bash scripts/setup-claude-interactive.sh   # fails with: 'config/SOUL.md is missing — run: claude /init-soul'
```

Same procedure works for the gemini and copilot setup scripts.

## Detailed description (for agents)

**Files modified (3):**

- `scripts/setup-claude-interactive.sh` (lines 62-74 in the new version)
- `scripts/setup-gemini-interactive.sh` (lines 56-67 in the new version)
- `scripts/setup-copilot-interactive.sh` (lines 56-69 in the new version)

**Change in `check_finalized`:**

Before:
```sh
check_finalized() {
  local file="$1" template="$2" label="$3" skill="$4"
  if [ ! -f "$file" ]; then
    MISSING_PREREQS+=("$label is missing — run: <cli> $skill")
  elif [ -f "$template" ] && diff -q "$file" "$template" >/dev/null 2>&1; then
    MISSING_PREREQS+=("$label is identical to its template — run: <cli> $skill to customize it")
  fi
}
```

After:
```sh
check_finalized() {
  local file="$1" label="$2" skill="$3"
  if [ ! -f "$file" ]; then
    MISSING_PREREQS+=("$label is missing — run: <cli> $skill")
  fi
}
```

Call sites updated to drop the now-unused `template` argument. The comment block above each helper documents that customization is optional and the contract is presence-only. The error message banner is updated from "missing or not customized" to "missing" to match the relaxed contract.

**Policy rationale.** Per the issue's mandatory-vs-optional question, the user chose **optional**. The `/init-soul` and `/init-personal-profile` skills are guided conversations whose contract is "produce a usable identity file"; accepting all defaults is a valid outcome of that conversation. The byte-diff check assumed the opposite. Aligning the script with the skill is less invasive than forcing the skill to inject divergence (no skill changes needed; no README change required).

**Out of scope / explicitly not changed.**

- The `/init-soul` and `/init-personal-profile` skills under `community-config/skills/` — unchanged. Optional-customization policy means they are already correct.
- Other `diff -q` usages in the same scripts (`setup-claude-interactive.sh:316`, `setup-gemini-interactive.sh:231`) — they implement an unrelated keep-or-refresh check on `~/.claude/rules/PROFILE.md` vs the repo copy, not a template prereq.
- `docs/cli-matrix.md` — consulted; no edit required (row 10 is granular at the script-capability level and already symmetric).

**Legacy ticket.** Issue #146 was classified `keep-legacy` by spec 0008 (pinned comment by @hcross). This PR therefore follows the pre-#176 contract: direct implementation PR closes the issue, no `/specs/` file, no PLAN comment, no class-tagged review findings.

Closes #146