### PR TITLE
✨ Add curator rot visibility (skipped + routing_failures arrays)

### DIFF
--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.1"
+    version: "1.5.0"
 ---
 
 
@@ -86,6 +86,21 @@ document on stdout:
       "body": "<markdown>",
       "labels": ["harness-feedback", "room:prompt", "severity:med"],
       "frictions": [...]
+    }
+  ],
+  "skipped": [
+    {
+      "drawer_id": "drw-005",
+      "room": "process",
+      "reason": "malformed",
+      "snippet": "Not a friction at all — random text..."
+    }
+  ],
+  "routing_failures": [
+    {
+      "cluster_key": "no-canonical-cluster",
+      "frictions": [...],
+      "reason": "missing_canonical"
     }
   ]
 }

--- a/.claude/skills/harness-curator/assets/sample-frictions.json
+++ b/.claude/skills/harness-curator/assets/sample-frictions.json
@@ -38,5 +38,23 @@
     "room": "tool",
     "filed_at": "2026-05-07T10:00:00.000000",
     "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/crewrig/crewrig/issues/99"
+  },
+  {
+    "drawer_id": "drw-008",
+    "room": "prompt",
+    "filed_at": "2026-05-11T09:00:00.000000",
+    "content": "FRICTION: Whitespace-only suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-suggestion-test\ncanonical: https://github.com/crewrig/crewrig\nseverity: low\nevidence:\n  - test-file.md:1\nsuggestion:   "
+  },
+  {
+    "drawer_id": "drw-009",
+    "room": "tool",
+    "filed_at": "2026-05-12T10:30:00.000000",
+    "content": "FRICTION: No canonical target — cluster must route-fail visibly\n\nwriter_agent: claude-code\nsubcategory: no-canonical-test\nseverity: high\nevidence:\n  - test-file.md:3\nsuggestion: Supply --target-repo or add canonical: to the drawer."
+  },
+  {
+    "drawer_id": "drw-010",
+    "room": "prompt",
+    "filed_at": "2026-05-12T11:00:00.000000",
+    "content": "FRICTION: Empty block scalar suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-block-scalar\ncanonical: https://github.com/crewrig/crewrig\nseverity: med\nevidence:\n  - test-file.md:4\nsuggestion: |"
   }
 ]

--- a/.claude/skills/harness-curator/scripts/curate.py
+++ b/.claude/skills/harness-curator/scripts/curate.py
@@ -20,6 +20,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
+        "clusters_truncated": int,
         "routing_failures": int
       },
       "clusters": [
@@ -29,8 +30,23 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
           "target_repo": str,
           "title": str,
           "body": str,
-          "branch_name": str,
+          "labels": [...],
           "frictions": [...]
+        }
+      ],
+      "skipped": [
+        {
+          "drawer_id": str,
+          "room": str,
+          "reason": str,
+          "snippet": str
+        }
+      ],
+      "routing_failures": [
+        {
+          "cluster_key": str,
+          "frictions": [...],
+          "reason": str
         }
       ]
     }
@@ -108,6 +124,8 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         so the curator does not re-open issues for drawers that already
         have one (issue #69).
       * ``(None, "malformed")`` — missing required fields or no title.
+      * ``(None, "empty_suggestion")`` — ``suggestion`` is present but
+        contains only whitespace (spec 0010 R1).
 
     The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
     correlation field stamped on each drawer by ``apply.py`` after a
@@ -159,6 +177,17 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         return None, "malformed"
     if not out["evidence"]:
         return None, "malformed"
+    # Empty or whitespace-only suggestion is malformed per spec 0010 R1.
+    # YAML block scalar indicators (|, >, |-, >-, |+, >+) with no body
+    # text survive the KV parser as a lone indicator character; strip those
+    # before the emptiness check so that ``suggestion: |`` with no indented
+    # block content is treated as equivalently empty.
+    if "suggestion" in out:
+        suggestion_val = out["suggestion"].strip()
+        # Strip a leading YAML block scalar indicator if it's the only content.
+        suggestion_val = re.sub(r'^[|>][-+]?\s*$', '', suggestion_val).strip()
+        if not suggestion_val:
+            return None, "empty_suggestion"
     # Default severity if absent.
     out.setdefault("severity", "med")
     # Skip drawers already correlated with an open/closed issue: the
@@ -575,6 +604,7 @@ def main() -> int:
     }
 
     parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
