### PR TITLE
📝 Add REVIEW launch trigger to retroactive-loop.md

### DIFF
--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -29,6 +29,32 @@ the *Class tagging discipline* section below; downstream skills
 (`developer`, `tester`, `spec-author` in delta mode) need only the
 *Routing matrix* row that names them.
 
+## REVIEW launch trigger
+
+The REVIEW stage begins the moment the implementation PR exists on the
+remote. The orchestrator SHALL:
+
+1. Apply the `iter:1` label to the implementation PR (per *Iteration
+   counter — GitHub label*).
+2. **Immediately** spawn the cold-start `pr-reviewer` with the PR
+   number — no pause, no prompt, no user acknowledgement requested.
+
+The spawn sequence is mode-conditional:
+
+| Mode | Action |
+|---|---|
+| **INTERMEDIATE** | Apply `iter:1` label; spawn `pr-reviewer` immediately. |
+| **MINIMAL** | Apply `iter:1` label; spawn `pr-reviewer` immediately. |
+| **AUTO** | Apply `iter:1` label; spawn `pr-reviewer` immediately. |
+| **FULL** | Post the non-blocking start-of-iteration notification on the logbook issue (per `AGENTS.md` → *Interaction modes*); apply `iter:1` label; spawn `pr-reviewer` immediately. The notification does NOT block spawning. |
+
+**Process violation.** Pausing after PR creation and waiting for user
+input before spawning the reviewer is a process violation in
+INTERMEDIATE, MINIMAL, and AUTO modes. The REVIEW loop in those modes
+is fully autonomous from the moment the PR exists — no user gate fires
+until the max-iteration guardrail (see *Max-iteration guardrail*) or the
+final merge-authorization request.
+
 ## Routing matrix
 
 The matrix below is the engine's authoritative reference. It is also

--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -173,10 +173,12 @@ sibling orchestrators racing the same PR converge on the same label
 state without coordinating through MemPalace.
 
 **Initial label.** The `iter:1` label SHALL be applied to the PR
-**before** the first reviewer is spawned (per *REVIEW launch trigger*
-above). PRs that never need a second pass therefore carry exactly one
-`iter:N` label on merge — a useful searchable signal for
-ticket-difficulty retrospectives.
+**before** the first reviewer is spawned — between PR creation and
+reviewer launch, not after the first verdict is consumed (see
+*REVIEW launch trigger* for the exact step ordering). PRs that never
+need a second pass therefore carry exactly one `iter:N` label on
+merge — a useful searchable signal for ticket-difficulty
+retrospectives.
 
 ## Termination
 

--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -172,12 +172,11 @@ cross-session-safe by virtue of being a GitHub primitive — two
 sibling orchestrators racing the same PR converge on the same label
 state without coordinating through MemPalace.
 
-**Initial label.** The first REVIEW pass on a freshly opened PR
-implies `iter:1`; the engine SHALL apply the `iter:1` label at the
-moment the first verdict is consumed, not at PR open time. PRs that
-never need a second pass therefore carry exactly one `iter:N` label
-on merge — a useful searchable signal for ticket-difficulty
-retrospectives.
+**Initial label.** The `iter:1` label SHALL be applied to the PR
+**before** the first reviewer is spawned (per *REVIEW launch trigger*
+above). PRs that never need a second pass therefore carry exactly one
+`iter:N` label on merge — a useful searchable signal for
+ticket-difficulty retrospectives.
 
 ## Termination
 


### PR DESCRIPTION
Add explicit launch-trigger rule to `docs/retroactive-loop.md` (spec 0038 + delta-01). The new section states when and how the orchestrator spawns the first `pr-reviewer` iteration, filling a gap that let orchestrators pause after PR creation. The `Initial label` paragraph is also amended to align its timing with the new trigger rule.

## How to read this PR?

Single file changed: `docs/retroactive-loop.md`. Two edits:
1. New section `## REVIEW launch trigger` inserted between `## Doc-only engine` and `## Routing matrix` — defines the mode-conditional spawn sequence and flags pausing as a process violation.
2. `Initial label` paragraph in `## Iteration counter — GitHub label` amended to state the label is applied before spawning (between PR creation and reviewer launch), not after verdict consumption.

## How to test this PR?

No executable code. Verify the new section:
1. States that `iter:1` label is applied before spawning.
2. Contains a mode table covering INTERMEDIATE, MINIMAL, AUTO, FULL.
3. Explicitly names pausing after PR creation a process violation in non-FULL modes.
4. The `Initial label` paragraph aligns with the trigger: label before spawning, not after verdict.
5. No other section of the file is modified.

## Detailed description (for agents)

- **File modified:** `docs/retroactive-loop.md`
- **Change 1:** Added `## REVIEW launch trigger` section between `## Doc-only engine` and `## Routing matrix`. The section mandates that the orchestrator (1) applies the `iter:1` label, then (2) immediately spawns the cold-start `pr-reviewer` — no user prompt or wait. A mode table covers INTERMEDIATE/MINIMAL/AUTO (immediate spawn) vs FULL (post non-blocking notification first, then spawn immediately). A "Process violation" paragraph explicitly prohibits pausing in INTERMEDIATE, MINIMAL, and AUTO modes.
- **Change 2:** `Initial label` paragraph in `## Iteration counter — GitHub label` amended. Old wording: "at the moment the first verdict is consumed, not at PR open time." New wording: "before the first reviewer is spawned — between PR creation and reviewer launch, not after the first verdict is consumed." Removes the timing contradiction introduced by the new launch trigger section (spec 0038 delta-01 R3 mandate).
- **Implements:** spec 0038 R1–R5 as amended by delta-01 (`specs/0038-review-loop-immediate-launch.delta-01.md`, merged PR #336).

Closes #315