### PR TITLE
📝 Document per-tier feedback routing for forks

### DIFF
--- a/crewrig.config.toml
+++ b/crewrig.config.toml
@@ -10,6 +10,10 @@
 #   - Override `feedback_repo` so MRs from the harness curator land on
 #     their own internal repo, not the public upstream.
 #
+# `feedback_repo` scopes to ADOPTER-OWNED tiers only (artifacts/community,
+# artifacts/org, extensions/org). Upstream-owned components always route
+# feedback to `canonical_repo`. See artifacts/FORMAT.md (Provenance & Forks).
+#
 # See artifacts/FORMAT.md (Provenance Block) and issue #41 for context.
 
 canonical_repo = "https://github.com/crewrig/crewrig"

--- a/crewrig.config.toml.template
+++ b/crewrig.config.toml.template
@@ -22,4 +22,12 @@ canonical_repo = "https://github.com/<YOUR-ORG>/<YOUR-REPO>"
 # Override this with your organization's internal repo so that friction
 # issues land on your own tracker rather than the upstream project.
 # For most adopting orgs this will differ from canonical_repo.
+#
+# Scope: feedback_repo governs ADOPTER-OWNED tiers only (artifacts/community,
+# artifacts/org, extensions/org). Upstream-owned components (artifacts/core,
+# artifacts/library, extensions/core, extensions/library) always route feedback
+# to canonical_repo, regardless of this value — frictions on components you did
+# not author keep flowing to the repo that maintains them. See
+# artifacts/FORMAT.md (Provenance & Forks); enforced by
+# scripts/check-feedback-routing.sh.
 feedback_repo  = "https://github.com/<YOUR-ORG>/<YOUR-REPO>"

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -104,6 +104,17 @@ Replace both values:
   friction issues opened by the harness curator land on the organization's
   tracker, not on the upstream project.
 
