### PR TITLE
📝 Add spec 0026.delta-02 — re-align to spec 0005 R10 non-blocking routing

### DIFF
--- a/specs/0026-reconcile-rule4-modes.delta-02.md
+++ b/specs/0026-reconcile-rule4-modes.delta-02.md
@@ -1,0 +1,92 @@
+---
+id: "0026"
+slug: reconcile-rule4-modes
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 281
+version: 3.0.0
+---
+
+# Reconcile review-finding handling with the interaction modes
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+Delta-01 set R2/R3 to "auto-route in every mode; FULL only notifies",
+which contradicts the deliberate design of **spec 0005 R10** (non-blocking
+findings: FULL / INTERMEDIATE present to the user, MINIMAL / AUTO
+auto-route) that `docs/retroactive-loop.md` already implements. This
+delta re-aligns R2/R3 to spec 0005 R10.
+
+Requirement 2 is replaced.
+
+- Current R2 (from delta-01):
+
+  > In every interaction mode, the team protocol SHALL require that every
+  > finding — blocking and non-blocking — is routed into the fix cycle
+  > automatically, in the same session, with no user gate other than the
+  > merge authorization. The REVIEW loop SHALL NOT fire an interactive
+  > per-finding fix, skip, or defer prompt in any mode.
+
+- Replacement R2:
+
+  > Review-finding handling SHALL be conditional on the ticket's
+  > interaction mode and SHALL match spec 0005 R10. In FULL and
+  > INTERMEDIATE modes, blocking findings SHALL be routed into the fix
+  > cycle automatically, and every non-blocking finding SHALL be presented
+  > to the user, with only the findings the user accepts routed into the
+  > fix cycle and the rest journalled in the logbook.
+
+Requirement 3 is replaced.
+
+- Current R3 (from delta-01):
+
+  > In FULL mode, the team protocol SHALL additionally require a
+  > non-blocking notification of the findings at the REVIEW iteration
+  > boundary; this notification SHALL NOT block the fix cycle and SHALL
+  > NOT be counted as a user gate.
+
+- Replacement R3:
+
+  > In MINIMAL and AUTO modes, the team protocol SHALL require that every
+  > finding — blocking and non-blocking — is routed into the fix cycle
+  > automatically, in the same session, with no user gate other than the
+  > merge authorization; non-blocking findings become blocking by default.
+
+The `Fully interactive mode notifies without gating` scenario (from
+delta-01) is replaced, since FULL and INTERMEDIATE do consult the user on
+non-blocking findings per spec 0005 R10.
+
+Current scenario (from delta-01):
+
+```text
+**Scenario:** Fully interactive mode notifies without gating
+
+Given a ticket runs in FULL mode and a reviewer posts blocking and
+      non-blocking findings
+When  the team-lead processes the review verdict
+Then  every finding is routed into the fix cycle automatically and a
+      non-blocking notification is posted at the iteration boundary;
+      no interactive per-finding prompt is fired
+```
+
+Replacement scenario:
+
+```text
+**Scenario:** Interactive modes consult the user on non-blocking findings
+
+Given a ticket runs in FULL or INTERMEDIATE mode and a reviewer posts
+      blocking and non-blocking findings
+When  the team-lead processes the review verdict
+Then  blocking findings are routed into the fix cycle automatically, every
+      non-blocking finding is presented to the user, and only the ones the
+      user accepts are routed; the rest are journalled and left unactioned
+```
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec reverting the mis-correction in 0026.delta-01 (#285). Re-aligns R2/R3 to the deliberate design of spec 0005 R10: FULL/INTERMEDIATE consult the user on non-blocking findings, MINIMAL/AUTO auto-route.

## How to read this PR?

Single new file: `specs/0026-reconcile-rule4-modes.delta-02.md`. Read `## MODIFIED` — it quotes delta-01's R2/R3/scenario (the wrong "auto-route everywhere" model) and replaces them with the spec 0005 R10 model.

## How to test this PR?

- `npx markdownlint-cli specs/0026-reconcile-rule4-modes.delta-02.md` → clean.
- Delta sections present in order; frontmatter `version` `3.0.0` (cumulative, MAJOR — reverses delta-01).
- Cross-check against `specs/0005-retroactive-routing-engine.md` R10 and `docs/retroactive-loop.md` → *Non-blocking conditional routing*: all three now agree.

## Detailed description (for agents)

Delta-01 (`version 2.0.0`) set R2/R3 to "every mode auto-routes; FULL only notifies; REVIEW never gates". That contradicted **spec 0005 R10** — a merged, deliberate design (with rationale in `docs/retroactive-loop.md` → *the asymmetry reflects the lifecycle's gating philosophy*) — under which non-blocking findings are presented to the user in FULL/INTERMEDIATE and auto-routed in MINIMAL/AUTO. `retroactive-loop.md` already implements spec 0005 R10 correctly; delta-01 was the outlier.

This delta (`version 3.0.0`, MAJOR) replaces:

- **R2** → FULL/INTERMEDIATE: blocking findings auto-route, non-blocking findings presented to the user, only accepted ones routed, rest journalled.
- **R3** → MINIMAL/AUTO: every finding auto-routes; non-blocking becomes blocking; only the merge gate remains.
- The `Fully interactive mode notifies without gating` scenario → `Interactive modes consult the user on non-blocking findings`.

R1, R4, R5 unchanged. The implementation-PR for #281 realizes the union (0026 + delta-01 + delta-02 = spec 0005 R10 model) by rewriting `agent-team-protocol.md` Rule 4 mode-conditionally and adding a clarifying note to the `(mode × stage)` matrix; `retroactive-loop.md` stays as-is.

Refs #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)