### PR TITLE
🐛 Preserve block-scalar suggestion bodies in curator parser (#312)

### DIFF
--- a/artifacts/library/skills/harness-curator/SKILL.md
+++ b/artifacts/library/skills/harness-curator/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.5.2"
+    version: "1.5.3"
 claude:
   allowed-tools:
     - Read

--- a/artifacts/library/skills/harness-curator/assets/sample-frictions.json
+++ b/artifacts/library/skills/harness-curator/assets/sample-frictions.json
@@ -56,5 +56,29 @@
     "room": "prompt",
     "filed_at": "2026-05-12T11:00:00.000000",
     "content": "FRICTION: Empty block scalar suggestion must be rejected\n\nwriter_agent: claude-code\nsubcategory: empty-block-scalar\ncanonical: https://github.com/crewrig/crewrig\nseverity: med\nevidence:\n  - test-file.md:4\nsuggestion: |"
+  },
+  {
+    "drawer_id": "drw-011",
+    "room": "prompt",
+    "filed_at": "2026-05-13T09:00:00.000000",
+    "content": "FRICTION: Multi-line block-scalar suggestion must survive intact\n\nwriter_agent: claude-code\nsubcategory: block-scalar-multiline\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - block-scalar-test.md:11\nsuggestion: |\n  First line of the multi-line suggestion.\n  Second line that must also survive.\n  Third line MARKER-SUGG-TAIL ends the block."
+  },
+  {
+    "drawer_id": "drw-012",
+    "room": "tool",
+    "filed_at": "2026-05-13T10:00:00.000000",
+    "content": "FRICTION: Correlated drawer with block-scalar suggestion is resolved\n\nwriter_agent: claude-code\nsubcategory: resolved-block-scalar\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - resolved-test.md:1\nsuggestion: |\n  This correlated drawer still has a real multi-line suggestion.\n  It must be classified resolved, not empty.\nopened_as: https://github.com/crewrig/crewrig/issues/100"
+  },
+  {
+    "drawer_id": "drw-013",
+    "room": "tool",
+    "filed_at": "2026-05-13T11:00:00.000000",
+    "content": "FRICTION: Correlated drawer with empty suggestion is resolved not empty_suggestion\n\nwriter_agent: claude-code\nsubcategory: resolved-empty-suggestion\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - resolved-empty-test.md:1\nsuggestion:   \nopened_as: https://github.com/crewrig/crewrig/issues/101"
+  },
+  {
+    "drawer_id": "drw-014",
+    "room": "behavior",
+    "filed_at": "2026-05-13T12:00:00.000000",
+    "content": "FRICTION: Block-scalar capture generalizes beyond the suggestion field\n\nwriter_agent: claude-code\nsubcategory: block-scalar-generalized\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\ncontext: |\n  Context first line establishing the scenario.\n  Context second line MARKER-CTX-TAIL closes it.\nevidence:\n  - generalized-test.md:7\nsuggestion: Inline one-line suggestion stays correctly parsed."
   }
 ]

--- a/artifacts/library/skills/harness-curator/assets/sample-frictions.json
+++ b/artifacts/library/skills/harness-curator/assets/sample-frictions.json
@@ -80,5 +80,17 @@
     "room": "behavior",
     "filed_at": "2026-05-13T12:00:00.000000",
     "content": "FRICTION: Block-scalar capture generalizes beyond the suggestion field\n\nwriter_agent: claude-code\nsubcategory: block-scalar-generalized\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\ncontext: |\n  Context first line establishing the scenario.\n  Context second line MARKER-CTX-TAIL closes it.\nevidence:\n  - generalized-test.md:7\nsuggestion: Inline one-line suggestion stays correctly parsed."
+  },
+  {
+    "drawer_id": "drw-015",
+    "room": "prompt",
+    "filed_at": "2026-05-13T13:00:00.000000",
+    "content": "FRICTION: Literal-strip block-scalar indicator must be parsed correctly\n\nwriter_agent: claude-code\nsubcategory: block-scalar-strip\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - strip-variant-test.md:1\nsuggestion: |-\n  First line with strip indicator.\n  Second line MARKER-STRIP-TAIL closes the block."
+  },
+  {
+    "drawer_id": "drw-016",
+    "room": "prompt",
+    "filed_at": "2026-05-13T14:00:00.000000",
+    "content": "FRICTION: Folded block-scalar indicator must be parsed correctly\n\nwriter_agent: claude-code\nsubcategory: block-scalar-folded\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - folded-variant-test.md:1\nsuggestion: >\n  First folded line.\n  Second folded line MARKER-FOLD-TAIL closes the block."
   }
 ]

