### PR TITLE
📝 Add delta-spec 01 for spec 0038 — fix R4 and relax R5

### DIFF
--- a/specs/0038-review-loop-immediate-launch.delta-01.md
+++ b/specs/0038-review-loop-immediate-launch.delta-01.md
@@ -37,7 +37,7 @@ with:
 
 with:
 
-> The implementation of spec 0038 MAY also amend the `Initial label`
+> The implementation of spec 0038 SHALL also amend the `Initial label`
 > paragraph in `## Iteration counter — GitHub label` of
 > `docs/retroactive-loop.md` to align its timing description with the
 > launch-trigger rule (applying `iter:1` before spawning rather than at

--- a/specs/0038-review-loop-immediate-launch.delta-01.md
+++ b/specs/0038-review-loop-immediate-launch.delta-01.md
@@ -1,0 +1,85 @@
+---
+id: "0038"
+slug: review-loop-immediate-launch
+delta: "01"
+status: approved
+complexity: small
+interaction-mode: AUTO
+related-issue: 315
+version: 1.0.0
+---
+
+# Delta-spec 01 — Fix R4 parenthetical and relax R5 to permit Initial label amendment
+
+## Intent
+
+Two defects were surfaced during the REVIEW loop on the implementation PR (#335):
+
+1. **Spec 0038 R4 carries an incorrect parenthetical.** R4 states the `iter:1`
+   label must be applied before spawning "(per the existing iteration-counter rule
+   in `retroactive-loop.md`)". The cited rule says the opposite — "apply the
+   label at the moment the first verdict is consumed, not at PR open time." The
+   parenthetical cites a contradicting authority, creating a self-defeating
+   reference.
+
+2. **Spec 0038 R5 is too narrow.** R5 prohibits modifying any section of
+   `retroactive-loop.md` other than the new launch-trigger section. This
+   inadvertently blocked the fix for the contradiction above: the `Initial label`
+   paragraph in `## Iteration counter — GitHub label` describes timing that
+   conflicts with R4, but R5 prevented the implementation from amending it.
+
+This delta-spec corrects R4 and relaxes R5 so the implementation can resolve
+the contradiction by amending the `Initial label` paragraph.
+
+## Requirements
+
+1. **R4 correction.** Spec 0038 R4 SHALL be superseded by this delta. The
+   revised rule reads:
+
+   > The `iter:1` label SHALL be applied to the implementation PR **before**
+   > spawning the first reviewer. This is the authoritative timing for the first
+   > iteration label.
+
+   The parenthetical "(per the existing iteration-counter rule in
+   `retroactive-loop.md`)" is removed; R4 now cites no prior authority because
+   this delta resolves the conflict in its favour.
+
+2. **R5 relaxation.** Spec 0038 R5 SHALL be superseded by this delta. The
+   revised constraint reads:
+
+   > The implementation of spec 0038 MAY also amend the `Initial label`
+   > paragraph in `## Iteration counter — GitHub label` of
+   > `docs/retroactive-loop.md` to align its timing description with the
+   > launch-trigger rule. No other section of `retroactive-loop.md` is modified.
+
+3. **`docs/retroactive-loop.md` amendment.** The `Initial label` paragraph in
+   `## Iteration counter — GitHub label` SHALL be amended by the implementation
+   to replace "at the moment the first verdict is consumed, not at PR open time"
+   with language consistent with the launch-trigger rule: the `iter:1` label is
+   applied before the first reviewer is spawned.
+
+4. No other requirement of spec 0038 (R1, R2, R3, R5 except as above) is
+   changed by this delta.
+
+## Scenarios
+
+**Scenario:** Implementation amends the Initial label paragraph.
+
+Given spec 0038 delta-01 is merged on `main`  
+And the implementation PR for #315 is updated  
+When a reviewer reads `docs/retroactive-loop.md`  
+Then the `## REVIEW launch trigger` section states that the `iter:1` label is
+applied before spawning  
+And the `Initial label` paragraph in `## Iteration counter — GitHub label`
+states the same timing  
+And the two descriptions do not contradict each other
+
+## Out of scope
+
+- Changing the label-increment mechanism (`gh pr edit` command).
+- Changing the "which PR carries the label" rule.
+- Any requirement of spec 0038 other than R4 and R5.
+
+## Open questions
+
+- None.

--- a/specs/0038-review-loop-immediate-launch.delta-01.md
+++ b/specs/0038-review-loop-immediate-launch.delta-01.md
@@ -6,7 +6,7 @@ status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 315
-version: 1.0.1
+version: 1.1.0
 ---
 
 # REVIEW loop must launch immediately after PR creation without prompting the user

--- a/specs/0038-review-loop-immediate-launch.delta-01.md
+++ b/specs/0038-review-loop-immediate-launch.delta-01.md
@@ -6,80 +6,44 @@ status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 315
-version: 1.0.0
+version: 1.0.1
 ---
 
-# Delta-spec 01 — Fix R4 parenthetical and relax R5 to permit Initial label amendment
+# REVIEW loop must launch immediately after PR creation without prompting the user
 
-## Intent
+## ADDED
 
-Two defects were surfaced during the REVIEW loop on the implementation PR (#335):
+(none)
 
-1. **Spec 0038 R4 carries an incorrect parenthetical.** R4 states the `iter:1`
-   label must be applied before spawning "(per the existing iteration-counter rule
-   in `retroactive-loop.md`)". The cited rule says the opposite — "apply the
-   label at the moment the first verdict is consumed, not at PR open time." The
-   parenthetical cites a contradicting authority, creating a self-defeating
-   reference.
+## MODIFIED
 
