### PR TITLE
📝 Add spec 0013 — layer taxonomy and boundary contract

### DIFF
--- a/specs/0013-layer-taxonomy-boundary-contract.md
+++ b/specs/0013-layer-taxonomy-boundary-contract.md
@@ -1,0 +1,115 @@
+---
+id: "0013"
+slug: layer-taxonomy-boundary-contract
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 227
+version: 1.0.0
+---
+
+# Layer Taxonomy and Boundary Contract
+
+## Intent
+
+CrewRig gains a normative document — `docs/layers.md` — that classifies every
+top-level repository path as belonging to the `core`, `overlay`, or `examples`
+layer. This document is the single authoritative boundary contract that makes the
+two-layer adoption model legible: any developer, any adopting organisation, and
+any downstream sub-specification implementation can consult it to know, without
+ambiguity, which paths are frozen upstream territory and which paths belong to
+the organisation.
+
+## Requirements
+
+1. The repository SHALL contain a normative document at `docs/layers.md` that
+   serves as the authoritative boundary contract for the three-layer adoption
+   model.
+2. `docs/layers.md` SHALL classify every top-level path in the repository, and
+   every critical sub-path where top-level classification alone is insufficient
+   to resolve the layer, into exactly one of three layers: `core`, `overlay`, or
+   `examples`.
+3. `docs/layers.md` SHALL define the `core` layer as the bounded set of paths
+   controlled exclusively by the upstream CrewRig project, which adopting
+   organisations SHALL NOT modify.
+4. `docs/layers.md` SHALL define the `overlay` layer as the bounded set of paths
+   reserved for adopting organisations' identity, server integrations, and
+   internal components, which upstream updates SHALL NOT touch.
+5. `docs/layers.md` SHALL define the `examples` layer as the set of
+   illustrative, template-intended paths that adopting organisations may copy and
+   adapt, but that are not part of the upstream contract and are not intended to
+   be extended in place.
+6. `docs/layers.md` SHALL classify as `core`, at minimum, the paths enumerated
+   in spec 0012 R6 (as amended by delta-01): `AGENTS.md`, `CLAUDE.md`, `docs/`,
+   `scripts/`, `specs/`, the five harness skill directories under
+   `community-config/skills/` (`spec-author`, `harness-curator`, `harness-report`,
+   `pr-logbook`, `pr-reviewer`), and the five harness agent directories under
+   `community-config/agents/` (`spec-author`, `harness-curator`, `pr-logbook`,
+   `pr-reviewer`, `architect`).
+7. `docs/layers.md` SHALL classify as `overlay`, at minimum, paths covering the
+   categories named in spec 0012 R7: `crewrig.config.toml`, `config/SOUL.md`,
+   `config/PROFILE.md`, `config/ORGANIZATION.md`, `config/TOOLS.md`,
+   `config/teams/`, `config/expertise/`, `config/level/`, `config/claude/`,
+   `config/gemini/`, `config/copilot/`, `community-config/mcp-servers/`,
+   `community-config/hooks/`, `community-config/themes/`, and the designated
+   areas for organisation-specific skills and agents.
+8. `docs/layers.md` SHALL classify as `examples`, at minimum, the illustrative
+   role skill directories under `community-config/skills/` that are not part of
+   the harness skill set (as enumerated in spec 0012 R8, amended by delta-01)
+   and the illustrative agent directories under `community-config/agents/` that
+   are not part of the harness agent set.
+9. For paths not yet present in the repository at authoring time — notably
+   `examples/`, planned by spec 0012 R11 — `docs/layers.md` SHALL note that the
+   path is forthcoming and reference the sub-specification that introduces it.
+10. `docs/layers.md` SHALL provide a classification structure (table, enumerated
+    list, or equivalent) that allows a reader to determine the layer of any given
+    repository path without requiring prior knowledge of the adoption model beyond
+    what the document itself states.
+11. Any path in the repository that `docs/layers.md` does not classify SHALL be
+    treated as a documentation gap, not as implicitly `core` or implicitly
+    `overlay` — the document SHALL be complete at the time it is introduced.
+
+## Scenarios
+
+**Scenario:** Developer identifies the layer of an org-specific config path
+
+Given a developer at an adopting organisation who wants to know whether they may
+customise `config/SOUL.md`
+When they consult `docs/layers.md`
+Then they find `config/SOUL.md` listed under the `overlay` layer with a
+description confirming it is reserved for the organisation's identity.
+
+**Scenario:** Contributor verifies that `docs/` is frozen upstream territory
+
+Given a contributor considering whether to add a documentation file directly to
+`docs/` in their organisation's repository
+When they consult `docs/layers.md`
+Then they find `docs/` listed under the `core` layer, understanding that any
+addition there must originate from an upstream CrewRig pull request, not a local
+org-side edit.
+
+**Scenario:** Reviewer detects a path missing from the classification
+
+Given `docs/layers.md` has been written but a top-level path (e.g., `tests/`)
+was omitted from the classification
+When a reviewer cross-references the document against the repository tree
+Then the gap is immediately visible — the path appears in the tree but is absent
+from the document's enumeration — and no ambiguity remains about whether the
+omission is intentional.
+
+## Out of scope
+
+- Restructuring or moving existing paths to match the taxonomy — covered by
+  sub-specs B, C, and D of spec 0012.
+- Creating the `examples/` directory and populating it — covered by the
+  directory-restructuring sub-spec.
+- Implementing the synchronisation mechanism that enforces core-layer immutability
+  at sync time — covered by sub-spec D.
+- Authoring the adoption guide that describes how an organisation populates the
+  overlay layer — covered by sub-spec E1.
+- Updating `AGENTS.md` to cross-reference `docs/layers.md` — the implementation
+  PR for this sub-spec MAY include it, but it is not normatively required here.
+
+## Open questions
+
+(none)


### PR DESCRIPTION
Spec-PR for sub-spec A of issue #224 (spec 0012 — core framework separation).

## How to read this PR?

Single file: `specs/0013-layer-taxonomy-boundary-contract.md`. Read it top to bottom — frontmatter, then the five mandatory sections. The requirements build on spec 0012 R1/R2/R6/R7/R8 (as amended by delta-01), so having those open side-by-side helps.

## How to test this PR?

1. Verify the frontmatter satisfies `docs/spec-format.md` (id, slug, status, complexity, interaction-mode, related-issue, version all present and correct).
2. Confirm all five mandatory body sections are present and non-empty.
3. Confirm the spec does not reference HOW (no technology names, no implementation choices in `## Intent` or `## Requirements`).
4. Confirm R6/R7/R8 path enumerations align with spec 0012 (as amended by delta-01) — no path added or removed beyond what the parent spec establishes.
5. Confirm `## Out of scope` explicitly excludes the sub-specs B/C/D/E1 concerns.

## Detailed description (for agents)

**Added:** `specs/0013-layer-taxonomy-boundary-contract.md`

- 11 requirements covering: existence of `docs/layers.md` (R1), completeness of classification (R2, R11), layer semantics definitions (R3–R5), minimum core/overlay/examples enumerations derived from spec 0012 (R6–R8), treatment of forthcoming paths (R9), and reader-legibility of the classification structure (R10).
- 3 scenarios: happy-path overlay lookup, happy-path core freeze verification, failure-path gap detection.
- Out of scope explicitly delegates restructuring, examples creation, sync mechanism, and adoption guide to downstream sub-specs.
- No open questions.

Related to #227. Does NOT close #227 (logbook stays open through DEV and REVIEW).