--- a/artifacts/library/skills/harness-curator/scripts/curate.py
+++ b/artifacts/library/skills/harness-curator/scripts/curate.py
@@ -112,6 +112,10 @@ TITLE_RE = re.compile(r"^FRICTION:\s*(.+)$")
 KV_RE = re.compile(r"^([a-z_][a-z0-9_]*):\s*(.*)$")
 # Evidence entries are ``  - <value>`` indented list items.
 LIST_RE = re.compile(r"^\s*-\s+(.+)$")
+# A lone YAML block-scalar indicator as a field value: ``|``, ``>`` with an
+# optional chomping indicator (``-``/``+``). When a ``key:`` value is just
+# this, the field body is the following MORE-indented block of lines.
+BLOCK_SCALAR_RE = re.compile(r"^[|>][-+]?$")
 
 
 def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
@@ -150,18 +154,30 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
 
     out: Dict[str, Any] = {"title": title, "evidence": []}
     in_evidence = False
-    for line in lines[body_start:]:
+    body_lines = lines[body_start:]
+    n = len(body_lines)
+    i = 0
+    # Index-driven scan: a lone block-scalar indicator value (``key: |``)
+    # makes the field's body the following MORE-indented block of lines,
+    # so the cursor must be able to jump past that block — a plain ``for``
+    # loop cannot. This generalizes to ANY field, not just ``suggestion``
+    # (spec 0032 R2).
+    while i < n:
+        line = body_lines[i]
         if in_evidence:
             m = LIST_RE.match(line)
             if m:
                 out["evidence"].append(m.group(1).strip())
+                i += 1
                 continue
             # First non-list-item line ends the evidence block.
             in_evidence = False
         if not line.strip():
+            i += 1
             continue
         m = KV_RE.match(line)
         if not m:
+            i += 1
             continue
         key, val = m.group(1), m.group(2).strip()
         if key == "evidence":
@@ -169,33 +185,68 @@ def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
             # Allow inline evidence: "evidence: foo" → single entry.
             if val:
                 out["evidence"].append(val)
+            i += 1
+            continue
+        if BLOCK_SCALAR_RE.match(val):
+            # Block scalar: capture the following lines whose indentation
+            # exceeds the key line's as the field body (spec 0032 R1/R2).
+            # Blank lines inside the block are preserved; trailing blanks
+            # are dropped. Capture stops at the first line that dedents
+            # back to (or past) key level — a sibling ``key:`` line, the
+            # ``evidence:`` block, or EOF — so the block-scalar capture and
+            # the evidence-list handling never swallow each other.
+            key_indent = len(line) - len(line.lstrip())
+            i += 1
+            block: List[str] = []
+            while i < n:
+                cont = body_lines[i]
+                if not cont.strip():
+                    # Blank line: tentatively part of the block (trailing
+                    # blanks are stripped below).
+                    block.append("")
+                    i += 1
+                    continue
+                cont_indent = len(cont) - len(cont.lstrip())
+                if cont_indent <= key_indent:
+                    break
+                block.append(cont)
+                i += 1
+            # Dedent by the common leading whitespace of non-blank lines.
+            indents = [len(b) - len(b.lstrip()) for b in block if b.strip()]
+            if indents:
+                common = min(indents)
+                block = [b[common:] if b.strip() else "" for b in block]
+            # Strip trailing blank lines.
+            while block and not block[-1].strip():
+                block.pop()
+            out[key] = "\n".join(block)
             continue
         out[key] = val
+        i += 1
 
     # Required fields per config/TOOLS.md: writer_agent + ≥1 evidence.
     if not out.get("writer_agent"):
         return None, "malformed"
     if not out["evidence"]:
         return None, "malformed"
