### PR TITLE
✨ Add docs/layers.md — layer taxonomy and boundary contract

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -157,8 +157,6 @@ from the examples layer.
 | Path | Description |
 |---|---|
 | `crewrig.config.toml` | Fork-level configuration: `canonical_repo`, `feedback_repo`, overlay path declarations. |
-| `config/SOUL.md` | Organisation identity: mission, values, working philosophy. |
-| `config/PROFILE.md` | Personal profile: user name, role, preferred language, tooling preferences. |
 | `config/ORGANIZATION.md` | Organisation overview: company context, code quality standards, collaboration norms. |
 | `config/TOOLS.md` | Tool and MCP server guidelines specific to the organisation. |
 
@@ -296,6 +294,8 @@ committed to the repository.
 | `.DS_Store` | macOS Finder metadata. |
 | `node_modules/` | Node.js dependencies installed locally — gitignored. |
 | `*.env` | Environment secrets — never committed. |
+| `config/SOUL.md` | User-generated from `config/SOUL.md.template` — gitignored, personal to each developer, never committed. |
+| `config/PROFILE.md` | User-generated from `config/PROFILE.md.template` — gitignored, personal to each developer, never committed. |
 
 ---
 
@@ -310,8 +310,8 @@ across multiple layers. This table provides a single-lookup view.
 | `config/release-monorepo.json` | core |
 | `config/launchd/` | core |
 | `config/systemd/` | core |
-| `config/SOUL.md` | overlay |
-| `config/PROFILE.md` | overlay |
+| `config/SOUL.md` | user-local (gitignored) |
+| `config/PROFILE.md` | user-local (gitignored) |
 | `config/ORGANIZATION.md` | overlay |
 | `config/TOOLS.md` | overlay |
 | `config/claude/` | overlay |

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -118,8 +118,8 @@ automatically on every relevant commit; never edited directly.
 
 Paths reserved exclusively for the adopting organisation. The upstream
 synchronisation mechanism will never modify these paths. An adopting
-organisation initialises them from the core-provided templates where
-templates exist.
+organisation initialises them by copying the relevant starting-point templates
+from the examples layer.
 
 ### Fork identity and configuration
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -31,6 +31,8 @@ refuse to proceed.
 |---|---|
 | `AGENTS.md` | Normative working rules for every agent. Single source of truth for the lifecycle. |
 | `CLAUDE.md` | Claude Code workspace bootstrap — imports `AGENTS.md`. |
+| `LICENSE` | Project license. |
+| `README.md` | Project overview and quick-start. |
 | `CONTRIBUTING.md` | Contribution guide. |
 | `DEVELOPMENT.md` | Local development setup guide. |
 | `Taskfile.yml` | Task runner definitions. |
@@ -38,6 +40,8 @@ refuse to proceed.
 | `.gitattributes` | Line-ending and diff attributes. |
 | `.markdownlintrc` | Markdown lint configuration. |
 | `renovate.json` | Automated dependency update configuration. |
+| `package.json` | Node.js tooling manifest (linting, markdown tooling). |
+| `package-lock.json` | Locked dependency tree for Node.js tooling. |
 
 ### Documentation and specifications
 
@@ -53,7 +57,6 @@ refuse to proceed.
 | `scripts/` | All build, install, setup, and utility scripts. |
 | `tests/` | Automated test suite. |
 | `docker/` | Docker infrastructure for end-to-end tests. |
-| `Taskfile.yml` | (see Repository governance above) |
 
 ### Community configuration — harness components
 
@@ -93,11 +96,13 @@ automatically on every relevant commit; never edited directly.
 | `.github/workflows/` | CI/CD pipeline definitions. |
 | `.github/copilot/` | GitHub Copilot workspace configuration. |
 
-### Extension distribution channel
+### Extension distribution channel and registry
 
 | Path | Description |
 |---|---|
