### PR TITLE
📝 Add adoption guide (spec 0017)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ for start/stop/status commands, log locations, migration steps, and
 troubleshooting. The architectural decision is recorded in
 [ADR 0006](docs/adr/0006-chromadb-http-server.md).
 
+## Adopting CrewRig
+
+Organisations that wish to adopt CrewRig without contributing upstream should
+follow the **[Adoption Guide](docs/adoption-guide.md)** — a step-by-step
+walkthrough covering fork initialisation, overlay configuration, build
+pipeline, CLI deployment, and upstream synchronisation. The guide covers all
+three supported CLIs (Claude Code, Gemini CLI, GitHub Copilot CLI) and is the
+primary onboarding surface for adopting organisations.
+
 ## Lifecycle Scenario
 
 A complete journey, from installing the framework to closing the

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -97,7 +97,8 @@ Replace both values:
   (`https://github.com/crewrig/crewrig`) so that the audit trail and
   license trace remain intact. Override this only if the organisation's
   fork is itself the canonical upstream for a downstream deployment.
-- `feedback_repo` — set to the organisation's own repository URL so that
+- `feedback_repo` — set to the URL of the organisation's own repository
+  (on any Git hosting platform — GitHub, GitLab, Gitea, etc.) so that
   friction issues opened by the harness curator land on the organisation's
   tracker, not on the upstream project.
 

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -88,7 +88,7 @@ Commit the file:
 
 ```bash
 git add crewrig.config.toml
-git commit -m "chore: initialise crewrig.config.toml for <YOUR-ORG>"
+git commit -m "⚙️ Initialise crewrig.config.toml for <YOUR-ORG>"
 ```
 
 ## Step 3 — Initialise the organisation identity
@@ -125,7 +125,7 @@ will not be overwritten by upstream syncs.
 
 ```bash
 git add config/ORGANIZATION.md
-git commit -m "chore: initialise config/ORGANIZATION.md for <YOUR-ORG>"
+git commit -m "⚙️ Initialise config/ORGANIZATION.md for <YOUR-ORG>"
 ```
 
 ## Step 4 — Initialise the tool configuration
@@ -160,7 +160,7 @@ Remove all placeholder comments before committing.
 
 ```bash
 git add config/TOOLS.md
-git commit -m "chore: initialise config/TOOLS.md for <YOUR-ORG>"
+git commit -m "⚙️ Initialise config/TOOLS.md for <YOUR-ORG>"
 ```
 
 ## Step 5 — Run the build pipeline
@@ -303,11 +303,9 @@ absent. Common causes: an incomplete migration from a pre-spec-0014 branch,
 a branch that predates the `artifacts/` directory restructuring, or a
 partially applied upstream sync that left a directory missing.
 
-**Effect:** The script exits non-zero with a message such as:
-
-```text
-error: source directory not found: artifacts/core/skills/
-```
+**Effect:** The script exits zero but the output directories (`.claude/skills/`,
+`.gemini/skills/`, etc.) are empty or partially populated. Missing source
+directories are silently skipped — no error message is emitted.
 
 **Resolution:** Verify that the repository tree matches the current `main`
 branch. Run `git status` and `git diff origin/main` to identify missing

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -57,10 +57,12 @@ configuration home. The repository may be public or private.
    # upstream https://github.com/crewrig/crewrig.git (fetch)
    ```
 
-The `upstream` remote is required by `bash scripts/sync-from-upstream.sh`
-(Step 7). The `origin` remote is the organisation's own repository. Upstream
-changes flow in via the sync script; the organisation's overlay content lives
-on top and is never touched by the sync.
+The sync script (`bash scripts/sync-from-upstream.sh`, Step 7) reads the
+upstream URL directly from `crewrig.config.toml → canonical_repo` — it does
+not rely on a named git remote. The `upstream` remote shown above is optional;
+retain it only if you want to run manual git operations such as `git log
+upstream/main`. Upstream changes flow in via the sync script; the
+organisation's overlay content lives on top and is never touched by the sync.
 
 ## Step 2 — Initialise the overlay configuration
 
@@ -209,11 +211,13 @@ git add .claude/skills .claude/agents \
 git commit -m "⚙️ Build CLI components for <YOUR-ORG>"
 ```
 