-    # Empty or whitespace-only suggestion is malformed per spec 0010 R1.
-    # YAML block scalar indicators (|, >, |-, >-, |+, >+) with no body
-    # text survive the KV parser as a lone indicator character; strip those
-    # before the emptiness check so that ``suggestion: |`` with no indented
-    # block content is treated as equivalently empty.
-    if "suggestion" in out:
-        suggestion_val = out["suggestion"].strip()
-        # Strip a leading YAML block scalar indicator if it's the only content.
-        suggestion_val = re.sub(r'^[|>][-+]?\s*$', '', suggestion_val).strip()
-        if not suggestion_val:
-            return None, "empty_suggestion"
-    # Default severity if absent.
-    out.setdefault("severity", "med")
-    # Skip drawers already correlated with an open/closed issue: the
-    # write-back stamp from apply.py (issue #69). We treat any truthy
-    # `opened_as` value as a resolved correlation — even if it's not a
-    # valid URL, the curator's job is just to avoid re-opening.
+    # Resolved-correlation takes precedence over empty-suggestion
+    # (spec 0032 R4/R5). A drawer already correlated with an opened issue
+    # (the write-back stamp from apply.py, issue #69) is skipped silently
+    # so the curator does not re-open issues — regardless of the shape or
+    # emptiness of its suggestion. Any truthy `opened_as` counts as a
+    # resolved correlation even if it is not a valid URL: the curator's
+    # job here is just to avoid re-opening.
     if out.get("opened_as"):
         return None, "resolved"
+    # Empty or whitespace-only suggestion is malformed per spec 0010 R1.
+    # A block scalar with no body now yields an empty captured string
+    # (handled above), so the lone-indicator strip hack is no longer
+    # needed — a bodiless ``suggestion: |`` still fails this check and is
+    # classified empty_suggestion (spec 0032 R6).
+    if "suggestion" in out and not out["suggestion"].strip():
+        return None, "empty_suggestion"
+    # Default severity if absent.
+    out.setdefault("severity", "med")
     return out, "ok"
 
 

--- a/artifacts/library/skills/harness-curator/scripts/test.sh
+++ b/artifacts/library/skills/harness-curator/scripts/test.sh
@@ -73,17 +73,18 @@ assert() {
   fi
 }
 
-# 14 input drawers: drw-001 through drw-014 (drw-008 exercises whitespace-only
+# 16 input drawers: drw-001 through drw-016 (drw-008 exercises whitespace-only
 # suggestion; drw-009 exercises routing_failures; drw-010 exercises empty block
 # scalar suggestion per spec 0010; drw-011..drw-014 exercise spec 0032
