### PR TITLE
📝 Add spec 0033 — curator empty-suggestion tolerance (#314)

### DIFF
--- a/specs/0033-curator-empty-suggestion-tolerance.md
+++ b/specs/0033-curator-empty-suggestion-tolerance.md
@@ -8,6 +8,8 @@ related-issue: 314
 version: 1.0.0
 ---
 
+# Curator accepts frictions with a present-but-empty suggestion field
+
 ## Intent
 
 Frictions whose `suggestion:` key is present but empty are accepted by the

--- a/specs/0033-curator-empty-suggestion-tolerance.md
+++ b/specs/0033-curator-empty-suggestion-tolerance.md
@@ -80,3 +80,9 @@ And the friction does not appear in `skipped[]` with reason `empty_suggestion`
   contract prospectively and takes precedence where the two diverge.
 - Changing how non-empty block-scalar suggestion bodies are captured — that
   contract is owned by spec 0032.
+
+## Open questions
+
+- None. Both reconciliation options were evaluated in issue #314; option (a)
+  — accept and strip the empty key — is unambiguously preferred as it
+  preserves evidence-backed signal that would otherwise be silently lost.

--- a/specs/0033-curator-empty-suggestion-tolerance.md
+++ b/specs/0033-curator-empty-suggestion-tolerance.md
@@ -1,0 +1,80 @@
+---
+id: "0033"
+slug: curator-empty-suggestion-tolerance
+status: approved
+complexity: small
+interaction-mode: AUTO
+related-issue: 314
+version: 1.0.0
+---
+
+## Intent
+
+Frictions whose `suggestion:` key is present but empty are accepted by the
+curator identically to frictions where the key is absent entirely. Only
+`writer_agent` and `evidence` remain hard-required; `suggestion` is optional
+at both the authoring and the ingestion layer.
+
+## Requirements
+
+1. The curator SHALL accept a friction whose `suggestion:` value is empty
+   (empty string, whitespace-only, or an empty block-scalar body) without
+   classifying the friction as malformed.
+2. A friction accepted under R1 SHALL NOT appear in `skipped[]` with reason
+   `empty_suggestion`.
+3. When a friction is accepted under R1, its parsed output object SHALL NOT
+   carry a `suggestion` key — the key is stripped, making the result
+   indistinguishable from a friction that omitted `suggestion` entirely.
+4. The `stats.skipped_malformed` count SHALL NOT include frictions dropped
+   solely because their `suggestion:` value is empty.
+5. A friction accepted under R1 that also carries a truthy `opened_as` value
+   SHALL still be classified `resolved`, as the resolved-correlation check
+   takes precedence over R1.
+
+## Scenarios
+
+**Scenario:** Trailing `suggestion:` with no value is accepted.
+
+Given a friction payload with a valid `FRICTION:` title, `writer_agent`,
+`evidence`, and a `suggestion:` key whose value is an empty string  
+When the curator processes the payload  
+Then the friction is accepted and enters the clustering pipeline  
+And `suggestion` is absent from the parsed friction object  
+And the friction does not appear in `skipped[]`
+
+**Scenario:** `suggestion: |` with no body is accepted.
+
+Given a friction payload with a valid `FRICTION:` title, `writer_agent`,
+`evidence`, and `suggestion: |` followed by no indented body lines  
+When the curator processes the payload  
+Then the friction is accepted  
+And `suggestion` is absent from the parsed friction object  
+And the friction does not appear in `skipped[]`
+
+**Scenario:** Whitespace-only `suggestion:` is accepted.
+
+Given a friction payload with a valid `FRICTION:` title, `writer_agent`,
+`evidence`, and `suggestion:` followed by whitespace only  
+When the curator processes the payload  
+Then the friction is accepted  
+And `suggestion` is absent from the parsed friction object  
+And the friction does not appear in `skipped[]`
+
+**Scenario:** Correlated friction with empty `suggestion:` is resolved.
+
+Given a friction payload with a truthy `opened_as:` field and an empty
+`suggestion:` value  
+When the curator processes the payload  
+Then the friction is classified `resolved` (the correlation check takes
+precedence over R1)  
+And the friction does not appear in `skipped[]` with reason `empty_suggestion`
+
+## Out of scope
+
+- Relaxing the hard requirements on `writer_agent` (non-empty) and `evidence`
+  (at least one entry).
+- Modifying spec 0010's scenario that lists "empty suggestion" as a malformed
+  case — spec 0010 remains on `main` as written; this spec amends the runtime
+  contract prospectively and takes precedence where the two diverge.
+- Changing how non-empty block-scalar suggestion bodies are captured — that
+  contract is owned by spec 0032.


### PR DESCRIPTION
Spec 0033 qualifies the contract change introduced by ticket #314: the curator must accept frictions whose `suggestion:` key is present but empty, treating them identically to frictions that omit the key entirely.

## How to read this PR?

Single file: `specs/0033-curator-empty-suggestion-tolerance.md`. Read Requirements R1–R5 first (the normative delta), then the four Scenarios (each maps to a test fixture in the implementation PR), then Out of scope (scope boundary vs. spec 0010 and spec 0032).

## How to test this PR?

Spec-only PR — no executable change. Verify: (1) frontmatter is valid YAML with all required fields; (2) five requirements use SHALL/MUST; (3) four scenarios cover whitespace-only, empty block-scalar, trailing-key, and correlated-but-empty cases; (4) Out of scope names spec 0010 and spec 0032 as the scope boundary.

## Detailed description (for agents)

- New file `specs/0033-curator-empty-suggestion-tolerance.md` with `id: "0033"`, `slug: curator-empty-suggestion-tolerance`, `status: approved`, `complexity: small`, `interaction-mode: AUTO`, `related-issue: 314`, `version: 1.0.0`.
- Intent: frictions with a present-but-empty `suggestion:` are accepted; the key is stripped from the parsed output.
- R1–R4: acceptance rule, no `skipped[]` entry, key absent from output, no increment to `skipped_malformed`.
- R5: resolved-correlation takes precedence over R1.
- Four scenarios: trailing key, `suggestion: |` with no body, whitespace-only, correlated override.
- Out of scope: hard requirements on `writer_agent`/`evidence` unchanged; spec 0010 text unchanged on `main`; block-scalar body capture unchanged (spec 0032).

Closes #314