### PR TITLE
🐛 Tolerate phantom core-paths entries in sync-from-upstream (#310)

### DIFF
--- a/.crewrig/core-paths.txt
+++ b/.crewrig/core-paths.txt
@@ -90,7 +90,7 @@ hooks
 extensions/core	strict
 extensions/library	strict
 
-# Public communications
+# Public communications (spec 0031)
 communication
 
 # Sync tooling (spec 0016)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Test sync-from-upstream script
         run: bash scripts/tests/test-sync-from-upstream.sh
 
+      - name: Check core-paths resolve at HEAD (spec 0031)
+        run: bash scripts/check-core-paths.sh
+
       - name: Test assembly verification
         run: bash scripts/tests/test-assembly-verification.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Check core-paths resolve at HEAD (spec 0031)
         run: bash scripts/check-core-paths.sh
 
+      - name: Test check-core-paths regression (spec 0031)
+        run: bash scripts/tests/test-check-core-paths.sh
+
       - name: Test assembly verification
         run: bash scripts/tests/test-assembly-verification.sh
 

--- a/scripts/check-core-paths.sh
+++ b/scripts/check-core-paths.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# check-core-paths.sh — Reject phantom entries in the core-paths manifest.
+#
+# Per spec 0031 (Requirement 5), continuous integration MUST fail a pull
+# request when any entry in .crewrig/core-paths.txt does not resolve to
+# tracked content at the repository HEAD. A "phantom" entry — a manifest
+# line naming a path with no tracked content — makes an adopter's
+# sync-from-upstream.sh run skip-with-warning at best, and historically
+# aborted the whole sync. This guard catches such an entry before it can
+# reach the canonical branch.
+#
+# Policy semantics (spec 0020) mirror sync-from-upstream.sh:
+#   strict / adopt-on-edit  Upstream-owned content — MUST resolve at HEAD.
+#   excluded                Org-owned — not guaranteed tracked in every
+#                           clone, so explicitly NOT checked.
+# The path/policy split logic below is intentionally identical to the
+# manifest parser in sync-from-upstream.sh (first whitespace field = path,
+# second token = policy, default `strict`; blank/`#` lines skipped; CRLF
+# tolerated).
+#
+# Usage:
+#   bash scripts/check-core-paths.sh
+#
+# Exits 0 if every strict/adopt-on-edit entry resolves at HEAD, non-zero
+# (with a per-entry failure list) otherwise.
+
+set -euo pipefail
+
+REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
+MANIFEST="$REPO_DIR/.crewrig/core-paths.txt"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "Error: manifest not found: $MANIFEST" >&2
+  exit 2
+fi
+
+# Parse the manifest into parallel arrays of paths and policies.
+# `while read` rather than `mapfile` for bash 3.2 compat (macOS default).
+PATHS=()
+POLICIES=()
+while IFS= read -r line || [ -n "$line" ]; do
+  # Strip a trailing carriage return (tolerate CRLF manifests).
+  line="${line%$'\r'}"
+  # Skip blank lines and comments.
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  # Split off the first whitespace-delimited field (path) and the rest (policy).
+  path="${line%%[[:space:]]*}"
+  rest="${line#"$path"}"
+  policy="${rest#"${rest%%[![:space:]]*}"}"   # ltrim
+  policy="${policy%%[[:space:]]*}"             # first token only
+  [ -z "$policy" ] && policy="strict"
+  PATHS+=("$path")
+  POLICIES+=("$policy")
+done < "$MANIFEST"
+
+failures=()
+checked=0
+for i in "${!PATHS[@]}"; do
+  path="${PATHS[$i]}"
+  policy="${POLICIES[$i]}"
+
+  # Org-owned entries are not guaranteed tracked content in every clone.
+  [ "$policy" = "excluded" ] && continue
+
+  checked=$((checked + 1))
+  if ! git -C "$REPO_DIR" cat-file -e "HEAD:$path" 2>/dev/null; then
+    echo "  FAIL $path ($policy) — does not resolve to tracked content at HEAD" >&2
+    failures+=("$path")
+  fi
+done
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "FAILED: ${#failures[@]} core-paths manifest entr(y/ies) do not resolve at HEAD:" >&2
+  for p in "${failures[@]}"; do
+    echo "  - $p" >&2
+  done
+  echo "" >&2
+  echo "Every strict/adopt-on-edit entry in .crewrig/core-paths.txt must resolve to" >&2
+  echo "tracked content at HEAD (spec 0031). Either commit the missing content, or" >&2
+  echo "remove the manifest entry (and its docs/layers.md row, per the co-maintenance" >&2
+  echo "rule in AGENTS.md)." >&2
+  exit 1
+fi
+
+echo "OK: all $checked strict/adopt-on-edit core-paths entries resolve at HEAD."

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -132,6 +132,18 @@ upstream_has_blob() {
 }
 
 # ---------------------------------------------------------------------------
+# resolves_at_fetch_head <path>
+# Return 0 iff <path> resolves to an object (blob OR tree) in the fetched
+# upstream tree. `git cat-file -e FETCH_HEAD:<path>` succeeds for either
+# object type, so the test is uniform across file and directory manifest
+# entries. A manifest entry that resolves to nothing upstream (a "phantom")
+# is skipped-with-warning by the apply loop rather than aborting the sync.
+# ---------------------------------------------------------------------------
+resolves_at_fetch_head() {
+  git cat-file -e "FETCH_HEAD:$1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
 # write_marker <path> <sha>
 # Record <sha> as the last-synced upstream blob marker for <path>.
 # ---------------------------------------------------------------------------
@@ -276,6 +288,10 @@ for i in "${!PATHS[@]}"; do
   path="${PATHS[$i]}"
   policy="${POLICIES[$i]}"
   [ "$policy" = "strict" ] || continue
+  # An entry absent from the fetched upstream tree (a "phantom") cannot be
+  # dirty against a non-existent upstream object. Skip it silently here — the
+  # single warning belongs to the apply loop below.
+  resolves_at_fetch_head "$path" || continue
   mapfile -d '' spec < <(pathspec_for "$path")
   if ! git diff --quiet FETCH_HEAD -- "${spec[@]}" 2>/dev/null; then
     DIRTY+=("$path")
@@ -305,10 +321,21 @@ for i in "${!PATHS[@]}"; do
       continue
       ;;
     strict)
+      if ! resolves_at_fetch_head "$path"; then
+        echo "Warning: skipping manifest entry absent from upstream: $path" >&2
+        continue
+      fi
       mapfile -d '' spec < <(pathspec_for "$path")
       git restore --source=FETCH_HEAD --worktree -- "${spec[@]}"
       ;;
     adopt-on-edit)