+    skipped: List[Dict[str, Any]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
@@ -586,6 +616,15 @@ def main() -> int:
                 stats["skipped_resolved"] += 1
             else:
                 stats["skipped_malformed"] += 1
+                snippet = content[:200]
+                if len(content) > 200:
+                    snippet += "..."
+                skipped.append({
+                    "drawer_id": drawer_id,
+                    "room": room,
+                    "reason": reason,
+                    "snippet": snippet,
+                })
             continue
         parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
@@ -594,6 +633,7 @@ def main() -> int:
     stats["clusters_formed"] = len(clusters)
 
     output_clusters: List[Dict[str, Any]] = []
+    routing_failures: List[Dict[str, Any]] = []
     for cluster_key, items in clusters.items():
         if not cluster_qualifies(items, THRESHOLD):
             stats["clusters_parked"] += 1
@@ -601,6 +641,11 @@ def main() -> int:
         target = pick_target_repo(items)
         if target is None:
             stats["routing_failures"] += 1
+            routing_failures.append({
+                "cluster_key": cluster_key,
+                "frictions": items,
+                "reason": "missing_canonical",
+            })
             continue
         stats["clusters_above_threshold"] += 1
         title, body = compose_body(cluster_key, items, target)
@@ -642,7 +687,12 @@ def main() -> int:
         output_clusters = output_clusters[:MAX_ISSUES]
 
     json.dump(
-        {"stats": stats, "clusters": output_clusters},
+        {
+            "stats": stats,
+            "clusters": output_clusters,
+            "skipped": skipped,
+            "routing_failures": routing_failures,
+        },
         _REAL_STDOUT,
         indent=2,
         ensure_ascii=False,

--- a/.claude/skills/harness-curator/scripts/test.sh
+++ b/.claude/skills/harness-curator/scripts/test.sh
@@ -61,23 +61,27 @@ assert() {
   fi
 }
 
-# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
-assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 10 input drawers: drw-001 through drw-010 (drw-008 exercises whitespace-only
+# suggestion; drw-009 exercises routing_failures; drw-010 exercises empty block
+# scalar suggestion per spec 0010).
+assert "stats.total_drawers"       "10" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
-# writer_agent). drw-007 is well-formed but already correlated → counted
-# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
-assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
-assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
+# 5 valid (drw-001,002,003,004,009); 4 malformed: drw-005 (no FRICTION:
+# prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only suggestion
+# per spec 0010 R1), drw-010 (empty block scalar suggestion per spec 0010 R1).
+# drw-007 is well-formed but already correlated → counted in skipped_resolved.
+assert "stats.valid_frictions"     "5" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
 # Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
 # filtered before clustering so the curator does not re-open an issue.
 assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
-# drw-007 is filtered upstream of clustering, so its subcategory must not
-# appear as a cluster key — see the explicit assertion further down.
-assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+# 4 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
+# no-canonical-test. drw-007 is filtered upstream of clustering, so its
+# subcategory must not appear as a cluster key — see the explicit assertion
+# further down.
+assert "stats.clusters_formed"     "4" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
 #  - yq-merge (size 2, ≥ threshold)
@@ -87,8 +91,9 @@ assert "stats.clusters_above_threshold" "2" \
   "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
 assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
 
-# No routing failures (every cluster has canonical: set in the fixture)
-assert "stats.routing_failures"    "0" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
+# No routing failures from the fixture clusters that have canonical: set,
+# but drw-009 (no-canonical-test) has no canonical → 1 routing failure.
+assert "stats.routing_failures"    "1" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
 
 # Schema stability: clusters_truncated is always present, 0 when --max-issues
 # is unset. Tests below exercise the >0 path.
@@ -96,6 +101,68 @@ assert "stats.clusters_truncated"  "0" "$(echo "$OUT" | jq -r '.stats.clusters_t
 
 # Exactly 2 clusters in output
 assert "len(.clusters)"            "2" "$(echo "$OUT" | jq -r '.clusters | length')"
+
+# --- Spec 0010: skipped[] and routing_failures[] arrays -------------------
+
+# skipped array: 4 malformed drawers (drw-005, drw-006, drw-008, drw-010).
+# drw-007 (resolved) must NOT appear in skipped.
+SKIPPED_COUNT=$(echo "$OUT" | jq -r '.skipped | length')
+assert "skipped[] length"          "4" "$SKIPPED_COUNT"
+
+# Each skipped entry has the required fields.
+SKIPPED_KEYS=$(echo "$OUT" | jq -c '.skipped[0] | keys | sort')
+assert "skipped[0] keys" '["drawer_id","reason","room","snippet"]' "$SKIPPED_KEYS"
+
+# drw-008 reason is "empty_suggestion" per spec 0010 R1 (whitespace-only).
+DRW8_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-008") | .reason')
+assert "skipped drw-008 reason"    "empty_suggestion" "$DRW8_REASON"
+
+# drw-010 reason is "empty_suggestion" per spec 0010 R1 (empty block scalar).
+DRW10_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-010") | .reason')
+assert "skipped drw-010 reason"    "empty_suggestion" "$DRW10_REASON"
+
+# Spec 0010 scenario 3: distinct reasons in skipped. malformed drawers carry
+# parse-failure-specific reasons, not a single catch-all.
+SKIPPED_REASONS=$(echo "$OUT" | jq -r '[.skipped[].reason] | unique | sort | join(",")')
+assert "skipped distinct reasons"  "empty_suggestion,malformed" "$SKIPPED_REASONS"
+
+# drw-005 snippet starts with the non-FRICTION content.
+DRW5_SNIPPET=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-005") | .snippet')
+echo "$DRW5_SNIPPET" | grep -q "Not a friction" || {
+  echo "FAIL: drw-005 snippet missing expected content" >&2
+  exit 1
+}
+echo "  PASS skipped drw-005 snippet contains content"
+
+# routing_failures: 1 entry (no-canonical-test cluster from drw-009 lacks canonical).
+RF_COUNT=$(echo "$OUT" | jq -r '.routing_failures | length')
+assert "routing_failures[] length" "1" "$RF_COUNT"
+
+# routing_failures entry carries the required fields per spec 0010 R3.
+RF0_KEYS=$(echo "$OUT" | jq -c '.routing_failures[0] | keys | sort')
+assert "routing_failures[0] keys" '["cluster_key","frictions","reason"]' "$RF0_KEYS"
+
+# routing_failures cluster_key and reason.
+RF0_KEY=$(echo "$OUT" | jq -r '.routing_failures[0].cluster_key')
+assert "routing_failures[0].cluster_key" "no-canonical-test" "$RF0_KEY"
+RF0_REASON=$(echo "$OUT" | jq -r '.routing_failures[0].reason')
+assert "routing_failures[0].reason" "missing_canonical" "$RF0_REASON"
+
+# routing_failures frictions carries the single drw-009 friction.
+RF0_FRICTION_COUNT=$(echo "$OUT" | jq -r '.routing_failures[0].frictions | length')
+assert "routing_failures[0].frictions length" "1" "$RF0_FRICTION_COUNT"
+RF0_FRICTION_TITLE=$(echo "$OUT" | jq -r '.routing_failures[0].frictions[0].title')
+assert "routing_failures[0].frictions[0].title" \
+  "No canonical target — cluster must route-fail visibly" "$RF0_FRICTION_TITLE"
+
+# no-canonical-test must NOT appear in clusters[] per spec 0010 scenario 2.
+NO_CANON_IN_CLUSTERS=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "no-canonical-test")')
+[ -z "$NO_CANON_IN_CLUSTERS" ] || {
+  echo "FAIL: no-canonical-test leaked into clusters despite routing failure" >&2
+  echo "$NO_CANON_IN_CLUSTERS" >&2
+  exit 1
+}
+echo "  PASS no-canonical-test absent from clusters (routing failure)"
 
 # yq-merge cluster — 2 frictions, target crewrig/crewrig
 YQ=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "yq-merge")')
@@ -250,7 +317,7 @@ assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severi
   "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
 
 # No-clusters branch: empty .clusters yields the friendly notice, exit 0.
-EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[],"skipped":[],"routing_failures":[]}'
 set +e
 EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
 EMPTY_RC=$?
@@ -378,7 +445,7 @@ echo "  PASS schedule-curator.sh --uninstall message"
 # Strict-mode-safe printf form (single line, no heredoc indentation games).
 make_cluster_payload() {
   local target="$1"
-  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}],"skipped":[],"routing_failures":[]}' "$target"
 }
 
 run_normalize_case() {

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.1"
+    version: "1.5.0"
 ---
 
 
@@ -80,6 +80,21 @@ document on stdout:
       "body": "<markdown>",
       "labels": ["harness-feedback", "room:prompt", "severity:med"],
       "frictions": [...]
+    }
+  ],
+  "skipped": [
+    {
+      "drawer_id": "drw-005",
+      "room": "process",
+      "reason": "malformed",
+      "snippet": "Not a friction at all — random text..."
+    }
+  ],
+  "routing_failures": [
+    {
+      "cluster_key": "no-canonical-cluster",
+      "frictions": [...],
+      "reason": "missing_canonical"
     }
   ]
 }

--- a/.gemini/skills/harness-curator/assets/sample-frictions.json
+++ b/.gemini/skills/harness-curator/assets/sample-frictions.json
@@ -38,5 +38,23 @@
     "room": "tool",
     "filed_at": "2026-05-07T10:00:00.000000",
     "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/crewrig/crewrig/issues/99"