-| `extension-skeleton/` | Scaffold templates for CrewRig extensions. Unchanged by this spec. |
+| `extension-skeleton/` | Scaffold templates for creating new CrewRig extensions. |
+| `extensions/` | Upstream-provided extension registry. Extensions authored here are distributed via `scripts/install-extension.sh`. |
+| `hooks/` | Cross-CLI transcript hook configuration files (`claude-transcript-hooks.json`, `gemini-transcript-hooks.json`, `copilot-transcript-hooks.json`, `mempalace-transcript.sh`). |
 
 ### Public communications
 
@@ -170,6 +175,8 @@ They must not be confused with the overlay files they seed.
 | `community-config/policies/` | Organisation-level policy files. |
 | `community-config/themes/` | UI theme files specific to the organisation. |
 | `community-config/commands/` | Organisation-specific slash-command definitions. |
+| `community-config/skills/<org-name>/` | Any skill directory in `community-config/skills/` not belonging to the harness skill set (see Core) and not listed under Examples is reserved for the adopting organisation's own role skills. |
+| `community-config/agents/<org-name>/` | Any agent directory in `community-config/agents/` not belonging to the harness agent set (see Core) and not listed under Examples is reserved for the adopting organisation's own agents. |
 
 ---
 
@@ -248,6 +255,7 @@ committed to the repository.
 | `.claude/worktrees/` | Claude Code worktree metadata. |
 | `.worktrees/` | Git worktrees created during agent team sessions. |
 | `.DS_Store` | macOS Finder metadata. |
+| `node_modules/` | Node.js dependencies installed locally — gitignored. |
 | `*.env` | Environment secrets — never committed. |
 
 ---

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -299,6 +299,32 @@ committed to the repository.
 
 ---
 
+## `config/` quick-reference
+
+The `config/` directory is the only top-level path with sub-paths distributed
+across multiple layers. This table provides a single-lookup view.
+
+| Path | Layer |
+|---|---|
+| `config/.env.example` | core |
+| `config/release-monorepo.json` | core |
+| `config/launchd/` | core |
+| `config/systemd/` | core |
+| `config/SOUL.md` | overlay |
+| `config/PROFILE.md` | overlay |
+| `config/ORGANIZATION.md` | overlay |
+| `config/TOOLS.md` | overlay |
+| `config/claude/` | overlay |
+| `config/gemini/` | overlay |
+| `config/copilot/` | overlay |
+| `config/level/` | examples |
+| `config/expertise/` | examples |
+| `config/teams/` | examples |
+| `config/SOUL.md.template` | examples |
+| `config/PROFILE.md.template` | examples |
+
+---
+
 ## Classification rules for future paths
 
 When a new path is added to the repository and this document has not yet been

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -57,6 +57,8 @@ refuse to proceed.
 | `scripts/` | All build, install, setup, and utility scripts. |
 | `tests/` | Automated test suite. |
 | `docker/` | Docker infrastructure for end-to-end tests. |
+| `config/.env.example` | Environment variable reference (gitignored `.env` is never committed). |
+| `config/release-monorepo.json` | Monorepo release tooling configuration. |
 
 ### Community configuration — harness components
 
@@ -121,26 +123,13 @@ templates exist.
 
 ### Fork identity and configuration
 
-| Path | Core template | Description |
-|---|---|---|
-| `crewrig.config.toml` | `crewrig.config.toml.template` *(planned — spec 0012 R12)* | Fork-level configuration: `canonical_repo`, `feedback_repo`, overlay path declarations. |
-| `config/SOUL.md` | `config/SOUL.md.template` | Organisation identity: mission, values, working philosophy. |
-| `config/PROFILE.md` | `config/PROFILE.md.template` | Personal profile: user name, role, preferred language, tooling preferences. |
-| `config/ORGANIZATION.md` | *(no template — free-form)* | Organisation overview: company context, code quality standards, collaboration norms. |
-| `config/TOOLS.md` | *(no template — free-form)* | Tool and MCP server guidelines specific to the organisation. |
-
-### Core templates (owned by upstream, consumed by overlay)
-
-These files live under `config/` but belong to the **core** layer: they are
-templates the organisation reads once to initialise the overlay files above.
-They must not be confused with the overlay files they seed.
-
-| Path | Seeds |
+| Path | Description |
 |---|---|
