### PR TITLE
📝 Reconcile REVIEW non-blocking gating: only FULL consults (Option Z)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,7 +340,7 @@ post hoc).
 | **SPECS** | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | No interview gate (spec authored autonomously); merge-authorization gate before merging the spec-PR. |
 | **PLAN** | `AskUserQuestion` to validate the plan comment before DEV starts; second `architect` cold-review remains autonomous. | `AskUserQuestion` to validate the plan comment before DEV starts; second `architect` cold-review remains autonomous. | — (plan authored and cold-reviewed autonomously; DEV starts on APPROVE without user prompt). | — (plan authored and cold-reviewed autonomously). |
 | **DEV** | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). |
-| **REVIEW** | Non-blocking notification posted on the logbook issue at the start and end of every iteration (per the FULL-mode rule above). No `AskUserQuestion`. | — (loop runs autonomously; iteration count visible via the `iter:N` PR label). | — (loop runs autonomously). | — (loop runs autonomously; halt at max-iteration guardrail pages the user per *Retroactive review loop*). |
+| **REVIEW** | Non-blocking notification posted on the logbook issue at the start and end of every iteration (per the FULL-mode rule above), **plus** a bounded `AskUserQuestion` to triage the non-blocking findings of each pass (spec 0006 R10 / spec 0005 R10 FULL branch). That triage is the sole REVIEW-loop gate. | — (loop runs autonomously; iteration count visible via the `iter:N` PR label). | — (loop runs autonomously). | — (loop runs autonomously; halt at max-iteration guardrail pages the user per *Retroactive review loop*). |
 
 Notes on the matrix:
 
@@ -348,9 +348,11 @@ Notes on the matrix:
   mode, including AUTO, MUST ask the user before any `gh pr merge`.
   *Branching Strategy* is not waivable.
 - FULL-mode REVIEW notifications are non-blocking — posting them does
-  not pause the loop. They are listed under "REVIEW" only because
-  they are the FULL-mode-specific surface the orchestrator must
-  produce; they are not gates.
+  not pause the loop. The one FULL-mode REVIEW gate is the bounded
+  non-blocking-finding triage `AskUserQuestion` (spec 0006 R10), under
+  which only FULL consults the user on optional findings; INTERMEDIATE,
+  MINIMAL, and AUTO fire no REVIEW gate. The per-iteration notifications
+  themselves are not gates.
 - The max-iteration guardrail (*Retroactive review loop*) pages the
   user in **every** mode, including AUTO. That paging is a gate by
   exception — the loop has halted and the user must decide whether

--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -375,19 +375,21 @@ are routed conditionally on the ticket's declared interaction mode (see
 R10 and the table in [`docs/retroactive-loop.md`](retroactive-loop.md) →
 *Non-blocking conditional routing*:
 
-- **FULL / INTERMEDIATE.** The team-lead MUST present every non-blocking
-  finding to the user and route only those the user accepts into the fix
-  cycle; the rest are journalled in the logbook and left unactioned. The
-  user sets the scope, not the reviewer's severity labels.
-- **MINIMAL / AUTO.** The team-lead MUST route every finding — blocking and
-  non-blocking — into the fix cycle automatically, in the same session,
-  with no user gate other than the merge authorization; in the autonomous
-  modes there is no user to defer to, so non-blocking findings become
-  blocking by default.
+- **FULL.** The team-lead MUST present every non-blocking finding to the
+  user and route only those the user accepts into the fix cycle; the rest
+  are journalled in the logbook and left unactioned. The user sets the
+  scope, not the reviewer's severity labels. This bounded per-pass triage
+  is the sole REVIEW-loop user gate (see *Interaction modes → User-gate
+  definition* in AGENTS.md and spec 0006 R10).
+- **INTERMEDIATE / MINIMAL / AUTO.** The team-lead MUST route every finding
+  — blocking and non-blocking — into the fix cycle automatically, in the
+  same session, with no user gate other than the merge authorization; in
+  these modes the REVIEW loop fires no triage prompt, so non-blocking
+  findings become blocking by default.
 
 In no mode may a finding be deferred to a follow-up ticket without
 authorization appropriate to that mode — the user's explicit decision in
-FULL / INTERMEDIATE, never silently in MINIMAL / AUTO.
+FULL, never silently in INTERMEDIATE / MINIMAL / AUTO.
 
 ## Team Shutdown
 

--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -207,33 +207,32 @@ the lifecycle's interaction mode (spec 0005 R10):
 | Mode | Non-blocking finding handling |
 |---|---|
 | **FULL** | Apply `AGENTS.md` → *Team Communication → Rule 4*: the orchestrator presents every non-blocking finding to the user and routes only those the user accepts into the loop. Findings the user defers are journalled in the logbook and left unactioned. |
