### PR TITLE
📝 Add spec 0013 delta-02 — SOUL.md and PROFILE.md are user-local, not overlay

### DIFF
--- a/specs/0013-layer-taxonomy-boundary-contract.delta-02.md
+++ b/specs/0013-layer-taxonomy-boundary-contract.delta-02.md
@@ -1,0 +1,73 @@
+---
+id: "0013"
+slug: layer-taxonomy-boundary-contract
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 227
+version: 1.2.0
+---
+
+# Layer Taxonomy and Boundary Contract
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+**R7** — Remove `config/SOUL.md` and `config/PROFILE.md` from the overlay
+enumeration. These files are gitignored (`.gitignore` lines 25–26) and are
+never committed to any repository — neither upstream nor in an adopting
+organisation's fork. Each developer generates them locally from the
+corresponding `examples`-layer templates (`config/SOUL.md.template`,
+`config/PROFILE.md.template`). Classifying gitignored, user-local files as
+`overlay` is a misclassification; they belong to the user-local category
+alongside `.env`.
+
+Original (as amended by delta-01):
+
+> 7\. `docs/layers.md` SHALL classify as `overlay`, at minimum, paths covering
+> the categories named in spec 0012 R7: `crewrig.config.toml`, `config/SOUL.md`,
+> `config/PROFILE.md`, `config/ORGANIZATION.md`, `config/TOOLS.md`,
+> `config/claude/`, `config/gemini/`, `config/copilot/`, `extensions/`,
+> `community-config/mcp-servers/`, `community-config/hooks/`,
+> `community-config/themes/`, and the designated areas for organisation-specific
+> skills and agents.
+
+Replacement:
+
+> 7\. `docs/layers.md` SHALL classify as `overlay`, at minimum, paths covering
+> the categories named in spec 0012 R7: `crewrig.config.toml`,
+> `config/ORGANIZATION.md`, `config/TOOLS.md`, `config/claude/`,
+> `config/gemini/`, `config/copilot/`, `extensions/`,
+> `community-config/mcp-servers/`, `community-config/hooks/`,
+> `community-config/themes/`, and the designated areas for organisation-specific
+> skills and agents.
+
+---
+
+**R11** — Extend the completeness requirement to explicitly cover the
+user-local / gitignored category: the document SHALL note that gitignored
+user-generated files (e.g. `config/SOUL.md`, `config/PROFILE.md`) carry no
+layer classification, in the same way as runtime-generated ephemeral paths.
+
+Original:
+
+> 11\. Any path in the repository that `docs/layers.md` does not classify SHALL
+> be treated as a documentation gap, not as implicitly `core` or implicitly
+> `overlay` — the document SHALL be complete at the time it is introduced.
+
+Replacement:
+
+> 11\. Any committed path in the repository that `docs/layers.md` does not
+> classify SHALL be treated as a documentation gap, not as implicitly `core`
+> or implicitly `overlay` — the document SHALL be complete at the time it is
+> introduced. Gitignored, user-generated files that are derived from examples-layer
+> templates (e.g. `config/SOUL.md` generated from `config/SOUL.md.template`)
+> carry no layer classification and SHALL be noted in the document's
+> user-local section alongside runtime-ephemeral paths.
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec triggered by user review before merging PR #234.

## How to read this PR?

Single file: `specs/0013-layer-taxonomy-boundary-contract.delta-02.md`. Two modifications:

- **R7 (overlay enumeration)**: Removes `config/SOUL.md` and `config/PROFILE.md`. These files are gitignored (`.gitignore` lines 25–26) and user-generated from examples-layer templates. They are never committed to any repository. Classifying gitignored files as `overlay` was incorrect.
- **R11 (completeness)**: Clarifies that gitignored, user-generated files (derived from examples templates) carry no layer classification and should be noted in the user-local section.

## How to test this PR?

1. Confirm `config/SOUL.md` and `config/PROFILE.md` appear in `.gitignore`.
2. Confirm `git ls-files config/SOUL.md config/PROFILE.md` returns empty.
3. Confirm the R7 replacement no longer lists those two paths.
4. Confirm the R11 replacement explicitly covers user-generated / gitignored files.
5. Verify version bumped to `1.2.0`.

## Detailed description (for agents)

**Added:** `specs/0013-layer-taxonomy-boundary-contract.delta-02.md`

Root cause: `config/SOUL.md` and `config/PROFILE.md` are gitignored personal files — each developer generates them locally from the corresponding `.template` files. Classifying gitignored files as `overlay` (which implies committed to the org's repo) was a mistake surfaced during user review.

Does NOT close #227.