-| `config/SOUL.md.template` | `config/SOUL.md` |
-| `config/PROFILE.md.template` | `config/PROFILE.md` |
-| `config/.env.example` | `.env` (never committed) |
-| `config/release-monorepo.json` | *(monorepo release tooling config — core)* |
+| `crewrig.config.toml` | Fork-level configuration: `canonical_repo`, `feedback_repo`, overlay path declarations. |
+| `config/SOUL.md` | Organisation identity: mission, values, working philosophy. |
+| `config/PROFILE.md` | Personal profile: user name, role, preferred language, tooling preferences. |
+| `config/ORGANIZATION.md` | Organisation overview: company context, code quality standards, collaboration norms. |
+| `config/TOOLS.md` | Tool and MCP server guidelines specific to the organisation. |
 
 ### Persona and context files
 
@@ -233,12 +222,28 @@ Agents in `community-config/agents/` not belonging to the harness agent set
 | `community-config/agents/visual-regression-tester/` |
 | `community-config/agents/web-conformity-checker/` |
 
+### Identity and configuration templates
+
+Default starting points for the overlay identity files. An adopting
+organisation copies one of these, customises it, and saves the result as the
+corresponding overlay path (`config/SOUL.md`, `config/PROFILE.md`,
+`crewrig.config.toml`). The templates themselves are illustrative; the
+organisation owns only the customised instances.
+
+| Path | Seeds overlay file |
+|---|---|
+| `config/SOUL.md.template` | `config/SOUL.md` |
+| `config/PROFILE.md.template` | `config/PROFILE.md` |
+| `crewrig.config.toml.template` *(forthcoming — spec 0012 R12)* | `crewrig.config.toml` |
+
 ### Forthcoming examples directory
 
 `examples/` — **not yet present** in the repository. Planned by spec 0012 R11
 (sub-spec B or C of the core framework separation). When introduced, it will
-serve as the primary landing zone for illustrative role skills and
-configuration templates, visually distinct from the core harness area.
+serve as the primary landing zone for illustrative role skills, configuration
+templates, and other starting-point artefacts, visually distinct from the core
+harness area. The identity templates above will physically relocate there at
+that point.
 
 ---
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -64,26 +64,47 @@ refuse to proceed.
 
 The harness skill set and harness agent set (as defined in spec 0012 R6,
 amended by delta-01) are core. All other skill and agent directories in
-`community-config/` are classified under **examples**.
+`community-config/` are classified under **examples** or **overlay** as
+detailed in those sections.
+
+`community-config/FORMAT.md` is the normative format contract for all
+community components (core).
+
+The harness components split into two semantic groups:
+
+**Harness system** — the friction-reporting and curation machinery:
 
 | Path | Description |
 |---|---|
-| `community-config/FORMAT.md` | Normative format contract for skills, agents, and commands. |
-| `community-config/skills/spec-author/` | Harness skill — qualification stage author. |
-| `community-config/skills/harness-curator/` | Harness skill — friction clustering and issue authoring. |
 | `community-config/skills/harness-report/` | Harness skill — friction tagging protocol. |
-| `community-config/skills/pr-logbook/` | Harness skill — PR and logbook composer. |
-| `community-config/skills/pr-reviewer/` | Harness skill — independent PR reviewer. |
-| `community-config/agents/spec-author/` | Harness agent — spec-author specialist. |
+| `community-config/skills/harness-curator/` | Harness skill — friction clustering and issue authoring. |
 | `community-config/agents/harness-curator/` | Harness agent — curator specialist. |
