### PR TITLE
📝 Transition spec 0047 to its approved lifecycle state

### DIFF
--- a/specs/0047-ci-capability-reference.md
+++ b/specs/0047-ci-capability-reference.md
@@ -1,7 +1,7 @@
 ---
 id: "0047"
 slug: ci-capability-reference
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 371


### PR DESCRIPTION
Metadata-only `status: draft` → `approved` on `specs/0047-ci-capability-reference.md`, recording that spec-PR #375 merged. Lifecycle-metadata carve-out per docs/spec-format.md → Recording a status transition; no normative content touched.

Closes #378