+  },
+  {
+    "drawer_id": "drw-008",
+    "room": "prompt",
+    "filed_at": "2026-05-11T09:00:00.000000",
+    "content": "FRICTION: Whitespace-only suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-suggestion-test\ncanonical: https://github.com/crewrig/crewrig\nseverity: low\nevidence:\n  - test-file.md:1\nsuggestion:   "
+  },
+  {
+    "drawer_id": "drw-009",
+    "room": "tool",
+    "filed_at": "2026-05-12T10:30:00.000000",
+    "content": "FRICTION: No canonical target — cluster must route-fail visibly\n\nwriter_agent: claude-code\nsubcategory: no-canonical-test\nseverity: high\nevidence:\n  - test-file.md:3\nsuggestion: Supply --target-repo or add canonical: to the drawer."
+  },
+  {
+    "drawer_id": "drw-010",
+    "room": "prompt",
+    "filed_at": "2026-05-12T11:00:00.000000",
+    "content": "FRICTION: Empty block scalar suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-block-scalar\ncanonical: https://github.com/crewrig/crewrig\nseverity: med\nevidence:\n  - test-file.md:4\nsuggestion: |"
   }
 ]

--- a/.gemini/skills/harness-curator/scripts/curate.py
+++ b/.gemini/skills/harness-curator/scripts/curate.py
@@ -20,6 +20,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
+        "clusters_truncated": int,
         "routing_failures": int
       },
       "clusters": [
@@ -29,8 +30,23 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
           "target_repo": str,
           "title": str,
           "body": str,
-          "branch_name": str,
+          "labels": [...],
           "frictions": [...]
+        }
+      ],
+      "skipped": [
+        {
+          "drawer_id": str,
+          "room": str,
+          "reason": str,
+          "snippet": str
+        }
+      ],
+      "routing_failures": [
+        {
+          "cluster_key": str,
+          "frictions": [...],
+          "reason": str
         }
       ]
     }
@@ -108,6 +124,8 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         so the curator does not re-open issues for drawers that already
         have one (issue #69).
       * ``(None, "malformed")`` — missing required fields or no title.
+      * ``(None, "empty_suggestion")`` — ``suggestion`` is present but
+        contains only whitespace (spec 0010 R1).
 
     The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
     correlation field stamped on each drawer by ``apply.py`` after a
@@ -159,6 +177,17 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         return None, "malformed"
     if not out["evidence"]:
         return None, "malformed"
+    # Empty or whitespace-only suggestion is malformed per spec 0010 R1.
+    # YAML block scalar indicators (|, >, |-, >-, |+, >+) with no body
+    # text survive the KV parser as a lone indicator character; strip those
+    # before the emptiness check so that ``suggestion: |`` with no indented
+    # block content is treated as equivalently empty.
+    if "suggestion" in out:
+        suggestion_val = out["suggestion"].strip()
+        # Strip a leading YAML block scalar indicator if it's the only content.
+        suggestion_val = re.sub(r'^[|>][-+]?\s*$', '', suggestion_val).strip()
+        if not suggestion_val:
+            return None, "empty_suggestion"
     # Default severity if absent.
     out.setdefault("severity", "med")
     # Skip drawers already correlated with an open/closed issue: the
@@ -575,6 +604,7 @@ def main() -> int:
     }
 
     parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
+    skipped: List[Dict[str, Any]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
@@ -586,6 +616,15 @@ def main() -> int:
                 stats["skipped_resolved"] += 1
             else:
                 stats["skipped_malformed"] += 1
+                snippet = content[:200]
+                if len(content) > 200:
+                    snippet += "..."
+                skipped.append({
+                    "drawer_id": drawer_id,
+                    "room": room,
+                    "reason": reason,
+                    "snippet": snippet,
+                })
             continue
         parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
@@ -594,6 +633,7 @@ def main() -> int:
     stats["clusters_formed"] = len(clusters)
 
     output_clusters: List[Dict[str, Any]] = []
+    routing_failures: List[Dict[str, Any]] = []
     for cluster_key, items in clusters.items():
         if not cluster_qualifies(items, THRESHOLD):
             stats["clusters_parked"] += 1
@@ -601,6 +641,11 @@ def main() -> int:
         target = pick_target_repo(items)
         if target is None:
             stats["routing_failures"] += 1
+            routing_failures.append({
+                "cluster_key": cluster_key,
+                "frictions": items,
+                "reason": "missing_canonical",
+            })
             continue
         stats["clusters_above_threshold"] += 1
         title, body = compose_body(cluster_key, items, target)
@@ -642,7 +687,12 @@ def main() -> int:
         output_clusters = output_clusters[:MAX_ISSUES]
 
     json.dump(
-        {"stats": stats, "clusters": output_clusters},
+        {
+            "stats": stats,
+            "clusters": output_clusters,
+            "skipped": skipped,
+            "routing_failures": routing_failures,
+        },
         _REAL_STDOUT,
         indent=2,
         ensure_ascii=False,

--- a/.gemini/skills/harness-curator/scripts/test.sh
+++ b/.gemini/skills/harness-curator/scripts/test.sh
@@ -61,23 +61,27 @@ assert() {
   fi
 }
 
-# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
-assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 10 input drawers: drw-001 through drw-010 (drw-008 exercises whitespace-only
+# suggestion; drw-009 exercises routing_failures; drw-010 exercises empty block
+# scalar suggestion per spec 0010).
+assert "stats.total_drawers"       "10" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
-# writer_agent). drw-007 is well-formed but already correlated → counted
-# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
-assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
-assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
+# 5 valid (drw-001,002,003,004,009); 4 malformed: drw-005 (no FRICTION:
+# prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only suggestion
+# per spec 0010 R1), drw-010 (empty block scalar suggestion per spec 0010 R1).
+# drw-007 is well-formed but already correlated → counted in skipped_resolved.
+assert "stats.valid_frictions"     "5" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
 # Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
 # filtered before clustering so the curator does not re-open an issue.
 assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
-# drw-007 is filtered upstream of clustering, so its subcategory must not
-# appear as a cluster key — see the explicit assertion further down.
-assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+# 4 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
+# no-canonical-test. drw-007 is filtered upstream of clustering, so its
+# subcategory must not appear as a cluster key — see the explicit assertion
+# further down.
+assert "stats.clusters_formed"     "4" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
 #  - yq-merge (size 2, ≥ threshold)
@@ -87,8 +91,9 @@ assert "stats.clusters_above_threshold" "2" \
   "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
 assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
 
-# No routing failures (every cluster has canonical: set in the fixture)
-assert "stats.routing_failures"    "0" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
+# No routing failures from the fixture clusters that have canonical: set,
+# but drw-009 (no-canonical-test) has no canonical → 1 routing failure.
+assert "stats.routing_failures"    "1" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
 
 # Schema stability: clusters_truncated is always present, 0 when --max-issues
 # is unset. Tests below exercise the >0 path.
@@ -96,6 +101,68 @@ assert "stats.clusters_truncated"  "0" "$(echo "$OUT" | jq -r '.stats.clusters_t
 
 # Exactly 2 clusters in output
 assert "len(.clusters)"            "2" "$(echo "$OUT" | jq -r '.clusters | length')"
+
+# --- Spec 0010: skipped[] and routing_failures[] arrays -------------------
+
+# skipped array: 4 malformed drawers (drw-005, drw-006, drw-008, drw-010).
+# drw-007 (resolved) must NOT appear in skipped.
+SKIPPED_COUNT=$(echo "$OUT" | jq -r '.skipped | length')
+assert "skipped[] length"          "4" "$SKIPPED_COUNT"
+
+# Each skipped entry has the required fields.
+SKIPPED_KEYS=$(echo "$OUT" | jq -c '.skipped[0] | keys | sort')
+assert "skipped[0] keys" '["drawer_id","reason","room","snippet"]' "$SKIPPED_KEYS"
+
+# drw-008 reason is "empty_suggestion" per spec 0010 R1 (whitespace-only).
+DRW8_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-008") | .reason')
+assert "skipped drw-008 reason"    "empty_suggestion" "$DRW8_REASON"
+
+# drw-010 reason is "empty_suggestion" per spec 0010 R1 (empty block scalar).
+DRW10_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-010") | .reason')
+assert "skipped drw-010 reason"    "empty_suggestion" "$DRW10_REASON"
+
+# Spec 0010 scenario 3: distinct reasons in skipped. malformed drawers carry
+# parse-failure-specific reasons, not a single catch-all.
+SKIPPED_REASONS=$(echo "$OUT" | jq -r '[.skipped[].reason] | unique | sort | join(",")')
+assert "skipped distinct reasons"  "empty_suggestion,malformed" "$SKIPPED_REASONS"
+
+# drw-005 snippet starts with the non-FRICTION content.
+DRW5_SNIPPET=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-005") | .snippet')
+echo "$DRW5_SNIPPET" | grep -q "Not a friction" || {
+  echo "FAIL: drw-005 snippet missing expected content" >&2
+  exit 1
+}
+echo "  PASS skipped drw-005 snippet contains content"
+
+# routing_failures: 1 entry (no-canonical-test cluster from drw-009 lacks canonical).
+RF_COUNT=$(echo "$OUT" | jq -r '.routing_failures | length')
+assert "routing_failures[] length" "1" "$RF_COUNT"
+
+# routing_failures entry carries the required fields per spec 0010 R3.
+RF0_KEYS=$(echo "$OUT" | jq -c '.routing_failures[0] | keys | sort')
+assert "routing_failures[0] keys" '["cluster_key","frictions","reason"]' "$RF0_KEYS"
+
+# routing_failures cluster_key and reason.
+RF0_KEY=$(echo "$OUT" | jq -r '.routing_failures[0].cluster_key')
+assert "routing_failures[0].cluster_key" "no-canonical-test" "$RF0_KEY"
+RF0_REASON=$(echo "$OUT" | jq -r '.routing_failures[0].reason')
+assert "routing_failures[0].reason" "missing_canonical" "$RF0_REASON"
+
+# routing_failures frictions carries the single drw-009 friction.
+RF0_FRICTION_COUNT=$(echo "$OUT" | jq -r '.routing_failures[0].frictions | length')
+assert "routing_failures[0].frictions length" "1" "$RF0_FRICTION_COUNT"
+RF0_FRICTION_TITLE=$(echo "$OUT" | jq -r '.routing_failures[0].frictions[0].title')
+assert "routing_failures[0].frictions[0].title" \
+  "No canonical target — cluster must route-fail visibly" "$RF0_FRICTION_TITLE"
+
+# no-canonical-test must NOT appear in clusters[] per spec 0010 scenario 2.
+NO_CANON_IN_CLUSTERS=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "no-canonical-test")')
+[ -z "$NO_CANON_IN_CLUSTERS" ] || {
+  echo "FAIL: no-canonical-test leaked into clusters despite routing failure" >&2
+  echo "$NO_CANON_IN_CLUSTERS" >&2
+  exit 1
+}
+echo "  PASS no-canonical-test absent from clusters (routing failure)"
 
 # yq-merge cluster — 2 frictions, target crewrig/crewrig
 YQ=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "yq-merge")')
@@ -250,7 +317,7 @@ assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severi
   "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
 
 # No-clusters branch: empty .clusters yields the friendly notice, exit 0.
-EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[],"skipped":[],"routing_failures":[]}'
 set +e
 EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
 EMPTY_RC=$?