-| `community-config/agents/pr-logbook/` | Harness agent — logbook composer specialist. |
-| `community-config/agents/pr-reviewer/` | Harness agent — PR reviewer specialist. |
-| `community-config/agents/architect/` | Harness agent — architect specialist (plan and design). |
+
+**SDLC lifecycle tools** — the SPECS → PLAN → DEV → REVIEW cycle machinery
+that enables CrewRig's own development (and through which harness-reports are
+implemented):
+
+| Path | Description |
+|---|---|
+| `community-config/skills/spec-author/` | Lifecycle skill — qualification stage author. |
+| `community-config/skills/pr-logbook/` | Lifecycle skill — PR and logbook composer. |
+| `community-config/skills/pr-reviewer/` | Lifecycle skill — independent PR reviewer. |
+| `community-config/agents/spec-author/` | Lifecycle agent — spec-author specialist. |
+| `community-config/agents/pr-logbook/` | Lifecycle agent — logbook composer specialist. |
+| `community-config/agents/pr-reviewer/` | Lifecycle agent — PR reviewer specialist. |
+| `community-config/agents/architect/` | Lifecycle agent — architect specialist (plan and design). |
 
 ### Built outputs
 
-Built by `scripts/build-components.sh` from `community-config/`. Regenerated
-automatically on every relevant commit; never edited directly.
+Built by `scripts/build-components.sh` from `community-config/`. These
+directories are **assembly zones**: after a build they contain both
+core-provided harness components and the adopting organisation's own compiled
+components. They are never edited directly; the source of truth is always
+`community-config/`.
+
+An adopting organisation may activate only a subset of CLIs; the sync
+mechanism respects this scope. The detailed assembly model (which CLI outputs
+exist, how org artefacts integrate) is defined in spec 0012 sub-spec E2.
 
 | Path | Description |
 |---|---|
@@ -98,13 +119,23 @@ automatically on every relevant commit; never edited directly.
 | `.github/workflows/` | CI/CD pipeline definitions. |
 | `.github/copilot/` | GitHub Copilot workspace configuration. |
 
-### Extension distribution channel and registry
+### Extension distribution channel
 
 | Path | Description |
 |---|---|
 | `extension-skeleton/` | Scaffold templates for creating new CrewRig extensions. |
-| `extensions/` | Upstream-provided extension registry. Extensions authored here are distributed via `scripts/install-extension.sh`. |
 | `hooks/` | Cross-CLI transcript hook configuration files (`claude-transcript-hooks.json`, `gemini-transcript-hooks.json`, `copilot-transcript-hooks.json`, `mempalace-transcript.sh`). |
+
+### Infrastructure service definitions
+
+Service management files for CrewRig's own infrastructure dependencies
+(e.g., ChromaDB for MemPalace). These are maintained by upstream and apply
+to every deployment of CrewRig.
+
+| Path | Description |
+|---|---|
+| `config/launchd/` | macOS launchd service definitions for CrewRig infrastructure services. |
+| `config/systemd/` | Linux systemd unit files for CrewRig infrastructure services. |
 
 ### Public communications
 
@@ -131,14 +162,6 @@ from the examples layer.
 | `config/ORGANIZATION.md` | Organisation overview: company context, code quality standards, collaboration norms. |
 | `config/TOOLS.md` | Tool and MCP server guidelines specific to the organisation. |
 
-### Persona and context files
-
-| Path | Description |
-|---|---|
-| `config/level/` | Seniority-level context rules (e.g., `10-level.md`). |
-| `config/expertise/` | Domain-expertise context rules. |
-| `config/teams/` | Per-team context and configuration. |
-
 ### CLI-specific overlay configuration
 
 | Path | Description |
@@ -148,24 +171,18 @@ from the examples layer.
 | `config/copilot/` | GitHub Copilot overlay configuration files. |
 | `.claude/settings.json` | Claude Code workspace-level settings (memory, permissions). |
 
-### System service definitions
+### Extensions and organisation-specific community configuration
 
 | Path | Description |
 |---|---|
-| `config/launchd/` | macOS launchd service definitions (organisation-specific launch agents). |
-| `config/systemd/` | Linux systemd unit files (organisation-specific services). |
-
-### Organisation-specific community configuration
-
-| Path | Description |
-|---|---|
+| `extensions/` | Organisation-owned extension registry. The adopting organisation places its own CrewRig extensions here. Upstream extensions are installed via `scripts/install-extension.sh` rather than committed directly. |
 | `community-config/mcp-servers/` | MCP server declarations specific to the organisation (Jira, Confluence, Slack, etc.). |
 | `community-config/hooks/` | Lifecycle hooks specific to the organisation. |
 | `community-config/policies/` | Organisation-level policy files. |
 | `community-config/themes/` | UI theme files specific to the organisation. |
 | `community-config/commands/` | Organisation-specific slash-command definitions. |
