### PR TITLE
📝 Make team-protocol Rule 4 mode-conditional per spec 0005 R10

### DIFF
--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -365,14 +365,29 @@ backstop, not a substitute for the side-effect check: a teammate whose
 work is visibly complete is never declared dead merely because the
 budget elapsed.
 
-**Rule 4 — Review findings are not auto-deferrals.** When a reviewer
-lists findings marked "non-blocking", that label means the PR can merge
-without them — it does NOT mean the findings should be deferred to a
-follow-up ticket without asking the user. The agent MUST present every
-finding to the user and implement each one in the same session unless
-the user explicitly decides to skip or defer it. The user sets the
-scope, not the reviewer's severity labels. Auto-deferring findings to
-follow-up tickets without user authorization is prohibited.
+**Rule 4 — Review findings are not auto-deferrals; handling is
+mode-conditional.** A reviewer's "non-blocking" label means the pull
+request *may merge* without that finding — it never means the finding may
+be silently dropped or deferred to a follow-up ticket. Blocking findings
+are always routed into the fix cycle, in every mode. Non-blocking findings
+are routed conditionally on the ticket's declared interaction mode (see
+*Interaction modes* in AGENTS.md), matching `specs/0005-retroactive-routing-engine.md`
+R10 and the table in [`docs/retroactive-loop.md`](retroactive-loop.md) →
+*Non-blocking conditional routing*:
+
+- **FULL / INTERMEDIATE.** The team-lead MUST present every non-blocking
+  finding to the user and route only those the user accepts into the fix
+  cycle; the rest are journalled in the logbook and left unactioned. The
+  user sets the scope, not the reviewer's severity labels.
+- **MINIMAL / AUTO.** The team-lead MUST route every finding — blocking and
+  non-blocking — into the fix cycle automatically, in the same session,
+  with no user gate other than the merge authorization; in the autonomous
+  modes there is no user to defer to, so non-blocking findings become
+  blocking by default.
+
+In no mode may a finding be deferred to a follow-up ticket without
+authorization appropriate to that mode — the user's explicit decision in
+FULL / INTERMEDIATE, never silently in MINIMAL / AUTO.
 
 ## Team Shutdown
 


### PR DESCRIPTION
Realizes spec 0026 (+ delta-01, delta-02): rewrites Team Communication Rule 4 so non-blocking findings route by interaction mode — FULL/INTERMEDIATE present to the user, MINIMAL/AUTO auto-route. Independent of the spec-PRs; closes #281.

## How to read this PR?

One file, `docs/agent-team-protocol.md`, one rule rewritten (Rule 4). Compare against `specs/0005-retroactive-routing-engine.md` R10 and `docs/retroactive-loop.md` → *Non-blocking conditional routing*: the three now state the same model.

## How to test this PR?

- `npx markdownlint-cli docs/agent-team-protocol.md` → clean.
- Confirm Rule 4's two bullets match spec 0005 R10 exactly (FULL/INTERMEDIATE consult; MINIMAL/AUTO auto-route).
- Confirm no other rule, template, or tier changed.

## Detailed description (for agents)

The previous Rule 4 was **unconditional** ("present every finding to the user… unless the user explicitly decides to skip or defer"), which both over-gated the autonomous modes and silently disagreed with the deliberate spec 0005 R10 design. This rewrite makes it mode-conditional:

- **FULL / INTERMEDIATE** — blocking findings auto-route; non-blocking findings are presented to the user, only accepted ones routed, the rest journalled (spec 0005 R10, FULL/INTERMEDIATE branch). This is the friction #281 behavior for the interactive modes — deliberate, not a defect.
- **MINIMAL / AUTO** — every finding auto-routes; non-blocking becomes blocking; only the merge gate remains (spec 0005 R10, MINIMAL/AUTO branch). This resolves friction #281 for the autonomous modes, where the old unconditional rule wrongly demanded a user consult.

`docs/retroactive-loop.md` already implemented spec 0005 R10 and is left unchanged. No change to AGENTS.md, tiers, or templates.

### Known follow-up (out of scope here)

A separate, real tension remains between **spec 0006**'s `(mode × stage)` matrix (which labels the INTERMEDIATE REVIEW cell "autonomous, no gate") and **spec 0005 R10** (which has INTERMEDIATE consult the user on non-blocking findings). Reconciling those two merged specs is a deliberate architectural decision beyond #281's scope and is intentionally **not** resolved by silently reinterpreting the matrix here. Recommend a dedicated ticket.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)