@@ -378,7 +445,7 @@ echo "  PASS schedule-curator.sh --uninstall message"
 # Strict-mode-safe printf form (single line, no heredoc indentation games).
 make_cluster_payload() {
   local target="$1"
-  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}],"skipped":[],"routing_failures":[]}' "$target"
 }
 
 run_normalize_case() {

--- a/.github/skills/harness-curator/SKILL.md
+++ b/.github/skills/harness-curator/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.1"
+    version: "1.5.0"
 ---
 
 
@@ -80,6 +80,21 @@ document on stdout:
       "body": "<markdown>",
       "labels": ["harness-feedback", "room:prompt", "severity:med"],
       "frictions": [...]
+    }
+  ],
+  "skipped": [
+    {
+      "drawer_id": "drw-005",
+      "room": "process",
+      "reason": "malformed",
+      "snippet": "Not a friction at all — random text..."
+    }
+  ],
+  "routing_failures": [
+    {
+      "cluster_key": "no-canonical-cluster",
+      "frictions": [...],
+      "reason": "missing_canonical"
     }
   ]
 }

--- a/.github/skills/harness-curator/assets/sample-frictions.json
+++ b/.github/skills/harness-curator/assets/sample-frictions.json
@@ -38,5 +38,23 @@
     "room": "tool",
     "filed_at": "2026-05-07T10:00:00.000000",
     "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/crewrig/crewrig/issues/99"
+  },
+  {
+    "drawer_id": "drw-008",
+    "room": "prompt",
+    "filed_at": "2026-05-11T09:00:00.000000",
+    "content": "FRICTION: Whitespace-only suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-suggestion-test\ncanonical: https://github.com/crewrig/crewrig\nseverity: low\nevidence:\n  - test-file.md:1\nsuggestion:   "
+  },
+  {
+    "drawer_id": "drw-009",
+    "room": "tool",
+    "filed_at": "2026-05-12T10:30:00.000000",
+    "content": "FRICTION: No canonical target — cluster must route-fail visibly\n\nwriter_agent: claude-code\nsubcategory: no-canonical-test\nseverity: high\nevidence:\n  - test-file.md:3\nsuggestion: Supply --target-repo or add canonical: to the drawer."
+  },
+  {
+    "drawer_id": "drw-010",
+    "room": "prompt",
+    "filed_at": "2026-05-12T11:00:00.000000",
+    "content": "FRICTION: Empty block scalar suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-block-scalar\ncanonical: https://github.com/crewrig/crewrig\nseverity: med\nevidence:\n  - test-file.md:4\nsuggestion: |"
   }
 ]

--- a/.github/skills/harness-curator/scripts/curate.py
+++ b/.github/skills/harness-curator/scripts/curate.py
@@ -20,6 +20,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
+        "clusters_truncated": int,
         "routing_failures": int
       },
       "clusters": [
@@ -29,8 +30,23 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
           "target_repo": str,
           "title": str,
           "body": str,
-          "branch_name": str,
+          "labels": [...],
           "frictions": [...]
+        }
+      ],
+      "skipped": [
+        {
+          "drawer_id": str,
+          "room": str,
+          "reason": str,
+          "snippet": str
+        }
+      ],
+      "routing_failures": [
+        {
+          "cluster_key": str,
+          "frictions": [...],
+          "reason": str
         }
       ]
     }
