### PR TITLE
🐛 Make pr-reviewer team-lead reporting conditional on invocation context (#319)

### DIFF
--- a/.claude/agents/pr-reviewer/AGENT.md
+++ b/.claude/agents/pr-reviewer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.3"
+    version: "1.1.4"
 ---
 
 
@@ -33,12 +33,19 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
-6. After completing the review, you MUST send your verdict to
-   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
-   without having sent the verdict message — idle without reporting is
-   a protocol violation. The message must include the PR number, the
-   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
-   summary of the key findings.
+6. After completing the review, report the verdict according to the
+   invocation context:
+   - **If a `team-lead` is addressable (TeamCreate context):** send the
+     verdict via `SendMessage` before your turn ends. Do NOT go idle
+     without having sent the verdict — idle without reporting is a
+     protocol violation. The message must include the PR number, the
+     event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+     summary of the key findings.
+   - **If invoked directly (no `team-lead` addressable):** conclude your
+     turn by returning the verdict summary as your final response text.
+     Do NOT attempt `SendMessage` and do NOT flag the absence of a
+     team-lead as a failure or protocol violation. The GitHub PR review
+     comment posted in step 5 is the canonical, durable artifact.
 
 ## Activation
 

--- a/.gemini/agents/pr-reviewer.md
+++ b/.gemini/agents/pr-reviewer.md
@@ -2,7 +2,7 @@
 name: pr-reviewer
 description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the GitHub MCP."
 ---
-<!-- crewrig-provenance: version="1.1.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.4" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # PR Reviewer Agent
 
@@ -28,12 +28,19 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
-6. After completing the review, you MUST send your verdict to
-   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
-   without having sent the verdict message — idle without reporting is
-   a protocol violation. The message must include the PR number, the
-   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
-   summary of the key findings.
+6. After completing the review, report the verdict according to the
+   invocation context:
+   - **If a `team-lead` is addressable (TeamCreate context):** send the
+     verdict via `SendMessage` before your turn ends. Do NOT go idle
+     without having sent the verdict — idle without reporting is a
+     protocol violation. The message must include the PR number, the
+     event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+     summary of the key findings.
+   - **If invoked directly (no `team-lead` addressable):** conclude your
+     turn by returning the verdict summary as your final response text.
+     Do NOT attempt `SendMessage` and do NOT flag the absence of a
+     team-lead as a failure or protocol violation. The GitHub PR review
+     comment posted in step 5 is the canonical, durable artifact.
 
 ## Activation
 

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.3"
+    version: "1.1.4"
 ---
 
 
@@ -33,12 +33,19 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
-6. After completing the review, you MUST send your verdict to
-   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
-   without having sent the verdict message — idle without reporting is
-   a protocol violation. The message must include the PR number, the
-   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
-   summary of the key findings.
+6. After completing the review, report the verdict according to the
+   invocation context:
+   - **If a `team-lead` is addressable (TeamCreate context):** send the
+     verdict via `SendMessage` before your turn ends. Do NOT go idle
+     without having sent the verdict — idle without reporting is a
+     protocol violation. The message must include the PR number, the
+     event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+     summary of the key findings.
+   - **If invoked directly (no `team-lead` addressable):** conclude your
+     turn by returning the verdict summary as your final response text.
+     Do NOT attempt `SendMessage` and do NOT flag the absence of a
+     team-lead as a failure or protocol violation. The GitHub PR review
+     comment posted in step 5 is the canonical, durable artifact.
 
 ## Activation
 

--- a/artifacts/core/agents/pr-reviewer/AGENT.md
+++ b/artifacts/core/agents/pr-reviewer/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.3"
+    version: "1.1.4"
 ---
 
 # PR Reviewer Agent
@@ -36,12 +36,19 @@ On activation:
 5. Post the verdict via the GitHub MCP `pull_request_review_write`
    tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
    `COMMENT`).
-6. After completing the review, you MUST send your verdict to
-   `team-lead` via `SendMessage` before your turn ends. Do NOT go idle
-   without having sent the verdict message — idle without reporting is
-   a protocol violation. The message must include the PR number, the
-   event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
-   summary of the key findings.
+6. After completing the review, report the verdict according to the
+   invocation context:
+   - **If a `team-lead` is addressable (TeamCreate context):** send the
+     verdict via `SendMessage` before your turn ends. Do NOT go idle
+     without having sent the verdict — idle without reporting is a
+     protocol violation. The message must include the PR number, the
+     event (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`), and a short
+     summary of the key findings.
+   - **If invoked directly (no `team-lead` addressable):** conclude your
+     turn by returning the verdict summary as your final response text.
+     Do NOT attempt `SendMessage` and do NOT flag the absence of a
+     team-lead as a failure or protocol violation. The GitHub PR review
+     comment posted in step 5 is the canonical, durable artifact.
 
 ## Activation
 


### PR DESCRIPTION
Step 6 of the pr-reviewer AGENT.md previously hard-coded a `SendMessage` to `team-lead`, causing a protocol violation error when the agent is invoked directly without a TeamCreate context. This PR makes the reporting step conditional on whether a team-lead is addressable.

## How to read this PR?

Single source change: `artifacts/core/agents/pr-reviewer/AGENT.md` step 6 (version 1.1.3 → 1.1.4). Built outputs in `.claude/agents/pr-reviewer/AGENT.md`, `.gemini/agents/pr-reviewer.md`, `.github/agents/pr-reviewer.md` are auto-generated and mirror the source.

## How to test this PR?

```bash
# Verify source change
grep -A 15 "^6\." artifacts/core/agents/pr-reviewer/AGENT.md

# Verify version bump
grep "version" artifacts/core/agents/pr-reviewer/AGENT.md

# Verify built outputs are in sync
bash scripts/build-components.sh
git diff  # should be clean
```

## Detailed description (for agents)

Modified `artifacts/core/agents/pr-reviewer/AGENT.md`:
- Step 6 split into two conditional branches:
  - **TeamCreate context** (`team-lead` addressable): existing `SendMessage` behavior preserved unchanged.
  - **Direct invocation** (no `team-lead`): conclude turn with verdict as final response text; no `SendMessage`; no failure flag; GitHub PR review comment (step 5) is the canonical artifact.
- Version bumped 1.1.3 → 1.1.4 (PATCH — wording change to existing contract).
- Built outputs regenerated via `scripts/build-components.sh`.

Implements spec 0034 requirements R1–R5. Closes #319.