### PR TITLE
📝 Add spec 0005.delta-01 — only FULL consults on non-blocking findings

### DIFF
--- a/specs/0005-retroactive-routing-engine.delta-01.md
+++ b/specs/0005-retroactive-routing-engine.delta-01.md
@@ -1,0 +1,55 @@
+---
+id: "0005"
+slug: retroactive-routing-engine
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 288
+version: 2.0.0
+---
+
+# Automatic retroactive routing engine
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+Requirement 10 is replaced. The original placed **INTERMEDIATE** on the
+"present non-blocking findings to the user" branch alongside FULL, which
+conflicts with the `AGENTS.md` `(mode × stage)` matrix (spec 0006), where
+the INTERMEDIATE REVIEW cell is autonomous. The canonical model chosen for
+issue #288 is **Option Z**: only FULL consults the user on non-blocking
+findings; INTERMEDIATE joins MINIMAL and AUTO on the auto-route branch.
+
+Original R10:
+
+```text
+10. Non-blocking findings SHALL be routed conditionally by mode:
+    - FULL / INTERMEDIATE — the orchestrator SHALL present every
+      non-blocking finding to the user (Rule 4) and route only those
+      the user accepts to the loop; the rest are journalled in the
+      logbook and left unactioned.
+    - MINIMAL / AUTO — the orchestrator SHALL route every non-blocking
+      finding into the loop using the same matrix; in autonomous modes
+      there is no user to defer to, so non-blocking findings become
+      blocking by default.
+```
+
+Replacement R10:
+
+```text
+10. Non-blocking findings SHALL be routed conditionally by mode:
+    - FULL — the orchestrator SHALL present every non-blocking finding
+      to the user (Rule 4) and route only those the user accepts to the
+      loop; the rest are journalled in the logbook and left unactioned.
+    - INTERMEDIATE / MINIMAL / AUTO — the orchestrator SHALL route every
+      non-blocking finding into the loop using the same matrix as
+      blocking findings; in these modes the REVIEW loop fires no user
+      gate, so non-blocking findings become blocking by default.
+```
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec for #288 (Option Z): narrows spec 0005 R10 so only FULL presents non-blocking findings to the user; INTERMEDIATE joins MINIMAL/AUTO on the auto-route branch. Pairs with spec 0006.delta-01.

## How to read this PR?

Single new file: `specs/0005-retroactive-routing-engine.delta-01.md`. `## MODIFIED` quotes the original R10 and the replacement — the only change is INTERMEDIATE moving from the "present to user" branch to the "auto-route" branch.

## How to test this PR?

- `npx markdownlint-cli specs/0005-retroactive-routing-engine.delta-01.md` → clean.
- Delta sections present in order; `version` `2.0.0`.

## Detailed description (for agents)

Realizes the #288 decision (Option Z — only FULL consults the user on optional/non-blocking findings). R10's FULL/INTERMEDIATE "present" branch becomes FULL-only; INTERMEDIATE auto-routes like MINIMAL/AUTO. The companion `specs/0006-interaction-modes-and-sizing.delta-01.md` pins the matching REVIEW gate contract; the implementation-PR updates `AGENTS.md` (matrix REVIEW row), `docs/agent-team-protocol.md` (Rule 4), and `docs/retroactive-loop.md` (table + worked example).

Refs #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)