-**Most-likely error — missing `crewrig.config.toml` or literal placeholders:**
+**Most-likely symptom — unreplaced placeholders in built outputs:**
 If `crewrig.config.toml` is absent or still contains the literal placeholder
-strings `<YOUR-ORG>` / `<YOUR-REPO>`, the script will warn that placeholders
-have been left unreplaced and may exit non-zero. Resolution: complete Step 2
-before running the build.
+strings `<YOUR-ORG>` / `<YOUR-REPO>`, the script exits zero but the built
+outputs will contain unreplaced placeholder values (e.g. skills referencing
+`https://github.com/<YOUR-ORG>/<YOUR-REPO>` literally). When config is absent
+the script warns on stderr; when config contains placeholder values no warning
+is emitted. Resolution: complete Step 2 before running the build.
 
 The organisation may also author or override components in
 `artifacts/community/` and `artifacts/organisation/` — these directories
@@ -285,8 +289,9 @@ bash scripts/sync-from-upstream.sh
 ```
 
 **Expected outcome:** The script exits zero, updates the core-layer paths
-listed in `.crewrig/core-paths.txt` from the `upstream` remote's `main`
-branch, and leaves all overlay paths (including `config/ORGANIZATION.md`,
+listed in `.crewrig/core-paths.txt` from the URL set in
+`crewrig.config.toml → canonical_repo`, and leaves all overlay paths
+(including `config/ORGANIZATION.md`,
 `config/TOOLS.md`, `crewrig.config.toml`, and `artifacts/community/`)
 untouched.
 
@@ -312,17 +317,20 @@ the `canonical_repo` / `feedback_repo` fields still contain the literal
 placeholder strings `https://github.com/<YOUR-ORG>/<YOUR-REPO>` (or are
 empty strings).
 
-**Effect:** `bash scripts/build-components.sh` may warn that substitution
-placeholders were left literal and produced unreplaced strings in the built
-outputs. The harness curator will open friction issues against the placeholder
-URL, which resolves to nothing.
+**Effect:** `bash scripts/build-components.sh` exits zero in both cases.
+When config is absent, the script warns on stderr that placeholders will be
+left literal. When config contains the placeholder URL, the script passes
+validation silently and emits no warning. In both cases the built outputs
+contain unreplaced values (skills and agents reference the placeholder URL
+literally). The harness curator will open friction issues against the
+placeholder URL, which resolves to nothing.
 
 **Resolution:** Follow Step 2. Copy `crewrig.config.toml.template` to
 `crewrig.config.toml`, replace both placeholder values with the
 organisation's actual GitHub repository URLs, and commit the file before
 re-running the build.
 