-| `community-config/skills/<org-name>/` | Any skill directory in `community-config/skills/` not belonging to the harness skill set (see Core) and not listed under Examples is reserved for the adopting organisation's own role skills. |
-| `community-config/agents/<org-name>/` | Any agent directory in `community-config/agents/` not belonging to the harness agent set (see Core) and not listed under Examples is reserved for the adopting organisation's own agents. |
+| `community-config/skills/<org-skill>/` | Any skill directory in `community-config/skills/` not belonging to the harness skill set (Core) and not listed under Examples is reserved for the adopting organisation's own role skills. |
+| `community-config/agents/<org-agent>/` | Any agent directory in `community-config/agents/` not belonging to the harness agent set (Core) and not listed under Examples is reserved for the adopting organisation's own agents. |
 
 ---
 
@@ -179,10 +196,25 @@ extended or overridden in place.
 A notice SHALL be present in each examples component indicating its
 demonstrative nature (spec 0012 R3).
 
+### Persona and context starting points
+
+Default persona and context files that CrewRig ships as illustrative
+starting points. An adopting organisation copies these into its own overlay
+and customises them. After copying, the customised version is `overlay`; the
+originals here remain `examples`.
+
+| Path | Description |
+|---|---|
+| `config/level/` | Seniority-level context rules (e.g., `10-level.md`). Starting points for an org's own level definitions. |
+| `config/expertise/` | Domain-expertise context rules. Starting points for an org's own expertise profiles. |
+| `config/teams/` | Per-team context and configuration. Starting points for an org's own team configs. |
+
 ### Illustrative skills
 
 Skills in `community-config/skills/` not belonging to the harness skill set
-(spec 0012 R8):
+(spec 0012 R8). These are actively used by the upstream CrewRig project for
+its own development workflow; they also serve as high-quality starting points
+for adopting organisations building their own role skills.
 
 | Path |
 |---|
@@ -200,7 +232,9 @@ Skills in `community-config/skills/` not belonging to the harness skill set
 ### Illustrative agents
 
 Agents in `community-config/agents/` not belonging to the harness agent set
