### PR TITLE
📝 Transition spec 0045 to its implemented lifecycle state

### DIFF
--- a/specs/0045-shared-plugin-marketplace.md
+++ b/specs/0045-shared-plugin-marketplace.md
@@ -1,7 +1,7 @@
 ---
 id: "0045"
 slug: shared-plugin-marketplace
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 360


### PR DESCRIPTION
Flip spec 0045 `shared-plugin-marketplace` frontmatter from `status: draft` to `status: implemented`, now that it is realized and merged via #362. Metadata-only, one-line lifecycle bookkeeping.

## How to read this PR?

Single one-line frontmatter change in `specs/0045-shared-plugin-marketplace.md` (`status: draft` → `implemented`). No normative content touched — the spec-format post-merge allowance permits metadata-only status edits.

## How to test this PR?

```sh
npx markdownlint-cli specs/0045-shared-plugin-marketplace.md   # exit 0
git diff main -- specs/0045-shared-plugin-marketplace.md       # only the status line changes
```

## Detailed description (for agents)

Lifecycle bookkeeping: spec 0045 was qualified (spec-PR #361), planned, implemented and merged (impl-PR #362, closing #360), so its terminal status is `implemented` — matching the 0042-0044 precedent. The diff modifies exactly one line of YAML frontmatter (`status`); the body, requirements, scenarios, and all other metadata are unchanged. No code, no build outputs, no other files.

Closes #363