### PR TITLE
📝 Add spec 0013 delta-01 — reclassify persona paths as examples

### DIFF
--- a/specs/0013-layer-taxonomy-boundary-contract.delta-01.md
+++ b/specs/0013-layer-taxonomy-boundary-contract.delta-01.md
@@ -1,0 +1,73 @@
+---
+id: "0013"
+slug: layer-taxonomy-boundary-contract
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 227
+version: 1.1.0
+---
+
+# Layer Taxonomy and Boundary Contract
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+**R7** — Remove `config/teams/`, `config/expertise/`, and `config/level/` from
+the overlay enumeration; reclassify them as examples (plan-review iter:4
+Finding 1: the implementation placed these paths under `examples` after an
+interactive classification review, contradicting R7's explicit enumeration).
+Also add `extensions/` to the overlay enumeration, reflecting the
+interactive-review decision that the adopting organisation owns its own
+extension registry (iter:4 consistency fix).
+
+Original:
+
+> 7\. `docs/layers.md` SHALL classify as `overlay`, at minimum, paths covering
+> the categories named in spec 0012 R7: `crewrig.config.toml`, `config/SOUL.md`,
+> `config/PROFILE.md`, `config/ORGANIZATION.md`, `config/TOOLS.md`,
+> `config/teams/`, `config/expertise/`, `config/level/`, `config/claude/`,
+> `config/gemini/`, `config/copilot/`, `community-config/mcp-servers/`,
+> `community-config/hooks/`, `community-config/themes/`, and the designated
+> areas for organisation-specific skills and agents.
+
+Replacement:
+
+> 7\. `docs/layers.md` SHALL classify as `overlay`, at minimum, paths covering
+> the categories named in spec 0012 R7: `crewrig.config.toml`, `config/SOUL.md`,
+> `config/PROFILE.md`, `config/ORGANIZATION.md`, `config/TOOLS.md`,
+> `config/claude/`, `config/gemini/`, `config/copilot/`, `extensions/`,
+> `community-config/mcp-servers/`, `community-config/hooks/`,
+> `community-config/themes/`, and the designated areas for organisation-specific
+> skills and agents.
+
+---
+
+**R8** — Extend the examples enumeration to include the persona and context
+starting-point files, in addition to the already-required illustrative skills
+and agents (plan-review iter:4 consistency fix following the R7 amendment above).
+
+Original:
+
+> 8\. `docs/layers.md` SHALL classify as `examples`, at minimum, the
+> illustrative role skill directories under `community-config/skills/` that
+> are not part of the harness skill set (as enumerated in spec 0012 R8,
+> amended by delta-01) and the illustrative agent directories under
+> `community-config/agents/` that are not part of the harness agent set.
+
+Replacement:
+
+> 8\. `docs/layers.md` SHALL classify as `examples`, at minimum: the
+> illustrative role skill directories under `community-config/skills/` that
+> are not part of the harness skill set (as enumerated in spec 0012 R8,
+> amended by delta-01); the illustrative agent directories under
+> `community-config/agents/` that are not part of the harness agent set; and
+> the persona and context starting-point directories `config/level/`,
+> `config/expertise/`, and `config/teams/`.
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec triggered by PR #234 REVIEW iter:4 Finding 1 (class: spec).

## How to read this PR?

Single file: `specs/0013-layer-taxonomy-boundary-contract.delta-01.md`. Two modifications:

- **R7 (overlay enumeration)**: Removes `config/level/`, `config/expertise/`, `config/teams/` (reclassified as examples after interactive user review). Adds `extensions/` (org-owned extension registry).
- **R8 (examples enumeration)**: Extends to explicitly include `config/level/`, `config/expertise/`, `config/teams/` alongside the already-required illustrative skills and agents.

## How to test this PR?

1. Verify frontmatter fields match spec 0013's id/slug/related-issue, with version bumped to `1.1.0`.
2. Confirm `## ADDED` and `## REMOVED` sections are both `(none)`.
3. Confirm the R7 replacement no longer lists `config/teams/`, `config/expertise/`, `config/level/` and does list `extensions/`.
4. Confirm the R8 replacement adds the three persona/context paths to the examples enumeration.

## Detailed description (for agents)

**Added:** `specs/0013-layer-taxonomy-boundary-contract.delta-01.md`

Triggered by: REVIEW iter:4 of PR #234, Finding 1 (class: spec).
Root cause: interactive classification review with the user determined that `config/level/`, `config/expertise/`, `config/teams/` are illustrative starting points (examples), not organisation-owned overlay files. Spec 0013 R7 had been authored before this decision was confirmed.

Does NOT close #227.