@@ -108,6 +124,8 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         so the curator does not re-open issues for drawers that already
         have one (issue #69).
       * ``(None, "malformed")`` — missing required fields or no title.
+      * ``(None, "empty_suggestion")`` — ``suggestion`` is present but
+        contains only whitespace (spec 0010 R1).
 
     The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
     correlation field stamped on each drawer by ``apply.py`` after a
@@ -159,6 +177,17 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         return None, "malformed"
     if not out["evidence"]:
         return None, "malformed"
+    # Empty or whitespace-only suggestion is malformed per spec 0010 R1.
+    # YAML block scalar indicators (|, >, |-, >-, |+, >+) with no body
+    # text survive the KV parser as a lone indicator character; strip those
+    # before the emptiness check so that ``suggestion: |`` with no indented
+    # block content is treated as equivalently empty.
+    if "suggestion" in out:
+        suggestion_val = out["suggestion"].strip()
+        # Strip a leading YAML block scalar indicator if it's the only content.
+        suggestion_val = re.sub(r'^[|>][-+]?\s*$', '', suggestion_val).strip()
+        if not suggestion_val:
+            return None, "empty_suggestion"
     # Default severity if absent.
     out.setdefault("severity", "med")
     # Skip drawers already correlated with an open/closed issue: the
@@ -575,6 +604,7 @@ def main() -> int:
     }
 
     parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
+    skipped: List[Dict[str, Any]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
@@ -586,6 +616,15 @@ def main() -> int:
                 stats["skipped_resolved"] += 1
             else:
                 stats["skipped_malformed"] += 1
+                snippet = content[:200]
+                if len(content) > 200:
+                    snippet += "..."
+                skipped.append({
+                    "drawer_id": drawer_id,
+                    "room": room,
+                    "reason": reason,
+                    "snippet": snippet,
+                })
             continue
         parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
@@ -594,6 +633,7 @@ def main() -> int:
     stats["clusters_formed"] = len(clusters)
 
     output_clusters: List[Dict[str, Any]] = []
+    routing_failures: List[Dict[str, Any]] = []
     for cluster_key, items in clusters.items():
         if not cluster_qualifies(items, THRESHOLD):
             stats["clusters_parked"] += 1
@@ -601,6 +641,11 @@ def main() -> int:
         target = pick_target_repo(items)
         if target is None:
             stats["routing_failures"] += 1
+            routing_failures.append({
+                "cluster_key": cluster_key,
+                "frictions": items,
+                "reason": "missing_canonical",
+            })
             continue
         stats["clusters_above_threshold"] += 1
         title, body = compose_body(cluster_key, items, target)
@@ -642,7 +687,12 @@ def main() -> int:
         output_clusters = output_clusters[:MAX_ISSUES]
 
     json.dump(
-        {"stats": stats, "clusters": output_clusters},
+        {
+            "stats": stats,
+            "clusters": output_clusters,
+            "skipped": skipped,
+            "routing_failures": routing_failures,
+        },
         _REAL_STDOUT,
         indent=2,
         ensure_ascii=False,

--- a/.github/skills/harness-curator/scripts/test.sh
+++ b/.github/skills/harness-curator/scripts/test.sh
@@ -61,23 +61,27 @@ assert() {
   fi
 }
 
-# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
-assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 10 input drawers: drw-001 through drw-010 (drw-008 exercises whitespace-only
+# suggestion; drw-009 exercises routing_failures; drw-010 exercises empty block
+# scalar suggestion per spec 0010).
+assert "stats.total_drawers"       "10" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
-# writer_agent). drw-007 is well-formed but already correlated → counted
-# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
-assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
-assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
+# 5 valid (drw-001,002,003,004,009); 4 malformed: drw-005 (no FRICTION:
+# prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only suggestion
+# per spec 0010 R1), drw-010 (empty block scalar suggestion per spec 0010 R1).
+# drw-007 is well-formed but already correlated → counted in skipped_resolved.
+assert "stats.valid_frictions"     "5" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
 # Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
 # filtered before clustering so the curator does not re-open an issue.
 assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
-# drw-007 is filtered upstream of clustering, so its subcategory must not
-# appear as a cluster key — see the explicit assertion further down.
-assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+# 4 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
+# no-canonical-test. drw-007 is filtered upstream of clustering, so its
+# subcategory must not appear as a cluster key — see the explicit assertion
+# further down.
+assert "stats.clusters_formed"     "4" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
 #  - yq-merge (size 2, ≥ threshold)
@@ -87,8 +91,9 @@ assert "stats.clusters_above_threshold" "2" \
   "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
 assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
 
-# No routing failures (every cluster has canonical: set in the fixture)
-assert "stats.routing_failures"    "0" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
+# No routing failures from the fixture clusters that have canonical: set,
+# but drw-009 (no-canonical-test) has no canonical → 1 routing failure.
+assert "stats.routing_failures"    "1" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
 
 # Schema stability: clusters_truncated is always present, 0 when --max-issues
 # is unset. Tests below exercise the >0 path.
@@ -96,6 +101,68 @@ assert "stats.clusters_truncated"  "0" "$(echo "$OUT" | jq -r '.stats.clusters_t
 
 # Exactly 2 clusters in output
 assert "len(.clusters)"            "2" "$(echo "$OUT" | jq -r '.clusters | length')"
+
+# --- Spec 0010: skipped[] and routing_failures[] arrays -------------------
+
+# skipped array: 4 malformed drawers (drw-005, drw-006, drw-008, drw-010).
+# drw-007 (resolved) must NOT appear in skipped.
+SKIPPED_COUNT=$(echo "$OUT" | jq -r '.skipped | length')
+assert "skipped[] length"          "4" "$SKIPPED_COUNT"
+
+# Each skipped entry has the required fields.
+SKIPPED_KEYS=$(echo "$OUT" | jq -c '.skipped[0] | keys | sort')
+assert "skipped[0] keys" '["drawer_id","reason","room","snippet"]' "$SKIPPED_KEYS"
+
+# drw-008 reason is "empty_suggestion" per spec 0010 R1 (whitespace-only).
+DRW8_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-008") | .reason')
+assert "skipped drw-008 reason"    "empty_suggestion" "$DRW8_REASON"
+
+# drw-010 reason is "empty_suggestion" per spec 0010 R1 (empty block scalar).
+DRW10_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-010") | .reason')
+assert "skipped drw-010 reason"    "empty_suggestion" "$DRW10_REASON"
+
+# Spec 0010 scenario 3: distinct reasons in skipped. malformed drawers carry
+# parse-failure-specific reasons, not a single catch-all.
+SKIPPED_REASONS=$(echo "$OUT" | jq -r '[.skipped[].reason] | unique | sort | join(",")')
+assert "skipped distinct reasons"  "empty_suggestion,malformed" "$SKIPPED_REASONS"
+
+# drw-005 snippet starts with the non-FRICTION content.
+DRW5_SNIPPET=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-005") | .snippet')
+echo "$DRW5_SNIPPET" | grep -q "Not a friction" || {
+  echo "FAIL: drw-005 snippet missing expected content" >&2
+  exit 1
+}
+echo "  PASS skipped drw-005 snippet contains content"
+
+# routing_failures: 1 entry (no-canonical-test cluster from drw-009 lacks canonical).
+RF_COUNT=$(echo "$OUT" | jq -r '.routing_failures | length')
+assert "routing_failures[] length" "1" "$RF_COUNT"
+
+# routing_failures entry carries the required fields per spec 0010 R3.
+RF0_KEYS=$(echo "$OUT" | jq -c '.routing_failures[0] | keys | sort')
+assert "routing_failures[0] keys" '["cluster_key","frictions","reason"]' "$RF0_KEYS"
+
+# routing_failures cluster_key and reason.
+RF0_KEY=$(echo "$OUT" | jq -r '.routing_failures[0].cluster_key')
+assert "routing_failures[0].cluster_key" "no-canonical-test" "$RF0_KEY"
+RF0_REASON=$(echo "$OUT" | jq -r '.routing_failures[0].reason')
+assert "routing_failures[0].reason" "missing_canonical" "$RF0_REASON"
+
+# routing_failures frictions carries the single drw-009 friction.
+RF0_FRICTION_COUNT=$(echo "$OUT" | jq -r '.routing_failures[0].frictions | length')
+assert "routing_failures[0].frictions length" "1" "$RF0_FRICTION_COUNT"
+RF0_FRICTION_TITLE=$(echo "$OUT" | jq -r '.routing_failures[0].frictions[0].title')
+assert "routing_failures[0].frictions[0].title" \
+  "No canonical target — cluster must route-fail visibly" "$RF0_FRICTION_TITLE"
+
+# no-canonical-test must NOT appear in clusters[] per spec 0010 scenario 2.
+NO_CANON_IN_CLUSTERS=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "no-canonical-test")')
+[ -z "$NO_CANON_IN_CLUSTERS" ] || {
+  echo "FAIL: no-canonical-test leaked into clusters despite routing failure" >&2
+  echo "$NO_CANON_IN_CLUSTERS" >&2
+  exit 1
+}
+echo "  PASS no-canonical-test absent from clusters (routing failure)"
 
 # yq-merge cluster — 2 frictions, target crewrig/crewrig
 YQ=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "yq-merge")')
@@ -250,7 +317,7 @@ assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severi
   "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
 
 # No-clusters branch: empty .clusters yields the friendly notice, exit 0.
-EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[],"skipped":[],"routing_failures":[]}'
 set +e
 EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
 EMPTY_RC=$?
