### PR TITLE
📝 Add spec 0044 — extension versioning and manifest enforcement

### DIFF
--- a/specs/0044-extension-versioning-manifest.md
+++ b/specs/0044-extension-versioning-manifest.md
@@ -1,0 +1,110 @@
+---
+id: "0044"
+slug: extension-versioning-manifest
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 351
+version: 1.0.0
+---
+
+# Extension versioning and manifest enforcement
+
+## Intent
+
+An extension skill or agent carries its own version that moves when the
+component itself changes, on the same convention `artifacts/` components already
+follow, so a contributor reads one uniform bump rule whether they touch an
+artifact or an extension component. Separately, the version of a distributable
+extension is declared once and the build refuses to let the extension's several
+manifests drift apart. This third and final child of the extension artifact
+lifecycle closes the versioning gap: today extension components have no bump
+discipline and an extension's manifests can silently diverge.
+
+## Requirements
+
+1. **(Independent component version)** An extension skill's or agent's
+   `metadata.provenance.version` SHALL track that component's own revisions
+   independently of the extension's package version.
+2. **(Bump on modification)** A change that modifies an extension skill or agent
+   already shipped on the primary branch SHALL bump that component's
+   `metadata.provenance.version` in the same change.
+3. **(New-component exemption)** A newly introduced extension component SHALL NOT
+   bump its `metadata.provenance.version` in-branch; it ships at its initial
+   version until merged, mirroring the `artifacts/` version-bump convention.
+4. **(Bump guard)** A continuous-integration guard SHALL fail the build when a
+   modified upstream-owned extension skill or agent ships without the required
+   `metadata.provenance.version` bump.
+5. **(Package single source)** The version of a distributable extension SHALL
+   have a single authoritative declaration across its manifests.
+6. **(Divergence guard)** A continuous-integration guard SHALL fail the build
+   when a manifest of an extension declares a version divergent from that
+   extension's single authoritative version declaration.
+7. **(Documentation co-maintenance)** The change that introduces requirements 2
+   through 4 SHALL extend the `AGENTS.md` version-bump convention affected-paths
+   list and `artifacts/FORMAT.md` to name the upstream-owned extension tiers, so
+   the documented convention and the enforced guard do not drift.
+
+## Scenarios
+
+**Scenario:** A modified extension component bumps its version and passes
+
+```text
+Given an extension skill already shipped on the primary branch
+When  a change modifies that skill and bumps its metadata.provenance.version
+Then  the continuous-integration guard passes for that component
+```
+
+**Scenario:** The guard rejects a modified component without a bump
+
+```text
+Given an upstream-owned extension skill already shipped on the primary branch
+When  a change modifies it without bumping its metadata.provenance.version
+Then  the continuous-integration guard fails the build and names the component
+```
+
+**Scenario:** A newly added extension component is exempt from the bump
+
+```text
+Given a change that adds a brand-new extension skill at its initial version
+When  the continuous-integration guard runs against the change
+Then  the guard does not require a version bump for the new component
+```
+
+**Scenario:** The guard rejects divergent extension manifests
+
+```text
+Given an extension whose manifests declare different versions
+When  the continuous-integration guard runs against the change
+Then  the guard fails the build and identifies the divergent manifest
+```
+
+## Out of scope
+
+- The presence of the `version` field in the `metadata.provenance` block —
+  mandated by sibling sub-spec 0041-B (spec 0043). This spec governs only the
+  field's bump dynamics, not its presence.
+- The provenance block schema and the per-CLI metadata carrier — owned by spec
+  0043 and spec 0042 respectively; cross-referenced, not re-mandated.
+- The choice of which manifest is the single authoritative source for an
+  extension's package version — HOW, deferred to this sub-spec's PLAN stage.
+- Any change to the `artifacts/` version-bump convention itself — it is the
+  template this spec mirrors, not a target of change beyond the affected-paths
+  list extension in requirement 7.
+- The extension release and tagging mechanism (semantic-release driver) — it
+  consumes the package version and is unchanged by this spec.
+
+## Open questions
+
+- [GROUNDING:] The bump guard (requirements 2-4) assumes extension skills and
+  agents carry a `metadata.provenance.version` field; that field is delivered by
+  spec 0043's implementation (the `greeter` back-fill), which is merged as a
+  spec but whose implementation has not yet landed on the primary branch.
+  Resolved as a DEV-sequencing dependency, already mandated by the #346 plan:
+  this spec's implementation SHALL follow spec 0043's implementation, so the
+  field exists before the guard keys on it.
+- [GROUNDING:] The three `extensions/core/hello-world` manifests (`package.json`,
+  `extension.json`, `gemini-extension.json`) currently all declare `0.1.0` and
+  are consistent, so the divergence guard (requirements 5-6) passes as-is and no
+  back-fill of existing manifests is required; the guard prevents future drift
+  rather than repairing a current one.


### PR DESCRIPTION
Qualifies sub-spec 0041-C (the third and final child of spec 0041's large-tier decomposition, planned on #346): per-component version bump dynamics for extension components plus a single-source manifest-version guard. SPECS-stage one-file spec-PR for issue #351.

## How to read this PR?

Single new file: `specs/0044-extension-versioning-manifest.md`. Read `## Intent`, then the 7 requirements: independent component version (R1), bump-on-modification with new-component exemption mirroring `artifacts/` (R2-R3), a bump CI guard extended to the extension tiers (R4), a single authoritative package-version declaration (R5) with a divergence guard (R6), and AGENTS.md + FORMAT.md doc co-maintenance (R7). The boundary with sibling 0041-B (spec 0043): that spec mandates the version field's *presence*; this one owns only its *bump dynamics*. The two GROUNDING notes are resolved: a DEV-sequencing dependency (this implements after 0043's back-fill) and the observation that hello-world's manifests are already consistent (guard prevents future drift, no repair needed).

## How to test this PR?

```sh
npx markdownlint-cli specs/0044-extension-versioning-manifest.md
```

Expected: clean. Verify the five mandatory sections in order, frontmatter parses, id/slug match the filename.

## Detailed description (for agents)

- **Added** `specs/0044-extension-versioning-manifest.md` (status `draft`, complexity `standard`, mode `INTERMEDIATE`, related-issue 351, version 1.0.0).
- **Scope**: carries spec 0041 R9-R12 only; render (0042) and provenance presence/schema (0043) are out of scope and cross-referenced.
- **Interview decisions**: (1) extension bump rule mirrors the `artifacts/` convention exactly (git status M bumps, A exempt); (2) doc co-maintenance of AGENTS.md + FORMAT.md is an in-scope requirement (R7), per #346 plan finding E.
- **Grounding**: `check-skill-versions.sh` keys on status M vs A over `artifacts/**`; hello-world's three manifests are currently all `0.1.0` (consistent); the version field presence is delivered by spec 0043's implementation (DEV-sequencing dependency noted).
- **Cross-spec**: completes the realization of merged spec 0041; mirrors the `artifacts/` Version Bump Convention; honors specs 0042/0043/0024-delta-01.