### PR TITLE
📝 Add spec 0012 delta-01 — define harness agent set

### DIFF
--- a/specs/0012-core-framework-separation.delta-01.md
+++ b/specs/0012-core-framework-separation.delta-01.md
@@ -1,0 +1,70 @@
+---
+id: "0012"
+slug: core-framework-separation
+status: draft
+complexity: large
+interaction-mode: INTERMEDIATE
+related-issue: 224
+version: 1.1.0
+---
+
+# Core Framework Separation
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+**R6** — Add harness agent set enumeration (plan-review iter:1 Finding 3: R8 used the
+term "harness agent set" with no corresponding definition in the spec).
+
+Original:
+
+> 6\. The core layer SHALL include, at minimum: the lifecycle governance files
+> (`AGENTS.md`, `docs/`), the harness skill set (`spec-author`,
+> `harness-curator`, `harness-report`, `pr-logbook`, `pr-reviewer`), the
+> build and install scripts (`scripts/`), and the specification history
+> (`specs/`).
+
+Replacement:
+
+> 6\. The core layer SHALL include, at minimum: the lifecycle governance files
+> (`AGENTS.md`, `docs/`), the harness skill set (`spec-author`,
+> `harness-curator`, `harness-report`, `pr-logbook`, `pr-reviewer`), the
+> harness agent set (`spec-author`, `harness-curator`, `pr-logbook`,
+> `pr-reviewer`, `architect`), the build and install scripts (`scripts/`),
+> and the specification history (`specs/`).
+
+---
+
+**R8** — Replace the undefined "harness agent set" reference with an explicit
+enumeration of illustrative agents sourced from `community-config/agents/`
+(plan-review iter:1 Finding 3).
+
+Original:
+
+> 8\. The examples directory SHALL include, at minimum: the illustrative role
+> skills currently in `community-config/skills/` that are not part of the
+> harness skill set (`architect`, `developer`, `tester`, `astro`, `frontend`,
+> `doc-writer`, `security`, `web-tester`, `github-actions`, `copywriting`)
+> and the illustrative agent definitions not belonging to the harness agent
+> set.
+
+Replacement:
+
+> 8\. The examples directory SHALL include, at minimum: the illustrative role
+> skills currently in `community-config/skills/` that are not part of the
+> harness skill set (`architect`, `developer`, `tester`, `astro`, `frontend`,
+> `doc-writer`, `security`, `web-tester`, `github-actions`, `copywriting`),
+> and the illustrative agent definitions currently in
+> `community-config/agents/` that are not part of the harness agent set
+> defined in R6 (`accessibility-auditor`, `accessibility-tester`,
+> `astro-developer`, `ci-configurator`, `ci-debugger`, `copywriter`,
+> `designer`, `developer`, `doc-writer`, `frontend-developer`,
+> `regression-sentinel`, `scenario-author`, `security`, `seo-specialist`,
+> `tester`, `visual-regression-tester`, `web-conformity-checker`).
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Resolves plan-review iter:1 Finding 3 (`class: spec`): R8 used the term
"harness agent set" with no corresponding definition in spec 0012.

## How to read this PR?

Single file: `specs/0012-core-framework-separation.delta-01.md`.
Two modifications, no additions or removals:

- **R6 MODIFIED** — adds "the harness agent set (`spec-author`, `harness-curator`,
  `pr-logbook`, `pr-reviewer`, `architect`)" alongside the existing harness-skill
  enumeration, making the core layer's agent boundary explicit.
- **R8 MODIFIED** — replaces the undefined "harness agent set" reference with an
  explicit enumeration of the 18 illustrative agent definitions from
  `community-config/agents/` that are NOT in the harness agent set.

After this delta merges, the architect will revise the PLAN comment to address
the remaining arch/tech findings (iter:1 Findings 1, 2, 4, 5).

## How to test this PR?

1. `npx markdownlint-cli "specs/0012-core-framework-separation.delta-01.md" --config .markdownlintrc` — passes.
2. Confirm `## ADDED`, `## MODIFIED`, `## REMOVED` are present in that order at H2 level.
3. Confirm R8 no longer references an undefined "harness agent set" — it enumerates the illustrative agents explicitly.
4. Confirm R6 now contains both "harness skill set" and "harness agent set" enumerations.
5. Confirm no implementation files are included — single new file only.

## Detailed description (for agents)

**Trigger:** plan-review iter:1 Finding 3 (`class: spec`) — routing precedence `spec > arch > tech` sent the entire pass to SPECS.

**Delta:** `specs/0012-core-framework-separation.delta-01.md`
- `id: "0012"`, `version: 1.1.0` (MINOR bump — additive normative content).
- `## ADDED`: none.
- `## MODIFIED`: R6 (harness agent set added) and R8 (illustrative agents enumerated explicitly).
- `## REMOVED`: none.

**After merge:** architect revises the PLAN comment addressing Findings 1, 2, 4, 5; second architect cold-reviews again (iter:2).