### PR TITLE
🔒 Back-port set -x suppression to claude-code.sh api_key arm

### DIFF
--- a/tests/e2e/lib/llm_judge_drivers/claude-code.sh
+++ b/tests/e2e/lib/llm_judge_drivers/claude-code.sh
@@ -78,7 +78,9 @@ _llm_judge_driver_claude-code_preflight() {
       if [[ -z "$api_key" ]]; then
         return 2
       fi
+      { set +x; } 2>/dev/null
       printf 'AUTH_TOKEN=%s\n' "$api_key"
+      { set -x; } 2>/dev/null
       return 0
       ;;
     *)


### PR DESCRIPTION
Security back-port spotted during the review of PR #131 (finding N7, issue #132): the `api_key` arm of `_llm_judge_driver_claude-code_preflight` emitted the bearer token via `printf` without `set -x` suppression guards.

## How to read this PR?

Single-file change in `tests/e2e/lib/llm_judge_drivers/claude-code.sh` lines 81–83. The `api_key` arm now mirrors the existing `oauth` arm (L70-72) and the `ollama-cloud.sh` driver introduced in PR #131 — both already apply the `{ set +x; } 2>/dev/null` / `{ set -x; } 2>/dev/null` pattern around token emissions.

## How to test this PR?

```bash
bash scripts/tests/test-e2e-llm-judge-lib.sh
# Expected: 33 passed / 0 failed / 0 skipped
```

## Detailed description (for agents)

**File:** `tests/e2e/lib/llm_judge_drivers/claude-code.sh`

**Change:** In function `_llm_judge_driver_claude-code_preflight`, `api_key` arm (previously line 81), wrapped the `printf 'AUTH_TOKEN=%s\n' "$api_key"` call with:
- `{ set +x; } 2>/dev/null` — before the printf
- `{ set -x; } 2>/dev/null` — after the printf

This prevents the API key from leaking into shell traces when `set -x` is active in the calling script, matching the pattern already applied to the `oauth` arm (L70-72) and `ollama-cloud.sh` (L47-49 of that driver).

No functional change. Test suite: 33/33 passed.

Closes #132