### PR TITLE
📝 Author overview pages for the four empty doc sections (spec 0028)

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -1,0 +1,101 @@
+# Authoring skills, agents & commands
+
+<!-- crewrig-doc: section=authoring nav_order=10 published=true title="Authoring skills, agents & commands" -->
+
+Skills, agents, and commands are CrewRig's reusable agent capabilities. The
+core idea is **author once, compile everywhere**: you write a single Markdown
+source file with YAML frontmatter, and `scripts/build-components.sh` generates
+the tool-specific outputs for Gemini CLI, Claude Code, and GitHub Copilot CLI.
+This page is the conceptual overview; the normative format contract lives in
+[`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
+
+## The single-source zone
+
+All authored components live under `artifacts/`, organized into tiers that
+declare ownership and deployment scope:
+
+| Tier | Owner | Purpose |
+|------|-------|---------|
+| `core/` | Upstream CrewRig | SDLC lifecycle tools and illustrative role skills/agents. Deployed to project scope. |
+| `library/` | Upstream CrewRig | Harness machinery (`harness-report`, `harness-curator`). Deployed to user-home scope. |
+| `community/` | Adopting organization | Sandbox for the organization's own skills, agents, commands, hooks, policies, and themes — not yet validated. |
+| `org/` | Adopting organization | Components promoted from `community/` after internal review. |
+
+The layer ownership and synchronization rules for these tiers are part of the
+[Layer taxonomy and boundary contract](layers.md).
+
+## Component types
+
+Three component types share the single-source pipeline:
+
+| Type | Source location | What it is |
+|------|-----------------|------------|
+| Skill | `<tier>/skills/<name>/SKILL.md` | Reusable agent behavior, activatable via `/skill-name`. |
+| Agent | `<tier>/agents/<name>/AGENT.md` | A sub-agent with a dedicated persona and system prompt. |
+| Command | `<tier>/commands/<name>.md` | A slash command with a prompt body. |
+
+A skill may ship optional resource subfolders alongside its `SKILL.md` —
+`scripts/`, `references/`, and `assets/` — which are propagated verbatim to the
+build outputs. The complete list of supported types, the frontmatter field
+reference, and the validation rules are in
+[`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
+
+## The source file
+
+Every source is Markdown with YAML frontmatter. Three universal fields are
+required — `name`, `description`, and `type` — and the body after the
+frontmatter is the prompt content shared across all tools. Tool-specific
+overrides are optional and only needed when a tool requires metadata beyond the
+universal fields (for example, Claude Code's `allowed-tools`). The body is never
+duplicated: it is written once and wrapped into each tool's format at build
+time.
+
+```markdown
+---
+name: my-skill
+description: "Brief description used for discovery and activation"
+type: skill
+---
+
+# My Skill
+
+Prompt content here — shared across all tools, written once.
+```
+
+## The build
+
+`scripts/build-components.sh` is the compiler. It is tier-agnostic: it discovers
+every tier directory under `artifacts/` and compiles each one, routing the
+output by tier. Core components are written into the committed project tree
+(`.claude/`, `.gemini/`, `.github/`); non-core tiers are written into a
+gitignored staging tree from which the setup scripts install to the user home.
+
+```bash
+task build-components           # All tools
+task build-components-gemini    # Gemini CLI only
+task build-components-claude    # Claude Code only
+task check-components           # Drift detection (used in CI)
+```
+
+A drift check (`--check`) verifies that the committed outputs match what the
+sources would generate, so a build output cannot silently fall out of sync with
+its source. The full invocation reference is in
+[`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
+
+## Provenance and versioning
+
+Each component carries a `metadata.provenance` block recording its canonical
+repository, its feedback target, and its version. The `version` field follows
+Semantic Versioning, and any change to a shipped source must bump it in the same
+diff — a CI gate (`scripts/check-skill-versions.sh`) enforces this. The
+provenance block is what lets feedback flow back to the right repository after a
+fork and what lets the harness loop pin the contract observed when a friction
+was reported. The forking workflow, placeholder resolution, and version
+semantics are detailed in [`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
+
+## Where to read next
+
+- The normative format contract: [`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
+- How tiers are owned and synced: [Layer taxonomy and boundary contract](layers.md).
+- The harness components you may author against:
+  [Harness engineering](harness-engineering.md).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,87 @@
+# Core concepts
+
+<!-- crewrig-doc: section=concepts nav_order=10 published=true title="Core concepts" -->
+
+This page introduces the five concepts that recur throughout CrewRig at a
+conceptual level. Each links to the detailed documentation that specifies it
+normatively; the goal here is shared vocabulary, not exhaustive coverage.
+
+## The layered context system
+
+An AI assistant's behavior is shaped by a stack of context files, each
+addressing one concern and combined in a fixed priority order. CrewRig organizes
+them with a numeric prefix from `00` to `60`:
+
+| Priority | Source | Concern |
+|----------|--------|---------|
+| 00 | `config/SOUL.md` | Agent identity and values |
+| 10 | `config/level/<LEVEL>.md` | Seniority-adapted guidance |
+| 20 | `config/ORGANIZATION.md` | Company-wide policies |
+| 30 | `config/PROFILE.md` | Personal information |
+| 40 | `config/expertise/<ROLE>.md` | Technical specialization |
+| 50 | `config/teams/<TEAM>.md` | Team practices and norms |
+| 60 | `config/TOOLS.md` | Memory architecture and MCP servers |
+
+The three supported tools consume the same source files but load them
+differently: Gemini CLI uses numeric-prefix files in `~/.gemini/` with enforced
+priority order, Claude Code combines them additively from `~/.claude/rules/`, and
+GitHub Copilot CLI applies them as `*.instructions.md` files in
+`~/.copilot/instructions/`. The build pipeline that reconciles these differences
+is documented in the [CLI support matrix](cli-matrix.md).
+
+## Core, overlay, and examples layering
+
+Every path in the repository belongs to exactly one of three layers, which
+governs who owns it and how an upstream synchronization treats it:
+
+- **`core`** — owned by the upstream CrewRig project. Adopting organizations do
+  not modify these paths; upstream updates land here cleanly.
+- **`overlay`** — owned by the adopting organization. Upstream updates never
+  touch these paths.
+- **`examples`** — illustrative templates the upstream project ships. An
+  organization may copy and adapt them, but is not expected to extend them in
+  place.
+
+This boundary contract is what lets an organization fork CrewRig, customize its
+own surface, and still pull upstream improvements without merge conflicts. The
+authoritative classification of every path — including the `adopt-on-edit`
+policy for catalogs like `config/expertise/` and `config/teams/` — lives in the
+[Layer taxonomy and boundary contract](layers.md).
+
+## Multi-CLI parity
+
+CrewRig implements each feature symmetrically across Gemini CLI, Claude Code, and
+GitHub Copilot CLI. Silent asymmetry is prohibited: where a feature cannot be
+mirrored on a given tool, the gap must be justified with concrete evidence that
+the target tool lacks the mechanism, rather than left unexplained. The per-tool
+integration points, parity checks, and gap-acceptance evidence are tracked in
+the [CLI support matrix](cli-matrix.md).
+
+## Shared cross-tool memory
+
+CrewRig uses a three-tier memory model so that knowledge an agent builds up
+persists and travels across tools:
+
+| Tier | System | Role | Persistence |
+|------|--------|------|-------------|
+| 1 | Sequential Thinking | Working memory (ephemeral) | Session only |
+| 2 | MemPalace | Agent memory (persistent) | Cross-session, cross-tool |
+| 3 | Obsidian | User knowledge base | Read free, write user-controlled |
+
+MemPalace is the tier that makes memory *shared*: it is read/write and visible
+across Gemini CLI, Claude Code, and Copilot CLI, so a decision recorded during a
+Claude Code session can be recovered later from Gemini CLI. The full memory
+protocol — how agents activate memory at session start, the wing/room/drawer
+structure, and the cross-tool task-handoff convention — is specified in the
+framework's tool rules (the priority-60 core rules file).
+
+## The harness feedback loop
+
+The harness turns frictions agents hit during real work into tracked
+improvements. When a recognition signal fires (for example, the user reverts the
+agent's action, or a tool surprises the agent a second time), the agent invokes
+the `harness-report` skill to tag the friction into a global memory wing. The
+`harness-curator` skill later clusters those tags and opens one descriptive
+GitHub issue per cluster, which is then fixed through the normal branch/PR
+workflow. The loop is covered in depth on the
+[Harness engineering](harness-engineering.md) page.

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -1,0 +1,93 @@
+# Harness engineering
+
+<!-- crewrig-doc: section=harness-engineering nav_order=10 published=true title="Harness engineering" -->
+
+The crew of agents CrewRig deploys is not static. When an agent hits a sharp
+edge during real work — a misleading prompt, a tool that does the wrong thing,
+an output format that breaks downstream parsing — that signal needs to reach the
+people who maintain the agent system, or the same friction repeats forever.
+Harness engineering is the built-in feedback loop that captures those signals
+and turns them into tracked work.
+
+This page is the conceptual overview. The two skills that implement the loop are
+`harness-report` and `harness-curator`, both under
+[`artifacts/library/skills/`](../artifacts/library/skills/).
+
+## The loop
+
+Frictions become shipped improvements through a four-stage loop:
+
+1. **Tag** — during real work, an agent invokes the `harness-report` skill the
+   moment a recognition signal fires. Each tag lands as a structured entry in
+   the global `harness-friction` memory wing.
+2. **Cluster** — the `harness-curator` skill reads the tagged frictions,
+   clusters them by subcategory, and opens one descriptive GitHub issue per
+   cluster against the repository declared in each component's provenance block.
+3. **Fix** — the issues are addressed through the normal branch/PR workflow; the
+   internal agent crew handles the implementation cycle.
+4. **Re-install** — after a fix ships, the build is regenerated and reinstalled.
+   The `metadata.provenance.version` bump in every modified source signals that
+   a new version is available.
+
+The tagging step is **fire-and-forget**: the reporting agent does not block or
+wait for an acknowledgment. It tags the friction and returns to the task. Reading
+the friction wing is the curator's job, not the working agent's.
+
+## Recognition signals — when to tag
+
+A friction is tagged when one of a fixed set of recognition signals fires.
+Tagging is mandatory the moment a signal fires, not optional or deferred:
+
+- **User pushback** — the user contests, corrects, or reverts the agent's
+  action, or reformulates the same intent because the previous response was
+  misaligned.
+- **Sibling-skill workaround** — the agent contorts around a constraint set by
+  another skill or agent, not by the user's request.
+- **Tool surprise (second time)** — a tool behaves surprisingly or
+  inconsistently for the second time in a session. First time is bad luck;
+  second is a pattern.
+- **Process gap** — a documented workflow step turns out to be missing,
+  ambiguous, contradictory, or out of date.
+- **Safeguard friction** — a rule or guard blocks a legitimate action and forces
+  a workaround the agent had to explain to the user.
+
+When in doubt, tag. Over-reporting is curatable; an un-reported friction that
+bites the next agent is the failure mode the loop exists to prevent.
+
+## The friction taxonomy
+
+Every friction is filed into exactly one of five fixed categories, which become
+the memory room it is written to. Finer sub-categorization is free-form inside
+the payload (a `subcategory:` field used as the clustering key):
+
+| Category | Used for |
+|----------|----------|
+| `tool` | An MCP tool, CLI, or script behaved unexpectedly or has a sharp edge. |
+| `prompt` | A skill or agent prompt was misleading, ambiguous, or led the agent astray. |
+| `format` | An output format broke parsing, mixed concerns, or was hard to consume. |
+| `behavior` | The agent did something it should not have, or skipped something it should have done. |
+| `process` | A documented workflow step is missing, contradictory, or out of date. |
+
+Each friction carries a structured payload — at minimum a non-empty
+`writer_agent` and one `evidence:` entry, plus optional `canonical`, `severity`,
+and `suggestion` fields. The full payload schema, the recognition-signal
+definitions, and the rules for what *not* to tag are specified normatively in
+the framework's tool rules (the priority-60 core rules file), which the
+`harness-report` skill operationalizes.
+
+## What not to tag
+
+The loop is for defects in the *agent system itself*, not for everything that
+goes wrong:
+
+- One-off mistakes the agent made that the system did not cause belong in the
+  agent's diary, not the friction wing.
+- Bugs in the user's code under review belong in the project logbook issue.
+- Missing features belong in a regular GitHub issue, not a friction report.
+
+## Where to read next
+
+- The reporting skill: [`artifacts/library/skills/harness-report/SKILL.md`](../artifacts/library/skills/harness-report/SKILL.md).
+- The curator skill: [`artifacts/library/skills/harness-curator/SKILL.md`](../artifacts/library/skills/harness-curator/SKILL.md).
+- How these components are owned and deployed:
+  [Layer taxonomy and boundary contract](layers.md).

--- a/docs/index.json
+++ b/docs/index.json
@@ -2,6 +2,28 @@
   "version": 1,
   "sections": [
     {
+      "section": "introduction",
+      "title": "Introduction",
+      "pages": [
+        {
+          "title": "Introduction",
+          "path": "docs/introduction.md",
+          "nav_order": 10
+        }
+      ]
+    },
+    {
+      "section": "concepts",
+      "title": "Concepts",
+      "pages": [
+        {
+          "title": "Core concepts",
+          "path": "docs/concepts.md",
+          "nav_order": 10
+        }
+      ]
+    },
+    {
       "section": "adoption",
       "title": "Adoption",
       "pages": [
@@ -18,12 +40,34 @@
       ]
     },
     {
+      "section": "authoring",
+      "title": "Authoring",
+      "pages": [
+        {
+          "title": "Authoring skills, agents & commands",
+          "path": "docs/authoring.md",
+          "nav_order": 10
+        }
+      ]
+    },
+    {
       "section": "lifecycle",
       "title": "Lifecycle",
       "pages": [
         {
           "title": "Retroactive review loop",
           "path": "docs/retroactive-loop.md",
+          "nav_order": 10
+        }
+      ]
+    },
+    {
+      "section": "harness-engineering",
+      "title": "Harness engineering",
+      "pages": [
+        {
+          "title": "Harness engineering",
+          "path": "docs/harness-engineering.md",
           "nav_order": 10
         }
       ]

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,81 @@
+# Introduction
+
+<!-- crewrig-doc: section=introduction nav_order=10 published=true title="Introduction" -->
+
+CrewRig is a centralized configuration framework for three command-line AI
+coding assistants — [Gemini CLI](https://github.com/google-gemini/gemini-cli),
+[Claude Code](https://claude.ai/code), and
+[GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-in-the-cli).
+Rather than configuring each tool by hand and re-doing the work for every
+teammate and every project, CrewRig holds a single source of truth and compiles
+it into the directory layout each tool expects.
+
+This page is the orientation a newcomer needs: what the framework is, the five
+pillars it stands on, and where to read next.
+
+## The mental model
+
+CrewRig sits **between** you and the AI assistants. You edit source files once,
+in this repository; build and setup scripts deploy them into each tool's
+configuration directory (`~/.gemini/`, `~/.claude/rules/`,
+`~/.copilot/instructions/` for context, plus project-scoped outputs for skills
+and agents). Three concerns share that pipeline:
+
+- **Who the assistant is for you** — a layered stack of context files that
+  encode your identity, seniority, team, role, and tooling.
+- **What capabilities it has** — reusable skills, agents, and commands authored
+  once and compiled to every tool.
+- **How the framework improves itself** — a feedback loop where agents report
+  the frictions they hit, and those reports become tracked work.
+
+CrewRig develops itself using its own mechanics: the internal agent crew
+(architect, developer, tester, pr-logbook, pr-reviewer) runs on the same skills
+and agents that ship with the framework. The development workflow is the product
+in action.
+
+## The five pillars
+
+Every agent and contributor should understand these five pillars. They are the
+load-bearing ideas; the rest of the documentation elaborates them.
+
+1. **Layered context system engineering** — priority-ordered context files
+   (numbered 00–60) deployed to each tool's user directory shape how the
+   assistant behaves for a specific user's identity, role, team, and seniority.
+2. **Shared cross-tool memory** — MemPalace provides persistent agent memory
+   that survives across sessions and across tools, so context built up in one
+   CLI is available in another.
+3. **Skill, agent, and command authoring** — `artifacts/` is the single-source
+   zone where these components are written once and compiled by
+   `scripts/build-components.sh` into outputs for all three supported tools.
+4. **Harness engineering** — a built-in feedback loop where agents invoke the
+   `harness-report` skill to tag frictions during real work, and the
+   `harness-curator` skill clusters those frictions into actionable GitHub
+   issues.
+5. **Multi-CLI parity** — features are implemented symmetrically across the
+   three tools. Silent asymmetry is prohibited; every parity gap requires
+   concrete evidence that the missing mechanism does not exist in the target
+   tool.
+
+These five pillars are also stated normatively in
+[`AGENTS.md`](../AGENTS.md), the working-rules document every agent loads.
+
+## The development lifecycle
+
+Non-trivial work in CrewRig flows through a four-stage lifecycle —
+**SPECS → PLAN → DEV → REVIEW** — where a review pass routes findings back to
+the stage that can fix them, and the cycle terminates only when a full review
+produces zero findings. The full contract lives in
+[ADR-0010](adr/0010-spec-plan-review-lifecycle.md); the working rules layer the
+operational protocol on top of it in [`AGENTS.md`](../AGENTS.md).
+
+## Where to read next
+
+- New to the concepts? Read [Core concepts](concepts.md) for the layered
+  context system, the layering model, parity, memory, and the harness loop.
+- Adopting CrewRig for your organization? Start with the
+  [Adoption guide](adoption-guide.md), then the
+  [Layer taxonomy and boundary contract](layers.md).
+- Building your own components? See
+  [Authoring skills, agents & commands](authoring.md).
+- Curious how the framework improves itself? See
+  [Harness engineering](harness-engineering.md).


### PR DESCRIPTION
Adds one published overview page each for the four previously-empty doc sections — Introduction, Concepts, Authoring, and Harness engineering — and regenerates the documentation index (now 8 sections / 25 published pages). Realizes spec 0028 (a child spec of 0027).

## How to read this PR?

1. `docs/introduction.md` — what CrewRig is, the five pillars, mental model, lifecycle, where-to-read-next.
2. `docs/concepts.md` — layered context (00–60), core/overlay/examples, multi-CLI parity, MemPalace, the harness loop.
3. `docs/authoring.md` — author-once/compile-everywhere, the artifact tiers, component types, `build-components.sh`.
4. `docs/harness-engineering.md` — the four-stage loop, recognition signals, the five-category friction taxonomy.
5. `docs/index.json` — regenerated; the four sections now appear with their overview pages.

## How to test this PR?

```sh
bash scripts/build-docs-index.sh --check        # no drift + lint clean
bash scripts/tests/test-build-docs-index.sh     # 13/13
markdownlint "**/*.md" --ignore node_modules --ignore extension-skeleton --ignore communication
```

Expected: `--check` clean, 13/13, markdownlint green. The index lists all 8 sections; the new pages sit under their sections at `nav_order=10`.

## Detailed description (for agents)

- **Added** four overview pages, each with the spec-0027 metadata block (`section`, `nav_order=10`, `published=true`, `title`) immediately after the H1.
- **Accuracy / anti-fabrication:** every claim is sourced from `AGENTS.md` (five pillars, lifecycle), `README.md` (memory tiers, harness stages, build), `artifacts/FORMAT.md` (component format, build routing, provenance), `docs/layers.md` (core/overlay/examples), and the `harness-report` / `harness-curator` skills + `artifacts/core/rules/60-tools.md` (the friction taxonomy + recognition signals). No invented behavior, flags, or URLs (e.g. MemPalace is described, not linked, since the sources give no canonical URL).
- **Links, not duplication:** repo-root-relative Markdown links to existing docs (`concepts.md`, `adr/0010-spec-plan-review-lifecycle.md`, `../AGENTS.md`, `../artifacts/FORMAT.md`).
- **Regenerated** `docs/index.json` (21 → 25 published pages; 4 → 8 sections).
- No `artifacts/**` source changed (no version bump); docs are CLI-agnostic (no CLI-matrix change).

Note: surfacing these on crewrig.org/docs requires a deliberate `docs-pin.json` bump in the site repo (spec 0002) — a separate follow-up.

Closes #298