### PR TITLE
📝 Add delta-spec 01 for spec 0039 — fix R2 MAP sweep reference

### DIFF
--- a/specs/0039-session-bootstrap-map-reminder.delta-01.md
+++ b/specs/0039-session-bootstrap-map-reminder.delta-01.md
@@ -20,15 +20,11 @@ version: 1.1.0
 **R2** — replace:
 
 > The section SHALL mandate, as the **first action before any work**,
-> the deterministic three-step sweep defined in `60-tools.md`:
->
-> a. `mempalace_status` — enumerate wings; confirm the `crewrig` wing
->    exists.
-> b. `mempalace_search` scoped to `wing="crewrig"`,
->    `room="task-handoff"` with `query="[TASK:ongoing]"` — discover
->    any in-flight cross-tool task.
-> c. `mempalace_diary_read` with the agent's own name — recover recent
->    per-agent reasoning trace.
+> the deterministic three-step sweep defined in `60-tools.md`: (a) `mempalace_status` —
+> enumerate wings; confirm the `crewrig` wing exists. (b) `mempalace_search` scoped to
+> `wing="crewrig"`, `room="task-handoff"` with `query="[TASK:ongoing]"` — discover any
+> in-flight cross-tool task. (c) `mempalace_diary_read` with the agent's own name —
+> recover recent per-agent reasoning trace.
 
 with:
 

--- a/specs/0039-session-bootstrap-map-reminder.delta-01.md
+++ b/specs/0039-session-bootstrap-map-reminder.delta-01.md
@@ -1,0 +1,47 @@
+---
+id: "0039"
+slug: session-bootstrap-map-reminder
+delta: "01"
+status: approved
+complexity: small
+interaction-mode: AUTO
+related-issue: 316
+version: 1.1.0
+---
+
+# Add session-bootstrap Memory Activation Protocol reminder to AGENTS.md
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+**R2** — replace:
+
+> The section SHALL mandate, as the **first action before any work**,
+> the deterministic three-step sweep defined in `60-tools.md`:
+>
+> a. `mempalace_status` — enumerate wings; confirm the `crewrig` wing
+>    exists.
+> b. `mempalace_search` scoped to `wing="crewrig"`,
+>    `room="task-handoff"` with `query="[TASK:ongoing]"` — discover
+>    any in-flight cross-tool task.
+> c. `mempalace_diary_read` with the agent's own name — recover recent
+>    per-agent reasoning trace.
+
+with:
+
+> The section SHALL mandate, as the **first action before any work**,
+> the complete deterministic session-start sweep defined in
+> `artifacts/core/rules/60-tools.md` → *Memory Activation Protocol →
+> Session Start* (all six steps, in order). The section SHALL NOT
+> enumerate the steps inline; it SHALL reference `60-tools.md` as the
+> authoritative source so that future revisions to the MAP propagate
+> automatically. The section MAY name the project-specific parameter
+> (`wing="crewrig"`) as a concrete aide-mémoire for step 3 without
+> reproducing the full step list.
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec 01 for spec 0039. Corrects R2 to reference the complete six-step MAP sweep in `60-tools.md` rather than enumerating three steps inline, preventing drift when the authoritative MAP is revised.

## How to read this PR?

Single new file: `specs/0039-session-bootstrap-map-reminder.delta-01.md`. Context: the original spec 0039 R2 listed only 3 of the 6 MAP session-start steps. This delta replaces the inline enumeration with a pointer to the authoritative source.

## How to test this PR?

No executable code. Verify: R2 replacement text references `60-tools.md` → *Memory Activation Protocol → Session Start* as authoritative; no inline step list; MAY name `wing="crewrig"` as aide-mémoire only.

## Detailed description (for agents)

- **Root cause:** spec 0039 R2 enumerated steps a/b/c (3 of 6 MAP steps). Omitted: step 1 (compute project-name), step 5 (`mempalace_kg_query`), step 6 (mandatory checkpoint write on `[TASK:ongoing]` found). Step 6 is especially consequential — MAP marks it mandatory.
- **Fix:** R2 now mandates the complete sweep via a pointer to `60-tools.md`, not an inline list. The pointer keeps AGENTS.md in sync with future MAP revisions automatically.
- **Version:** 1.1.0 (MINOR — existing requirement MODIFIED without breaking implementations).

Closes #316 (partial — spec qualification only)