### PR TITLE
📝 Add spec 0025 — harden agent team protocol

### DIFF
--- a/specs/0025-harden-agent-team-protocol.md
+++ b/specs/0025-harden-agent-team-protocol.md
@@ -1,0 +1,91 @@
+---
+id: "0025"
+slug: harden-agent-team-protocol
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 280
+version: 1.0.0
+---
+
+# Harden the agent team protocol: issue-triggered team assembly and silent-agent timeout
+
+## Intent
+
+An agent picking up a tracked GitHub issue can no longer downgrade that
+work to solo inline handling, and an agent waiting on a silent teammate
+has a bounded, explicit signal telling it when to stop waiting and fall
+back. A reader of the team protocol finds, in one place, both the rule
+that a referenced issue number forces a team and the time bound after
+which an unresponsive teammate is treated as dead. Nothing about the
+existing team templates, tiers, or communication rules changes; the two
+additions sharpen guidance that was previously implicit.
+
+## Requirements
+
+1. The team protocol SHALL state that when a unit of work references a
+   tracked GitHub issue number, assembling a team is mandatory and the
+   work SHALL NOT be downgraded to the `trivial` tier's inline handling
+   on the basis of perceived small scope.
+2. The team protocol SHALL preserve the existing exemption for trivial
+   single-file edits that the user explicitly scopes as inline, and
+   SHALL make explicit that this exemption does not apply to work
+   anchored on a tracked issue.
+3. The team protocol SHALL give a bounded waiting heuristic for a
+   teammate that has produced no result message and no observable
+   side-effect, after which the team-lead SHALL treat the teammate as
+   dead and apply the existing idle-fallback remedy.
+4. The waiting heuristic SHALL be expressed as guidance that composes
+   with the existing idle-notification handling, and SHALL NOT contradict
+   the rule that observable side-effects are checked before an apparent
+   silence is treated as a protocol violation.
+5. The additions SHALL be confined to the team protocol documentation and
+   SHALL NOT alter any existing requirement of the lifecycle, the
+   interaction modes, or the complexity tiers.
+
+## Scenarios
+
+**Scenario:** A referenced issue forces a team
+
+```text
+Given a user asks the agent to fix a problem and references a tracked
+      GitHub issue number
+When  the agent classifies the work
+Then  it assembles a team sized to the scope and does not handle the work
+      as a trivial inline edit, regardless of how small the fix appears
+```
+
+**Scenario:** A user-scoped inline edit remains exempt
+
+```text
+Given a user explicitly scopes a one-file change as an inline edit and
+      references no tracked issue
+When  the agent classifies the work
+Then  the trivial inline exemption still applies and no team is required
+```
+
+**Scenario:** A silent teammate crosses the waiting bound
+
+```text
+Given a teammate has produced no result message and no observable
+      side-effect after the bounded waiting period
+When  the team-lead next evaluates the teammate's state
+Then  the team-lead treats the teammate as dead and spawns a fresh
+      direct agent with a self-contained brief, per the idle-fallback rule
+```
+
+## Out of scope
+
+- Any harness-level mechanism (heartbeat events, a TaskStatus polling
+  API, runtime timeouts): the suggested runtime improvement in issue #279
+  is outside CrewRig's reach as a configuration framework; this spec
+  documents an agent-side waiting heuristic only.
+- Changes to the existing idle-notification handling, the report-before-idle
+  rule, or the idle-fallback remedy beyond adding the waiting bound that
+  triggers them.
+- Any change to the complexity-tier definitions themselves; the spec only
+  forbids downgrading issue-anchored work to the trivial tier.
+
+## Open questions
+
+- None.


### PR DESCRIPTION
Qualifies the WHAT for two friction reports: issue-triggered team assembly (#280) and a bounded silent-agent waiting heuristic (#279). Spec-only PR per the spec-PR workflow; the implementation lands in a separate PR that closes both issues.

## How to read this PR?

Single new file: `specs/0025-harden-agent-team-protocol.md`. Read `## Intent` then the five requirements. R1–R2 cover #280 (referenced issue forces a team, trivial-inline exemption narrowed); R3–R4 cover #279 (bounded waiting heuristic composing with existing idle handling); R5 fences the blast radius to the team-protocol doc.

## How to test this PR?

- `npx markdownlint-cli specs/0025-harden-agent-team-protocol.md` → clean.
- Frontmatter parses as YAML; the five mandatory sections are present in order.
- Verify `id`/`slug` match the filename, and `0025` is free on `main`.

## Detailed description (for agents)

New spec at `complexity: small`, `interaction-mode: AUTO`, `related-issue: 280`. It documents, as additive guidance only, two sharpenings of `docs/agent-team-protocol.md`:

- A referenced tracked-issue number makes team assembly mandatory and forbids downgrading to the `trivial` inline tier (addresses #280; the doc's *When this applies* and *Solo work prohibition* already imply this but do not state the issue→team guard sharply).
- A bounded waiting heuristic after which a silent teammate (no result message, no observable side-effect) is treated as dead and the existing idle-fallback remedy applies (addresses #279; complements Team Communication Rules 1–3 without altering them).

Out of scope: any harness-level heartbeat/timeout/TaskStatus mechanism (#279's runtime suggestion is outside a config framework's reach), and any change to tier definitions or the existing communication rules.

Refs #279, #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)