### PR TITLE
📝 Add Session Bootstrap section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,18 @@ five pillars without needing to read README.md or ADRs:
    every parity gap requires concrete evidence that the missing mechanism does
    not exist in the target CLI.
 
+## Session Bootstrap
+
+**Before any work begins**, the agent SHALL run the complete deterministic
+session-start sweep defined in
+`artifacts/core/rules/60-tools.md` → *Memory Activation Protocol → Session Start*
+(all six steps, in order). The project-specific parameter for step 3 is
+`wing="crewrig"`, `room="task-handoff"`.
+
+Skipping the sweep is a process violation equivalent to missing a lifecycle
+stage. A REVIEW pass that audits a session where the sweep was omitted SHALL
+emit a `class: tech` finding citing this section.
+
 ## Lifecycle
 
 Every non-trivial ticket SHALL flow through the four-stage lifecycle


### PR DESCRIPTION
Add mandatory `## Session Bootstrap` section to `AGENTS.md` (after *What is CrewRig?*, before *Lifecycle*), implementing spec 0039 + delta-01. The section requires agents to run the complete six-step MAP sweep from `60-tools.md` before any work begins.

## How to read this PR?

Single file changed: `AGENTS.md`. New section `## Session Bootstrap` inserted between `## What is CrewRig?` (line 29) and `## Lifecycle` (line 30). The section mandates the full MAP sweep, provides the project-specific parameter (`wing="crewrig"`, `room="task-handoff"`), and classifies skipping as a process violation.

## How to test this PR?

No executable code. Verify:
1. The new section appears immediately after *What is CrewRig?* and before *Lifecycle*.
2. It references `artifacts/core/rules/60-tools.md` → *Memory Activation Protocol → Session Start* as authoritative.
3. It names `wing="crewrig"`, `room="task-handoff"` as the project-specific step-3 parameter.
4. It explicitly classifies omitting the sweep as a process violation with a `class: tech` finding clause.
5. No other section is modified.

## Detailed description (for agents)

- **File modified:** `AGENTS.md`
- **Change:** New `## Session Bootstrap` section (10 lines) inserted between `## What is CrewRig?` and `## Lifecycle` (spec 0039 R1).
- **Content:** Mandates the complete deterministic session-start sweep from `60-tools.md` (all six steps) before any work begins (spec 0039 R2 as amended by delta-01). Names the project parameter for step 3. Includes process-violation clause with `class: tech` finding trigger (spec 0039 R3). References `60-tools.md` as authoritative (spec 0039 R4). No other sections modified (spec 0039 R5).
- **No artifacts/ changes:** `AGENTS.md` is not under `artifacts/`; no build required.

Closes #316