### PR TITLE
📝 Add spec 0026 — reconcile review-finding handling with interaction modes

### DIFF
--- a/specs/0026-reconcile-rule4-modes.md
+++ b/specs/0026-reconcile-rule4-modes.md
@@ -1,0 +1,87 @@
+---
+id: "0026"
+slug: reconcile-rule4-modes
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 281
+version: 1.0.0
+---
+
+# Reconcile review-finding handling with the interaction modes
+
+## Intent
+
+When a reviewer posts findings during the REVIEW loop, what happens next
+depends on the ticket's interaction mode. In the fully interactive mode a
+user still decides, finding by finding, what to fix, skip, or defer; in
+every more autonomous mode the team fixes every finding in the same
+session without pausing for the user, and the only place the user is
+asked anything remains the merge authorization. A reader of the team
+protocol finds one rule that names this mode dependency explicitly,
+instead of a single rule that reads as if the user is always consulted.
+
+## Requirements
+
+1. The team protocol SHALL make the handling of reviewer findings
+   conditional on the ticket's declared interaction mode.
+2. In the fully interactive mode, the team protocol SHALL require that
+   every finding — blocking and non-blocking — is presented to the user
+   for a fix, skip, or defer decision before the fix cycle proceeds.
+3. In every non-fully-interactive mode, the team protocol SHALL require
+   that every finding — blocking and non-blocking — is routed into the
+   fix cycle automatically, in the same session, with no user gate other
+   than the merge authorization.
+4. The team protocol SHALL preserve the existing meaning of the
+   non-blocking label as "the pull request may merge without this," and
+   SHALL forbid silently deferring any finding to a follow-up ticket
+   without authorization appropriate to the mode.
+5. The reconciled rule SHALL remain consistent with the user-gate
+   definition of the lifecycle, under which only the interactive question
+   and the merge authorization block execution; presentation that does
+   not block SHALL NOT be counted as a user gate.
+
+## Scenarios
+
+**Scenario:** Autonomous mode auto-routes findings
+
+```text
+Given a ticket runs in a non-fully-interactive mode and a reviewer posts
+      blocking and non-blocking findings
+When  the team-lead processes the review verdict
+Then  every finding is assigned into the fix cycle in the same session
+      without asking the user, and the user is asked only at the merge gate
+```
+
+**Scenario:** Fully interactive mode consults the user
+
+```text
+Given a ticket runs in the fully interactive mode and a reviewer posts
+      blocking and non-blocking findings
+When  the team-lead processes the review verdict
+Then  every finding is presented to the user, who decides per finding
+      whether to fix, skip, or defer before the fix cycle proceeds
+```
+
+**Scenario:** No finding is silently dropped
+
+```text
+Given a reviewer marks a finding non-blocking in any mode
+When  the team-lead processes the review verdict
+Then  the finding is either implemented in-session or deferred only with
+      authorization appropriate to the mode, never dropped silently
+```
+
+## Out of scope
+
+- Any change to the interaction-mode definitions themselves or to the
+  user-gate definition; this spec aligns finding handling with those
+  contracts, it does not amend them.
+- Any change to the merge-authorization gate, which remains invariant
+  across every mode.
+- The routing-class taxonomy (`tech` / `arch` / `spec`) and the
+  retroactive review loop mechanics, which are untouched.
+
+## Open questions
+
+- None.


### PR DESCRIPTION
Qualifies the WHAT for friction #281: review-finding handling should depend on the interaction mode, not always consult the user. Spec-only PR; the implementation (rewriting team-protocol Rule 4) lands separately.

## How to read this PR?

Single new file: `specs/0026-reconcile-rule4-modes.md`. Read `## Intent`, then R1–R5. The crux: R2 keeps the interactive (FULL) behavior, R3 makes every more autonomous mode auto-route findings into the fix cycle with no gate beyond merge, R5 ties this to the existing user-gate definition.

## How to test this PR?

- `npx markdownlint-cli specs/0026-reconcile-rule4-modes.md` → clean.
- Frontmatter parses; five mandatory sections present in order; `id`/`slug` match filename; `0026` free on `main`.

## Detailed description (for agents)

New spec at `complexity: standard` (the change touches gate semantics, so the architect belongs in the PLAN loop), `interaction-mode: AUTO`, `related-issue: 281`.

Context: `docs/agent-team-protocol.md` Team Communication **Rule 4** currently mandates presenting every finding to the user, which contradicts friction #281 (which wanted autonomous routing) *and* the interaction-mode contract (in AUTO/INTERMEDIATE, presentation is non-blocking and the loop runs autonomously; only FULL gates). This spec reconciles the two by binding finding-handling to the declared mode rather than reversing Rule 4 outright:

- FULL: present every finding for a per-finding fix/skip/defer decision (current Rule 4 behavior).
- INTERMEDIATE / MINIMAL / AUTO: auto-route every finding into the fix cycle in-session; the only user gate stays the merge authorization.

The non-blocking label keeps its meaning ("PR may merge without this"); no finding may be silently deferred. Out of scope: the mode definitions, the user-gate definition, and the merge gate (all unchanged).

Refs #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)