### PR TITLE
🐛 Add idiomatic-French calque catalog to core rules (#311)

### DIFF
--- a/artifacts/core/rules/60-tools.md
+++ b/artifacts/core/rules/60-tools.md
@@ -641,3 +641,57 @@ content.
 | 1 | Sequential Thinking | Session | Session | Session | Must flush to Tier 2 |
 | 2 | MemPalace | All sessions, all tools | Free | Free | Automatic |
 | 3 | Obsidian | User vault | Free | User consent | User-managed |
+
+---
+
+## Idiomatic French
+
+When the user's preferred language is French, produce all agent-authored prose
+directed at the user — chat messages, progress updates, plan summaries, logbook
+comments — in idiomatic French. Avoid direct calques of English software-
+engineering jargon.
+
+### Calque catalog
+
+Use the idiomatic French equivalent on the right; avoid the English calque on
+the left.
+
+| English calque (avoid) | Idiomatic French (use) |
+|---|---|
+| gate / user gate | point de validation |
+| build (noun/verb) | construction / compilation / construire |
+| install (noun/verb) | installation / installer |
+| scope (noun) | portée |
+| merge (noun/verb) | fusion / fusionner |
+| opt-in | activation à la demande |
+| tier | palier |
+| worktree | espace de travail |
+| spec-PR | PR de spécification |
+| lint / linter (noun) | analyse statique / vérificateur stylistique |
+| commit (noun) | validation |
+| spawner / shipper / merger / amender (anglicized -er verbs) | describe the action in French (*instancier*, *livrer*, *fusionner*, *corriger*…) |
+
+The catalog is non-exhaustive. When in doubt, prefer the longer idiomatic
+phrasing over the calque — verbosity in the target language costs less than
+the cognitive friction of franglais.
+
+### Translation boundary
+
+The following items MUST NOT be translated, regardless of the active
+interaction language. Present them in their original form, typically within
+backtick spans:
+
+- Code identifiers, variable names, function names, field names
+- File paths and directory names
+- CLI tool names and commands
+- GitHub label values and frontmatter field names
+- Literal skill, agent, and role names (e.g., `spec-author`, `team-lead`,
+  `pr-reviewer`, `iter:1`)
+- Proper nouns (product names, organization names)
+
+### Scope
+
+This rule applies to ephemeral user-facing prose only. Content written into
+the repository or posted on GitHub (commit messages, PR bodies, spec files,
+issue comments) follows the English-only project-content rule in `AGENTS.md`
+and is **not** subject to this section.


### PR DESCRIPTION
Adds an "Idiomatic French" section to `artifacts/core/rules/60-tools.md` (priority-60 core rules file, deployed to all three CLIs) providing a calque catalog and translation boundary so that all agents produce idiomatic French prose directed at the user, not just the spec-author skill.

## How to read this PR?

Single-file change: `artifacts/core/rules/60-tools.md`. The new section is appended after `## Memory Activation Summary`. It contains a calque catalog table, a translation boundary list, and a scope paragraph.

## How to test this PR?

```bash
# Verify the section is present and well-formed
grep -c "Idiomatic French" artifacts/core/rules/60-tools.md   # expect 2

# Verify no broken markdown (lint-markdown CI check)
# Verify cli-matrix.md is unchanged (row 7b still accurate — deployment paths unchanged)
```

## Detailed description (for agents)

Modified `artifacts/core/rules/60-tools.md`:
- New `## Idiomatic French` section appended after `## Memory Activation Summary`.
- Calque catalog table: 12 entries covering the most frequent anglicisms flagged in issue #311 (gate, build, install, scope, merge, opt-in, tier, worktree, spec-PR, lint, commit, anglicized -er verbs).
- Translation boundary list: code identifiers, paths, CLI names, label values, skill/agent names, proper nouns — all exempt from translation.
- Scope paragraph: applies to ephemeral user-facing prose only; English-only project-content rule (AGENTS.md) is unaffected.
- No version bump needed: `artifacts/core/rules/` is not in the version-bump enforcement path.
- No cli-matrix.md update needed: deployment paths for row 7b are unchanged.
- No `build-components.sh` run needed: rules files are not managed by the build script.

Implements spec 0035. Closes #311.