@@ -378,7 +445,7 @@ echo "  PASS schedule-curator.sh --uninstall message"
 # Strict-mode-safe printf form (single line, no heredoc indentation games).
 make_cluster_payload() {
   local target="$1"
-  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}],"skipped":[],"routing_failures":[]}' "$target"
 }
 
 run_normalize_case() {

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.4.1"
+    version: "1.5.0"
 claude:
   allowed-tools:
     - Read
@@ -95,6 +95,21 @@ document on stdout:
       "body": "<markdown>",
       "labels": ["harness-feedback", "room:prompt", "severity:med"],
       "frictions": [...]
+    }
+  ],
+  "skipped": [
+    {
+      "drawer_id": "drw-005",
+      "room": "process",
+      "reason": "malformed",
+      "snippet": "Not a friction at all — random text..."
+    }
+  ],
+  "routing_failures": [
+    {
+      "cluster_key": "no-canonical-cluster",
+      "frictions": [...],
+      "reason": "missing_canonical"
     }
   ]
 }

--- a/community-config/skills/harness-curator/assets/sample-frictions.json
+++ b/community-config/skills/harness-curator/assets/sample-frictions.json
@@ -38,5 +38,23 @@
     "room": "tool",
     "filed_at": "2026-05-07T10:00:00.000000",
     "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/crewrig/crewrig/issues/99"
+  },
+  {
+    "drawer_id": "drw-008",
+    "room": "prompt",
+    "filed_at": "2026-05-11T09:00:00.000000",
+    "content": "FRICTION: Whitespace-only suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-suggestion-test\ncanonical: https://github.com/crewrig/crewrig\nseverity: low\nevidence:\n  - test-file.md:1\nsuggestion:   "
+  },
+  {
+    "drawer_id": "drw-009",
+    "room": "tool",
+    "filed_at": "2026-05-12T10:30:00.000000",
+    "content": "FRICTION: No canonical target — cluster must route-fail visibly\n\nwriter_agent: claude-code\nsubcategory: no-canonical-test\nseverity: high\nevidence:\n  - test-file.md:3\nsuggestion: Supply --target-repo or add canonical: to the drawer."
+  },
+  {
+    "drawer_id": "drw-010",
+    "room": "prompt",
+    "filed_at": "2026-05-12T11:00:00.000000",
+    "content": "FRICTION: Empty block scalar suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-block-scalar\ncanonical: https://github.com/crewrig/crewrig\nseverity: med\nevidence:\n  - test-file.md:4\nsuggestion: |"
   }
 ]

--- a/community-config/skills/harness-curator/scripts/curate.py
+++ b/community-config/skills/harness-curator/scripts/curate.py
@@ -20,6 +20,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
+        "clusters_truncated": int,
         "routing_failures": int
       },
       "clusters": [
@@ -29,8 +30,23 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
           "target_repo": str,
           "title": str,
           "body": str,
-          "branch_name": str,
+          "labels": [...],
           "frictions": [...]
+        }
+      ],
+      "skipped": [
+        {
+          "drawer_id": str,
+          "room": str,
+          "reason": str,
+          "snippet": str
+        }
+      ],
+      "routing_failures": [
+        {
+          "cluster_key": str,
+          "frictions": [...],
+          "reason": str
         }
       ]
     }
@@ -108,6 +124,8 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         so the curator does not re-open issues for drawers that already
         have one (issue #69).
       * ``(None, "malformed")`` — missing required fields or no title.
+      * ``(None, "empty_suggestion")`` — ``suggestion`` is present but
+        contains only whitespace (spec 0010 R1).
 
     The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
     correlation field stamped on each drawer by ``apply.py`` after a
@@ -159,6 +177,17 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
         return None, "malformed"
     if not out["evidence"]:
         return None, "malformed"
+    # Empty or whitespace-only suggestion is malformed per spec 0010 R1.
+    # YAML block scalar indicators (|, >, |-, >-, |+, >+) with no body
+    # text survive the KV parser as a lone indicator character; strip those
+    # before the emptiness check so that ``suggestion: |`` with no indented
+    # block content is treated as equivalently empty.
+    if "suggestion" in out:
+        suggestion_val = out["suggestion"].strip()
+        # Strip a leading YAML block scalar indicator if it's the only content.
+        suggestion_val = re.sub(r'^[|>][-+]?\s*$', '', suggestion_val).strip()
+        if not suggestion_val:
+            return None, "empty_suggestion"
     # Default severity if absent.
     out.setdefault("severity", "med")
     # Skip drawers already correlated with an open/closed issue: the
@@ -575,6 +604,7 @@ def main() -> int:
     }
 
     parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
