### PR TITLE
🐛 Raise Chroma daemon file-descriptor limits and reap orphaned wrappers

### DIFF
--- a/config/launchd/com.mempalace.chroma-server.plist
+++ b/config/launchd/com.mempalace.chroma-server.plist
@@ -27,6 +27,18 @@
     <key>KeepAlive</key>
     <true/>
 
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+
     <key>StandardOutPath</key>
     <string>__MEMPALACE_HOME__/chroma-server.log</string>
 

--- a/config/systemd/mempalace-chroma-server.service
+++ b/config/systemd/mempalace-chroma-server.service
@@ -9,6 +9,7 @@ WorkingDirectory=%h/.mempalace
 ExecStart=%h/.local/pipx/venvs/mempalace/bin/python3.13 %h/.local/pipx/venvs/mempalace/bin/chroma run --path %h/.mempalace/palace --host 127.0.0.1 --port 8001
 Restart=always
 RestartSec=3
+LimitNOFILE=65536
 StandardOutput=append:%h/.mempalace/chroma-server.log
 StandardError=append:%h/.mempalace/chroma-server.log
 

--- a/docs/runbooks/chroma-http-server.md
+++ b/docs/runbooks/chroma-http-server.md
@@ -45,6 +45,44 @@ restarts the daemon within seconds of a crash; the manual `start` and
   for the supervisor's own diagnostics.
 - **systemd specifics** — `journalctl --user -u mempalace-chroma-server`.
 
+### Applying the raised file-descriptor limit to a running daemon
+
+The shipped supervisor units declare an open-file floor of `65536`
+(launchd `SoftResourceLimits`/`HardResourceLimits` → `NumberOfFiles`;
+systemd `LimitNOFILE`). A fresh install inherits it automatically, but a
+daemon already running under the old unit keeps its previous limit until
+the supervisor re-execs it. Remediate an existing install without a host
+restart:
+
+- **macOS** — reload the launchd job so it re-reads the updated plist:
+
+  ```sh
+  launchctl bootout gui/$(id -u)/com.mempalace.chroma-server
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.mempalace.chroma-server.plist
+  ```
+
+- **Linux** — reload the unit definition and restart the service:
+
+  ```sh
+  systemctl --user daemon-reload
+  systemctl --user restart mempalace-chroma-server
+  ```
+
+Verify the new limit took effect by inspecting the running daemon's
+open-file limit:
+
+- **macOS** — `launchctl print gui/$(id -u)/com.mempalace.chroma-server`
+  reports the job's resource limits; look for the `number of files`
+  entry under the `inherited limits` / `hard/soft limits` section.
+
+- **Linux** — read the kernel's per-process limit:
+
+  ```sh
+  cat /proc/"$(pgrep -f 'chroma run')"/limits | grep 'Max open files'
+  ```
+
+Both should report `65536` (or higher) once the reload completes.
+
 ## Migrating from the legacy `PersistentClient` setup
 
 If you upgraded a working CrewRig install across the #98 boundary:

--- a/scripts/lib/mempalace-http-wrapper.py
+++ b/scripts/lib/mempalace-http-wrapper.py
@@ -26,6 +26,32 @@ design — it would re-introduce the corruption bug.
 """
 import os
 import sys
+import threading
+import time
+
+# ── Step 0: orphan self-reap watchdog (spec 0029 R5) ─────────────────────────
+# An MCP stdio server normally exits on stdin EOF: ``mempalace.mcp_server.main()``
+# loops on ``sys.stdin.readline()`` and breaks when it returns empty, which the
+# OS then releases the daemon-side ``HttpClient`` sockets for (sockets close on
+# process exit). That covers the common case where the parent agent session dies
+# and closes the write-end of the stdin pipe. But if the parent dies while some
+# other process keeps that pipe's write-end open, stdin never EOFs and the
+# orphaned wrapper lingers, holding its daemon connection open indefinitely —
+# the exact leak R5 forbids. This watchdog is a belt-and-suspenders guard for
+# that case: it polls ``os.getppid()`` and self-terminates when the parent is
+# reaped (reparented to PID 1 = orphaned). It deliberately does NOT read stdin,
+# so it cannot steal JSON-RPC bytes that ``main()`` owns. It uses ``os._exit``,
+# not ``sys.exit``: ``sys.exit`` only raises ``SystemExit`` in its own thread
+# and would not terminate the process from this daemon thread (cold-review
+# finding #2).
+def _reap_if_orphaned(poll_interval: float = 5.0) -> None:
+    while True:
+        time.sleep(poll_interval)
+        if os.getppid() == 1:
+            os._exit(0)
+
+
+threading.Thread(target=_reap_if_orphaned, daemon=True).start()
 
 # ── Step 1: patch BEFORE any mempalace import resolves chromadb ──────────────
 import chromadb as _chromadb

--- a/scripts/tests/test-chroma-fd-limits.sh
+++ b/scripts/tests/test-chroma-fd-limits.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-chroma-fd-limits.sh — Regression test for spec 0029.
+#
+# Spec 0029 (R1–R3) requires both shipped daemon supervisor units to
+# declare an open-file-descriptor floor of at least 65536, so a fresh
+# install inherits the raised limit without manual tuning:
+#
+#   - launchd: SoftResourceLimits AND HardResourceLimits, each carrying a
+#     NumberOfFiles >= 65536 (R1 soft, R2 hard).
+#   - systemd: LimitNOFILE >= 65536 (systemd's single scalar sets both
+#     soft and hard).
+#
+# This is a static config-assertion test (no daemon is started). It locks
+# the floor in place so a future refactor of either unit cannot silently
+# drop the limit and re-introduce the descriptor-exhaustion failure.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+FLOOR=65536
+
+note_pass() { echo "PASS  $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "FAIL  $1 — $2"; FAIL=$((FAIL + 1)); }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="${REPO_DIR}/config/launchd/com.mempalace.chroma-server.plist"
+SERVICE="${REPO_DIR}/config/systemd/mempalace-chroma-server.service"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: extract the <integer> value following a given limit <key> in the
+# plist. Matches:
+#   <key>SoftResourceLimits</key>
+#   <dict>
+#       <key>NumberOfFiles</key>
+#       <integer>65536</integer>
+#   </dict>
+# by scanning from the limit key to the first NumberOfFiles integer after it.
+# ─────────────────────────────────────────────────────────────────────────────
+plist_limit() {
+  local key="$1" file="$2"
+  awk -v key="$key" '
+    $0 ~ "<key>" key "</key>" { hot = 1; next }
+    hot && /<key>NumberOfFiles<\/key>/ { want = 1; next }
+    want {
+      if (match($0, /<integer>[0-9]+<\/integer>/)) {
+        v = substr($0, RSTART, RLENGTH)
+        gsub(/[^0-9]/, "", v)
+        print v
+        exit
+      }
+    }
+  ' "$file"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1 — launchd plist exists and declares the soft + hard floor.
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ ! -f "$PLIST" ]]; then
+  note_fail "launchd plist present" "missing $PLIST"
+else
+  soft="$(plist_limit SoftResourceLimits "$PLIST")"
+  hard="$(plist_limit HardResourceLimits "$PLIST")"
+
+  if [[ -n "$soft" ]] && (( soft >= FLOOR )); then
+    note_pass "launchd SoftResourceLimits NumberOfFiles >= ${FLOOR} (got ${soft})"
+  else
+    note_fail "launchd SoftResourceLimits NumberOfFiles >= ${FLOOR}" \
+      "got '${soft:-<absent>}'"
+  fi
+
+  if [[ -n "$hard" ]] && (( hard >= FLOOR )); then
+    note_pass "launchd HardResourceLimits NumberOfFiles >= ${FLOOR} (got ${hard})"
+  else
+    note_fail "launchd HardResourceLimits NumberOfFiles >= ${FLOOR}" \
+      "got '${hard:-<absent>}'"
+  fi
+
+  # R2: hard limit must be at least the soft limit so the soft limit is
+  # actually enforceable rather than capped below the intended value.
+  if [[ -n "$soft" && -n "$hard" ]] && (( hard >= soft )); then
+    note_pass "launchd hard limit >= soft limit (${hard} >= ${soft})"
+  else
+    note_fail "launchd hard limit >= soft limit" \
+      "soft='${soft:-<absent>}' hard='${hard:-<absent>}'"
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2 — systemd unit exists and declares LimitNOFILE >= floor.
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ ! -f "$SERVICE" ]]; then
+  note_fail "systemd unit present" "missing $SERVICE"
+else
+  nofile="$(grep -E '^[[:space:]]*LimitNOFILE=' "$SERVICE" \
+    | tail -n1 | sed -E 's/.*LimitNOFILE=([0-9]+).*/\1/')"
+  if [[ -n "$nofile" ]] && (( nofile >= FLOOR )); then
+    note_pass "systemd LimitNOFILE >= ${FLOOR} (got ${nofile})"
+  else
+    note_fail "systemd LimitNOFILE >= ${FLOOR}" "got '${nofile:-<absent>}'"
+  fi
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Realizes spec [0029](https://github.com/crewrig/crewrig/blob/main/specs/0029-chroma-daemon-fd-limits.md): the shared ChromaDB daemon no longer inherits the macOS default 256 open-file limit (which saturated after ~4 days and surfaced as MemPalace "No palace found"), and orphaned MCP wrapper processes self-reap so they stop leaking daemon sockets.

## How to read this PR?

1. `config/launchd/com.mempalace.chroma-server.plist` and `config/systemd/mempalace-chroma-server.service` — the core fix: declare a 65536 open-file floor on both supervisors (R1–R3).
2. `scripts/lib/mempalace-http-wrapper.py` — the socket-leak containment (R4–R5). Read the long comment block: `mempalace.mcp_server.main()` already exits on stdin EOF (the common orphan case), so this adds only a `getppid()`-poll watchdog for the residual case where the parent dies but the stdin write-end is held open elsewhere. It uses `os._exit` (a daemon thread cannot terminate the process via `sys.exit`) and never reads stdin (so it cannot steal JSON-RPC bytes `main()` owns).
3. `docs/runbooks/chroma-http-server.md` — live-reload procedure for an already-running daemon (R6).
4. `scripts/tests/test-chroma-fd-limits.sh` — static regression test locking the 65536 floor in both units.

## How to test this PR?

```sh
bash scripts/tests/test-chroma-fd-limits.sh   # expect: 4 passed, 0 failed
plutil -lint config/launchd/com.mempalace.chroma-server.plist   # expect: OK
python3 -c "import ast; ast.parse(open('scripts/lib/mempalace-http-wrapper.py').read())"
```

Deployment (applies the raised limit to the live daemon) follows the new runbook subsection: macOS `launchctl bootout`/`bootstrap`, Linux `systemctl --user daemon-reload && restart`.

## Detailed description (for agents)

- **launchd plist**: added `SoftResourceLimits` and `HardResourceLimits` dicts, each `NumberOfFiles` = 65536, after `KeepAlive`. Placeholders untouched; `plutil -lint` passes.
- **systemd unit**: added `LimitNOFILE=65536` in `[Service]` (systemd's single scalar sets both soft and hard).
- **`scripts/lib/common.sh`**: NO change — verified the macOS install path substitutes only the three `__…__` placeholders via `sed` and the Linux path is a straight `cp`, so the new keys pass through verbatim.
- **wrapper watchdog**: a `daemon=True` thread polls `os.getppid()` every 5s and calls `os._exit(0)` when reparented to PID 1 (orphaned). Sockets close on process exit, so termination alone releases the daemon-side fd — satisfying R4's "successive sessions" clause without an explicit close.
- **Blast radius**: CLI Matrix NOT triggered (`scripts/lib/**`, `config/launchd/**`, `config/systemd/**`, runbooks are absent from the trigger surface); no version bump (no `artifacts/` source); no build outputs; `scripts/build-components.sh` not run.

Closes #302