### PR TITLE
🐛 Add scannable recap format rule to core rules (#313)

### DIFF
--- a/artifacts/core/rules/60-tools.md
+++ b/artifacts/core/rules/60-tools.md
@@ -644,6 +644,41 @@ content.
 
 ---
 
+## Scannable Recap Format
+
+When composing a situation recap, status update, or progress message directed
+at the user, apply this structure:
+
+1. **Decision or outcome first.** Open with one short sentence that stands
+   alone. A user who reads only that sentence must understand what happened or
+   what was decided.
+2. **Detail as tight bullets.** Push supporting information into bullets — one
+   idea per bullet. Never stack parentheticals inside a bullet. Cap at one
+   em-dash per sentence.
+3. **Cap prose paragraphs at two sentences.** When a summary requires more
+   than two sentences, convert the extra content into bullets.
+
+### Anti-patterns to avoid
+
+- **Stacked parentheticals** — `"The merge (which resolved the conflict in X
+  (introduced by Y)) succeeded"` — the nested aside buries the outcome.
+- **Multiple em-dashes in one sentence** — `"CI failed — lint-specs — see
+  below"` — use a bullet list instead.
+- **Stacked consecutive emphasis** — `"**step 1** … **step 2** … **step 3**"`
+  in the same sentence — emphasis loses meaning when over-used.
+- **Buried decision** — opening with context before stating the outcome forces
+  the user to read to the end before knowing what happened.
+
+### Scope
+
+This rule applies to ephemeral user-facing prose — situation recaps, stage
+transitions, progress updates, and logbook-comment summaries. It does NOT
+apply to repository-bound artifacts (commit messages, PR bodies, spec files,
+plan comments) or to skill-contracted output formats (e.g., the `pr-reviewer`
+verdict block — that format is a protocol contract, not a recap).
+
+---
+
 ## Idiomatic French
 
 When the user's preferred language is French, produce all agent-authored prose


### PR DESCRIPTION
Adds a "Scannable Recap Format" section to `artifacts/core/rules/60-tools.md` mandating decision-first, bullet-detail structure for all agent situation recaps and progress messages. Fixes the dense-prose pattern flagged in issue #313.

## How to read this PR?

Single-file change: `artifacts/core/rules/60-tools.md`. The new `## Scannable Recap Format` section is inserted between `## Memory Activation Summary` and `## Idiomatic French`. It contains a three-point structure rule, an anti-patterns list, and a scope paragraph.

## How to test this PR?

```bash
grep -c "Scannable Recap Format" artifacts/core/rules/60-tools.md  # expect 2
# CI lint-markdown and lint-specs pass
```

## Detailed description (for agents)

Modified `artifacts/core/rules/60-tools.md`:
- New `## Scannable Recap Format` section with:
  - Three-point structure: decision first, detail as bullets, paragraph cap at two sentences.
  - Anti-patterns: stacked parentheticals, multiple em-dashes, stacked emphasis, buried decision.
  - Scope: ephemeral user-facing prose only; repo-bound artifacts and skill-contracted formats exempt.
- No version bump (rules file, not in enforcement path).
- No cli-matrix.md update (deployment paths unchanged).
- No `build-components.sh` run (rules files not managed by build script).

Implements spec 0036. Closes #313.