### PR TITLE
📝 Add spec 0026.delta-01 — REVIEW loop never gates; FULL only notifies

### DIFF
--- a/specs/0026-reconcile-rule4-modes.delta-01.md
+++ b/specs/0026-reconcile-rule4-modes.delta-01.md
@@ -1,0 +1,82 @@
+---
+id: "0026"
+slug: reconcile-rule4-modes
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 281
+version: 2.0.0
+---
+
+# Reconcile review-finding handling with the interaction modes
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+Requirement 2 is replaced. The original required the fully interactive
+mode to gate the fix cycle on a per-finding user decision, which
+contradicts the authoritative `(mode × stage)` matrix in `AGENTS.md`:
+the REVIEW loop fires no user gate in any mode, and FULL only posts a
+non-blocking notification.
+
+- Original R2:
+
+  > In the fully interactive mode, the team protocol SHALL require that
+  > every finding — blocking and non-blocking — is presented to the user
+  > for a fix, skip, or defer decision before the fix cycle proceeds.
+
+- Replacement R2:
+
+  > In every interaction mode, the team protocol SHALL require that every
+  > finding — blocking and non-blocking — is routed into the fix cycle
+  > automatically, in the same session, with no user gate other than the
+  > merge authorization. The REVIEW loop SHALL NOT fire an interactive
+  > per-finding fix, skip, or defer prompt in any mode.
+
+Requirement 3 is replaced. FULL mode no longer differs by consulting the
+user; it differs only by emitting a non-blocking notification.
+
+- Original R3:
+
+  > In every non-fully-interactive mode, the team protocol SHALL require
+  > that every finding — blocking and non-blocking — is routed into the
+  > fix cycle automatically, in the same session, with no user gate other
+  > than the merge authorization.
+
+- Replacement R3:
+
+  > In FULL mode, the team protocol SHALL additionally require a
+  > non-blocking notification of the findings at the REVIEW iteration
+  > boundary; this notification SHALL NOT block the fix cycle and SHALL
+  > NOT be counted as a user gate.
+
+The `Fully interactive mode consults the user` scenario is replaced,
+since FULL no longer consults the user inside the REVIEW loop.
+
+- Original scenario:
+
+  > **Scenario:** Fully interactive mode consults the user
+  >
+  > Given a ticket runs in the fully interactive mode and a reviewer posts
+  >       blocking and non-blocking findings
+  > When  the team-lead processes the review verdict
+  > Then  every finding is presented to the user, who decides per finding
+  >       whether to fix, skip, or defer before the fix cycle proceeds
+
+- Replacement scenario:
+
+  > **Scenario:** Fully interactive mode notifies without gating
+  >
+  > Given a ticket runs in FULL mode and a reviewer posts blocking and
+  >       non-blocking findings
+  > When  the team-lead processes the review verdict
+  > Then  every finding is routed into the fix cycle automatically and a
+  >       non-blocking notification is posted at the iteration boundary;
+  >       no interactive per-finding prompt is fired
+
+## REMOVED
+
+(none)

--- a/specs/0026-reconcile-rule4-modes.delta-01.md
+++ b/specs/0026-reconcile-rule4-modes.delta-01.md
@@ -56,26 +56,30 @@ user; it differs only by emitting a non-blocking notification.
 The `Fully interactive mode consults the user` scenario is replaced,
 since FULL no longer consults the user inside the REVIEW loop.
 
-- Original scenario:
+Original scenario:
 
-  > **Scenario:** Fully interactive mode consults the user
-  >
-  > Given a ticket runs in the fully interactive mode and a reviewer posts
-  >       blocking and non-blocking findings
-  > When  the team-lead processes the review verdict
-  > Then  every finding is presented to the user, who decides per finding
-  >       whether to fix, skip, or defer before the fix cycle proceeds
+```text
+**Scenario:** Fully interactive mode consults the user
 
-- Replacement scenario:
+Given a ticket runs in the fully interactive mode and a reviewer posts
+      blocking and non-blocking findings
+When  the team-lead processes the review verdict
+Then  every finding is presented to the user, who decides per finding
+      whether to fix, skip, or defer before the fix cycle proceeds
+```
 
-  > **Scenario:** Fully interactive mode notifies without gating
-  >
-  > Given a ticket runs in FULL mode and a reviewer posts blocking and
-  >       non-blocking findings
-  > When  the team-lead processes the review verdict
-  > Then  every finding is routed into the fix cycle automatically and a
-  >       non-blocking notification is posted at the iteration boundary;
-  >       no interactive per-finding prompt is fired
+Replacement scenario:
+
+```text
+**Scenario:** Fully interactive mode notifies without gating
+
+Given a ticket runs in FULL mode and a reviewer posts blocking and
+      non-blocking findings
+When  the team-lead processes the review verdict
+Then  every finding is routed into the fix cycle automatically and a
+      non-blocking notification is posted at the iteration boundary;
+      no interactive per-finding prompt is fired
+```
 
 ## REMOVED
 


### PR DESCRIPTION
Delta-spec correcting R2/R3 of spec 0026 (#283), which contradicted the authoritative (mode × stage) matrix in AGENTS.md. Spec-only PR; the implementation of #281 realizes the union of 0026 + this delta.

## How to read this PR?

Single new file: `specs/0026-reconcile-rule4-modes.delta-01.md`. Read `## MODIFIED` — it replaces R2, R3, and the FULL-mode scenario. The crux: the REVIEW loop fires **no user gate in any mode**; FULL differs only by a non-blocking notification.

## How to test this PR?

- `npx markdownlint-cli specs/0026-reconcile-rule4-modes.delta-01.md` → clean.
- Delta sections `## ADDED`, `## MODIFIED`, `## REMOVED` present in order; frontmatter `id` `0026`, `version` `2.0.0`.

## Detailed description (for agents)

Spec 0026 R2 required FULL mode to gate the fix cycle on a per-finding user decision. That contradicts the `(mode × stage)` matrix in `AGENTS.md`, whose REVIEW row states FULL posts a non-blocking notification with **no `AskUserQuestion`**, and INTERMEDIATE/MINIMAL/AUTO run autonomously. `docs/retroactive-loop.md` → *Non-blocking conditional routing* carries the same stale assumption (FULL **and** INTERMEDIATE → "user decides").

This delta (`version: 2.0.0`, MAJOR — breaking normative change) replaces:

- **R2** → findings auto-route into the fix cycle in **every** mode, no user gate but merge; the REVIEW loop SHALL NOT fire an interactive per-finding prompt in any mode.
- **R3** → FULL mode adds only a non-blocking notification at the REVIEW iteration boundary; not a gate.
- The `Fully interactive mode consults the user` scenario → `Fully interactive mode notifies without gating`.

R1, R4, R5 are unchanged. The implementation-PR for #281 realizes 0026 + delta-01 and fixes the `retroactive-loop.md` table to match.

Refs #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)