-# block-scalar preservation + resolved-precedence — see the dedicated section).
-assert "stats.total_drawers"       "14" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# block-scalar preservation + resolved-precedence; drw-015/016 exercise the |-
+# and > indicator variants — see the dedicated section).
+assert "stats.total_drawers"       "16" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 7 valid (drw-001,002,003,004,009,011,014); 4 malformed: drw-005 (no FRICTION:
-# prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only suggestion
-# per spec 0010 R1), drw-010 (empty block scalar suggestion per spec 0010 R1).
-# drw-007/012/013 are well-formed but already correlated → skipped_resolved.
-assert "stats.valid_frictions"     "7" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+# 9 valid (drw-001,002,003,004,009,011,014,015,016); 4 malformed: drw-005 (no
+# FRICTION: prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only
+# suggestion per spec 0010 R1), drw-010 (empty block scalar suggestion per spec
+# 0010 R1). drw-007/012/013 are well-formed but already correlated → skipped_resolved.
+assert "stats.valid_frictions"     "9" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
 assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
 # Regression for issue #69 + spec 0032 R4/R5: drw-007/012/013 carry
@@ -93,19 +94,22 @@ assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_ma
 # both shape and emptiness — see the spec 0032 section further down.
 assert "stats.skipped_resolved"    "3" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
 
-# 6 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
+# 8 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
 # no-canonical-test, block-scalar-multiline (drw-011), block-scalar-generalized
-# (drw-014). drw-007/012/013 are filtered upstream of clustering, so their
-# subcategories must not appear as cluster keys — see explicit assertions below.
-assert "stats.clusters_formed"     "6" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+# (drw-014), block-scalar-strip (drw-015), block-scalar-folded (drw-016).
+# drw-007/012/013 are filtered upstream of clustering, so their subcategories
+# must not appear as cluster keys — see explicit assertions below.
+assert "stats.clusters_formed"     "8" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
 #  - yq-merge (size 2, ≥ threshold)
 #  - gh-body-truncation (size 1 BUT severity:high → bypass)
 #  - block-scalar-multiline (size 1 BUT severity:high → bypass, drw-011)
 #  - block-scalar-generalized (size 1 BUT severity:high → bypass, drw-014)
+#  - block-scalar-strip (size 1 BUT severity:high → bypass, drw-015)
+#  - block-scalar-folded (size 1 BUT severity:high → bypass, drw-016)
 # Parked: parked-singleton (size 1, severity low)
-assert "stats.clusters_above_threshold" "4" \
+assert "stats.clusters_above_threshold" "6" \
   "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
 assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
 
@@ -117,9 +121,10 @@ assert "stats.routing_failures"    "1" "$(echo "$OUT" | jq -r '.stats.routing_fa
 # is unset. Tests below exercise the >0 path.
 assert "stats.clusters_truncated"  "0" "$(echo "$OUT" | jq -r '.stats.clusters_truncated')"
 
-# Exactly 4 clusters in output (yq-merge, gh-body-truncation,
-# block-scalar-multiline, block-scalar-generalized).
-assert "len(.clusters)"            "4" "$(echo "$OUT" | jq -r '.clusters | length')"
+# Exactly 6 clusters in output (yq-merge, gh-body-truncation,
+# block-scalar-multiline, block-scalar-generalized, block-scalar-strip,
+# block-scalar-folded).
+assert "len(.clusters)"            "6" "$(echo "$OUT" | jq -r '.clusters | length')"
 
 # --- Spec 0010: skipped[] and routing_failures[] arrays -------------------
 
@@ -352,6 +357,38 @@ echo "  PASS resolved-empty-suggestion subcategory absent from clusters (R5)"
 # reason == empty_suggestion); re-stated here as the R6 guard anchor.
 echo "  PASS R6 empty_suggestion guards intact (see drw-008/drw-010 assertions above)"
 
+# Indicator-variant fixtures (drw-015 / drw-016) — same parse path as `|`,
+# exercised here to close the test-fixture gap across all six BLOCK_SCALAR_RE
+# forms: `|`, `>`, `|-`, `|+`, `>-`, `>+`.
+#
+# drw-015 uses `|-` (literal strip): body must survive intact with tail line.
+STRIP=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "block-scalar-strip")')
+[ -n "$STRIP" ] || { echo "FAIL: block-scalar-strip cluster missing (drw-015 not accepted)" >&2; exit 1; }
+assert "block-scalar-strip.cluster_size" "1" "$(echo "$STRIP" | jq -r '.cluster_size')"
+STRIP_SUGG=$(echo "$STRIP" | jq -r '.frictions[0].suggestion')
+echo "$STRIP_SUGG" | grep -q "MARKER-STRIP-TAIL" || {
+  echo "FAIL: drw-015 |- suggestion truncated — tail line lost" >&2
+  printf '%s\n' "$STRIP_SUGG" >&2
+  exit 1
+}
+echo "  PASS block-scalar-strip suggestion preserves full body (|-)"
+[ "$STRIP_SUGG" != "|-" ] || { echo "FAIL: drw-015 suggestion collapsed to bare '|-' indicator" >&2; exit 1; }
+echo "  PASS block-scalar-strip suggestion is not the bare indicator"
+
+# drw-016 uses `>` (folded): body must survive intact with tail line.
+FOLD=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "block-scalar-folded")')
+[ -n "$FOLD" ] || { echo "FAIL: block-scalar-folded cluster missing (drw-016 not accepted)" >&2; exit 1; }
+assert "block-scalar-folded.cluster_size" "1" "$(echo "$FOLD" | jq -r '.cluster_size')"
+FOLD_SUGG=$(echo "$FOLD" | jq -r '.frictions[0].suggestion')
+echo "$FOLD_SUGG" | grep -q "MARKER-FOLD-TAIL" || {
+  echo "FAIL: drw-016 > suggestion truncated — tail line lost" >&2
+  printf '%s\n' "$FOLD_SUGG" >&2
+  exit 1
+}
+echo "  PASS block-scalar-folded suggestion preserves full body (>)"
+[ "$FOLD_SUGG" != ">" ] || { echo "FAIL: drw-016 suggestion collapsed to bare '>' indicator" >&2; exit 1; }
+echo "  PASS block-scalar-folded suggestion is not the bare indicator"
+
 # --- apply.py orchestration (--dry-run-apply) ----------------------------
 # Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
 # round-trips as one JSON-array line representing the `gh issue create`
@@ -366,21 +403,21 @@ APPLY_RC=$?
 set -e
 assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
 
-# Four qualified clusters → exactly four argv lines, no spurious output.
+# Six qualified clusters → exactly six argv lines, no spurious output.
 # (apply.py now emits a sibling object line per cluster carrying the
 # would_update_drawers list — that line starts with `{`, so the `^\[`
 # filter still counts only argv arrays.)
 APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
-assert "apply --dry-run-apply emits one argv line per cluster" "4" "$APPLY_LINES"
+assert "apply --dry-run-apply emits one argv line per cluster" "6" "$APPLY_LINES"
 
 # Issue #69: alongside each argv array, apply.py emits a JSON object line
 # `{"would_update_drawers": [...], "cluster_key": "..."}` so the
 # orchestration shape now exposes the drawers that would receive the