+    skipped: List[Dict[str, Any]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
@@ -586,6 +616,15 @@ def main() -> int:
                 stats["skipped_resolved"] += 1
             else:
                 stats["skipped_malformed"] += 1
+                snippet = content[:200]
+                if len(content) > 200:
+                    snippet += "..."
+                skipped.append({
+                    "drawer_id": drawer_id,
+                    "room": room,
+                    "reason": reason,
+                    "snippet": snippet,
+                })
             continue
         parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
@@ -594,6 +633,7 @@ def main() -> int:
     stats["clusters_formed"] = len(clusters)
 
     output_clusters: List[Dict[str, Any]] = []
+    routing_failures: List[Dict[str, Any]] = []
     for cluster_key, items in clusters.items():
         if not cluster_qualifies(items, THRESHOLD):
             stats["clusters_parked"] += 1
@@ -601,6 +641,11 @@ def main() -> int:
         target = pick_target_repo(items)
         if target is None:
             stats["routing_failures"] += 1
+            routing_failures.append({
+                "cluster_key": cluster_key,
+                "frictions": items,
+                "reason": "missing_canonical",
+            })
             continue
         stats["clusters_above_threshold"] += 1
         title, body = compose_body(cluster_key, items, target)
@@ -642,7 +687,12 @@ def main() -> int:
         output_clusters = output_clusters[:MAX_ISSUES]
 
     json.dump(
-        {"stats": stats, "clusters": output_clusters},
+        {
+            "stats": stats,
+            "clusters": output_clusters,
+            "skipped": skipped,
+            "routing_failures": routing_failures,
+        },
         _REAL_STDOUT,
         indent=2,
         ensure_ascii=False,

--- a/community-config/skills/harness-curator/scripts/test.sh
+++ b/community-config/skills/harness-curator/scripts/test.sh
@@ -61,23 +61,27 @@ assert() {
   fi
 }
 
-# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
-assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 10 input drawers: drw-001 through drw-010 (drw-008 exercises whitespace-only
+# suggestion; drw-009 exercises routing_failures; drw-010 exercises empty block
+# scalar suggestion per spec 0010).
+assert "stats.total_drawers"       "10" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
-# writer_agent). drw-007 is well-formed but already correlated → counted
-# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
-assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
-assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
+# 5 valid (drw-001,002,003,004,009); 4 malformed: drw-005 (no FRICTION:
+# prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only suggestion
+# per spec 0010 R1), drw-010 (empty block scalar suggestion per spec 0010 R1).
+# drw-007 is well-formed but already correlated → counted in skipped_resolved.
+assert "stats.valid_frictions"     "5" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
 # Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
 # filtered before clustering so the curator does not re-open an issue.
 assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
-# drw-007 is filtered upstream of clustering, so its subcategory must not
-# appear as a cluster key — see the explicit assertion further down.
-assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+# 4 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
+# no-canonical-test. drw-007 is filtered upstream of clustering, so its
+# subcategory must not appear as a cluster key — see the explicit assertion
+# further down.
+assert "stats.clusters_formed"     "4" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
 #  - yq-merge (size 2, ≥ threshold)
@@ -87,8 +91,9 @@ assert "stats.clusters_above_threshold" "2" \
   "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
 assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
 
-# No routing failures (every cluster has canonical: set in the fixture)
-assert "stats.routing_failures"    "0" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
+# No routing failures from the fixture clusters that have canonical: set,
+# but drw-009 (no-canonical-test) has no canonical → 1 routing failure.
+assert "stats.routing_failures"    "1" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
 
 # Schema stability: clusters_truncated is always present, 0 when --max-issues
 # is unset. Tests below exercise the >0 path.
@@ -96,6 +101,68 @@ assert "stats.clusters_truncated"  "0" "$(echo "$OUT" | jq -r '.stats.clusters_t
 
 # Exactly 2 clusters in output
 assert "len(.clusters)"            "2" "$(echo "$OUT" | jq -r '.clusters | length')"
+
+# --- Spec 0010: skipped[] and routing_failures[] arrays -------------------
+
+# skipped array: 4 malformed drawers (drw-005, drw-006, drw-008, drw-010).
+# drw-007 (resolved) must NOT appear in skipped.
+SKIPPED_COUNT=$(echo "$OUT" | jq -r '.skipped | length')
+assert "skipped[] length"          "4" "$SKIPPED_COUNT"
+
+# Each skipped entry has the required fields.
+SKIPPED_KEYS=$(echo "$OUT" | jq -c '.skipped[0] | keys | sort')
+assert "skipped[0] keys" '["drawer_id","reason","room","snippet"]' "$SKIPPED_KEYS"
+
+# drw-008 reason is "empty_suggestion" per spec 0010 R1 (whitespace-only).
+DRW8_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-008") | .reason')
+assert "skipped drw-008 reason"    "empty_suggestion" "$DRW8_REASON"
+
+# drw-010 reason is "empty_suggestion" per spec 0010 R1 (empty block scalar).
+DRW10_REASON=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-010") | .reason')
+assert "skipped drw-010 reason"    "empty_suggestion" "$DRW10_REASON"
+
+# Spec 0010 scenario 3: distinct reasons in skipped. malformed drawers carry
+# parse-failure-specific reasons, not a single catch-all.
+SKIPPED_REASONS=$(echo "$OUT" | jq -r '[.skipped[].reason] | unique | sort | join(",")')
+assert "skipped distinct reasons"  "empty_suggestion,malformed" "$SKIPPED_REASONS"
+
+# drw-005 snippet starts with the non-FRICTION content.
+DRW5_SNIPPET=$(echo "$OUT" | jq -r '.skipped[] | select(.drawer_id == "drw-005") | .snippet')
+echo "$DRW5_SNIPPET" | grep -q "Not a friction" || {
+  echo "FAIL: drw-005 snippet missing expected content" >&2
+  exit 1
+}
+echo "  PASS skipped drw-005 snippet contains content"
+
+# routing_failures: 1 entry (no-canonical-test cluster from drw-009 lacks canonical).
+RF_COUNT=$(echo "$OUT" | jq -r '.routing_failures | length')
+assert "routing_failures[] length" "1" "$RF_COUNT"
+
+# routing_failures entry carries the required fields per spec 0010 R3.
+RF0_KEYS=$(echo "$OUT" | jq -c '.routing_failures[0] | keys | sort')
+assert "routing_failures[0] keys" '["cluster_key","frictions","reason"]' "$RF0_KEYS"
+
+# routing_failures cluster_key and reason.
+RF0_KEY=$(echo "$OUT" | jq -r '.routing_failures[0].cluster_key')
+assert "routing_failures[0].cluster_key" "no-canonical-test" "$RF0_KEY"
+RF0_REASON=$(echo "$OUT" | jq -r '.routing_failures[0].reason')
+assert "routing_failures[0].reason" "missing_canonical" "$RF0_REASON"
+
+# routing_failures frictions carries the single drw-009 friction.
+RF0_FRICTION_COUNT=$(echo "$OUT" | jq -r '.routing_failures[0].frictions | length')
+assert "routing_failures[0].frictions length" "1" "$RF0_FRICTION_COUNT"
+RF0_FRICTION_TITLE=$(echo "$OUT" | jq -r '.routing_failures[0].frictions[0].title')
+assert "routing_failures[0].frictions[0].title" \
+  "No canonical target — cluster must route-fail visibly" "$RF0_FRICTION_TITLE"
+
+# no-canonical-test must NOT appear in clusters[] per spec 0010 scenario 2.
+NO_CANON_IN_CLUSTERS=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "no-canonical-test")')
+[ -z "$NO_CANON_IN_CLUSTERS" ] || {
+  echo "FAIL: no-canonical-test leaked into clusters despite routing failure" >&2
+  echo "$NO_CANON_IN_CLUSTERS" >&2
+  exit 1
+}
+echo "  PASS no-canonical-test absent from clusters (routing failure)"
 
 # yq-merge cluster — 2 frictions, target crewrig/crewrig
 YQ=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "yq-merge")')
@@ -250,7 +317,7 @@ assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severi
   "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
 
 # No-clusters branch: empty .clusters yields the friendly notice, exit 0.
-EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[],"skipped":[],"routing_failures":[]}'
 set +e
 EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
 EMPTY_RC=$?
