### PR TITLE
📝 Add spec 0024 delta-01 — requalify extension-build exclusion

### DIFF
--- a/specs/0024-extension-tiers.delta-01.md
+++ b/specs/0024-extension-tiers.delta-01.md
@@ -5,7 +5,7 @@ status: draft
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 343
-version: 1.0.1
+version: 1.1.0
 ---
 
 # Extension tiers — core, library, and org segmentation
@@ -24,17 +24,22 @@ None.
   replaced with:
 
   > - The per-command-line-tool rendering of extension components from their pivot
-  >   source is governed by
-  >   [`specs/0041-extension-artifact-lifecycle.md`](0041-extension-artifact-lifecycle.md),
+  >   source is governed by spec 0041 (extension artifact lifecycle, issue #342),
   >   not by this tier-segmentation spec. This spec asserts no position on whether
   >   extension components are compiled; `scripts/build-components.sh` itself still
   >   compiles `artifacts/` only.
+
+  Spec 0041 is cited by name and ticket rather than by file path, so this
+  amendment's normative content holds on `main` regardless of the relative merge
+  order of the two independent spec-PRs.
 
   Rationale: the original bullet could be read as a standing assertion that
   extension components are never compiled. Spec 0041 R2 introduces exactly such a
   rendering step, so the framing is narrowed to "out of scope for the
   tier-segmentation concern" without asserting the absence of any extension build
-  in the framework. No requirement of spec 0024 changes.
+  in the framework. No `## Requirements` line of spec 0024 changes; the amendment
+  narrows a normative boundary in `## Out of scope`, which is why this delta is a
+  MINOR bump (1.1.0) rather than a PATCH.
 
 ## REMOVED
 

--- a/specs/0024-extension-tiers.delta-01.md
+++ b/specs/0024-extension-tiers.delta-01.md
@@ -1,0 +1,41 @@
+---
+id: "0024"
+slug: extension-tiers
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 343
+version: 1.0.1
+---
+
+# Extension tiers — core, library, and org segmentation
+
+## ADDED
+
+None.
+
+## MODIFIED
+
+- `## Out of scope`, original bullet:
+
+  > - Building extensions — extensions are installed (copied/linked), not compiled
+  >   by `scripts/build-components.sh`.
+
+  replaced with:
+
+  > - The per-command-line-tool rendering of extension components from their pivot
+  >   source is governed by
+  >   [`specs/0041-extension-artifact-lifecycle.md`](0041-extension-artifact-lifecycle.md),
+  >   not by this tier-segmentation spec. This spec asserts no position on whether
+  >   extension components are compiled; `scripts/build-components.sh` itself still
+  >   compiles `artifacts/` only.
+
+  Rationale: the original bullet could be read as a standing assertion that
+  extension components are never compiled. Spec 0041 R2 introduces exactly such a
+  rendering step, so the framing is narrowed to "out of scope for the
+  tier-segmentation concern" without asserting the absence of any extension build
+  in the framework. No requirement of spec 0024 changes.
+
+## REMOVED
+
+None.


### PR DESCRIPTION
Narrows spec 0024's out-of-scope exclusion of extension building so it no longer reads as a standing assertion that extension components are never compiled. Immutable-amendment delta driven by spec 0041 R2 (issue #342); ships as its own one-file spec-PR.

## How to read this PR?

Single new file: `specs/0024-extension-tiers.delta-01.md`. It follows the delta-spec convention (`## ADDED` / `## MODIFIED` / `## REMOVED`). Only `## MODIFIED` is non-empty: it quotes the original `## Out of scope` bullet and replaces it with a narrower form that points the building concern at spec 0041 (cited by name and ticket, not file path, so the reference survives any merge order). No `## Requirements` line of 0024 changes.

## How to test this PR?

```sh
npx markdownlint-cli specs/0024-extension-tiers.delta-01.md
```

Expected: no output (clean). Verify the three delta sections are present in order at H2 and the frontmatter `version` bumps the parent to **1.1.0** (MINOR).

## Detailed description (for agents)

- **Added** `specs/0024-extension-tiers.delta-01.md` (id 0024, status `draft`, related-issue 343, version **1.1.0** — MINOR over the parent's 1.0.0).
- **Modified** (via delta) the parent's `## Out of scope` bullet on extension building: from "extensions are installed (copied/linked), not compiled by `scripts/build-components.sh`" to a requalified statement that the per-CLI rendering of extension components is governed by spec 0041, not by the tier-segmentation spec, and that `scripts/build-components.sh` itself still compiles `artifacts/` only.
- **Version rationale**: the change edits `## Out of scope`, a frozen normative body section. Removing a normative exclusion is a boundary change, hence MINOR (1.1.0), not PATCH — per the cold spec-review of this PR (logbook on #343). MAJOR is not warranted: 0024's implementation already merged and loosening an exclusion does not invalidate it.
- **Rationale**: prevents the original bullet from being read as a permanent prohibition that spec 0041 R2 would contradict. Append-only discipline (`docs/spec-format.md` → *Delta-spec convention*) requires this be a delta, not an in-place edit of the merged 0024.