### PR TITLE
📝 Clarify spec append-only governs content, not lifecycle metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,7 +446,8 @@ Rules:
   *Agent Team Protocol → Standard Team Templates → Security rule*)
   applies to every re-spawn that touches it.
 - A `spec`-class loop SHALL produce a delta-spec PR; the original
-  spec on `main` is immutable.
+  spec's content on `main` is immutable (lifecycle metadata such as
+  `status` aside — see `docs/spec-format.md`).
 - The loop SHALL NOT change the logbook issue (Rule A still holds).
 - When an implementation branch (`feat/<NNNN>-<slug>` and siblings) is
   opened against `main` while the corresponding spec-PR is still open,

--- a/docs/adr/0010-spec-plan-review-lifecycle.md
+++ b/docs/adr/0010-spec-plan-review-lifecycle.md
@@ -177,8 +177,10 @@ Normative rules:
    (e.g. `security` per the trigger surface defined in `AGENTS.md` →
    *Agent Team Protocol*).
 3. A `spec`-class loop SHALL produce a delta-spec PR, not an edit to
-   the original spec on `main`. The original spec is immutable once
-   merged; deltas chain via the format defined in #167.
+   the original spec on `main`. The original spec's normative content is
+   immutable once merged; deltas chain via the format defined in #167.
+   Lifecycle metadata (`status`, `superseded-by`) is exempt and transitions
+   per `docs/spec-format.md` → *Recording a status transition*.
 4. The loop SHALL NOT modify the logbook issue's identity. Every
    iteration appends to the same logbook (per `AGENTS.md` → *Logbook
    Issues*, Rule A).

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -48,7 +48,7 @@ refuse to proceed.
 | Path | Description |
 |---|---|
 | `docs/` | All normative and reference documentation, including ADRs, format specs, and this file. |
-| `specs/` | Immutable specification history. Spec files are append-only; existing files are never edited after merge. |
+| `specs/` | Immutable specification history. Spec **content** is append-only; existing files are not edited after merge except for lifecycle-metadata transitions (`status`, `superseded-by`) — see [`docs/spec-format.md`](spec-format.md). |
 
 ### Build and install tooling
 

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -112,8 +112,10 @@ loop and waste a downstream iteration.
 
 `spec`-class findings produced by the REVIEW loop (per ADR-0010 →
 *Finding classification taxonomy*) do not edit the original spec on
-`main`. The original is immutable once merged; corrections chain via
-delta-spec files.
+`main`. The original's **normative content** is immutable once merged;
+corrections chain via delta-spec files. (Lifecycle *metadata* — `status`,
+`superseded-by` — is exempt from this freeze; see *Lifecycle states →
+Recording a status transition*.)
 
 ### File layout
 
@@ -194,6 +196,30 @@ table below is the contract.
 
 A `status` regression (e.g. `approved` → `draft`) is prohibited; if a
 spec must be re-opened, supersede it instead.
+
+### Recording a status transition
+
+The append-only rule (see *Delta-spec convention*) governs a spec's
+**normative content** — the body sections (`## Intent`, `## Requirements`,
+`## Scenarios`, `## Out of scope`, `## Open questions`) and the identifying
+frontmatter fields (`id`, `slug`). It does **not** freeze the
+lifecycle-tracking metadata: the `status` and `superseded-by` fields are
+*expected* to change after merge, since the table above defines transitions
+that occur once the spec PR, the implementation PR, or a superseding spec
+lands.
+
+Such a transition SHALL be recorded by a **metadata-only edit** to the
+merged spec's frontmatter. The authority named in the table above changes
+the `status` field (and sets `superseded-by` when moving to `superseded`)
+and touches nothing else — no body line, no `id`, no `slug`, no `version`.
+A diff that alters any normative content under cover of a status bump is a
+violation. The `version` field stays immutable on the original after merge;
+the cumulative version lives on the highest-numbered delta (per
+*Versioning*).
+
+This carve-out is deliberately narrow: it admits lifecycle metadata only.
+Meaning-preserving editorial edits to body prose (orthography, typo fixes)
+are **not** covered here and remain prohibited pending a separate amendment.
 
 ## Naming convention
 

--- a/specs/0019-artifact-build-install-scope.md
+++ b/specs/0019-artifact-build-install-scope.md
@@ -1,7 +1,7 @@
 ---
 id: "0019"
 slug: artifact-build-install-scope
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 258


### PR DESCRIPTION
Resolves a contradiction in `docs/spec-format.md`: the *Lifecycle states*
table transitions `status` after merge, but the append-only rule said merged
specs are never edited — freezing every spec at `draft`. The append-only rule
governs normative content, not lifecycle metadata.

## How to read this PR?

1. `docs/spec-format.md` — the new `### Recording a status transition`
   subsection under *Lifecycle states*, plus a one-line pointer added to the
   *Delta-spec convention* immutability sentence. This is the substance.
2. `docs/layers.md` — the `specs/` row reworded to match.
3. `specs/0019-artifact-build-install-scope.md` — `status: draft` →
   `implemented` (its implementation PR #261 is merged), the first application
   of the clarified rule.

## How to test this PR?

```bash
task spec:lint                                   # "Linting passed!"
npx markdownlint-cli docs/spec-format.md docs/layers.md specs/0019-artifact-build-install-scope.md   # exit 0
```

Confirm the carve-out is narrow: only `status`/`superseded-by` are exempted;
`version` and all body content stay immutable; editorial/orthographic edits
remain prohibited (deferred to a later amendment).

## Detailed description (for agents)

Docs-only clarification. The append-only rule is restated to govern a spec's
**normative content** (body sections + identifying frontmatter `id`/`slug`),
explicitly **not** the lifecycle-tracking metadata (`status`,
`superseded-by`). Such fields transition post-merge via a metadata-only edit
by the authority named in the *Lifecycle states* table. `version` immutability
is unchanged. The carve-out is deliberately narrow and defers the
editorial-edit carve-out + the en-GB→en-US sweep to a separate amendment.
`spec 0019` is flipped to `implemented` as the first application.

No skill/agent source touched → no version bump. No core-path reclassified →
`.crewrig/core-paths.txt` untouched. Not a CLI-matrix trigger surface.

Closes #262