+> **`feedback_repo` governs adopter-owned tiers only.** It redirects
+> feedback for the components *your* fork authors (`artifacts/community`,
+> `artifacts/org`, `extensions/org`). It has **no effect** on upstream-owned
+> components (`artifacts/core`, `artifacts/library`, `extensions/core`,
+> `extensions/library`): frictions on those always route to `canonical_repo`,
+> so overriding `feedback_repo` does **not** capture feedback on components you
+> did not author — that feedback keeps flowing upstream where the components are
+> maintained. This is by design (spec 0030) and enforced by
+> `scripts/check-feedback-routing.sh`. See
+> [`artifacts/FORMAT.md`](../artifacts/FORMAT.md) → *Provenance & Forks*.
+
 Commit the file:
 
 ```bash

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -90,8 +90,12 @@ Semantic Versioning, and any change to a shipped source must bump it in the same
 diff — a CI gate (`scripts/check-skill-versions.sh`) enforces this. The
 provenance block is what lets feedback flow back to the right repository after a
 fork and what lets the harness loop pin the contract observed when a friction
-was reported. The forking workflow, placeholder resolution, and version
-semantics are detailed in [`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
+was reported. The feedback target is resolved **per tier**: components in
+upstream-owned tiers (`core`, `library`) always route feedback to their
+`canonical` repository, while adopter-owned tiers (`community`, `org`) route to
+the fork's configured `feedback_repo`. The forking workflow, placeholder
+resolution, and version semantics are detailed in
+[`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
 
 ## Where to read next
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -83,5 +83,8 @@ agent's action, or a tool surprises the agent a second time), the agent invokes
 the `harness-report` skill to tag the friction into a global memory wing. The
 `harness-curator` skill later clusters those tags and opens one descriptive
 GitHub issue per cluster, which is then fixed through the normal branch/PR
-workflow. The loop is covered in depth on the
-[Harness engineering](harness-engineering.md) page.
+workflow. Where that issue lands depends on the component's tier: frictions on
+upstream-owned components (`core`, `library`) always reach the upstream
+repository, while frictions on a fork's own components (`community`, `org`)
+land on the fork's configured `feedback_repo`. The loop is covered in depth on
+the [Harness engineering](harness-engineering.md) page.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -192,7 +192,7 @@ from the examples layer.
 
 | Path | Description |
 |---|---|
-| `crewrig.config.toml` | Fork-level configuration: `canonical_repo`, `feedback_repo`, overlay path declarations. |
+| `crewrig.config.toml` | Fork-level configuration: `canonical_repo`, `feedback_repo` (scopes to adopter-owned tiers only — upstream-owned components always route feedback to `canonical_repo`), overlay path declarations. |
 | `config/ORGANIZATION.md` | Organization overview: company context, code quality standards, collaboration norms. |
 | `config/TOOLS.md` | Tool and MCP server guidelines specific to the organization. |
 


### PR DESCRIPTION
Propagates the per-tier feedback-routing rule (merged via spec 0030 / PR #307) to the adoption-facing surfaces. No new contract — prose is aligned to already-merged behavior in `artifacts/FORMAT.md` and `docs/cli-matrix.md`.

## How to read this PR?

Six small clarifying edits, all conveying one rule: `feedback_repo` governs **adopter-owned tiers only** (`artifacts/community`, `artifacts/org`, `extensions/org`); upstream-owned components (`artifacts/core`, `artifacts/library`, `extensions/core`, `extensions/library`) always route feedback to `canonical_repo`.

Read in this order:

1. `crewrig.config.toml.template` — the file forks copy and edit; highest-value clarification (the `feedback_repo` comment).
2. `crewrig.config.toml` — the canonical config's own header comment (brief mirror).
3. `docs/adoption-guide.md` — a blockquote carve-out right where adopters are told to set `feedback_repo`.
4. `docs/authoring.md` — per-tier nuance added to the provenance-block explanation.
5. `docs/concepts.md` — short conceptual note in "The harness feedback loop".
6. `docs/layers.md` — light touch on the `crewrig.config.toml` row.

The canonical phrasing in `artifacts/FORMAT.md` → *Provenance & Forks* was mirrored for tone/terminology; FORMAT.md itself is unchanged (already done in #307). Docs cross-reference FORMAT.md rather than duplicating its full treatment.

## How to test this PR?

```bash
# Confirm every feedback_repo mention now carries or references the per-tier nuance
grep -rn "feedback_repo" crewrig.config.toml* docs/adoption-guide.md docs/layers.md

# Lint the changed markdown
npx --no-install markdownlint-cli docs/adoption-guide.md docs/authoring.md docs/concepts.md docs/layers.md
```

Expected: each `feedback_repo` mention is accompanied by the adopter-owned-tier scope note; markdownlint exits 0.

## Detailed description (for agents)

- **`crewrig.config.toml.template`** — added a "Scope:" paragraph to the `feedback_repo` comment naming the adopter-owned tiers, stating that upstream-owned tiers always route to `canonical_repo` regardless of this value, and pointing at `artifacts/FORMAT.md` (Provenance & Forks) + `scripts/check-feedback-routing.sh`.
- **`crewrig.config.toml`** — added a brief mirror of the same scope note to the header comment.
- **`docs/adoption-guide.md`** — added a blockquote after the `feedback_repo` bullet in the forking-config section explaining the carve-out (by design, spec 0030; enforced by `scripts/check-feedback-routing.sh`; cross-references FORMAT.md). The troubleshooting section (~l.360) was intentionally left unchanged — it covers placeholder misconfiguration, not routing scope.
- **`docs/authoring.md`** — extended the provenance/versioning paragraph with the per-tier resolution rule.
- **`docs/concepts.md`** — added a short conceptual sentence on where curator-opened issues land per tier.
- **`docs/layers.md`** — annotated the `crewrig.config.toml` table row with the adopter-owned-tier scope.

None of the changed files are in the CLI-matrix trigger surface, so no `docs/cli-matrix.md` update is required. No `/specs/` files touched. Markdownlint passes clean on all changed `.md` files.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)