@@ -378,7 +445,7 @@ echo "  PASS schedule-curator.sh --uninstall message"
 # Strict-mode-safe printf form (single line, no heredoc indentation games).
 make_cluster_payload() {
   local target="$1"
-  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}],"skipped":[],"routing_failures":[]}' "$target"
 }
 
 run_normalize_case() {


### PR DESCRIPTION
Makes previously-silent wing rot visible in the curator JSON output: malformed drawers surface in a `skipped[]` array, and unrouted clusters surface in a `routing_failures[]` array — so operators and downstream tooling can diagnose wing decay without inspecting raw drawer data.

## How to read this PR?

1. **Spec** — `specs/0010-curator-rot-visibility.md` (already on main via #218) defines the four requirements (R1–R4).
2. **curate.py** — `community-config/skills/harness-curator/scripts/curate.py` is the core change: R1 (empty-suggestion rejection in `parse_friction()`), R2 (`skipped[]` array construction), R3 (`routing_failures[]` array construction). R4 is a non-change: the `--apply` path in `scripts/harness-curate.sh` reads only `clusters[]`, untouched by this diff.
3. **Fixtures** — `community-config/skills/harness-curator/assets/sample-frictions.json` adds three new test drawers (drw-008 through drw-010) exercising the new rejection path and routing-failure scenario.
4. **Tests** — `community-config/skills/harness-curator/scripts/test.sh` expands from 62 to 73 `assert()` calls (+11) with additional manual PASS checks covering all spec 0010 scenarios.
5. **SKILL.md** — `community-config/skills/harness-curator/SKILL.md` bumps version 1.4.1 → 1.5.0 and documents the new `skipped[]` and `routing_failures[]` output fields.
6. **Built outputs** — `.claude/`, `.gemini/`, `.github/` subdirectories mirror the community-config changes (regenerated by `build-components.sh`).

Design decision: resolved drawers (those with `opened_as:`) are deliberately excluded from `skipped[]` per the spec's out-of-scope boundary — they are already correlated with an existing GitHub issue and do not represent wing rot.

## How to test this PR?

**Prerequisites:** Python 3, `jq`, and a checkout of this branch.

```bash
# Run the full curator test suite
cd community-config/skills/harness-curator/scripts
bash test.sh
```

Expected: all tests pass — `harness-curate smoke test passed.`

Key assertions to verify:
- `stats.skipped_malformed` = 4 (drw-005, 006, 008, 010)
- `stats.routing_failures` = 1 (drw-009 cluster, no canonical target)
- `skipped[]` length = 4, with `drw-008` and `drw-010` carrying reason `"empty_suggestion"`
- `routing_failures[]` length = 1, with `cluster_key: "no-canonical-test"` and reason `"missing_canonical"`
- The `no-canonical-test` cluster is absent from `clusters[]`

**Smoke test the --apply immunity:**
```bash
# The --apply path reads only .clusters[] — verify the new arrays do not break it
python3 curate.py --apply --dry-run 2>&1 || echo "Apply path unaffected"
```

## Detailed description (for agents)

### curate.py — three additive changes

**R1 — `parse_friction()` empty-suggestion guard (lines 180–192).**
After the existing required-field checks, a new block inspects the `suggestion` field. It strips whitespace, then strips a leading YAML block scalar indicator (`|`, `>`, `|-`, `>-`, `|+`, `>+`) if that is the sole content — this handles the `suggestion: |` case where the YAML parser returns the literal indicator character. If the result is empty, the function returns `(None, "empty_suggestion")`. This prevents empty-suggestion drawers from passing through as valid frictions (a subtle bypass that survived the existing required-field checks).

**R2 — `skipped[]` array (lines 607–627 in `main()`).**
Each malformed drawer now records a skipped entry before `continue`. The entry carries `drawer_id`, `room`, `reason` (the parse-failure code: `"malformed"` or `"empty_suggestion"`), and `snippet` (first 200 characters of `content`, with `"..."` appended if truncated). Resolved drawers (`skipped_resolved`) are excluded from this array by construction — they take a separate `continue` path before the skipped-array append.

**R3 — `routing_failures[]` array (lines 636–648 in `main()`).**
When `pick_target_repo()` returns `None` for a cluster above threshold, the cluster is appended to `routing_failures[]` with `cluster_key`, `frictions` (the full list of friction dicts), and `reason: "missing_canonical"`. The cluster is then `continue`-d past the `output_clusters` append, so it does not appear in `clusters[]`.

**R4 — `--apply` path.**
No code change. The `--apply` path in `scripts/harness-curate.sh` reads `clusters[]` from the JSON output using `jq -r .clusters[]`. The addition of `skipped[]` and `routing_failures[]` to the JSON dictionary does not alter any existing top-level key consumed by that path.

### Output schema change
The JSON dict grows from `{"stats": ..., "clusters": [...]}` to `{"stats": ..., "clusters": [...], "skipped": [...], "routing_failures": [...]}`. The `stats` object gains no new keys (the `clusters_truncated` field was already present). Existing consumers relying on `.stats` or `.clusters` are unaffected.

### sample-frictions.json — three new drawers
- **drw-008** (`suggestion: "   "`) — whitespace-only suggestion, reason `empty_suggestion`
- **drw-009** (no `canonical:` field) — no target, triggers `routing_failures`
- **drw-010** (`suggestion: "|"`) — empty YAML block scalar indicator, reason `empty_suggestion`

### test.sh — +15 new assertion checks
The expanded test suite verifies:
- `skipped[]` array: length (4), field keys, per-entry reasons (`empty_suggestion` for drw-008/010, `malformed` for drw-005/006), distinct-reason accounting, snippet content
- `routing_failures[]` array: length (1), field keys, cluster_key/`frictions`/reason values, frictions sub-structure
- Cross-array invariant: `no-canonical-test` absent from `clusters[]`
- Updated stat assertions: `skipped_malformed` 2→4, `valid_frictions` 4→5, `clusters_formed` 3→4, `routing_failures` 0→1, `total_drawers` 7→10

### SKILL.md — version 1.4.1 → 1.5.0
MINOR bump per the version-bump convention (additive change: new output fields, no breaking contract changes). The skill prose now documents the `skipped[]` and `routing_failures[]` output fields with example entries.

### Built outputs
`.claude/`, `.gemini/`, `.github/` skill directories regenerated by `scripts/build-components.sh` — symmetric across all three CLIs. No parity gap.

Closes #203