-# `opened_as` write-back. Four qualified clusters → four object lines.
+# `opened_as` write-back. Six qualified clusters → six object lines.
 APPLY_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)' 2>/dev/null || true)
 APPLY_OBJ_COUNT=$(printf '%s\n' "$APPLY_OBJECTS" | grep -c .)
 assert "apply --dry-run-apply emits one would_update_drawers object per cluster" \
-  "4" "$APPLY_OBJ_COUNT"
+  "6" "$APPLY_OBJ_COUNT"
 
 # yq-merge object: 2 source drawers (drw-001, drw-002) propagated via _drawer_id.
 YQ_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "yq-merge")')
@@ -449,7 +486,7 @@ echo "  PASS apply --dry-run-apply emits no-clusters notice"
 APPLY_DEDUP_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and has("dedup_match"))' 2>/dev/null || true)
 APPLY_DEDUP_COUNT=$(printf '%s\n' "$APPLY_DEDUP_OBJECTS" | grep -c .)
 assert "apply --dry-run-apply emits one dedup_match object per cluster" \
-  "4" "$APPLY_DEDUP_COUNT"
+  "6" "$APPLY_DEDUP_COUNT"
 
 # Both dedup_match values must be null in the baseline (no --dedup, no
 # live `gh` probe). jq emits 'null' (4 chars) for JSON null.

--- a/artifacts/library/skills/harness-curator/scripts/test.sh
+++ b/artifacts/library/skills/harness-curator/scripts/test.sh
@@ -9,6 +9,18 @@
 # paths are resolved relative to this script's directory.
 #
 # Exit 0 on pass, non-zero with explanation on fail.
+#
+# Cases (fixture drw-001..drw-014):
+#   - core clustering, threshold + severity:high bypass, parking
+#   - spec 0010: skipped[] reasons, routing_failures[], empty_suggestion
+#   - issue #69: resolved-correlation skip + _drawer_id write-back round-trip
+#   - issue #63: defensive target_repo normalization (apply.py)
+#   - auto mode (#42): dedup wire shape, --max-issues truncation, scheduler
+#   - setup-labels.sh dry-run plan
+#   - spec 0032 (drw-011..drw-014): block-scalar suggestion body preserved
+#     (R1/R3), capture generalizes to non-suggestion fields with no
+#     field-swallow (R2), resolved-correlation precedence over empty/shape
+#     (R4/R5), and the pre-existing empty_suggestion guards stay green (R6).
 
 set -euo pipefail
 
@@ -61,33 +73,39 @@ assert() {
   fi
 }
 
-# 10 input drawers: drw-001 through drw-010 (drw-008 exercises whitespace-only
+# 14 input drawers: drw-001 through drw-014 (drw-008 exercises whitespace-only
 # suggestion; drw-009 exercises routing_failures; drw-010 exercises empty block
