### PR TITLE
📝 Permit meaning-preserving editorial edits to merged specs (spec 0022)

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -48,7 +48,7 @@ refuse to proceed.
 | Path | Description |
 |---|---|
 | `docs/` | All normative and reference documentation, including ADRs, format specs, and this file. The `docs/org/` subtree is carved out as overlay (spec 0020) — see the Overlay layer. |
-| `specs/` | Immutable specification history. Spec **content** is append-only; existing files are not edited after merge except for lifecycle-metadata transitions (`status`, `superseded-by`) — see [`docs/spec-format.md`](spec-format.md). The `specs/org/` subtree is carved out as overlay (spec 0020) — see the Overlay layer. |
+| `specs/` | Immutable specification history. Spec **content** is append-only; existing files are not edited after merge except for lifecycle-metadata transitions (`status`, `superseded-by`) and meaning-preserving editorial edits (orthography, typo fixes) — see [`docs/spec-format.md`](spec-format.md). The `specs/org/` subtree is carved out as overlay (spec 0020) — see the Overlay layer. |
 
 ### Build and install tooling
 

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -114,8 +114,9 @@ loop and waste a downstream iteration.
 *Finding classification taxonomy*) do not edit the original spec on
 `main`. The original's **normative content** is immutable once merged;
 corrections chain via delta-spec files. (Lifecycle *metadata* — `status`,
-`superseded-by` — is exempt from this freeze; see *Lifecycle states →
-Recording a status transition*.)
+`superseded-by` — and meaning-preserving editorial edits are exempt from this
+freeze; see *Lifecycle states → Recording a status transition* and *Editorial
+edits*.)
 
 ### File layout
 

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -217,9 +217,29 @@ violation. The `version` field stays immutable on the original after merge;
 the cumulative version lives on the highest-numbered delta (per
 *Versioning*).
 
-This carve-out is deliberately narrow: it admits lifecycle metadata only.
-Meaning-preserving editorial edits to body prose (orthography, typo fixes)
-are **not** covered here and remain prohibited pending a separate amendment.
+This carve-out admits lifecycle metadata. A second, equally narrow carve-out
+admits meaning-preserving editorial edits to body prose; it is defined next.
+
+### Editorial edits
+
+Alongside the lifecycle-metadata carve-out above, the append-only rule permits
+**meaning-preserving editorial edits** — orthography and typo corrections — to
+the body prose of a merged spec. An editorial edit may change the spelling or
+surface form of a word but SHALL NOT alter meaning. Permitted: fixing a
+misspelling, normalising a British spelling to American, repairing a typo.
+
+Forbidden, still: any change to the substance of a requirement, scenario,
+intent, or out-of-scope item. Correcting the spelling of a word inside a
+requirement is allowed; changing what that requirement obliges, permits, or
+forbids is not. Substantive corrections chain via **delta-specs** (see
+*Delta-spec convention*), never as in-place edits — exactly as before this
+carve-out. A diff that alters normative meaning under cover of an editorial
+fix is a violation, mirroring the same guard on the lifecycle-metadata
+carve-out.
+
+This carve-out is deliberately narrow in the same spirit as the
+lifecycle-metadata one: it admits surface-form corrections only, leaving every
+normative guarantee of the merged spec untouched.
 
 ## Naming convention
 


### PR DESCRIPTION
Realises spec 0022 (#271): widens the spec append-only rule with a second narrow
carve-out permitting meaning-preserving editorial edits (orthography, typos) to
merged spec body prose, while normative substance stays append-only.

## How to read this PR?

Two files. `docs/spec-format.md` gains an `### Editorial edits` subsection
beside the existing lifecycle-metadata carve-out (replacing the line that said
such edits "remain prohibited pending a separate amendment"). `docs/layers.md`
extends the `specs/` row's exception clause to match. This unblocks the deferred,
separate en-GB → en-US sweep — NO sweep is performed here.

## How to test this PR?

```bash
task spec:lint                                  # "Linting passed!"
npx markdownlint-cli docs/spec-format.md docs/layers.md   # exit 0
```

Confirm the boundary reads correctly: spelling/surface-form fixes permitted;
any change to a requirement/scenario/intent/out-of-scope substance still
forbidden and chained via delta-specs.

## Detailed description (for agents)

R1–R4: append-only now permits meaning-preserving editorial edits to merged spec
prose; substantive changes still chain via delta-specs; the boundary and the
"under cover of an editorial fix" guard mirror the lifecycle-metadata carve-out.
No `/specs/*.md` edited (the amendment only ENABLES it; the sweep is a deferred
spec). No skill/agent source → no version bump. `docs/layers.md` `specs/` row
refined (descriptive prose only — no core-path reclassification, so
`.crewrig/core-paths.txt` is untouched).

Closes #270