-### Build exits non-zero due to missing source directory
+### Build output directories are empty or partially populated
 
 **Cause:** A source directory expected by `scripts/build-components.sh` is
 absent. Common causes: an incomplete migration from a pre-spec-0014 branch,

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -300,10 +300,10 @@ has been locally modified, the script will list the offending paths and
 exit 1 with a message similar to:
 
 ```text
-error: the following core-layer paths have local modifications:
+Error: the following core-layer paths have local modifications:
   config/SOUL.md
   artifacts/core/skills/developer/SKILL.md
-Revert them or promote them to overlay overrides before syncing.
+Revert these changes before running sync, or promote them to overlay overrides.
 ```
 
 Resolution: see [Troubleshooting — dirty-core refusal](#dirty-core-refusal) below.
@@ -317,7 +317,7 @@ the `canonical_repo` / `feedback_repo` fields still contain the literal
 placeholder strings `https://github.com/<YOUR-ORG>/<YOUR-REPO>` (or are
 empty strings).
 
-**Effect:** `bash scripts/build-components.sh` exits zero in both cases.
+**Effect — `bash scripts/build-components.sh`:** Exits zero in both cases.
 When config is absent, the script warns on stderr that placeholders will be
 left literal. When config contains the placeholder URL, the script passes
 validation silently and emits no warning. In both cases the built outputs
@@ -325,10 +325,18 @@ contain unreplaced values (skills and agents reference the placeholder URL
 literally). The harness curator will open friction issues against the
 placeholder URL, which resolves to nothing.
 
+**Effect — `bash scripts/sync-from-upstream.sh`:** Exits 1 and prints
+an error when `canonical_repo` is absent or empty:
+
+```text
+Error: canonical_repo is not set in crewrig.config.toml
+Set canonical_repo to the upstream repository URL before running sync.
+```
+
 **Resolution:** Follow Step 2. Copy `crewrig.config.toml.template` to
 `crewrig.config.toml`, replace both placeholder values with the
-organisation's actual GitHub repository URLs, and commit the file before
-re-running the build.
+organisation's actual Git repository URLs, and commit the file before
+re-running either script.
 
 ### Build output directories are empty or partially populated
 

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -1,0 +1,345 @@
+# Adoption Guide
+
+This guide walks an organisation through forking CrewRig, initialising the
+overlay configuration, running the build pipeline, deploying to CLI rules
+directories, and staying in sync with upstream. Follow the steps in order.
+No step requires reading script source code — all expected outcomes and
+error messages are described inline.
+
+## Prerequisites
+
+Before starting, ensure the following are in place:
+
+- **`git`** — to clone, commit, and interact with branches.
+- **`bash`** — version 4 or later; required by all setup and build scripts.
+- **A TOML-capable editor** — for editing `crewrig.config.toml`.
+  Any plain-text editor works; the TOML syntax used is minimal.
+- **Write access to a GitHub repository** — the organisation's fork of
+  CrewRig. This repository will serve as the overlay configuration home
+  for the organisation.
+- **The target CLI tools installed** — Claude Code, Gemini CLI, and/or
+  GitHub Copilot CLI, whichever CLIs the organisation uses. The guide
+  does not cover installing those tools; treat them as installed before
+  proceeding.
+
+## Step 1 — Fork the repository
+
+Create the organisation's GitHub repository from the upstream CrewRig
+repository.
+
+1. Navigate to [https://github.com/crewrig/crewrig](https://github.com/crewrig/crewrig).
+2. Click **Fork** and select the organisation's GitHub account as the
+   destination.
+3. Clone the fork locally:
+
+   ```bash
+   git clone git@github.com:<YOUR-ORG>/<YOUR-REPO>.git
+   cd <YOUR-REPO>
+   ```
+
+4. Add the upstream remote so future syncs can pull from it:
+
+   ```bash
+   git remote add upstream https://github.com/crewrig/crewrig.git
+   ```
+
+The fork is now the organisation's overlay configuration repository. Upstream
+changes flow in via `bash scripts/sync-from-upstream.sh` (Step 7); the
+organisation's overlay content lives on top and is never touched by the sync.
+
+## Step 2 — Initialise the overlay configuration
+
+Copy the configuration template and replace the placeholder values with the
+organisation's own repository URLs.
+
+```bash
+cp crewrig.config.toml.template crewrig.config.toml
+```
+
+Open `crewrig.config.toml` in a TOML-capable editor. The template ships with
+the following placeholders:
+
+```toml
+# canonical_repo — the upstream repository this fork traces back to.
+# Forks should keep this pointing at the upstream they forked from so
+# that the audit trail and license trace remain intact.
+# Replace with your own repo URL only if YOUR repo IS the canonical
+# upstream for this deployment.
+canonical_repo = "https://github.com/<YOUR-ORG>/<YOUR-REPO>"
+
+# feedback_repo — where the harness curator opens friction MRs.
+# Override this with your organisation's internal repo so that friction
+# issues land on your own tracker rather than the upstream project.
+# For most adopting orgs this will differ from canonical_repo.
+feedback_repo  = "https://github.com/<YOUR-ORG>/<YOUR-REPO>"
+```
+
+Replace both values:
+
+- `canonical_repo` — set to the upstream CrewRig URL
+  (`https://github.com/crewrig/crewrig`) so that the audit trail and
+  license trace remain intact. Override this only if the organisation's
+  fork is itself the canonical upstream for a downstream deployment.
+- `feedback_repo` — set to the organisation's own repository URL so that
+  friction issues opened by the harness curator land on the organisation's
+  tracker, not on the upstream project.
+
+Commit the file:
+
+```bash
+git add crewrig.config.toml
+git commit -m "chore: initialise crewrig.config.toml for <YOUR-ORG>"
+```
+
+## Step 3 — Initialise the organisation identity
+
+Copy the organisation identity template and populate its sections.
+
+```bash
+cp config/ORGANIZATION.md.template config/ORGANIZATION.md
+```
+
+Open `config/ORGANIZATION.md` and fill in each section. The template
+provides guidance comments inside each section. At minimum, complete:
+
+- **Identity** — a 2–4 sentence description of the organisation, its scale,
+  and its mission.
+- **Values and Principles** — 3–6 core engineering values that guide
+  trade-off decisions.
+- **Objectives** — the organisation's current strategic engineering
+  objectives.
+- **Assets** — significant shared platforms, product lines, libraries, or
+  data stores that agents should be aware of.
+- **Governance** — who owns architectural decisions, how breaking changes
+  are communicated, and any approval gates.
+- **General Rules** — cross-cutting rules that apply to all engineering
+  work regardless of team or stack (e.g., secrets management, language
+  convention, data-protection baseline).
+- **Regulatory Context** — any compliance or legal constraints relevant
+  to engineering (GDPR, PCI-DSS, HIPAA, etc.). If none apply, state so
+  explicitly.
+
+Remove all placeholder comments and placeholder text (`[Replace with …]`)
+before committing. This file is overlay — owned by the organisation — and
+will not be overwritten by upstream syncs.
+
+```bash
+git add config/ORGANIZATION.md
+git commit -m "chore: initialise config/ORGANIZATION.md for <YOUR-ORG>"
+```
+
+## Step 4 — Initialise the tool configuration
+
+Copy the tool configuration template and fill in the organisation-specific
+sections.
+
+```bash
+cp config/TOOLS.md.template config/TOOLS.md
+```
+
+Open `config/TOOLS.md`. This file layers organisation-specific settings
+on top of the framework defaults (three-tier memory architecture, MemPalace
+protocol, harness loop, Sequential Thinking) that the upstream framework
+ships via the core rules file deployed at priority 60. Do **not** duplicate
+framework content; use this file only for:
+
+- **Tooling Preferences** — editors, terminal setup, communication
+  platforms, and any org-wide CLI tools that are always available.
+- **MCP Server Declarations** — MCP servers specific to the organisation's
+  integrations (Jira, Confluence, Slack, internal APIs). Framework MCP
+  servers (MemPalace, SequentialThinking, GitHub) are already covered by
+  the core rules file — do not redeclare them here. If the organisation
+  has no additional MCP servers, write "No additional MCP servers beyond
+  the framework defaults."
+- **Workflow Preferences** — org-wide workflow conventions not already
+  captured in `config/ORGANIZATION.md` or team/expertise files. If all
+  conventions are already captured elsewhere, write "No additional workflow
+  preferences beyond what is described in AGENTS.md."
+
+Remove all placeholder comments before committing.
+
+```bash
+git add config/TOOLS.md
+git commit -m "chore: initialise config/TOOLS.md for <YOUR-ORG>"
+```
+
+## Step 5 — Run the build pipeline
+
+Run the build script to compile all artifact sources into CLI-specific outputs.
+
+```bash
+bash scripts/build-components.sh
+```
+
+**Expected outcome:** The script exits zero and populates the following
+output directories:
+
+```text
+.claude/skills/        Claude Code skills
+.claude/agents/        Claude Code agents
+.gemini/skills/        Gemini CLI skills
+.gemini/agents/        Gemini CLI agents
+.github/skills/        GitHub Copilot CLI skills
+.github/agents/        GitHub Copilot CLI agents
+```
+
+**Most-likely error — missing `crewrig.config.toml` or literal placeholders:**
+If `crewrig.config.toml` is absent or still contains the literal placeholder
+strings `<YOUR-ORG>` / `<YOUR-REPO>`, the script will warn that placeholders
+have been left unreplaced and may exit non-zero. Resolution: complete Step 2
+before running the build.
+
+The organisation may also author or override components in
+`artifacts/community/` and `artifacts/organisation/` — these directories
+are the designated sandbox for org-specific skills, agents, commands, hooks,
+policies, MCP server configurations, and themes. The build script compiles
+those alongside the upstream components. The guide does not cover how to
+author new components; see `artifacts/FORMAT.md` for the unified-source
+specification.
+
+## Step 6 — Deploy to CLI rules directories
+
+Deploy the built outputs to the user-home CLI rules directories by running
+the interactive setup script for each active CLI. These scripts are
+interactive: they will prompt for copy vs. symlink mode and confirm before
+modifying user-home directories.
+
+### Claude Code
+
+```bash
+bash scripts/setup-claude-interactive.sh
+```
+
+Deploys to `~/.claude/rules/`. Each context file is installed with its
+numeric prefix (e.g., `00-soul.md`, `20-organization.md`) so Claude Code
+loads them in priority order.
+
+### Gemini CLI
+
+```bash
+bash scripts/setup-gemini-interactive.sh
+```
+
+Deploys to `~/.gemini/` directly — there is no `rules/` subdirectory for
+Gemini CLI. Files land with numeric prefixes (e.g., `00_SOUL.md`,
+`20_ORGANIZATION.md`) in the `~/.gemini/` directory itself. This differs
+from Claude Code's `~/.claude/rules/` layout; the setup script handles the
+difference automatically.
+
+### GitHub Copilot CLI
+
+```bash
+bash scripts/setup-copilot-interactive.sh
+```
+
+Deploys to `~/.copilot/instructions/` as `*.instructions.md` files
+(e.g., `00-soul.instructions.md`, `20-organization.instructions.md`).
+This naming convention is specific to GitHub Copilot CLI and differs from
+both Claude Code (plain `.md` files in `~/.claude/rules/`) and Gemini CLI
+(numeric-prefix `.md` files in `~/.gemini/`). The setup script handles the
+naming automatically.
+
+### Symlink vs. copy mode
+
+Each setup script will ask whether to copy or symlink the files. The default
+and recommended mode is **copy**: files are physically deployed to the target
+directory and are immune to changes on the source branch. Symlink mode is
+available for development workflows where live edits to the repository should
+be reflected immediately in the CLI, but it comes with a security disclaimer:
+a malicious branch swap would alter the CLI context without an explicit
+re-run.
+
+## Step 7 — Sync from upstream
+
+After the organisation's fork is in use, pull future upstream core-layer
+changes without touching overlay content.
+
+```bash
+bash scripts/sync-from-upstream.sh
+```
+
+**Expected outcome:** The script exits zero, updates the core-layer paths
+listed in `.crewrig/core-paths.txt` from the `upstream` remote's `main`
+branch, and leaves all overlay paths (including `config/ORGANIZATION.md`,
+`config/TOOLS.md`, `crewrig.config.toml`, and `artifacts/community/`)
+untouched.
+
+**Most-likely error — dirty-core guard:** If at least one core-layer path
+has been locally modified, the script will list the offending paths and
+exit 1 with a message similar to:
+
+```text
+error: the following core-layer paths have local modifications:
+  config/SOUL.md
+  artifacts/core/skills/developer/SKILL.md
+Revert them or promote them to overlay overrides before syncing.
+```
+
+Resolution: see [Troubleshooting — dirty-core refusal](#dirty-core-refusal) below.
+
+## Troubleshooting
+
+### `crewrig.config.toml` absent or has empty values
+
+**Cause:** `crewrig.config.toml` does not exist in the repository root, or
+the `canonical_repo` / `feedback_repo` fields still contain the literal
+placeholder strings `https://github.com/<YOUR-ORG>/<YOUR-REPO>` (or are
+empty strings).
+
+**Effect:** `bash scripts/build-components.sh` may warn that substitution
+placeholders were left literal and produced unreplaced strings in the built
+outputs. The harness curator will open friction issues against the placeholder
+URL, which resolves to nothing.
+
+**Resolution:** Follow Step 2. Copy `crewrig.config.toml.template` to
+`crewrig.config.toml`, replace both placeholder values with the
+organisation's actual GitHub repository URLs, and commit the file before
+re-running the build.
+
+### Build exits non-zero due to missing source directory
+
+**Cause:** A source directory expected by `scripts/build-components.sh` is
+absent. Common causes: an incomplete migration from a pre-spec-0014 branch,
+a branch that predates the `artifacts/` directory restructuring, or a
+partially applied upstream sync that left a directory missing.
+
+**Effect:** The script exits non-zero with a message such as:
+
+```text
+error: source directory not found: artifacts/core/skills/
+```
+
+**Resolution:** Verify that the repository tree matches the current `main`
+branch. Run `git status` and `git diff origin/main` to identify missing
+files. If the branch predates spec 0014, rebase it onto `main` or re-apply
+the migration steps described in `specs/0014-*.md`. After restoring the
+missing directories, re-run `bash scripts/build-components.sh`.
+
+### Dirty-core refusal during sync {#dirty-core-refusal}
+
+**Cause:** At least one path listed in `.crewrig/core-paths.txt` has been
+locally modified. The sync script enforces a dirty-core guard to prevent
+upstream changes from silently overwriting local modifications to core-layer
+files.
+
+**Effect:** `bash scripts/sync-from-upstream.sh` exits 1 and lists the
+offending paths.
+
+**Resolution:** Choose one of two paths for each offending file:
+
+1. **Revert the modification** — if the change was experimental or
+   unintended, restore the file to its committed state:
+
+   ```bash
+   git checkout -- <path/to/core-file>
+   ```
+
+   Then re-run `bash scripts/sync-from-upstream.sh`.
+
+2. **Promote to an overlay override** — if the change is intentional and
+   must survive future upstream syncs, move it to the corresponding
+   overlay directory (`artifacts/community/` or `artifacts/organisation/`)
+   so the sync does not touch it. Commit the override, then re-run the
+   sync. The `.crewrig/core-paths.txt` manifest lists exactly which paths
+   are considered core; files outside that list are overlay and are always
+   left untouched by the sync.

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -14,38 +14,53 @@ Before starting, ensure the following are in place:
 - **`bash`** — version 4 or later; required by all setup and build scripts.
 - **A TOML-capable editor** — for editing `crewrig.config.toml`.
   Any plain-text editor works; the TOML syntax used is minimal.
-- **Write access to a GitHub repository** — the organisation's fork of
-  CrewRig. This repository will serve as the overlay configuration home
-  for the organisation.
+- **Write access to a Git repository** — the organisation's copy of
+  CrewRig, hosted on any Git platform (GitHub, GitLab, Gitea, or a
+  self-hosted instance). The repository may be public or private and
+  will serve as the overlay configuration home for the organisation.
 - **The target CLI tools installed** — Claude Code, Gemini CLI, and/or
   GitHub Copilot CLI, whichever CLIs the organisation uses. The guide
   does not cover installing those tools; treat them as installed before
   proceeding.
 
-## Step 1 — Fork the repository
+## Step 1 — Set up the organisation repository
 
-Create the organisation's GitHub repository from the upstream CrewRig
-repository.
+Create a repository on any Git hosting platform (GitHub, GitLab, Gitea,
+Bitbucket, or a self-hosted instance) to serve as the organisation's overlay
+configuration home. The repository may be public or private.
 
-1. Navigate to [https://github.com/crewrig/crewrig](https://github.com/crewrig/crewrig).
-2. Click **Fork** and select the organisation's GitHub account as the
-   destination.
-3. Clone the fork locally:
+1. Clone the upstream CrewRig repository and push it to the organisation's Git
+   host. On GitHub you may use the **Fork** button as a shortcut; on any other
+   host, or when you want a private repository, clone and re-push manually:
+
+   ```bash
+   git clone https://github.com/crewrig/crewrig.git <YOUR-REPO>
+   cd <YOUR-REPO>
+   git remote rename origin upstream
+   git remote add origin <YOUR-GIT-HOST>/<YOUR-ORG>/<YOUR-REPO>.git
+   git push -u origin main
+   ```
+
+   If you used the GitHub Fork button, clone your fork and skip the push above:
 
    ```bash
    git clone git@github.com:<YOUR-ORG>/<YOUR-REPO>.git
    cd <YOUR-REPO>
-   ```
-
-4. Add the upstream remote so future syncs can pull from it:
-
-   ```bash
    git remote add upstream https://github.com/crewrig/crewrig.git
    ```
 
-The fork is now the organisation's overlay configuration repository. Upstream
-changes flow in via `bash scripts/sync-from-upstream.sh` (Step 7); the
-organisation's overlay content lives on top and is never touched by the sync.
+2. Verify that both remotes are present:
+
+   ```bash
+   git remote -v
+   # origin   <YOUR-GIT-HOST>/<YOUR-ORG>/<YOUR-REPO>.git (fetch)
+   # upstream https://github.com/crewrig/crewrig.git (fetch)
+   ```
+
+The `upstream` remote is required by `bash scripts/sync-from-upstream.sh`
+(Step 7). The `origin` remote is the organisation's own repository. Upstream
+changes flow in via the sync script; the organisation's overlay content lives
+on top and is never touched by the sync.
 
 ## Step 2 — Initialise the overlay configuration
 
@@ -181,6 +196,17 @@ output directories:
 .gemini/agents/        Gemini CLI agents
 .github/skills/        GitHub Copilot CLI skills
 .github/agents/        GitHub Copilot CLI agents
+```
+
+Commit the built outputs so the repository always contains up-to-date CLI
+component files and the next collaborator does not need to re-run the build
+from scratch:
+
+```bash
+git add .claude/skills .claude/agents \
+        .gemini/skills .gemini/agents \
+        .github/skills .github/agents
+git commit -m "⚙️ Build CLI components for <YOUR-ORG>"
 ```
 
 **Most-likely error — missing `crewrig.config.toml` or literal placeholders:**


### PR DESCRIPTION
This PR introduces `docs/adoption-guide.md`, the primary onboarding surface for organisations adopting CrewRig without contributing upstream, and updates `README.md` to reference it from the "How It Works" section.

## How to read this PR?

Start with `docs/adoption-guide.md` — the entire content of the guide is in that one new file. Then look at the `README.md` diff, which adds a single "Adopting CrewRig" subsection pointing at the guide. No scripts, no artifacts, and no build outputs were modified.

## How to test this PR?

1. Check that every file path referenced in the guide (`crewrig.config.toml.template`, `config/ORGANIZATION.md.template`, `config/TOOLS.md.template`, `scripts/build-components.sh`, `scripts/setup-claude-interactive.sh`, `scripts/setup-gemini-interactive.sh`, `scripts/setup-copilot-interactive.sh`, `scripts/sync-from-upstream.sh`, `.crewrig/core-paths.txt`) exists in the repository tree.
2. Verify that the three troubleshooting entries match the actual error messages emitted by the respective scripts (grep the scripts for the error text).
3. Confirm that CLI-specific differences are called out explicitly: Gemini deploys to `~/.gemini/` (no `rules/` subdirectory), Copilot uses `*.instructions.md` naming in `~/.copilot/instructions/`.
4. Confirm the README change appears after the "Memory Architecture" subsection and before "Lifecycle Scenario".

## Detailed description (for agents)

**`docs/adoption-guide.md` (new file, 310 lines):**
- `## Prerequisites` — git, bash ≥ 4, a TOML-capable editor, write access to a GitHub repository, and the target CLI tools installed (treated as given).
- `## Step 1 — Fork the repository` — GitHub fork flow, clone, and adding the `upstream` remote.
- `## Step 2 — Initialise the overlay configuration` — `cp crewrig.config.toml.template crewrig.config.toml`; shows the exact placeholder values from the template (`canonical_repo`, `feedback_repo`); explains semantics of each field; instructs to commit.
- `## Step 3 — Initialise the organisation identity` — `cp config/ORGANIZATION.md.template config/ORGANIZATION.md`; enumerates all seven sections with brief descriptions; instructs to remove placeholder comments before committing.
- `## Step 4 — Initialise the tool configuration` — `cp config/TOOLS.md.template config/TOOLS.md`; covers Tooling Preferences, MCP Server Declarations, and Workflow Preferences; explicitly warns not to redeclare framework MCP servers.
- `## Step 5 — Run the build pipeline` — `bash scripts/build-components.sh`; lists all six expected output directories; documents the most-likely error (missing/literal `crewrig.config.toml`); mentions `artifacts/community/` and `artifacts/organisation/` without detailing authoring.
- `## Step 6 — Deploy to CLI rules directories` — three sub-sections, one per CLI, with the exact command and the deploy target path for each. Explicitly calls out: Claude Code → `~/.claude/rules/` (plain `.md` files); Gemini → `~/.gemini/` directly, no `rules/` subdirectory; Copilot → `~/.copilot/instructions/` as `*.instructions.md`. Symlink vs. copy mode explained with the security caveat.
- `## Step 7 — Sync from upstream` — `bash scripts/sync-from-upstream.sh`; expected outcome and the dirty-core error message.
- `## Troubleshooting` — three entries: (1) missing/placeholder `crewrig.config.toml`; (2) build exits non-zero due to missing source directory; (3) dirty-core refusal with two resolution paths (revert or promote to overlay).

**`README.md` (modified):**
- Added a `## Adopting CrewRig` subsection between "Memory Architecture" (end of "How It Works") and "Lifecycle Scenario". Contains a two-sentence description and a link to `docs/adoption-guide.md`.

Closes #231