+      # Phantom guard at the top of the arm covers both sub-branches: the
+      # directory branch already tolerates absence via `git ls-tree`, but the
+      # blob restore below would abort under `set -e` on an unresolved entry.
+      if ! resolves_at_fetch_head "$path"; then
+        echo "Warning: skipping manifest entry absent from upstream: $path" >&2
+        continue
+      fi
       # A directory entry (a tree at FETCH_HEAD) is reconciled member-by-member
       # with add/delete history awareness; a blob entry keeps the spec-0020
       # two-tier decision below.

--- a/scripts/tests/test-check-core-paths.sh
+++ b/scripts/tests/test-check-core-paths.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# test-check-core-paths.sh — Regression tests for check-core-paths.sh (spec 0031).
+#
+# check-core-paths.sh is the CI guard that rejects "phantom" manifest entries —
+# a .crewrig/core-paths.txt line naming a strict/adopt-on-edit path that does
+# not resolve to tracked content at HEAD. This is the parity sibling mandated by
+# the repo convention "every check-*.sh has a test-*.sh".
+#
+# Cases:
+#   a. Phantom strict entry → exit 1, stderr names the failing entry.
+#   b. Phantom adopt-on-edit entry → exit 1, stderr names the failing entry.
+#   c. Fully resolvable manifest → exit 0 with the OK line on stdout.
+#   d. Phantom excluded entry → exit 0 (excluded is org-owned, NOT checked).
+#
+# Usage:
+#   bash scripts/tests/test-check-core-paths.sh
+
+# -e intentionally omitted: pass/fail counters control the harness; adding -e
+# would abort on expected non-zero exits from the script under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-core-paths.sh"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# init_git_repo <dir>
+init_git_repo() {
+  local dir="$1"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@example.com"
+  git -C "$dir" config user.name "Test"
+  git -C "$dir" config commit.gpgsign false
+}
+
+# make_initial_commit <repo> [<file> <content>]...
+make_initial_commit() {
+  local repo="$1"; shift
+  while [ "$#" -ge 2 ]; do
+    local file="$1" content="$2"; shift 2
+    mkdir -p "$repo/$(dirname "$file")"
+    printf '%s' "$content" > "$repo/$file"
+    git -C "$repo" add "$file"
+  done
+  git -C "$repo" commit -q -m "initial"
+}
+
+# write_manifest <repo> <content>
+# Write .crewrig/core-paths.txt (read from disk by the script — not committed).
+write_manifest() {
+  local repo="$1" content="$2"
+  mkdir -p "$repo/.crewrig"
+  printf '%s' "$content" > "$repo/.crewrig/core-paths.txt"
+}
+
+# run_check <repo>
+# Run the script under test with CREWRIG_REPO_DIR set, capturing stdout, stderr,
+# and exit code into the globals CHECK_EXIT / CHECK_STDOUT / CHECK_STDERR.
+run_check() {
+  local repo="$1" out_file err_file
+  out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
+  err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
+  CHECK_EXIT=0
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  CHECK_STDOUT="$(cat "$out_file")"
+  CHECK_STDERR="$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+}
+
+# ---------------------------------------------------------------------------
+# Case a — Phantom strict entry → exit 1, stderr names the failing entry.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "real.txt" "tracked content"
+  write_manifest "$repo" $'real.txt\tstrict\nphantom.txt\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-a: phantom strict entry fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-a: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF "FAIL phantom.txt (strict)"; then
+    echo "PASS  case-a: stderr names the failing strict entry"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-a: stderr did not name phantom.txt (strict)"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case b — Phantom adopt-on-edit entry → exit 1, stderr names the failing entry.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "real.txt" "tracked content"
+  write_manifest "$repo" $'real.txt\tstrict\nphantom.txt\tadopt-on-edit\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-b: phantom adopt-on-edit entry fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-b: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF "FAIL phantom.txt (adopt-on-edit)"; then
+    echo "PASS  case-b: stderr names the failing adopt-on-edit entry"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-b: stderr did not name phantom.txt (adopt-on-edit)"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case c — Fully resolvable manifest → exit 0 with the OK line on stdout.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt"  "tracked content" \
+    "other.txt" "other tracked content"
+  write_manifest "$repo" $'real.txt\tstrict\nother.txt\tadopt-on-edit\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-c: fully resolvable manifest passes the check (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-c: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDOUT" | grep -qF "OK: all 2 strict/adopt-on-edit core-paths entries resolve at HEAD."; then
+    echo "PASS  case-c: OK line emitted on stdout with the checked count"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-c: missing/incorrect OK line"
+    echo "      actual stdout: $CHECK_STDOUT"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case d — Phantom excluded entry → exit 0 (excluded is org-owned, skipped, NOT
+#          failed). Confirms the policy carve-out matches sync-from-upstream.sh.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "real.txt" "tracked content"
+  # phantom-excluded.txt resolves nowhere at HEAD, but `excluded` is skipped.
+  write_manifest "$repo" $'real.txt\tstrict\nphantom-excluded.txt\texcluded\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-d: phantom excluded entry is skipped, not failed (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-d: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  # Only the strict entry should be counted (the excluded one is not checked).
+  if echo "$CHECK_STDOUT" | grep -qF "OK: all 1 strict/adopt-on-edit core-paths entries resolve at HEAD."; then
+    echo "PASS  case-d: excluded entry omitted from the checked count"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-d: excluded entry was counted or OK line malformed"
+    echo "      actual stdout: $CHECK_STDOUT"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+echo "Results: $pass/$total passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -37,6 +37,18 @@
 #      adopt-on-edit directory (warns, exit 0, no add) rather than trust an
 #      untrustworthy history.
 #
+# Spec-0031 phantom-entry tolerance cases:
+#   n. Phantom tolerance — the manifest declares a strict entry absent from the
+#      fetched upstream AND a resolvable adopt-on-edit sibling. The sync warns
+#      once for the phantom (apply-loop warn-and-skip; the strict dirty guard
+#      skips it silently), restores the resolvable sibling from upstream, and
+#      exits 0. The warn line appears EXACTLY once. This case bites if the
+#      apply-loop `resolves_at_fetch_head` guard is reverted: `set -e` + a
+#      `git restore` on a non-existent FETCH_HEAD path would exit non-zero.
+#   o. Clean-sync negative assertion — a fully resolvable manifest emits NO
+#      "Warning: skipping manifest entry" line on stderr (spec 0031 "fully
+#      resolvable manifest syncs cleanly" scenario; architect advisory #1).
+#
 # Usage:
 #   bash scripts/tests/test-sync-from-upstream.sh
 
@@ -736,6 +748,119 @@ run_case_stderr() {
   else
     echo "FAIL  case-m: shallow guard did not prevent the add"
     fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case n — Spec-0031 phantom tolerance: a strict manifest entry absent from the
+#          fetched upstream is skipped-with-warning (exactly once) while a
+#          resolvable adopt-on-edit sibling is still restored, and the sync
+#          exits 0. Confirms the warn-and-skip fires only in the apply loop
+#          (the strict dirty guard skips the phantom silently — no duplicate
+#          warning) and that a phantom never aborts the whole sync.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" "core-file.txt" "upstream content v1"
+  commit_files "$upstream" "advance core-file" "core-file.txt" "upstream content v2"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  # phantom.txt is declared but exists nowhere upstream; core-file.txt resolves.
+  printf 'phantom.txt\tstrict\ncore-file.txt\tadopt-on-edit\n' \
+    > "$adopter/.crewrig/core-paths.txt"
+  # Adopter vendored the OLD upstream v1 (matches upstream history) so the
+  # adopt-on-edit sibling is eligible to update to v2 — proving the apply loop
+  # continued past the phantom and actually restored the sibling.
+  make_initial_commit "$adopter" "core-file.txt" "upstream content v1"
+
+  phantom_exit=0
+  phantom_stderr="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" 2>&1 >/dev/null)" || phantom_exit=$?
+
+  if [ "$phantom_exit" -eq 0 ]; then
+    echo "PASS  case-n: phantom entry does not abort sync (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-n: expected exit 0, got $phantom_exit"
+    echo "      actual stderr: $phantom_stderr"
+    fail=$((fail + 1))
+  fi
+
+  warn_line="Warning: skipping manifest entry absent from upstream: phantom.txt"
+  if echo "$phantom_stderr" | grep -qF "$warn_line"; then
+    echo "PASS  case-n: warn-and-skip line emitted for the phantom entry"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-n: missing warn-and-skip line for phantom.txt"
+    echo "      actual stderr: $phantom_stderr"
+    fail=$((fail + 1))
+  fi
+
+  warn_count="$(echo "$phantom_stderr" | grep -cF "$warn_line")"
+  if [ "$warn_count" -eq 1 ]; then
+    echo "PASS  case-n: warn-and-skip line emitted exactly once (apply loop only)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-n: expected exactly 1 warn line, got $warn_count"
+    echo "      actual stderr: $phantom_stderr"
+    fail=$((fail + 1))
+  fi
+
+  sibling_after="$(cat "$adopter/core-file.txt" 2>/dev/null)"
+  if [ "$sibling_after" = "upstream content v2" ]; then
+    echo "PASS  case-n: resolvable sibling restored from upstream (v2)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-n: sibling not restored (expected 'upstream content v2', got '$sibling_after')"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case o — Spec-0031 negative assertion: a fully resolvable manifest syncs
+#          cleanly and emits NO "Warning: skipping manifest entry" line. Guards
+#          against a regression where the warn-and-skip path fires spuriously on
+#          a manifest with no phantom entries (architect advisory #1).
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream content" \
+    "other.txt"     "other content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\tstrict\nother.txt\tstrict\n' \
+    > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "core-file.txt" "upstream content" \
+    "other.txt"     "other content"
+
+  clean_exit=0
+  clean_stderr="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" 2>&1 >/dev/null)" || clean_exit=$?
+
+  if [ "$clean_exit" -eq 0 ]; then
+    echo "PASS  case-o: fully resolvable manifest syncs cleanly (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-o: expected exit 0, got $clean_exit"
+    echo "      actual stderr: $clean_stderr"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$clean_stderr" | grep -qF "Warning: skipping manifest entry"; then
+    echo "FAIL  case-o: unexpected skip warning on a fully resolvable manifest"
+    echo "      actual stderr: $clean_stderr"
+    fail=$((fail + 1))
+  else
+    echo "PASS  case-o: no skip warning emitted on a fully resolvable manifest"
+    pass=$((pass + 1))
   fi
 }
 