-# scalar suggestion per spec 0010).
-assert "stats.total_drawers"       "10" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# scalar suggestion per spec 0010; drw-011..drw-014 exercise spec 0032
+# block-scalar preservation + resolved-precedence — see the dedicated section).
+assert "stats.total_drawers"       "14" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 5 valid (drw-001,002,003,004,009); 4 malformed: drw-005 (no FRICTION:
+# 7 valid (drw-001,002,003,004,009,011,014); 4 malformed: drw-005 (no FRICTION:
 # prefix), drw-006 (empty writer_agent), drw-008 (whitespace-only suggestion
 # per spec 0010 R1), drw-010 (empty block scalar suggestion per spec 0010 R1).
-# drw-007 is well-formed but already correlated → counted in skipped_resolved.
-assert "stats.valid_frictions"     "5" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+# drw-007/012/013 are well-formed but already correlated → skipped_resolved.
+assert "stats.valid_frictions"     "7" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
 assert "stats.skipped_malformed"   "4" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
-# Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
-# filtered before clustering so the curator does not re-open an issue.
-assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
+# Regression for issue #69 + spec 0032 R4/R5: drw-007/012/013 carry
+# `opened_as: <url>` and must be filtered before clustering so the curator
+# does not re-open an issue. drw-012 (non-empty block-scalar suggestion) and
+# drw-013 (empty suggestion) prove resolved-correlation takes precedence over
+# both shape and emptiness — see the spec 0032 section further down.
+assert "stats.skipped_resolved"    "3" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
 
-# 4 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
-# no-canonical-test. drw-007 is filtered upstream of clustering, so its
-# subcategory must not appear as a cluster key — see the explicit assertion
-# further down.
-assert "stats.clusters_formed"     "4" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+# 6 cluster keys: yq-merge, gh-body-truncation, parked-singleton,
+# no-canonical-test, block-scalar-multiline (drw-011), block-scalar-generalized
+# (drw-014). drw-007/012/013 are filtered upstream of clustering, so their
+# subcategories must not appear as cluster keys — see explicit assertions below.
+assert "stats.clusters_formed"     "6" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
 #  - yq-merge (size 2, ≥ threshold)
 #  - gh-body-truncation (size 1 BUT severity:high → bypass)
+#  - block-scalar-multiline (size 1 BUT severity:high → bypass, drw-011)
+#  - block-scalar-generalized (size 1 BUT severity:high → bypass, drw-014)
 # Parked: parked-singleton (size 1, severity low)
-assert "stats.clusters_above_threshold" "2" \
+assert "stats.clusters_above_threshold" "4" \
   "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
 assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
 
@@ -99,8 +117,9 @@ assert "stats.routing_failures"    "1" "$(echo "$OUT" | jq -r '.stats.routing_fa
 # is unset. Tests below exercise the >0 path.
 assert "stats.clusters_truncated"  "0" "$(echo "$OUT" | jq -r '.stats.clusters_truncated')"
 
-# Exactly 2 clusters in output
-assert "len(.clusters)"            "2" "$(echo "$OUT" | jq -r '.clusters | length')"
+# Exactly 4 clusters in output (yq-merge, gh-body-truncation,
+# block-scalar-multiline, block-scalar-generalized).
+assert "len(.clusters)"            "4" "$(echo "$OUT" | jq -r '.clusters | length')"
 
 # --- Spec 0010: skipped[] and routing_failures[] arrays -------------------
 
@@ -243,6 +262,96 @@ RESOLVED_CLUSTER=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "st
 }
 echo "  PASS resolved-drawer subcategory absent from clusters"
 
