### PR TITLE
📝 Transition spec 0041 family to its realized lifecycle state

### DIFF
--- a/specs/0024-extension-tiers.delta-01.md
+++ b/specs/0024-extension-tiers.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0024"
 slug: extension-tiers
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 343

--- a/specs/0041-extension-artifact-lifecycle.md
+++ b/specs/0041-extension-artifact-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 id: "0041"
 slug: extension-artifact-lifecycle
-status: draft
+status: approved
 complexity: large
 interaction-mode: INTERMEDIATE
 related-issue: 342

--- a/specs/0042-extension-pivot-render.md
+++ b/specs/0042-extension-pivot-render.md
@@ -1,7 +1,7 @@
 ---
 id: "0042"
 slug: extension-pivot-render
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 347

--- a/specs/0043-extension-provenance-routing.md
+++ b/specs/0043-extension-provenance-routing.md
@@ -1,7 +1,7 @@
 ---
 id: "0043"
 slug: extension-provenance-routing
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 349

--- a/specs/0044-extension-versioning-manifest.md
+++ b/specs/0044-extension-versioning-manifest.md
@@ -1,7 +1,7 @@
 ---
 id: "0044"
 slug: extension-versioning-manifest
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 351


### PR DESCRIPTION
Records the lifecycle status of the now-realized spec 0041 family. Metadata-only frontmatter edit, sanctioned by `docs/spec-format.md` → *Recording a status transition* (the `status` field is exempt from the append-only freeze).

## How to read this PR?

Five one-line frontmatter edits, nothing else (diff is `+5/-5`, status field only):

| Spec | draft → |
|---|---|
| 0042 / 0043 / 0044 | `implemented` (implementation PRs #354 / #356 / #358 merged) |
| 0041 | `approved` (spec-PR merged; realized via its three children, no own implementation PR) |
| 0024 delta-01 | `approved` (spec-PR #345 merged) |

## How to test this PR?

```sh
git diff --stat   # 5 files, +5/-5, status lines only
npx markdownlint-cli "specs/**/*.md"
```

`lint-specs` CI validates the frontmatter schema (status enum).

## Detailed description (for agents)

- **No normative content changed** — only the lifecycle-tracking `status` field, which `docs/spec-format.md` explicitly admits to a metadata-only post-merge edit (the carve-out alongside `superseded-by`).
- 0041 is set to `approved` rather than `implemented` because it is the large-tier umbrella spec with no implementation PR of its own; its WHAT was realized through children 0042/0043/0044, each independently `implemented`.
- Companion housekeeping: the realization epic #346 is closed (completed).