-| **INTERMEDIATE** | Same as FULL — Rule 4 applies; the user decides. |
-| **MINIMAL** | The orchestrator SHALL route every non-blocking finding into the loop using the same precedence matrix as blocking findings. In autonomous modes there is no user to defer to. |
+| **INTERMEDIATE** | The orchestrator SHALL route every non-blocking finding into the loop using the same precedence matrix as blocking findings; the REVIEW loop fires no user gate (spec 0005 R10 as amended for #288). |
+| **MINIMAL** | Same as INTERMEDIATE — every non-blocking finding is routed via the precedence matrix; no user gate. |
 | **AUTO** | Same as MINIMAL — non-blocking becomes effectively blocking, routed via the matrix. |
 
-The asymmetry reflects the lifecycle's gating philosophy: modes that
-keep the user in the loop give the user the last word on scope; modes
-that explicitly delegate scope to the engine route every signal
-through the matrix so that termination genuinely means "no work
-left", not "no work the engine bothered to do".
+The asymmetry reflects the lifecycle's gating philosophy: only FULL
+keeps the user in the loop during REVIEW and gives the user the last
+word on scope; every other mode delegates scope to the engine and
+routes every signal through the matrix so that termination genuinely
+means "no work left", not "no work the engine bothered to do".
 
 ## Worked example — PR #183 iteration 2
 
 The closest live fixture is the second iteration of PR #183 (the
 plan-format ticket, issue #169), where the cold review surfaced three
-non-blocking findings under `INTERMEDIATE` mode. Per the table above,
-the orchestrator applied Rule 4: each finding was presented to the
-user, who decided which to absorb in-session and which to journal.
-The PR merged after the user-accepted findings landed.
+non-blocking findings under `INTERMEDIATE` mode. Under the model as
+amended for #288, INTERMEDIATE fires no REVIEW gate, so the engine
+routes all three findings into the loop using the same precedence
+matrix as blocking findings — none are presented to the user for a
+keep-or-defer decision. Had the same findings surfaced under `FULL`,
+the orchestrator would instead present them for a bounded per-pass
+triage and route only the ones the user accepts (per the table above).
 
 The fixture predates this spec's `iter:N` label convention — the
 label was not applied retroactively — so readers should treat the
-example as a *retrofit* ("had the engine existed, here is how it
-would have routed") rather than a literal record of label state.
-The substantive routing decision the example demonstrates — three
-non-blocking findings, INTERMEDIATE mode, Rule 4 deciding which
-absorb and which defer — is the engine's intended behavior
-unchanged.
+example as a *retrofit* ("had the engine existed, here is how it would
+route today") rather than a literal record of label state.
 
 - <https://github.com/crewrig/crewrig/pull/183>
 


### PR DESCRIPTION
Realizes the #288 decision (Option Z): only FULL consults the user on optional/non-blocking findings during REVIEW; INTERMEDIATE, MINIMAL, and AUTO auto-route. Brings Rule 4, the AGENTS.md matrix, and the retroactive-loop.md table into agreement with the merged deltas on specs 0005 and 0006.

## How to read this PR?

Three files, all aligned to the same model:
1. `docs/agent-team-protocol.md` — Rule 4: FULL presents non-blocking findings (bounded per-pass triage = the sole REVIEW gate); INTERMEDIATE/MINIMAL/AUTO auto-route.
2. `AGENTS.md` — `(mode × stage)` matrix REVIEW row: FULL cell gains the bounded triage `AskUserQuestion`; the notes bullet updated.
3. `docs/retroactive-loop.md` — *Non-blocking conditional routing* table (INTERMEDIATE → auto-route), the asymmetry prose, and the PR #183 worked example updated.

## How to test this PR?

- `npx markdownlint-cli docs/agent-team-protocol.md AGENTS.md docs/retroactive-loop.md` → clean.
- Cross-check the three against `specs/0005-retroactive-routing-engine.delta-01.md` (R10) and `specs/0006-interaction-modes-and-sizing.delta-01.md` (R10): all four sources now say FULL-only consult.
- Confirm no other rule, tier, or template changed.

## Detailed description (for agents)

Implements Option Z from #288 (the canonical model chosen by the user). Before this PR, three artifacts disagreed on INTERMEDIATE: spec 0005 R10 had it consult, the AGENTS.md matrix had it autonomous. The merged deltas (0005.delta-01, 0006.delta-01) set the canonical model to **only FULL consults**; this PR makes the operational docs match.

- **Rule 4** (`agent-team-protocol.md`): FULL branch = present non-blocking findings, route accepted, journal rest (bounded per-pass triage, the sole REVIEW-loop gate); INTERMEDIATE/MINIMAL/AUTO branch = auto-route every finding, non-blocking becomes blocking.
- **AGENTS.md matrix**: FULL REVIEW cell now reads "notification … **plus** a bounded `AskUserQuestion` to triage non-blocking findings"; the notes bullet records that FULL is the only mode with a REVIEW gate.
- **retroactive-loop.md**: INTERMEDIATE row moved to auto-route; asymmetry prose narrowed to "only FULL"; the PR #183 worked example reframed (under the amended model INTERMEDIATE auto-routes all three findings).

`specs/` are untouched here (the amendments shipped as the merged deltas). Not under `artifacts/`, so no `build-components.sh` run required. AGENTS.md is not in the CLI-matrix trigger list, so no `docs/cli-matrix.md` update is required.

Note on branch naming: this impl realizes two delta-specs (0005, 0006) rather than a single spec id, so the branch is named after the issue (`docs/0288-…`) rather than one spec id.

Closes #288