-(spec 0012 R8, amended by delta-01):
+(spec 0012 R8, amended by delta-01). Same dual-use nature as the illustrative
+skills: actively used by upstream, and illustrative starting points for adopting
+organisations.
 
 | Path |
 |---|

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,263 @@
+# CrewRig — Layer Taxonomy and Boundary Contract
+
+This document is the **authoritative boundary contract** for the two-layer
+adoption model introduced by spec 0012 (core framework separation). Every
+path in this repository is classified as belonging to exactly one of three
+layers. No path is left unclassified; an omission here is a documentation
+gap, not an implicit assignment.
+
+---
+
+## Layer definitions
+
+| Layer | Owner | Immutability contract |
+|---|---|---|
+| **`core`** | Upstream CrewRig project | Adopting organisations **SHALL NOT** modify these paths. Upstream updates land here cleanly. |
+| **`overlay`** | Adopting organisation | Upstream updates **SHALL NOT** touch these paths. The organisation owns them entirely. |
+| **`examples`** | Upstream CrewRig project (authoritative) | Illustrative templates. Adopting organisations may copy and adapt them but are not expected to extend them in place. |
+
+---
+
+## Core layer
+
+Paths controlled exclusively by the upstream CrewRig project. An adopting
+organisation that modifies a `core` path will receive a conflict on the next
+upstream synchronisation; the sync mechanism (spec 0012, sub-spec D) will
+refuse to proceed.
+
+### Repository governance
+
+| Path | Description |
+|---|---|
+| `AGENTS.md` | Normative working rules for every agent. Single source of truth for the lifecycle. |
+| `CLAUDE.md` | Claude Code workspace bootstrap — imports `AGENTS.md`. |
+| `CONTRIBUTING.md` | Contribution guide. |
+| `DEVELOPMENT.md` | Local development setup guide. |
+| `Taskfile.yml` | Task runner definitions. |
+| `.gitignore` | Repository-wide ignore rules. |
+| `.gitattributes` | Line-ending and diff attributes. |
+| `.markdownlintrc` | Markdown lint configuration. |
+| `renovate.json` | Automated dependency update configuration. |
+
+### Documentation and specifications
+
+| Path | Description |
+|---|---|
+| `docs/` | All normative and reference documentation, including ADRs, format specs, and this file. |
+| `specs/` | Immutable specification history. Spec files are append-only; existing files are never edited after merge. |
+
+### Build and install tooling
+
+| Path | Description |
+|---|---|
+| `scripts/` | All build, install, setup, and utility scripts. |
+| `tests/` | Automated test suite. |
+| `docker/` | Docker infrastructure for end-to-end tests. |
+| `Taskfile.yml` | (see Repository governance above) |
+
+### Community configuration — harness components
+
+The harness skill set and harness agent set (as defined in spec 0012 R6,
+amended by delta-01) are core. All other skill and agent directories in
+`community-config/` are classified under **examples**.
+
+| Path | Description |
+|---|---|
+| `community-config/FORMAT.md` | Normative format contract for skills, agents, and commands. |
+| `community-config/skills/spec-author/` | Harness skill — qualification stage author. |
+| `community-config/skills/harness-curator/` | Harness skill — friction clustering and issue authoring. |
+| `community-config/skills/harness-report/` | Harness skill — friction tagging protocol. |
+| `community-config/skills/pr-logbook/` | Harness skill — PR and logbook composer. |
+| `community-config/skills/pr-reviewer/` | Harness skill — independent PR reviewer. |
+| `community-config/agents/spec-author/` | Harness agent — spec-author specialist. |
+| `community-config/agents/harness-curator/` | Harness agent — curator specialist. |
+| `community-config/agents/pr-logbook/` | Harness agent — logbook composer specialist. |
+| `community-config/agents/pr-reviewer/` | Harness agent — PR reviewer specialist. |
+| `community-config/agents/architect/` | Harness agent — architect specialist (plan and design). |
+
+### Built outputs
+
+Built by `scripts/build-components.sh` from `community-config/`. Regenerated
+automatically on every relevant commit; never edited directly.
+
+| Path | Description |
+|---|---|
+| `.claude/skills/` | Compiled Claude Code skill definitions. |
+| `.claude/agents/` | Compiled Claude Code agent definitions. |
+| `.gemini/skills/` | Compiled Gemini CLI skill definitions. |
+| `.gemini/agents/` | Compiled Gemini CLI agent definitions. |
+| `.gemini/commands/` | Compiled Gemini CLI slash-command definitions (bootstrap helpers). |
+| `.github/skills/` | Compiled GitHub Copilot skill definitions. |
+| `.github/agents/` | Compiled GitHub Copilot agent definitions. |
+| `.github/copilot-instructions.md` | Copilot system prompt built from `AGENTS.md`. |
+| `.github/workflows/` | CI/CD pipeline definitions. |
+| `.github/copilot/` | GitHub Copilot workspace configuration. |
+
+### Extension distribution channel
+
+| Path | Description |
+|---|---|
+| `extension-skeleton/` | Scaffold templates for CrewRig extensions. Unchanged by this spec. |
+
+### Public communications
+
+| Path | Description |
+|---|---|
+| `communication/` | Conference talks, demos, and public presentation materials. |
+
+---
+
+## Overlay layer
+
+Paths reserved exclusively for the adopting organisation. The upstream
+synchronisation mechanism will never modify these paths. An adopting
+organisation initialises them from the core-provided templates where
+templates exist.
+
+### Fork identity and configuration
+
+| Path | Core template | Description |
+|---|---|---|
+| `crewrig.config.toml` | `crewrig.config.toml.template` *(planned — spec 0012 R12)* | Fork-level configuration: `canonical_repo`, `feedback_repo`, overlay path declarations. |
+| `config/SOUL.md` | `config/SOUL.md.template` | Organisation identity: mission, values, working philosophy. |
+| `config/PROFILE.md` | `config/PROFILE.md.template` | Personal profile: user name, role, preferred language, tooling preferences. |
+| `config/ORGANIZATION.md` | *(no template — free-form)* | Organisation overview: company context, code quality standards, collaboration norms. |
+| `config/TOOLS.md` | *(no template — free-form)* | Tool and MCP server guidelines specific to the organisation. |
+
+### Core templates (owned by upstream, consumed by overlay)
+
+These files live under `config/` but belong to the **core** layer: they are
+templates the organisation reads once to initialise the overlay files above.
+They must not be confused with the overlay files they seed.
+
+| Path | Seeds |
+|---|---|
+| `config/SOUL.md.template` | `config/SOUL.md` |
+| `config/PROFILE.md.template` | `config/PROFILE.md` |
+| `config/.env.example` | `.env` (never committed) |
+| `config/release-monorepo.json` | *(monorepo release tooling config — core)* |
+
+### Persona and context files
+
+| Path | Description |
+|---|---|
+| `config/level/` | Seniority-level context rules (e.g., `10-level.md`). |
+| `config/expertise/` | Domain-expertise context rules. |
+| `config/teams/` | Per-team context and configuration. |
+
+### CLI-specific overlay configuration
+
+| Path | Description |
+|---|---|
+| `config/claude/` | Claude Code overlay rules and workspace settings. |
+| `config/gemini/` | Gemini CLI overlay configuration files. |
+| `config/copilot/` | GitHub Copilot overlay configuration files. |
+| `.claude/settings.json` | Claude Code workspace-level settings (memory, permissions). |
+
+### System service definitions
+
+| Path | Description |
+|---|---|
+| `config/launchd/` | macOS launchd service definitions (organisation-specific launch agents). |
+| `config/systemd/` | Linux systemd unit files (organisation-specific services). |
+
+### Organisation-specific community configuration
+
+| Path | Description |
+|---|---|
+| `community-config/mcp-servers/` | MCP server declarations specific to the organisation (Jira, Confluence, Slack, etc.). |
+| `community-config/hooks/` | Lifecycle hooks specific to the organisation. |
+| `community-config/policies/` | Organisation-level policy files. |
+| `community-config/themes/` | UI theme files specific to the organisation. |
+| `community-config/commands/` | Organisation-specific slash-command definitions. |
+
+---
+
+## Examples layer
+
+Illustrative paths authored by the upstream CrewRig project to demonstrate
+the framework to newcomers. Adopting organisations may copy any of these
+into their overlay and adapt them freely; they are not intended to be
+extended or overridden in place.
+
+A notice SHALL be present in each examples component indicating its
+demonstrative nature (spec 0012 R3).
+
+### Illustrative skills
+
+Skills in `community-config/skills/` not belonging to the harness skill set
+(spec 0012 R8):
+
+| Path |
+|---|
+| `community-config/skills/architect/` |
+| `community-config/skills/astro/` |
+| `community-config/skills/copywriting/` |
+| `community-config/skills/developer/` |
+| `community-config/skills/doc-writer/` |
+| `community-config/skills/frontend/` |
+| `community-config/skills/github-actions/` |
+| `community-config/skills/security/` |
+| `community-config/skills/tester/` |
+| `community-config/skills/web-tester/` |
+
+### Illustrative agents
+
+Agents in `community-config/agents/` not belonging to the harness agent set
+(spec 0012 R8, amended by delta-01):
+
+| Path |
+|---|
+| `community-config/agents/accessibility-auditor/` |
+| `community-config/agents/accessibility-tester/` |
+| `community-config/agents/astro-developer/` |
+| `community-config/agents/ci-configurator/` |
+| `community-config/agents/ci-debugger/` |
+| `community-config/agents/copywriter/` |
+| `community-config/agents/designer/` |
+| `community-config/agents/developer/` |
+| `community-config/agents/doc-writer/` |
+| `community-config/agents/frontend-developer/` |
+| `community-config/agents/regression-sentinel/` |
+| `community-config/agents/scenario-author/` |
+| `community-config/agents/security/` |
+| `community-config/agents/seo-specialist/` |
+| `community-config/agents/tester/` |
+| `community-config/agents/visual-regression-tester/` |
+| `community-config/agents/web-conformity-checker/` |
+
+### Forthcoming examples directory
+
+`examples/` — **not yet present** in the repository. Planned by spec 0012 R11
+(sub-spec B or C of the core framework separation). When introduced, it will
+serve as the primary landing zone for illustrative role skills and
+configuration templates, visually distinct from the core harness area.
+
+---
+
+## Ephemeral and tool-generated paths
+
+The following paths are generated at runtime or by tooling and are not part
+of the adoption model. They carry no layer classification and MUST NOT be
+committed to the repository.
+
+| Path | Origin |
+|---|---|
+| `.claude/scheduled_tasks.lock` | Claude Code internal lock file. |
+| `.claude/settings.local.json` | Local-only Claude Code overrides. |
+| `.claude/worktrees/` | Claude Code worktree metadata. |
+| `.worktrees/` | Git worktrees created during agent team sessions. |
+| `.DS_Store` | macOS Finder metadata. |
+| `*.env` | Environment secrets — never committed. |
+
+---
+
+## Classification rules for future paths
+
+When a new path is added to the repository and this document has not yet been
+updated, the following default rules apply until an explicit classification is
+merged:
+
+1. A new file or directory added by an upstream CrewRig pull request is **`core`** by default.
+2. A new file or directory added exclusively by an adopting organisation is **`overlay`** by default.
+3. Any ambiguity MUST be resolved by opening an issue and merging a delta to this document before the next upstream synchronisation cycle.