-2. **Spec 0038 R5 is too narrow.** R5 prohibits modifying any section of
-   `retroactive-loop.md` other than the new launch-trigger section. This
-   inadvertently blocked the fix for the contradiction above: the `Initial label`
-   paragraph in `## Iteration counter — GitHub label` describes timing that
-   conflicts with R4, but R5 prevented the implementation from amending it.
+**R4** — replace:
 
-This delta-spec corrects R4 and relaxes R5 so the implementation can resolve
-the contradiction by amending the `Initial label` paragraph.
+> The implementation PR number SHALL be recorded in the `iter:1` label on
+> the PR before spawning (per the existing iteration-counter rule in
+> `retroactive-loop.md`).
 
-## Requirements
+with:
 
-1. **R4 correction.** Spec 0038 R4 SHALL be superseded by this delta. The
-   revised rule reads:
+> The `iter:1` label SHALL be applied to the implementation PR before
+> spawning the first reviewer. This is the authoritative timing for the first
+> iteration label; no prior authority is cited because this delta supersedes
+> the conflicting `Initial label` timing in `retroactive-loop.md` (see
+> modified R5 below).
 
-   > The `iter:1` label SHALL be applied to the implementation PR **before**
-   > spawning the first reviewer. This is the authoritative timing for the first
-   > iteration label.
+**R5** — replace:
 
-   The parenthetical "(per the existing iteration-counter rule in
-   `retroactive-loop.md`)" is removed; R4 now cites no prior authority because
-   this delta resolves the conflict in its favour.
+> No other section of `retroactive-loop.md` is modified by this spec.
 
-2. **R5 relaxation.** Spec 0038 R5 SHALL be superseded by this delta. The
-   revised constraint reads:
+with:
 
-   > The implementation of spec 0038 MAY also amend the `Initial label`
-   > paragraph in `## Iteration counter — GitHub label` of
-   > `docs/retroactive-loop.md` to align its timing description with the
-   > launch-trigger rule. No other section of `retroactive-loop.md` is modified.
+> The implementation of spec 0038 MAY also amend the `Initial label`
+> paragraph in `## Iteration counter — GitHub label` of
+> `docs/retroactive-loop.md` to align its timing description with the
+> launch-trigger rule (applying `iter:1` before spawning rather than at
+> verdict consumption time). No other section of `retroactive-loop.md` is
+> modified.
 
-3. **`docs/retroactive-loop.md` amendment.** The `Initial label` paragraph in
-   `## Iteration counter — GitHub label` SHALL be amended by the implementation
-   to replace "at the moment the first verdict is consumed, not at PR open time"
-   with language consistent with the launch-trigger rule: the `iter:1` label is
-   applied before the first reviewer is spawned.
+## REMOVED
 
-4. No other requirement of spec 0038 (R1, R2, R3, R5 except as above) is
-   changed by this delta.
-
-## Scenarios
-
-**Scenario:** Implementation amends the Initial label paragraph.
-
-Given spec 0038 delta-01 is merged on `main`  
-And the implementation PR for #315 is updated  
-When a reviewer reads `docs/retroactive-loop.md`  
-Then the `## REVIEW launch trigger` section states that the `iter:1` label is
-applied before spawning  
-And the `Initial label` paragraph in `## Iteration counter — GitHub label`
-states the same timing  
-And the two descriptions do not contradict each other
-
-## Out of scope
-
-- Changing the label-increment mechanism (`gh pr edit` command).
-- Changing the "which PR carries the label" rule.
-- Any requirement of spec 0038 other than R4 and R5.
-
-## Open questions
-
-- None.
+(none)


### PR DESCRIPTION
Delta-spec 01 for spec 0038 (`specs/0038-review-loop-immediate-launch.delta-01.md`). Corrects an incorrect parenthetical in R4 that cited a contradicting authority, and relaxes R5 to allow the implementation to amend the `Initial label` paragraph in `retroactive-loop.md`.

## How to read this PR?

Single new file: `specs/0038-review-loop-immediate-launch.delta-01.md`. Read spec 0038 first (`specs/0038-review-loop-immediate-launch.md`) for context, then this delta for the amendments.

## How to test this PR?

No executable code. Verify:
1. The delta-spec carries frontmatter with `delta: "01"` and matching `id`/`slug`.
2. R4 revised rule removes the incorrect parenthetical.
3. R5 relaxation explicitly permits amending the `Initial label` paragraph and no other paragraph.
4. R1, R2, R3 of spec 0038 are untouched.

## Detailed description (for agents)

- **Root cause surfaced:** PR #335 (implementation of spec 0038) introduced a contradiction between the new `## REVIEW launch trigger` section (iter:1 label applied before spawning) and the pre-existing `Initial label` paragraph in `## Iteration counter — GitHub label` (iter:1 label applied at verdict consumption time). Spec 0038 R4 incorrectly cited the pre-existing rule as supporting authority when it in fact stated the opposite. Spec 0038 R5 prevented the implementation from fixing the contradiction by blocking amendments to other sections.
- **Delta-spec R1:** Supersedes spec 0038 R4. New rule: apply iter:1 label before spawning; no parenthetical citation.
- **Delta-spec R2:** Supersedes spec 0038 R5. Implementation may additionally amend the `Initial label` paragraph; no other section of `retroactive-loop.md` is modified.
- **Delta-spec R3:** Mandates the `Initial label` paragraph amendment in the implementation.

Closes #315 (partial — spec qualification only; implementation retried after merge)