### PR TITLE
✨ Add sync-from-upstream script and core-paths manifest (spec 0016)

### DIFF
--- a/.crewrig/core-paths.txt
+++ b/.crewrig/core-paths.txt
@@ -1,0 +1,60 @@
+# Core-layer paths — machine-readable manifest for sync-from-upstream.sh
+# One path per line. Blank lines and lines starting with # are ignored.
+# Maintained by upstream CrewRig. Any PR that adds, removes, or reclassifies
+# a core-layer path in docs/layers.md MUST update this file in the same diff.
+
+# Repository governance
+AGENTS.md
+CLAUDE.md
+CONTRIBUTING.md
+DEVELOPMENT.md
+LICENSE
+README.md
+Taskfile.yml
+.gitattributes
+.gitignore
+.markdownlintrc
+package-lock.json
+package.json
+renovate.json
+
+# Documentation and specifications
+docs
+specs
+
+# Build and install tooling
+scripts
+tests
+docker
+config/.env.example
+config/release-monorepo.json
+config/launchd
+config/systemd
+
+# Artifact zones — core and library
+artifacts/FORMAT.md
+artifacts/core
+artifacts/library
+
+# Built outputs
+.claude/skills
+.claude/agents
+.gemini/skills
+.gemini/agents
+.gemini/commands
+.github/copilot-instructions.md
+.github/copilot
+.github/skills
+.github/agents
+.github/workflows
+
+# Extension distribution channel
+extension-skeleton
+hooks
+
+# Public communications
+communication
+
+# Sync tooling (spec 0016)
+.crewrig
+scripts/sync-from-upstream.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Test e2e auth Ollama Cloud mount (issue #114)
         run: bash scripts/tests/test-e2e-auth-ollama.sh
 
+      - name: Test sync-from-upstream script
+        run: bash scripts/tests/test-sync-from-upstream.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,10 @@ See [`docs/cli-matrix-maintenance.md`](docs/cli-matrix-maintenance.md) for the f
 `CLAUDE.md`, `GEMINI.md`, or CLI-prefixed `Taskfile.yml` entries MUST consult and update
 `docs/cli-matrix.md` in the same diff.
 
+**Core-paths manifest co-maintenance.** Any PR that adds, removes, or reclassifies a
+core-layer path in `docs/layers.md` MUST update `.crewrig/core-paths.txt` in the same diff.
+This manifest is the machine-readable source of truth consumed by `scripts/sync-from-upstream.sh`.
+
 ## Agent Team Protocol
 
 See [`docs/agent-team-protocol.md`](docs/agent-team-protocol.md) for the full protocol: team templates, worktree isolation, team communication rules, team shutdown, and team sizing by complexity.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -143,6 +143,12 @@ to every deployment of CrewRig.
 |---|---|
 | `communication/` | Conference talks, demos, and public presentation materials. |
 
+### Sync tooling
+
+| Path | Description |
+|---|---|
+| `.crewrig/` | Machine-readable sync manifest and related tooling. `.crewrig/core-paths.txt` enumerates core-layer paths consumed by `scripts/sync-from-upstream.sh`. |
+
 ---
 
 ## Overlay layer

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# sync-from-upstream.sh — Pull core-layer files from the canonical upstream.
+#
+# Usage:
+#   bash scripts/sync-from-upstream.sh
+#
+# Reads the upstream URL from crewrig.config.toml (canonical_repo field).
+# Refuses to proceed if any core-layer path has local modifications relative
+# to FETCH_HEAD — the adopting organisation must revert or promote those
+# changes to overlay overrides before syncing.
+#
+# On success, restores each core-layer path from FETCH_HEAD into the working
+# tree without staging or committing anything. Review the diff with
+# 'git diff' before deciding what to commit.
+
+set -e
+
+# CREWRIG_REPO_DIR may be set by tests to override the default discovery.
+REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
+CONFIG="$REPO_DIR/crewrig.config.toml"
+MANIFEST="$REPO_DIR/.crewrig/core-paths.txt"
+
+# ---------------------------------------------------------------------------
+# Read canonical_repo — strip surrounding quotes, reject empty/absent value.
+# ---------------------------------------------------------------------------
+CANONICAL_REPO=$(grep '^canonical_repo' "$CONFIG" 2>/dev/null | sed 's/.*= *"\(.*\)".*/\1/')
+
+if [ -z "$CANONICAL_REPO" ]; then
+  echo "Error: canonical_repo is not set in crewrig.config.toml" >&2
+  echo "Set canonical_repo to the upstream repository URL before running sync." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch upstream.
+# ---------------------------------------------------------------------------
+echo "Fetching $CANONICAL_REPO ..."
+git fetch "$CANONICAL_REPO"
+
+# ---------------------------------------------------------------------------
+# Dirty-core detection: compare each core path against FETCH_HEAD.
+# ---------------------------------------------------------------------------
+DIRTY=()
+while IFS= read -r path; do
+  # Skip blank lines and comments.
+  [[ -z "$path" || "$path" == \#* ]] && continue
+  if ! git diff --quiet FETCH_HEAD -- "$path" 2>/dev/null; then
+    DIRTY+=("$path")
+  fi
+done < "$MANIFEST"
+
+if [ ${#DIRTY[@]} -gt 0 ]; then
+  echo "Error: the following core-layer paths have local modifications:" >&2
+  for p in "${DIRTY[@]}"; do
+    echo "  $p" >&2
+  done
+  echo "Revert these changes before running sync, or promote them to overlay overrides." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Apply: restore each core path from FETCH_HEAD into the working tree.
+# git restore --source=FETCH_HEAD --worktree does NOT stage or commit.
+# ---------------------------------------------------------------------------
+while IFS= read -r path; do
+  [[ -z "$path" || "$path" == \#* ]] && continue
+  git restore --source=FETCH_HEAD --worktree -- "$path"
+done < "$MANIFEST"
+
+echo "Sync complete. Review the changes with 'git diff' before committing."

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# test-sync-from-upstream.sh — Regression tests for sync-from-upstream.sh.
+#
+# Cases:
+#   1. Clean-core sync: no local modifications → exit 0, files reflect upstream
+#   2. Dirty-core refusal: core path modified → exit non-zero, stderr names it
+#   3. Empty canonical_repo: canonical_repo = "" → exit non-zero, no git fetch
+#   4. Absent canonical_repo: key missing entirely → exit non-zero, no git fetch
+#
+# Usage:
+#   bash scripts/tests/test-sync-from-upstream.sh
+
+# -e intentionally omitted: pass/fail counters control the harness; adding -e
+# would abort on expected non-zero exits from the script under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/sync-from-upstream.sh"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# init_git_repo <dir>
+# Initialise a bare-minimum git repo with identity set.
+init_git_repo() {
+  local dir="$1"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@example.com"
+  git -C "$dir" config user.name "Test"
+  git -C "$dir" config commit.gpgsign false
+}
+
+# make_initial_commit <repo> [<file> <content>]...
+# Create an initial commit with one or more files.
+make_initial_commit() {
+  local repo="$1"; shift
+  while [ "$#" -ge 2 ]; do
+    local file="$1" content="$2"; shift 2
+    mkdir -p "$repo/$(dirname "$file")"
+    printf '%s' "$content" > "$repo/$file"
+    git -C "$repo" add "$file"
+  done
+  git -C "$repo" commit -q -m "initial"
+}
+
+# run_case <name> <repo> <expected_exit>
+run_case() {
+  local name="$1" repo="$2" expected_exit="$3"
+  local actual_exit=0
+  ( cd "$repo" && CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >/dev/null 2>&1 ) || actual_exit=$?
+
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "PASS  $name (exit $actual_exit)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $name (expected exit $expected_exit, got $actual_exit)"
+    fail=$((fail + 1))
+  fi
+}
+
+# run_case_stderr <name> <repo> <expected_exit> <stderr_pattern>
+# Like run_case but also checks that stderr matches a grep pattern.
+run_case_stderr() {
+  local name="$1" repo="$2" expected_exit="$3" pattern="$4"
+  local actual_exit=0
+  local stderr_out
+  stderr_out="$(cd "$repo" && CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" 2>&1 >/dev/null)" || actual_exit=$?
+
+  local ok=1
+  if [ "$actual_exit" -ne "$expected_exit" ]; then
+    echo "FAIL  $name (expected exit $expected_exit, got $actual_exit)"
+    ok=0
+  fi
+  if ! echo "$stderr_out" | grep -q "$pattern"; then
+    echo "FAIL  $name (stderr did not contain: $pattern)"
+    echo "      actual stderr: $stderr_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  $name"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 — Clean-core sync: all paths clean → exit 0
+# ---------------------------------------------------------------------------
+{
+  # Build an "upstream" repo that acts as the canonical remote.
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream content" \
+    "other.txt"     "other content"
+
+  # Build the adopting repo that will call sync-from-upstream.sh.
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+
+  # Write a minimal crewrig.config.toml pointing at upstream.
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+
+  # Write a manifest listing just core-file.txt.
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+
+  # Give the adopter an initial commit that matches upstream exactly.
+  make_initial_commit "$adopter" \
+    "core-file.txt" "upstream content" \
+    "other.txt"     "other content"
+
+  run_case "clean-core sync exits 0" "$adopter" 0
+
+  # After sync, the working-tree file should still hold upstream content
+  # (in the clean case nothing changes, but restore must succeed).
+  synced_content="$(cat "$adopter/core-file.txt" 2>/dev/null)"
+  if [ "$synced_content" = "upstream content" ]; then
+    echo "PASS  clean-core sync: file content correct"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  clean-core sync: expected 'upstream content', got '$synced_content'"
+    fail=$((fail + 1))
+  fi
+
+  # Index must not be modified (no staged changes).
+  staged="$(git -C "$adopter" diff --cached --name-only)"
+  if [ -z "$staged" ]; then
+    echo "PASS  clean-core sync: index unchanged"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  clean-core sync: unexpected staged changes: $staged"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 2 — Dirty-core refusal: local modification → exit non-zero + stderr
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "core-file.txt" "upstream content"
+
+  # Introduce a local modification on the core path.
+  printf 'local override content\n' > "$adopter/core-file.txt"
+
+  run_case_stderr \
+    "dirty-core refusal exits non-zero" \
+    "$adopter" \
+    1 \
+    "core-file.txt"
+
+  # Working tree must still contain the local modification (unchanged by script).
+  content_after="$(cat "$adopter/core-file.txt" 2>/dev/null)"
+  if [ "$content_after" = "local override content" ]; then
+    echo "PASS  dirty-core refusal: working tree unchanged"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  dirty-core refusal: working tree was unexpectedly modified"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 3 — Empty canonical_repo → exit non-zero, no git fetch attempted
+# ---------------------------------------------------------------------------
+{
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  # canonical_repo present but empty string.
+  printf 'canonical_repo = ""\n' > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" "core-file.txt" "content"
+
+  run_case_stderr \
+    "empty canonical_repo exits non-zero" \
+    "$adopter" \
+    1 \
+    "canonical_repo"
+}
+
+# ---------------------------------------------------------------------------
+# Case 4 — Absent canonical_repo key → exit non-zero, no git fetch attempted
+# ---------------------------------------------------------------------------
+{
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  # No canonical_repo key at all.
+  printf '# empty config\n' > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" "core-file.txt" "content"
+
+  run_case_stderr \
+    "absent canonical_repo exits non-zero" \
+    "$adopter" \
+    1 \
+    "canonical_repo"
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+echo "Results: $pass/$total passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Implements spec 0016 — Sync from Upstream. Introduces `scripts/sync-from-upstream.sh` and the machine-readable core-layer manifest `.crewrig/core-paths.txt` that it consumes, enabling adopting organisations to pull upstream CrewRig updates cleanly without touching overlay paths.

## How to read this PR?

Start with `.crewrig/core-paths.txt` to understand what the core layer covers, then read `scripts/sync-from-upstream.sh` for the sync logic (config read → fetch → dirty-core detection → restore). `scripts/tests/test-sync-from-upstream.sh` exercises all four scenarios. `AGENTS.md` and `docs/layers.md` receive the co-maintenance rule and layer classification respectively.

## How to test this PR?

```bash
# Run the unit tests (no network — uses temp git repos as fixtures):
bash scripts/tests/test-sync-from-upstream.sh

# Smoke test against a real upstream (reads crewrig.config.toml):
bash scripts/sync-from-upstream.sh
# Review changes with:
git diff
# Restore originals:
git restore .
```

## Detailed description (for agents)

**`.crewrig/core-paths.txt`** (new)
- One path per line, blank lines and `#` comments skipped.
- Enumerates every core-layer path from `docs/layers.md`: repository governance files, `docs/`, `specs/`, `scripts/`, `tests/`, `docker/`, `config/` sub-paths, `artifacts/FORMAT.md`, `artifacts/core/`, `artifacts/library/`, all built-output directories (`.claude/`, `.gemini/`, `.github/`), `extension-skeleton/`, `hooks/`, `communication/`, and `.crewrig/` itself.

**`scripts/sync-from-upstream.sh`** (new, executable)
- Reads `canonical_repo` from `crewrig.config.toml` via `grep` + `sed`; exits 1 immediately if absent or empty — before any `git fetch`.
- Supports `CREWRIG_REPO_DIR` env var override (testability).
- Fetches `$CANONICAL_REPO`; iterates manifest paths and collects any that differ from `FETCH_HEAD`.
- If any dirty path found: prints offending paths to stderr, exits 1, leaves working tree unchanged.
- If clean: applies each path via `git restore --source=FETCH_HEAD --worktree` (never stages or commits).

**`scripts/tests/test-sync-from-upstream.sh`** (new, executable)
- Four scenarios using temp git repos as fixtures — no network calls.
- Case 1: clean-core sync → exit 0, correct file content, index unchanged.
- Case 2: dirty-core refusal → exit 1, offending path in stderr, working tree unchanged.
- Case 3: empty `canonical_repo` → exit 1 before fetch, "canonical_repo" in stderr.
- Case 4: absent `canonical_repo` key → exit 1 before fetch, "canonical_repo" in stderr.
- All 7 assertions pass.

**`AGENTS.md`** (modified)
- Added "Core-paths manifest co-maintenance" paragraph under CLI Matrix Maintenance: any PR changing core-layer classification in `docs/layers.md` MUST update `.crewrig/core-paths.txt` in the same diff. Size: 30 546 bytes (under the 35 KB limit from spec 0011).

**`docs/layers.md`** (modified)
- Added "Sync tooling" subsection to the Core layer section classifying `.crewrig/` as core.

Closes #230