### PR TITLE
📝 Transition spec 0046 to its approved lifecycle state

### DIFF
--- a/specs/0046-multi-engine-ci-parity.md
+++ b/specs/0046-multi-engine-ci-parity.md
@@ -1,7 +1,7 @@
 ---
 id: "0046"
 slug: multi-engine-ci-parity
-status: draft
+status: approved
 complexity: large
 interaction-mode: INTERMEDIATE
 related-issue: 366


### PR DESCRIPTION
Records the SPECS-stage outcome for spec 0046: its spec-PR #367 is merged on `main`, so `status` advances `draft` → `approved`.

## How to read this PR?

One-line metadata-only change to `specs/0046-multi-engine-ci-parity.md` frontmatter (`status: draft` → `status: approved`). No body line, no `id`/`slug`/`version` touched — conforms to `docs/spec-format.md` → *Recording a status transition*.

## How to test this PR?

```sh
git diff main -- specs/0046-multi-engine-ci-parity.md   # exactly one line: the status field
markdownlint specs/0046-multi-engine-ci-parity.md       # exit 0
```

## Detailed description (for agents)

Lifecycle-metadata carve-out edit. The append-only freeze on a merged spec's normative content does not cover the `status` field, which is *expected* to transition per the lifecycle table. Authority: spec reviewer (the SPECS cold review on #367 returned APPROVE). Closes the dedicated transition issue.

Closes #369