### PR DESCRIPTION
Realizes spec 0031 (PR #320): a phantom core-paths manifest entry (`communication`, which has no tracked content) aborts `sync-from-upstream.sh` under `set -e`, breaking sync for every adopter. This makes documented layers non-phantom by construction, makes sync warn-and-skip unresolvable entries instead of aborting, and adds a CI guard so a phantom can never reach `main` again.

Closes #310

## How to read this PR?

Read in this order:
1. `communication/.gitkeep` + `.crewrig/core-paths.txt` — materializes the documented "Public communications" layer so it resolves upstream (the data root cause). The path/policy are unchanged; only a `(spec 0031)` provenance comment is added.
2. `scripts/sync-from-upstream.sh` — the keystone: one `resolves_at_fetch_head` helper (`git cat-file -e FETCH_HEAD:$path`, valid for blob and tree) gating three sites so an entry absent from upstream is skipped-with-warning (exit 0) instead of aborting. Entries that resolve keep their exact prior semantics — a resolvable-but-locally-modified `strict` path still aborts the sync (spec 0020 dirty-guard intact).
3. `scripts/check-core-paths.sh` (new) + `.github/workflows/build.yml` — CI fails a PR when any `strict`/`adopt-on-edit` entry does not resolve at HEAD; `excluded` org-owned paths are intentionally skipped (not guaranteed tracked in every clone).
4. `scripts/tests/test-sync-from-upstream.sh` (cases n + o) and `scripts/tests/test-check-core-paths.sh` (new parity sibling) — regression + negative coverage.

Non-obvious decision: the friction offered "drop the entry OR materialize it"; materialize was chosen because `communication/` is wired into the GitHub Pages pipeline (`.github/workflows/pages.yml`) — dropping would orphan it. Full blast-radius and the PLAN live on issue #310.

## How to test this PR?

```sh
git fetch crewrig && git checkout feat/0031-core-paths-phantom-tolerance
bash scripts/check-core-paths.sh                 # exit 0: all strict/adopt-on-edit entries resolve at HEAD
bash scripts/tests/test-sync-from-upstream.sh    # 40/40 pass (incl. case n phantom-skip, case o no-false-warning)
bash scripts/tests/test-check-core-paths.sh      # 8/8 pass (phantom strict/adopt fail; resolvable ok; excluded skipped)
```

Expected: all three exit 0 / all green. The guard is proven non-vacuous — reverting the strict-arm guard makes sync exit 1 on the phantom fixture, failing case n.

## Detailed description (for agents)

- **`communication/.gitkeep`** (new, empty): materializes the tree so `HEAD:communication` and `FETCH_HEAD:communication` resolve. Keeps `pages.yml` (uploads `communication/` as the Pages artifact) coherent. Not Markdown, and `communication` is already in the markdownlint ignore list — no lint impact.
- **`.crewrig/core-paths.txt`**: `# Public communications` → `# Public communications (spec 0031)`. No path added/removed/reclassified → no `docs/layers.md` co-maintenance trigger.
- **`scripts/sync-from-upstream.sh`** (+27): `resolves_at_fetch_head()` helper; guard in the strict dirty-guard loop (silent `continue` on an unresolved entry), and warn-and-skip guards in the `strict)` and `adopt-on-edit)` apply arms emitting `Warning: skipping manifest entry absent from upstream: <path>` once on stderr. Resolvable entries and the `:(exclude)` carve-out are untouched.
- **`scripts/check-core-paths.sh`** (new, +86, `755`): asserts every `strict`/`adopt-on-edit` manifest entry resolves at `HEAD`; skips `excluded`; lists failures on stderr and exits 1, else prints `OK: all <N> ... resolve at HEAD.` Honors `CREWRIG_REPO_DIR`.
- **`.github/workflows/build.yml`** (+6): two new `check-components` steps — run the guard, and run its regression test.
- **Tests**: `test-sync-from-upstream.sh` 34→40 (case n phantom tolerance with verbatim warning + sibling-restored assertions; case o negative no-warning on a clean sync); new `test-check-core-paths.sh` 8/8.
- No `artifacts/` change → no `build-components.sh`, no version bump, no CLI-matrix update.