### PR DESCRIPTION
Implements spec 0013 (sub-spec A of spec 0012 — core framework separation). Introduces the normative boundary contract classifying every repository path as `core`, `overlay`, or `examples`.

## How to read this PR?

Single file: `docs/layers.md`. Structure: layer definitions table → core paths (governance, docs, scripts, harness components, built outputs) → overlay paths (fork config, identity files, CLI-specific configs, org-specific community-config) → examples paths (illustrative skills + agents, forthcoming `examples/` directory) → ephemeral paths → default classification rules.

Pay attention to:
- The "Core templates owned by upstream" sub-section under Overlay (e.g., `config/SOUL.md.template` is `core`, `config/SOUL.md` is `overlay`).
- The `community-config/` split: harness skills/agents are `core`; illustrative skills/agents are `examples`; mcp-servers, hooks, policies, themes, commands are `overlay`.
- The forthcoming `examples/` note under the examples layer.

## How to test this PR?

1. Cross-check core path list against spec 0012 R6 (as amended by delta-01) — every path there must appear here.
2. Cross-check overlay path list against spec 0012 R7 categories — all categories must be covered.
3. Cross-check examples lists against spec 0012 R8 (as amended by delta-01) — all 10 illustrative skills and 17 illustrative agents must appear.
4. Run `find . -maxdepth 2 -not -path './.git/*' -not -path './.worktrees/*'` and verify no top-level path is absent from `docs/layers.md` (spec 0013 R11).
5. Confirm `examples/` is marked as forthcoming with reference to spec 0012 R11 (spec 0013 R9).

## Detailed description (for agents)

**Added:** `docs/layers.md` (263 lines)

Sections:
- **Layer definitions** — table defining the three layers and their immutability contracts.
- **Core layer** — seven sub-sections covering repository governance files, docs/specs, build tooling, harness skill and agent directories, built outputs (`.claude/`, `.gemini/`, `.github/`), extension skeleton, and public communications.
- **Overlay layer** — five sub-sections covering fork config/identity, core templates (clarifying that `.template` files under `config/` are `core`), persona and context files, CLI-specific overlay configs, system service definitions, and org-specific community-config areas.
- **Examples layer** — 10 illustrative skills, 17 illustrative agents (exact enumeration from delta-01), and a forthcoming `examples/` directory note.
- **Ephemeral paths** — runtime/tool-generated paths excluded from the model.
- **Default classification rules** — tiebreaker rules for future paths not yet in this document.

Closes #227.