### PR TITLE
🐛 Prohibit prose gates in AGENTS.md User-gate definition (#318)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,7 +311,13 @@ A **user gate** is defined narrowly as one of two actions:
    ask JUST BEFORE every `gh pr merge` invocation.
 
 Both gates **block** agent execution until the user responds. Nothing
-else does. The following outputs are explicitly **NOT** user gates and
+else does. **A prose question or status message directed at the user is
+NOT a gate, even when it ends with `?`. The host CLI's text-output
+guidance biases toward prose communication; that bias does NOT override
+this contract. Every INTERMEDIATE or FULL mode gate SHALL NOT be
+realised as a prose question — it MUST be an `AskUserQuestion` call.**
+
+The following outputs are explicitly **NOT** user gates and
 SHALL NOT pause the agent:
 
 - Logbook comments (per *Logbook Issues → Rule B*) — informational.


### PR DESCRIPTION
Adds an explicit negative constraint to the `User-gate definition` section of `AGENTS.md`: a prose question is NOT a gate, even when it ends with `?`, and every INTERMEDIATE or FULL mode gate MUST be realised as an `AskUserQuestion` call.

## How to read this PR?

Single file: `AGENTS.md`. The change is a 5-line bold paragraph inserted between the gate enumeration and the non-gate list in the `User-gate definition` section (around line 313).

## How to test this PR?

```bash
grep "prose question" AGENTS.md  # should appear in the new constraint
grep "SHALL NOT be realised as a prose" AGENTS.md
```

CI `lint-markdown` validates the Markdown. No other linter applies to AGENTS.md.

## Detailed description (for agents)

Modified `AGENTS.md` → `### User-gate definition`:
- Inserted bold paragraph after the gate enumeration and before the non-gate list:
  - States explicitly that a prose question is NOT a gate.
  - Identifies the host CLI text-output bias as the root cause.
  - Mandates SHALL NOT for prose gates and MUST for AskUserQuestion.
- No other section modified.
- AGENTS.md has no version field; no version bump applies.

Implements spec 0037 R1–R4. Closes #318.