### PR TITLE
📝 Add Pre-Edit Guard section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,29 @@ rule takes over.
 - The `import/gitlab` branch tracks the legacy GitLab project (`gitlab` remote) and serves as inspiration only.
 - Non-trivial tickets follow the **Spec-PR workflow** (see section below): a `spec/<NNNN>-<slug>` PR qualifies the WHAT and merges to `main` before the implementation branch is cut.
 
+## Pre-Edit Guard
+
+Before writing or editing **any** file in the repository, the agent MUST
+confirm that all three of the following conditions hold:
+
+1. **A GitHub issue exists** for the work — pre-existing or freshly created
+   in this session.
+2. **A feature branch is active** — the current working context is NOT
+   `main` (or `master`). The branch name MUST follow the
+   `<prefix>/<NNNN>-<slug>` convention defined in *Branching Strategy* above.
+3. **A dedicated worktree is in use** — the working directory is
+   `.worktrees/<ticket-id>/`, NOT the repository root.
+
+**Process violation.** Editing any file without satisfying all three
+conditions is a process violation. A REVIEW pass that audits a session
+where the guard was bypassed SHALL emit a `class: tech` finding citing
+this section.
+
+**Exemption.** Trivial single-file edits explicitly scoped by the user in
+the same conversational turn are exempt from condition 3 (worktree), but
+NOT from conditions 1 (issue) and 2 (feature branch). There is no
+edit-without-branch exemption.
+
 ## Spec-PR workflow
 
 This section operationalises the SPECS stage of the lifecycle defined in


### PR DESCRIPTION
Add mandatory `## Pre-Edit Guard` section to `AGENTS.md` (after *Branching Strategy*, before *Spec-PR workflow*), implementing spec 0040. The section requires a GitHub issue, feature branch, and dedicated worktree before any file is written or edited.

## How to read this PR?

Single file changed: `AGENTS.md`. New section `## Pre-Edit Guard` inserted between `## Branching Strategy` (line 122) and `## Spec-PR workflow` (line 123). The section enumerates three conditions, defines the process-violation consequence, and scopes the exemption.

## How to test this PR?

No executable code. Verify:
1. The section appears immediately after *Branching Strategy* and before *Spec-PR workflow*.
2. Conditions 1/2/3 match spec 0040 R2a/b/c.
3. The process-violation paragraph references `class: tech` REVIEW finding.
4. The exemption correctly covers condition 3 (worktree) only — not conditions 1 and 2.
5. No other section is modified.

## Detailed description (for agents)

- **File modified:** `AGENTS.md`
- **Change:** New `## Pre-Edit Guard` section (23 lines) after *Branching Strategy*, before *Spec-PR workflow* (spec 0040 R1).
- **Content:** Three-condition guard (issue + branch + worktree) with MUST modal (spec 0040 R2). Process-violation clause with `class: tech` finding trigger (spec 0040 R3). Exemption for trivial single-file edits scoped by user in-turn — waives worktree only, never ticket/branch (spec 0040 R4). No other sections modified (spec 0040 R5).
- **No artifacts/ changes:** no build step required.

Closes #317