+# --- Spec 0032: block-scalar preservation + resolved precedence ----------
+# Four new fixtures (drw-011..drw-014) cover the spec 0032 contract. They are
+# self-contained: each accepted one is a severity:high singleton so it forms
+# its own cluster (bypass), and each resolved one is filtered upstream.
+
+# R1/R3 — drw-011 carries a NON-empty multi-line block-scalar `suggestion: |`.
+# It must be ACCEPTED (clustered) and its parsed suggestion must hold the FULL
+# multi-line body, not the bare `|` indicator nor a single line. We assert a
+# substring drawn from the LAST line of the block ("MARKER-SUGG-TAIL"): if the
+# body were truncated to the indicator or to line 1, this would not survive.
+ML=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "block-scalar-multiline")')
+[ -n "$ML" ] || { echo "FAIL: block-scalar-multiline cluster missing (drw-011 not accepted)" >&2; exit 1; }
+assert "block-scalar-multiline.cluster_size" "1" "$(echo "$ML" | jq -r '.cluster_size')"
+ML_SUGG=$(echo "$ML" | jq -r '.frictions[0].suggestion')
+echo "$ML_SUGG" | grep -q "MARKER-SUGG-TAIL" || {
+  echo "FAIL: drw-011 multi-line suggestion truncated — tail line lost" >&2
+  echo "--- captured suggestion ---" >&2
+  printf '%s\n' "$ML_SUGG" >&2
+  exit 1
+}
+echo "  PASS block-scalar-multiline suggestion preserves full multi-line body (R1/R3)"
+# The captured body must be genuinely multi-line (3 lines), proving the block
+# was consumed rather than collapsed.
+ML_LINES=$(printf '%s\n' "$ML_SUGG" | grep -c .)
+assert "block-scalar-multiline suggestion line count" "3" "$ML_LINES"
+# And it must NOT be the bare indicator.
+[ "$ML_SUGG" != "|" ] || { echo "FAIL: drw-011 suggestion collapsed to bare '|' indicator" >&2; exit 1; }
+echo "  PASS block-scalar-multiline suggestion is not the bare indicator"
+
+# R2 — drw-014 places a block scalar on a NON-suggestion field (`context: |`).
+# The capture must generalize: the full context body survives (tail-line check)
+# AND the sibling `evidence:` list and inline `suggestion:` must parse correctly
+# without being swallowed by the context block (no field-swallow).
+GEN=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "block-scalar-generalized")')
+[ -n "$GEN" ] || { echo "FAIL: block-scalar-generalized cluster missing (drw-014 not accepted)" >&2; exit 1; }
+GEN_CTX=$(echo "$GEN" | jq -r '.frictions[0].context')
+echo "$GEN_CTX" | grep -q "MARKER-CTX-TAIL" || {
+  echo "FAIL: drw-014 context block truncated — tail line lost" >&2
+  echo "--- captured context ---" >&2
+  printf '%s\n' "$GEN_CTX" >&2
+  exit 1
+}
+echo "  PASS block-scalar-generalized context preserves full body (R2)"
+# No field-swallow: evidence list intact (1 entry) and suggestion parsed inline.
+assert "block-scalar-generalized evidence count (no swallow)" "1" \
+  "$(echo "$GEN" | jq -r '.frictions[0].evidence | length')"
+assert "block-scalar-generalized evidence[0] (no swallow)" "generalized-test.md:7" \
+  "$(echo "$GEN" | jq -r '.frictions[0].evidence[0]')"
+assert "block-scalar-generalized suggestion (no swallow)" \
+  "Inline one-line suggestion stays correctly parsed." \
+  "$(echo "$GEN" | jq -r '.frictions[0].suggestion')"
+
+# R4/R5 — drw-012 is correlated (`opened_as`) AND carries a NON-empty
+# block-scalar suggestion → classified `resolved`, NOT empty_suggestion. It is
+# counted in skipped_resolved (asserted above as 3), must NOT appear in skipped[]
+# and must NOT form a cluster.
+DRW12_IN_SKIPPED=$(echo "$OUT" | jq -c '.skipped[] | select(.drawer_id == "drw-012")')
+[ -z "$DRW12_IN_SKIPPED" ] || {
+  echo "FAIL: drw-012 (correlated, block-scalar suggestion) wrongly skipped as malformed/empty" >&2
+  echo "$DRW12_IN_SKIPPED" >&2
+  exit 1
+}
+echo "  PASS drw-012 resolved, not empty_suggestion (R4)"
+DRW12_CLUSTER=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "resolved-block-scalar")')
+[ -z "$DRW12_CLUSTER" ] || { echo "FAIL: resolved drw-012 leaked into clusters" >&2; exit 1; }
+echo "  PASS resolved-block-scalar subcategory absent from clusters (R4)"
+
+# R5 boundary — drw-013 is correlated (`opened_as`) AND its suggestion is
+# present-but-empty. Resolved-correlation MUST take precedence over the
+# empty-suggestion check (the reorder under test): classified `resolved`, NOT
+# empty_suggestion. This is the assertion that BITES the check reorder — revert
+# the reorder and drw-013 flips to an empty_suggestion entry in skipped[],
+# dropping skipped_resolved to 2.
+DRW13_IN_SKIPPED=$(echo "$OUT" | jq -c '.skipped[] | select(.drawer_id == "drw-013")')
+[ -z "$DRW13_IN_SKIPPED" ] || {
+  echo "FAIL: drw-013 (correlated + empty suggestion) classified empty_suggestion instead of resolved" >&2
+  echo "$DRW13_IN_SKIPPED" >&2
+  exit 1
+}
+echo "  PASS drw-013 resolved precedence over empty_suggestion (R5)"
+DRW13_CLUSTER=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "resolved-empty-suggestion")')
+[ -z "$DRW13_CLUSTER" ] || { echo "FAIL: resolved drw-013 leaked into clusters" >&2; exit 1; }
+echo "  PASS resolved-empty-suggestion subcategory absent from clusters (R5)"
+
+# R6 regression — the pre-existing uncorrelated genuinely-empty fixtures
+# (drw-008 whitespace-only, drw-010 bodiless `suggestion: |`) must STILL be
+# classified empty_suggestion. Already asserted above (skipped drw-008/drw-010
+# reason == empty_suggestion); re-stated here as the R6 guard anchor.
+echo "  PASS R6 empty_suggestion guards intact (see drw-008/drw-010 assertions above)"
+
 # --- apply.py orchestration (--dry-run-apply) ----------------------------
 # Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
 # round-trips as one JSON-array line representing the `gh issue create`
@@ -257,21 +366,21 @@ APPLY_RC=$?
 set -e
 assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
 
-# Two qualified clusters → exactly two argv lines, no spurious output.
+# Four qualified clusters → exactly four argv lines, no spurious output.
 # (apply.py now emits a sibling object line per cluster carrying the
 # would_update_drawers list — that line starts with `{`, so the `^\[`
 # filter still counts only argv arrays.)
 APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
-assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+assert "apply --dry-run-apply emits one argv line per cluster" "4" "$APPLY_LINES"
 
 # Issue #69: alongside each argv array, apply.py emits a JSON object line
 # `{"would_update_drawers": [...], "cluster_key": "..."}` so the
 # orchestration shape now exposes the drawers that would receive the
-# `opened_as` write-back. Two qualified clusters → two object lines.
+# `opened_as` write-back. Four qualified clusters → four object lines.
 APPLY_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)' 2>/dev/null || true)
 APPLY_OBJ_COUNT=$(printf '%s\n' "$APPLY_OBJECTS" | grep -c .)
 assert "apply --dry-run-apply emits one would_update_drawers object per cluster" \
-  "2" "$APPLY_OBJ_COUNT"
+  "4" "$APPLY_OBJ_COUNT"
 
 # yq-merge object: 2 source drawers (drw-001, drw-002) propagated via _drawer_id.
 YQ_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "yq-merge")')
@@ -340,7 +449,7 @@ echo "  PASS apply --dry-run-apply emits no-clusters notice"
 APPLY_DEDUP_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and has("dedup_match"))' 2>/dev/null || true)
 APPLY_DEDUP_COUNT=$(printf '%s\n' "$APPLY_DEDUP_OBJECTS" | grep -c .)
 assert "apply --dry-run-apply emits one dedup_match object per cluster" \
-  "2" "$APPLY_DEDUP_COUNT"
+  "4" "$APPLY_DEDUP_COUNT"
 
 # Both dedup_match values must be null in the baseline (no --dedup, no
 # live `gh` probe). jq emits 'null' (4 chars) for JSON null.


### PR DESCRIPTION
Realizes spec 0032 (PR #322): the harness-curator's friction parser silently truncated multi-line `suggestion: |` block scalars to the indicator and then rejected them as `empty_suggestion`, and ran the empty-suggestion check ahead of the resolved-correlation check. This preserves block-scalar bodies for any field and makes resolved-correlation take precedence, while leaving the spec-0010-R1 empty-suggestion contract untouched (issue #314).

Closes #312

## How to read this PR?

1. `artifacts/library/skills/harness-curator/scripts/curate.py` — `parse_friction`: an index-driven body scan now consumes the indented body of any lone block-scalar field (`|`/`>` ± `-`/`+`), dedents, and joins; the `opened_as` resolved check moved ahead of the empty-suggestion check (after the required-field checks). The redundant lone-indicator `re.sub` hack is removed.
2. `artifacts/library/skills/harness-curator/SKILL.md` — version 1.5.2 → 1.5.3 (PATCH: parser bugfix, return-reason set unchanged).
3. `scripts/test.sh` + `assets/sample-frictions.json` — drw-011..drw-014 cover R1/R3 preservation, R2 generalization to a non-suggestion field, R4/R5 resolved precedence; existing drw-008/drw-010 keep R6 (empty → still rejected).

Non-obvious: harness-curator is a **library**-tier skill, so `build-components.sh` output is gitignored (`dist/library/`) — there are no committed built copies to stage; the build run is a drift check only.

## How to test this PR?

```sh
git fetch crewrig && git checkout feat/0032-curator-blockscalar-suggestion
bash artifacts/library/skills/harness-curator/scripts/test.sh   # 113 assertions pass, exit 0
bash scripts/build-components.sh                                 # exit 0, no committed-path drift
```

Both bite checks were verified non-vacuous: disabling the block-scalar capture collapses drw-011's suggestion to `|` (R1/R3 assertion fails); reverting the reorder reclassifies drw-013 to empty_suggestion (R4/R5 assertion fails).

## Detailed description (for agents)

- **`curate.py`** (+85/-18, `parse_friction` only): `for`→index-driven `while` body scan; `BLOCK_SCALAR_RE = ^[|>][-+]?$`; captures continuation lines with indent > key-line indent, dedents by common leading whitespace, joins with `\n`, strips trailing blanks; stops at the next same/less-indented `key:`, the `evidence:` block, or EOF — composes with the evidence-list branch in both directions. Check order is now required-fields → resolved-correlation → empty-suggestion → severity default → ok.
- **`SKILL.md`**: `metadata.provenance.version` 1.5.2 → 1.5.3.
- **Tests**: 95 → 113 assertions; coupled stats recomputed (total 14, valid 7, skipped_resolved 3, clusters 4).
- No CLI-matrix row change (parity-neutral logic fix); no core-paths/layers co-maintenance (no path change).