### PR TITLE
📝 Harden agent team protocol: issue-triggered teams and silent-agent timeout

### DIFF
--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -82,6 +82,15 @@ agents are available. Inline solo work on a ticket is reserved for trivial
 single-file edits explicitly scoped that way by the user. If in doubt,
 assemble the team.
 
+**Issue-anchored work forces a team.** When the unit of work references a
+tracked GitHub issue number, assembling a team is mandatory: such work
+SHALL NOT be downgraded to the `trivial` tier's inline handling on the
+basis of perceived small scope. "Small fix" and "scoped solo work" are
+orthogonal — a two-line fix on a tracked issue still requires a team. The
+trivial single-file inline exemption above applies only to a change the
+user explicitly scopes as inline with no tracked issue behind it; it never
+applies to issue-anchored work, however small the fix looks.
+
 ## Worktree Isolation
 
 Parallel agent teams operating on the same git working directory collide on branch checkout and the staging index, corrupting each other's work. To prevent this, the orchestrating agent **MUST** create a dedicated git worktree **before** issuing any `TaskCreate` call or `Agent` spawn for the ticket:
@@ -340,6 +349,21 @@ violation, the team-lead MUST:
 Sending a status-check ping on every idle notification is itself a
 protocol violation: it manufactures the very noise this rule exists
 to prevent.
+
+**Bounded wait before declaring death.** Rules 2 and 3 assume the
+team-lead eventually receives *some* signal — a second idle
+notification, or one it can reconcile against side-effects. A teammate
+can also die with no signal at all: no result message, no idle
+notification, no side-effect. To bound this case, the team-lead SHALL
+keep a wall-clock waiting budget per spawned teammate — roughly 30
+minutes for a `pr-logbook` or `pr-reviewer`, proportionally more for a
+long implementation task. When the budget elapses with no result
+message and no observable side-effect (checked per Rule 3 step 2), the
+team-lead SHALL treat the teammate as dead and apply Rule 2 — spawn a
+fresh direct `Agent` with a self-contained brief. The budget is a
+backstop, not a substitute for the side-effect check: a teammate whose
+work is visibly complete is never declared dead merely because the
+budget elapsed.
 
 **Rule 4 — Review findings are not auto-deferrals.** When a reviewer
 lists findings marked "non-blocking", that label means the PR can merge


### PR DESCRIPTION
Realizes spec 0025: two additive guidance blocks in `docs/agent-team-protocol.md` — a referenced tracked-issue number forces a team (#280), and a bounded waiting budget declares a signal-less teammate dead (#279). Independent of the spec-PR #282, which it does not auto-close.

## How to read this PR?

One file, `docs/agent-team-protocol.md`, two additive blocks:
1. *Solo work prohibition* gains an **Issue-anchored work forces a team** paragraph (R1–R2 of spec 0025).
2. *Team Communication* gains a **Bounded wait before declaring death** paragraph after Rule 3 (R3–R4).

Both are purely additive; no existing rule, template, tier, or requirement changes (R5).

## How to test this PR?

- `npx markdownlint-cli docs/agent-team-protocol.md` → clean.
- Confirm the two new paragraphs read as guidance that composes with the existing *When this applies*, *Solo work prohibition*, and Team Communication Rules 1–3 without contradicting them.
- Trace each spec 0025 requirement (R1–R5) to a sentence in the diff.

## Detailed description (for agents)

Added under *Solo work prohibition*: an **Issue-anchored work forces a team** block stating that a referenced tracked-issue number makes team assembly mandatory and forbids downgrading to the `trivial` inline tier on perceived-scope grounds, while preserving the user-scoped inline exemption for non-issue work (spec 0025 R1, R2).

Added under *Team Communication*, after Rule 3's closing paragraph: a **Bounded wait before declaring death** block introducing a per-teammate wall-clock waiting budget (~30 min for `pr-logbook`/`pr-reviewer`, more for long implementation tasks). When it elapses with no result message and no observable side-effect (checked per Rule 3 step 2), the team-lead treats the teammate as dead and applies Rule 2 (fresh direct `Agent`). The budget is explicitly a backstop, never overriding the side-effect-first check (spec 0025 R3, R4).

No change to AGENTS.md, the CLI matrix, tiers, or any existing requirement (spec 0025 R5). Not under `artifacts/`, so no `build-components.sh` run is required.

Closes #279
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)