### PR TITLE
📝 Delta-spec 01 — correct Gemini deploy path in spec 0017 (adoption-guide)

### DIFF
--- a/specs/0017-adoption-guide.delta-01.md
+++ b/specs/0017-adoption-guide.delta-01.md
@@ -40,7 +40,7 @@ Replacement:
 
 Original:
 
-> 6. The guide SHALL cover all three CLIs — Claude Code (`~/.claude/rules/`),
+> 1. The guide SHALL cover all three CLIs — Claude Code (`~/.claude/rules/`),
 >    Gemini CLI (`~/.gemini/rules/`), and GitHub Copilot CLI (its equivalent
 >    instructions path) — treating them symmetrically. Where a CLI-specific
 >    detail differs, the guide SHALL call it out explicitly rather than
@@ -48,7 +48,7 @@ Original:
 
 Replacement:
 
-> 6. The guide SHALL cover all three CLIs — Claude Code (`~/.claude/rules/`),
+> 1. The guide SHALL cover all three CLIs — Claude Code (`~/.claude/rules/`),
 >    Gemini CLI (`~/.gemini/`), and GitHub Copilot CLI (`~/.copilot/instructions/`)
 >    — treating them symmetrically. Where CLI-specific details differ (Gemini
 >    deploys directly to `~/.gemini/` with no `rules/` subdirectory; Copilot

--- a/specs/0017-adoption-guide.delta-01.md
+++ b/specs/0017-adoption-guide.delta-01.md
@@ -1,0 +1,62 @@
+---
+id: "0017"
+slug: adoption-guide
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 231
+version: 1.0.1
+---
+
+# Adoption Guide
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+**R3 — "Deploy to CLI rules directories" step** — correct Gemini target path and reference setup scripts.
+
+Original:
+
+> - **Deploy to CLI rules directories** — copy or symlink the built outputs
+>   to the user-home CLI rules directories for each active CLI: `~/.claude/rules/`
+>   for Claude Code, `~/.gemini/rules/` for Gemini CLI, and the equivalent
+>   path for GitHub Copilot CLI.
+
+Replacement:
+
+> - **Deploy to CLI rules directories** — run the deploy scripts for each
+>   active CLI: `bash scripts/setup-claude-interactive.sh` (deploys to
+>   `~/.claude/rules/`), `bash scripts/setup-gemini-interactive.sh` (deploys
+>   to `~/.gemini/` — Gemini has no `rules/` subdirectory; files land directly
+>   in `~/.gemini/` with numeric prefixes), `bash scripts/setup-copilot-interactive.sh`
+>   (deploys to `~/.copilot/instructions/`).
+
+**Rationale:** `scripts/setup-gemini-interactive.sh` sets `GEMINI_HOME="${HOME}/.gemini"` and deploys files directly under `~/.gemini/` with no `rules/` subdirectory. The original R3 incorrectly stated `~/.gemini/rules/`. The step now references the three `setup-*-interactive.sh` scripts explicitly rather than describing a manual copy/symlink, since those scripts handle priority-prefix renaming, settings.json wiring, and hook deployment.
+
+**R6** — correct Gemini target path and name Copilot path explicitly.
+
+Original:
+
+> 6. The guide SHALL cover all three CLIs — Claude Code (`~/.claude/rules/`),
+>    Gemini CLI (`~/.gemini/rules/`), and GitHub Copilot CLI (its equivalent
+>    instructions path) — treating them symmetrically. Where a CLI-specific
+>    detail differs, the guide SHALL call it out explicitly rather than
+>    defaulting silently to Claude Code behaviour.
+
+Replacement:
+
+> 6. The guide SHALL cover all three CLIs — Claude Code (`~/.claude/rules/`),
+>    Gemini CLI (`~/.gemini/`), and GitHub Copilot CLI (`~/.copilot/instructions/`)
+>    — treating them symmetrically. Where CLI-specific details differ (Gemini
+>    deploys directly to `~/.gemini/` with no `rules/` subdirectory; Copilot
+>    uses `*.instructions.md` file naming), the guide SHALL call them out
+>    explicitly.
+
+**Rationale:** Same correction as R3 above. Additionally, R6 previously left the Copilot path as "its equivalent instructions path" without naming it; now made explicit as `~/.copilot/instructions/` per `scripts/setup-copilot-interactive.sh` line 17 (`COPILOT_INSTRUCTIONS="${COPILOT_HOME}/instructions"`).
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Correct `~/.gemini/rules/` → `~/.gemini/` in R3 and R6 of spec 0017, and add explicit Copilot path (`~/.copilot/instructions/`) to R6. Both paths were wrong or incomplete in the original spec; the PLAN review surfaced the Gemini error as a `class: spec` finding (issue #231 iter:1 F2).

## How to read this PR?

Single new file: `specs/0017-adoption-guide.delta-01.md`. The `## MODIFIED` section quotes both original requirement paragraphs verbatim and shows the replacement text with rationale.

## How to test this PR?

Cross-check the replacement R3 and R6 texts against `scripts/setup-gemini-interactive.sh` line 6 (Gemini path) and `scripts/setup-copilot-interactive.sh` line 17 (Copilot path).

## Detailed description (for agents)

R3 step "Deploy to CLI rules directories" said `~/.gemini/rules/` and described a manual copy/symlink. R6 said `~/.gemini/rules/` and left Copilot as "equivalent path". Both are corrected: Gemini deploys to `~/.gemini/` directly (no `rules/` subdirectory), Copilot to `~/.copilot/instructions/`. R3 now references the three `setup-*-interactive.sh` scripts explicitly. Version bump: 1.0.1 (PATCH — path correction in existing requirements).

Closes #231
