### PR TITLE
📝 Add spec 0006.delta-01 — pin REVIEW user-gate contract (FULL-only triage)

### DIFF
--- a/specs/0006-interaction-modes-and-sizing.delta-01.md
+++ b/specs/0006-interaction-modes-and-sizing.delta-01.md
@@ -1,0 +1,39 @@
+---
+id: "0006"
+slug: interaction-modes-and-sizing
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 288
+version: 2.0.0
+---
+
+# Interaction modes and complexity-based team sizing
+
+## ADDED
+
+The reconciliation chosen for issue #288 (Option Z) pins the REVIEW-stage
+user-gate contract that was previously left implicit in the `AGENTS.md`
+matrix and contradicted by spec 0005 R10. This delta adds that contract as
+a normative requirement so the gate semantics are owned by this spec — the
+interaction-mode authority — rather than asserted only in operational doc.
+
+```text
+10. The REVIEW-stage user-gate contract SHALL be: in FULL mode the
+    orchestrator SHALL fire a bounded AskUserQuestion to triage the
+    non-blocking findings of a REVIEW pass (per spec 0005 R10, FULL
+    branch), in addition to the per-iteration non-blocking notification;
+    in INTERMEDIATE, MINIMAL, and AUTO modes the REVIEW loop SHALL fire
+    no user gate. The AGENTS.md (mode x stage) matrix SHALL reflect this
+    contract in its REVIEW row, and the bounded FULL triage
+    AskUserQuestion SHALL be the sole exception to the prior "REVIEW
+    fires no AskUserQuestion" reading of the FULL cell.
+```
+
+## MODIFIED
+
+(none)
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec for #288 (Option Z): adds R10 to spec 0006 fixing the REVIEW-stage gate contract — FULL fires a bounded triage AskUserQuestion on non-blocking findings, INTERMEDIATE/MINIMAL/AUTO fire no REVIEW gate. Pairs with spec 0005.delta-01.

## How to read this PR?

Single new file: `specs/0006-interaction-modes-and-sizing.delta-01.md`. `## ADDED` introduces R10 — the gate contract is now owned by spec 0006 (the interaction-mode authority) instead of asserted only in `AGENTS.md` prose.

## How to test this PR?

- `npx markdownlint-cli specs/0006-interaction-modes-and-sizing.delta-01.md` → clean.
- Delta sections present in order; `version` `2.0.0`.

## Detailed description (for agents)

The #288 contradiction was that `AGENTS.md`'s matrix said FULL REVIEW fires no AskUserQuestion while spec 0005 R10 had FULL (and INTERMEDIATE) consult. Option Z resolves it: only FULL consults, via a bounded per-pass triage AskUserQuestion. This delta records that contract as spec 0006 R10 so the gate semantics are spec-owned. The implementation-PR then updates the `AGENTS.md` matrix REVIEW row, `docs/agent-team-protocol.md` Rule 4, and `docs/retroactive-loop.md` to match.

Refs #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)