### PR TITLE
✨ Add CI capability reference contract (spec 0047, sub-spec A)

### DIFF
--- a/.crewrig/core-paths.txt
+++ b/.crewrig/core-paths.txt
@@ -100,3 +100,6 @@ scripts/sync-from-upstream.sh	strict
 
 # Documentation publication contract (spec 0027)
 scripts/build-docs-index.sh	strict
+
+# Continuous-integration reference (spec 0047)
+ci	strict

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -1,0 +1,232 @@
+# CrewRig — platform-neutral CI capability reference (spec 0047).
+#
+# One entry per continuous-integration job, identified by a stable `id` that
+# IS the pipeline job's YAML key on every engine (contract C2). The shape of
+# this file is described normatively in `docs/ci-reference-format.md`
+# (contract C1); the decision is recorded in `docs/adr/0012-ci-reference-contract.md`.
+#
+# Portable capabilities are generated into every engine's pipeline by
+# sub-spec B. Engine-specific capabilities carry an `exception` with evidence
+# that the mechanism has no faithful equivalent on the other supported
+# engines (spec 0047 R5); they are hand-authored, never generated.
+#
+# This reference DESCRIBES existing jobs. It generates nothing, runs no drift
+# check, and executes no pipeline — those are sub-specs B (#372), C (#373),
+# and D (#374).
+
+capabilities:
+  # --- Portable: build.yml jobs -------------------------------------------
+  # build.yml fires on pull_request and push to [main, release/**]
+  # (.github/workflows/build.yml lines 3-9).
+
+  - id: build
+    name: "Build all extensions"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: check-components
+    name: "Check community component drift and run build-component tests"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: lint-markdown
+    name: "Lint Markdown files"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: lint-specs
+    name: "Lint specification files"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: test-harness-curate
+    name: "Smoke-test the harness curator"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  # check-skill-versions and check-extension-version-bump compare the change
+  # against its base ref; the workflow gates them on
+  # `if: github.event_name == 'pull_request'`
+  # (.github/workflows/build.yml lines 173, 186), so the neutral trigger is
+  # pull-request only.
+  - id: check-skill-versions
+    name: "Enforce version bump on changed skill/agent sources"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: check-extension-version-bump
+    name: "Enforce carrier-version bump on changed extension sources"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: check-agents-size
+    name: "Check AGENTS.md file size"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  - id: check-feedback-routing
+    name: "Enforce upstream-tier feedback routing"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+
+  # --- Portable: standalone workflows -------------------------------------
+
+  # scripting-conventions.yml gates on pull_request to [main, release/**] with
+  # a path filter (.github/workflows/scripting-conventions.yml lines 3-9).
+  - id: grep-anti-patterns
+    name: "Flag scripting anti-patterns in scripts and hooks"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+        paths:
+          - "scripts/**"
+          - "hooks/**"
+          - ".github/workflows/scripting-conventions.yml"
+    portability: portable
+
+  # security-mcp.yml gates on pull_request to [main] with a path filter on the
+  # MCP/dependency manifests (.github/workflows/security-mcp.yml lines 3-11).
+  - id: audit
+    name: "Run dependency security audit"
+    trigger:
+      - on: pull-request
+        branches: [main]
+        paths:
+          - "**/package.json"
+          - "**/settings.json"
+          - "**/mcp.json"
+          - "**/mcp.json.template"
+          - "**/extension.json"
+    portability: portable
+
+  # --- Engine-specific: bot-mention assistants ----------------------------
+  # A bot-mention trigger (an issue or review comment) is engine-specific,
+  # never portable (spec 0047 R5).
+
+  - id: claude
+    name: "Claude Code mention-triggered assistant"
+    trigger:
+      - on: manual
+    portability: specific
+    exception:
+      engine: github-actions
+      evidence: >
+        Triggered by GitHub `issue_comment` / `pull_request_review_comment`
+        events gated on a literal `@claude` mention
+        (.github/workflows/claude.yml lines 3-13). GitLab CI exposes no
+        comment-event pipeline trigger, so there is no faithful equivalent on
+        the other supported engines. A bot-mention trigger is treated as
+        engine-specific, never portable (spec 0047 R5); the analogous non-GHA
+        surfaces are marked [GAP] in docs/cli-matrix.md.
+
+  - id: copilot
+    name: "GitHub Copilot CLI mention-triggered assistant"
+    trigger:
+      - on: manual
+    portability: specific
+    exception:
+      engine: github-actions
+      evidence: >
+        Triggered by GitHub `issue_comment` / `pull_request_review_comment`
+        events gated on a literal `@copilot-cli` mention
+        (.github/workflows/copilot.yml lines 13-23); native `@copilot`
+        dispatch is configured at the repository/organization level, not
+        portable to GitLab CI. A bot-mention trigger is treated as
+        engine-specific, never portable (spec 0047 R5).
+
+  # --- Engine-specific: GitHub-native delivery surfaces --------------------
+
+  # pages.yml deploys the `communication/` site to GitHub Pages on push to main
+  # and via workflow_dispatch (.github/workflows/pages.yml lines 3-8). GitHub
+  # Pages is a GitHub-hosted product; GitLab's equivalent (GitLab Pages) is a
+  # distinct surface with its own job contract, so the deploy capability is
+  # engine-specific and hand-authored per engine.
+  - id: pages-deploy
+    name: "Deploy the communication site to GitHub Pages"
+    trigger:
+      - on: push
+        branches: [main]
+        paths:
+          - "communication/**"
+      - on: manual
+    portability: specific
+    exception:
+      engine: github-actions
+      evidence: >
+        Uses the GitHub-Pages-specific action chain
+        `actions/configure-pages` → `actions/upload-pages-artifact` →
+        `actions/deploy-pages` against the `github-pages` deployment
+        environment (.github/workflows/pages.yml lines 26-38). GitHub Pages is
+        a GitHub-hosted product with no faithful equivalent on GitLab CI
+        (GitLab Pages is a distinct surface with its own job contract), so the
+        deploy capability is hand-authored per engine, not generated.
+
+  # release-extension.yml packages an extension and creates a GitHub Release on
+  # a matching version tag (.github/workflows/release-extension.yml lines 3-6).
+  - id: package-and-release
+    name: "Package an extension and create a GitHub Release on a version tag"
+    trigger:
+      - on: tag
+        tag-pattern: "*-v[0-9]*.[0-9]*.[0-9]*"
+    portability: specific
+    exception:
+      engine: github-actions
+      evidence: >
+        Creates a GitHub Release via `softprops/action-gh-release`
+        (.github/workflows/release-extension.yml lines 69-74), a
+        GitHub-Releases-specific surface. GitLab's release mechanism
+        (`release:` keyword / release-cli) is a distinct, non-interchangeable
+        contract, so the release capability has no faithful equivalent on the
+        other supported engines and is hand-authored per engine.
+
+  # release-monorepo.yml runs the semantic-release monorepo pipeline on push to
+  # main (.github/workflows/release-monorepo.yml lines 3-7).
+  - id: release
+    name: "Run the monorepo semantic-release pipeline"
+    trigger:
+      - on: push
+        branches: [main]
+    portability: specific
+    exception:
+      engine: github-actions
+      evidence: >
+        Runs `scripts/monorepo-release.sh` driven by the GitHub
+        `${{ secrets.GITHUB_TOKEN }}` with `issues: write` /
+        `pull-requests: write` permissions to create GitHub Releases and
+        comment on GitHub issues/PRs
+        (.github/workflows/release-monorepo.yml lines 9-43). The release
+        tooling targets the GitHub Releases and GitHub issue APIs, which have
+        no faithful equivalent on GitLab CI, so the capability is hand-authored
+        per engine, not generated.

--- a/docs/adr/0012-ci-reference-contract.md
+++ b/docs/adr/0012-ci-reference-contract.md
@@ -1,0 +1,74 @@
+# ADR 0012 — CI capability reference contract
+
+<!-- crewrig-doc: section=architecture-adr nav_order=120 published=true title="ADR 0012 — CI capability reference contract" -->
+
+**Status:** Proposed (issue #371; keystone of the multi-engine CI/CD parity EPIC #368)
+
+## Context
+
+Multi-engine CI/CD parity (spec 0046, EPIC #368) needs one engine-neutral
+description of what the project's CI does *before* any engine's pipeline can
+be generated (sub-spec B) or drift-checked (sub-spec C). Today the CI lives
+only as GitHub Actions YAML (`.github/workflows/*.yml`); there is no neutral
+source of truth, so a second engine could only be hand-translated, with no way
+to detect divergence. [Spec 0047](../../specs/0047-ci-capability-reference.md)
+requires a single reference (stable id, neutral trigger, portability mark)
+plus a normative description of its own shape (R1–R9), and a traceability id
+by which any engine's job attributes to exactly one capability (R6) — readable
+by the `yq` parser sub-spec C uses.
+
+## Decision
+
+Introduce `ci/ci-capabilities.yml`, a platform-neutral YAML reference: one
+entry per CI job, each with a stable `id`, a `trigger` from a closed neutral
+vocabulary (`push`, `pull-request`, `tag`, `scheduled`, `manual`) with
+portable filters (`branches`, `paths`, `tag-pattern`), a
+`portability: portable|specific` mark, and an evidence-backed `exception` per
+`specific` entry. Job-to-capability traceability (C2): the capability `id` IS
+the pipeline job's YAML key on every engine — read via `yq '.jobs | keys'`
+(GHA) or top-level keys-minus-reserved (GitLab), with a trailing key-comment
+`# ci-capability: <id>` fallback for engine-reserved job names (GitLab
+`pages`). The shape is described normatively in
+[`docs/ci-reference-format.md`](../ci-reference-format.md), which pins the
+exact extraction expressions. YAML is chosen because `yq` is already a CI
+dependency; no new validation toolchain enters. `ci/` is a new top-level
+core-layer path, registered in [`docs/layers.md`](../layers.md) and
+`.crewrig/core-paths.txt`.
+
+## Alternatives considered
+
+- **C2 as an own-line YAML comment on the job node** — rejected: empirically
+  unreadable by `yq` v4.53.3 (`line_comment` / `head_comment` / `foot_comment`
+  all return empty on the job node); only reachable via a brittle,
+  position-dependent sibling-relative path.
+- **C2 as a custom data field in the job map** (`jobs.<id>.ci-capability`) —
+  rejected: `actionlint` and GitLab CI lint reject unknown job keywords; the
+  only valid variant degrades to a sidecar id→jobs file, a second artifact to
+  keep in sync — the exact drift C2 exists to remove.
+- **C2 as a trailing key-comment** (`<job>: # ci-capability: <id>`) — proven
+  readable (`yq '.<job> | key | line_comment'`), retained only as the fallback
+  for engine-reserved job names; not primary because it duplicates the id and
+  can silently disagree with the job key.
+- **JSON Schema reference instead of YAML + a prose format doc** — rejected:
+  introduces a validator toolchain absent from CI today, against the YAML/`yq`
+  decision; validity is enforced by sub-spec C's checker against the four spec
+  scenarios.
+- **Reference under `.github/`** — rejected: frames the neutral contract as
+  GitHub-owned, contradicting R9 and the platform-neutrality intent.
+
+## Consequences
+
+- B and C build against a frozen C1/C2: B names each generated portable job by
+  its `id` and hand-authors the `specific` jobs; C reads `.jobs | keys` and
+  fails closed on undocumented drift or untraceable jobs.
+- `id == job key` couples capability rename and job rename into one act — they
+  cannot silently diverge; the cost is that a job key is constrained to the id
+  charset and the GitLab-reserved-name fallback is needed for `pages`.
+- The engine × capability axis is self-documented by the YAML, distinct from
+  the CLI × feature matrix; [`docs/cli-matrix.md`](../cli-matrix.md) carries
+  one cross-reference row, not an engine sub-table.
+- Adding a third engine requires only a new mapping from the neutral
+  vocabulary and naming its jobs by the existing ids — no capability
+  definition changes (R9).
+- `ci/` joining the core manifest means adopters receive the reference on sync
+  and `check-core-paths.sh` guards it.

--- a/docs/ci-reference-format.md
+++ b/docs/ci-reference-format.md
@@ -1,0 +1,284 @@
+# CI capability reference format
+
+<!-- crewrig-doc: section=reference nav_order=60 published=true title="CI capability reference format" -->
+
+This document is the **normative description** of the shape of
+`ci/ci-capabilities.yml` — the platform-neutral CI capability reference
+mandated by [spec 0047](../specs/0047-ci-capability-reference.md) and decided
+in [ADR-0012](adr/0012-ci-reference-contract.md). It is contract **C1**: a
+candidate reference is judged valid or invalid against the rules below, and a
+further continuous-integration engine is supported by describing only its
+mapping of these capabilities — never by altering a capability definition
+(spec 0047 R7).
+
+The traceability convention (**C2**) — how a pipeline job in any engine is
+attributed to exactly one capability — is pinned in *Traceability* below,
+with the exact, tested `yq` extraction expressions sub-spec C relies on.
+
+## Purpose and scope
+
+The reference is **one** platform-neutral enumeration of every
+continuous-integration capability the project relies on, at the granularity of
+one job. It is a *description*, not a generator and not a drift check:
+
+- It does **not** generate any engine's pipeline — that is sub-spec B (#372).
+- It does **not** check divergence between the reference and the engines —
+  that is sub-spec C (#373).
+- It does **not** execute any pipeline on a live engine.
+
+It exists so that, before any engine's pipeline is derived or checked, there
+is one agreed answer to "what does this project's CI do", independent of any
+engine.
+
+## File location and ownership
+
+- **Path:** `ci/ci-capabilities.yml` — one reference per repository.
+- **Layer:** core, sync policy `strict` (upstream-owned; a local modification
+  halts the upstream sync). Registered in
+  [`docs/layers.md`](layers.md) and `.crewrig/core-paths.txt`.
+- **Format:** YAML, chosen because `yq` (mikefarah) is already a CI dependency
+  (`.github/workflows/build.yml`); no new validation toolchain is introduced.
+
+## Capability entry schema
+
+The reference is a YAML document with a single top-level key `capabilities:`
+whose value is a **list** of capability entries. Each entry is a mapping with
+these keys:
+
+| Key | Required | Type | Constraint |
+|---|---|---|---|
+| `id` | always | string | The stable traceability identifier. Unique across the reference. Equals the pipeline job's YAML key (see *Traceability*). |
+| `name` | always | string | Human-readable label for the capability. |
+| `trigger` | always | list | One or more trigger objects (see *Neutral trigger vocabulary*). |
+| `portability` | always | enum | `portable` or `specific` (see *Portability and exceptions*). |
+| `exception` | iff `specific` | mapping | `{engine, evidence}` (see *Portability and exceptions*). |
+
+**Granularity — one capability is exactly one job (spec 0047 R1).** The steps
+*inside* a job are an implementation detail of that one capability, **not**
+separate capabilities. For example the `check-components` job runs roughly two
+dozen steps; it is one capability, not two dozen. A candidate reference is not
+invalid for collapsing a job's steps into a single entry — that is the
+required shape.
+
+## Neutral trigger vocabulary
+
+Each `trigger` entry is a mapping with an `on:` kind drawn from a **closed**
+set, optionally qualified by **portable filters**.
+
+**Trigger kinds (closed set, spec 0047 R2):**
+
+| Kind | Meaning |
+|---|---|
+| `push` | A push to a branch. |
+| `pull-request` | A pull-or-merge request (the neutral name; GHA `pull_request`, GitLab `merge_request_event`). |
+| `tag` | A tag push. |
+| `scheduled` | A time-scheduled run. |
+| `manual` | A manually or out-of-band initiated run. An issue/review comment (bot mention) is modeled as `manual`. |
+
+A trigger whose `on:` kind is **not** one of these five makes the reference
+invalid (see *Validity rules*, Scenario 2).
+
+**Portable filters (normalized trigger attributes, spec 0047 R3):**
+
+| Filter | Applies to | Meaning |
+|---|---|---|
+| `branches` | `push`, `pull-request` | The branch set the trigger qualifies on. |
+| `paths` | `push`, `pull-request` | The path set the trigger qualifies on. |
+| `tag-pattern` | `tag` | A glob qualifying the matched tag. Absent → matches any tag. |
+
+`trigger` is a **list** so that a capability firing on both `push` and
+`pull-request` (the real `build` / `lint-markdown` jobs) is **one** capability
+with two trigger objects — not two capabilities. A filter key outside the set
+above is invalid.
+
+## Portability and exceptions
+
+`portability` marks whether a capability crosses engines (spec 0047 R4):
+
+- **`portable`** — faithfully expressible on every supported engine. Sub-spec
+  B generates it into each engine's pipeline.
+- **`specific`** — tied to a single engine. Hand-authored per engine; never
+  generated.
+
+Every `specific` capability **SHALL** carry an `exception` (spec 0047 R5):
+
+| Field | Required | Meaning |
+|---|---|---|
+| `engine` | yes | The engine id where the capability lives (e.g. `github-actions`). |
+| `evidence` | yes | A statement that the mechanism has **no faithful equivalent** on the other supported engines. |
+
+`evidence` accepts any of: a **quoted sentence**, a **command + its output**,
+or a **URL** — mirroring the gap-acceptance evidence discipline of
+[`docs/cli-matrix-maintenance.md`](cli-matrix-maintenance.md). A `specific`
+capability with **no** `exception`, or with an empty `evidence`, makes the
+reference invalid (see *Validity rules*, Scenario 3).
+
+**Bot-mention rule (spec 0047 R5).** A bot-mention trigger — an issue comment
+or a pull-request review comment that dispatches an assistant (e.g. the
+`@claude` and `@copilot-cli` workflows) — **SHALL** be treated as
+engine-specific, **never** portable, regardless of how its `trigger` is
+modeled.
+
+## Traceability (contract C2)
+
+**The capability `id` IS the pipeline job's YAML key, on every engine.** A
+pipeline job named `lint-markdown` in any engine is, by that fact, attributed
+to the capability whose `id` is `lint-markdown`. There is no separate
+annotation to keep in sync — the id is the job's name in the structured
+document, so it is directly addressable in `yq`'s data model. Renaming a job
+and renaming its capability become the same act; they cannot silently
+disagree.
+
+**Uniqueness (spec 0047 R6).** Each `id` is unique across the reference, so a
+job key attributes to **exactly one** capability. A missing or duplicated `id`
+makes the reference invalid (see *Validity rules*, Scenario 4).
+
+**Untraceable jobs.** A pipeline job whose key is **not** an `id` in the
+reference (and which carries no fallback annotation, below) is *untraceable*.
+Sub-spec C's drift harness fails closed on it.
+
+### Tested extraction expressions
+
+Sub-spec C relies on these exact `yq` (mikefarah v4.x) access paths. Each is
+shown with a passing sample.
+
+**GitHub Actions — list every job's capability id (primary path):**
+
+```console
+$ yq '.jobs | keys' .github/workflows/build.yml
+- build
+- check-components
+- lint-markdown
+- lint-specs
+- test-harness-curate
+- check-skill-versions
+- check-extension-version-bump
+- check-agents-size
+- check-feedback-routing
+```
+
+The GHA job keys are already valid id syntax and unique by the schema's own
+rule, so the ids fall straight out of the data model.
+
+**GitLab CI — list job ids (top-level keys minus the reserved keyword set):**
+
+GitLab pipelines place jobs at the top level, alongside reserved keywords
+(`stages`, `workflow`, `default`, `include`, `variables`, `image`,
+`before_script`, `after_script`, `cache`, `services`, `pages`). The
+extraction **MUST bind the key before testing membership** — binding it with
+`as $k` first, so the reserved-set membership test runs against the key and
+not against a pipe-rebound `.`:
+
+```console
+$ yq '[ keys[] as $k | $k
+        | select(["stages","workflow","default","include","variables",
+                  "image","before_script","after_script","cache","services",
+                  "pages"] | contains([$k]) | not) ]' .gitlab-ci.yml
+- lint-markdown
+- check-skill-versions
+```
+
+> **Do not** use the form `select([reserved] | contains([.]) | not)`. Inside
+> `select(...)` the pipe in `[reserved] | contains([.])` rebinds `.` to the
+> reserved **array**, so `[.]` wraps the array rather than the current key;
+> the predicate never matches, `not` is always true, and **every reserved key
+> leaks through unfiltered**. The `keys[] as $k | $k | … contains([$k])` form
+> above binds the key before the pipe and filters correctly.
+
+### Reserved-name fallback annotation
+
+Where an engine **forces** a job key that cannot equal the capability id —
+GitLab reserves `pages`, and a descriptive id like `pages-deploy` deliberately
+differs from the GHA job key `deploy` — the job carries a **trailing
+key-comment** binding it to its capability:
+
+```yaml
+# GitLab CI (.gitlab-ci.yml, authored by sub-spec B)
+pages: # ci-capability: pages-deploy
+  stage: deploy
+  script: [...]
+```
+
+retrieved with (passing sample):
+
+```console
+$ yq '.pages | key | line_comment' .gitlab-ci.yml
+ci-capability: pages-deploy
+```
+
+This trailing key-comment placement **is** addressable in yq's data model
+(`key | line_comment`), unlike an own-line comment placed as the first child
+of the job map, for which `line_comment` / `head_comment` / `foot_comment`
+all return empty on the job node. The fallback is used only for
+reserved-or-forced job names; the primary contract remains id == job key.
+
+### The complete harvest
+
+To attribute every job, sub-spec C harvests the set of capability ids as:
+
+> **(top-level job keys − reserved keywords) ∪ (reserved-named jobs bearing a
+> `# ci-capability: <id>` trailing key-comment, mapped to their `<id>`).**
+
+The second clause is what keeps a reserved-named deploy job (e.g. GitLab
+`pages`) from being silently dropped as untraceable. The combined harvest,
+proven against a realistic GitLab document containing the reserved keywords,
+two portable job keys, and a `pages: # ci-capability: pages-deploy` job:
+
+```console
+$ yq '
+  [ keys[] as $k | $k
+      | select(["stages","workflow","default","include","variables","image",
+                "before_script","after_script","cache","services","pages"]
+               | contains([$k]) | not) ]
+  + [ .[] | select(key | line_comment | test("^ci-capability: "))
+          | (key | line_comment | sub("^ci-capability: ", "")) ]
+' .gitlab-ci.yml
+- lint-markdown
+- check-skill-versions
+- pages-deploy
+```
+
+On GitHub Actions the harvest is simply `.jobs | keys`; GHA imposes no
+reserved-name collision on the jobs CrewRig defines, so the fallback clause is
+needed only where a future engine forces a reserved job name.
+
+## Validity rules (judgeability)
+
+A candidate reference is **valid** iff every entry satisfies the schema above.
+The conditions below map one-to-one onto the spec 0047 scenarios; sub-spec C's
+checker implements against them.
+
+1. **Portable capability resolves (Scenario 1, valid).** An entry with a
+   unique `id` and a `trigger` whose every `on:` kind is in the neutral
+   vocabulary is **accepted**; its `id` and trigger resolve, and any pipeline
+   job whose key (or fallback annotation) equals that `id` attributes to
+   exactly that capability.
+2. **Unknown trigger (Scenario 2, invalid).** Any `trigger` whose `on:` kind
+   is not one of `push`, `pull-request`, `tag`, `scheduled`, `manual` (or any
+   filter outside `branches`, `paths`, `tag-pattern`) makes the reference
+   **invalid**, naming the unrecognized trigger.
+3. **Engine-specific without evidence (Scenario 3, invalid).** A capability
+   marked `portability: specific` that carries no `exception`, or whose
+   `exception.evidence` is empty, makes the reference **invalid** — the
+   evidence is required before the capability is accepted as a known
+   exception.
+4. **Missing or duplicate id (Scenario 4, invalid).** If two capabilities
+   share one `id`, or any capability has none, the reference is **invalid** —
+   the traceability id must be present and unique.
+
+## Adding a further engine
+
+A new continuous-integration engine is supported by describing **only** its
+mapping of the existing neutral vocabulary (spec 0047 R7, R9):
+
+- It names each portable job by the capability's existing `id` (the C2
+  contract), or carries the `# ci-capability: <id>` trailing key-comment where
+  the engine forces a reserved job name.
+- It maps each neutral trigger kind to the engine's own trigger syntax (e.g.
+  `pull-request` → GHA `on: pull_request`, GitLab `rules:` on
+  `$CI_PIPELINE_SOURCE == "merge_request_event"`).
+- It hand-authors the `specific` capabilities whose `exception` names that
+  engine, and skips those whose exception names another engine.
+
+It **never** edits a capability definition. The capability set and the neutral
+vocabulary are the stable contract; each engine is one mapping over them.

--- a/docs/cli-matrix.md
+++ b/docs/cli-matrix.md
@@ -54,6 +54,16 @@ One row per integration point. ✅ = present, ❌ = absent, note when relevant.
 | 24 | e2e pillar 03 — skill build                              | `tests/e2e/scenarios/03-skill-build/`, ADR 0005 | ✅ runs `scripts/build-components.sh --target claude` inside the container; asserts `.claude/` populated + first `SKILL.md` has `metadata:` frontmatter | ✅ same with `--target gemini` → `.gemini/` | ✅ same with `--target copilot` → `.github/` |
 | 25 | e2e pillar 04 — harness loop                             | `tests/e2e/scenarios/04-harness-loop/`, ADR 0005 | ✅ simulated path (drawer write to `wing=harness-friction` + curator-style search); MemPalace sidecar; LLM-judge on the friction summary | ✅ same simulated path | ✅ same simulated path. **[GAP-soft]** — full interactive `harness-report` skill invocation is not yet driven non-interactively from any CLI; the simulation matches what the curator reads and is parity-equivalent for v1. |
 
+> **Cross-reference — CI-engine × capability axis (spec 0047, ADR-0012).** The
+> CI-engine × CI-capability axis is a *different* axis from the CLI × feature
+> matrix above and is self-documented by its own source of truth:
+> [`ci/ci-capabilities.yml`](../ci/ci-capabilities.yml), normatively described
+> by [`docs/ci-reference-format.md`](ci-reference-format.md). This row is a
+> **voluntary cross-reference for discoverability**, not a triggered CLI-matrix
+> obligation — `ci/` does not appear on the *CLI Matrix Maintenance* literal
+> trigger list. Consult the reference, not this matrix, when adding or
+> mapping a CI engine.
+
 ## Parity gaps
 
 The following features exist for one CLI but not the other. Each gap is a

--- a/docs/index.json
+++ b/docs/index.json
@@ -100,6 +100,11 @@
           "title": "Documentation publication contract",
           "path": "docs/publication-contract.md",
           "nav_order": 50
+        },
+        {
+          "title": "CI capability reference format",
+          "path": "docs/ci-reference-format.md",
+          "nav_order": 60
         }
       ]
     },
@@ -171,6 +176,11 @@
           "title": "ADR 0011 — Artifact build/install scope model",
           "path": "docs/adr/0011-artifact-build-install-scope.md",
           "nav_order": 110
+        },
+        {
+          "title": "ADR 0012 — CI capability reference contract",
+          "path": "docs/adr/0012-ci-reference-contract.md",
+          "nav_order": 120
         }
       ]
     }

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -71,6 +71,12 @@ against drift. Org-overlay documentation under `docs/org/` is `excluded` from
 sync and is unioned into the organization's own site build under the same
 contract — never flowing back upstream.
 
+### Continuous-integration reference (spec 0047)
+
+| Path | Description |
+|---|---|
+| `ci/` | Platform-neutral CI capability reference (`ci/ci-capabilities.yml`). One entry per CI job — the engine-agnostic source of truth that the per-engine pipelines (GitHub Actions today, GitLab CI and others later) are derived from and drift-checked against. Core/`strict`; its normative shape is `docs/ci-reference-format.md` (ADR-0012). Top-level rather than under `.github/` so the reference reads as engine-neutral, not GitHub-owned. |
+
 ### Build and install tooling
 
 | Path | Description |


### PR DESCRIPTION
Realizes sub-spec A (spec 0047) — the keystone CI capability reference contract for the multi-engine CI/CD parity EPIC #368. Introduces `ci/ci-capabilities.yml` (the platform-neutral source of truth) plus its normative format doc, freezing contracts C1 (schema) and C2 (capability id = pipeline job key) that sub-specs B/C/D build against.

## How to read this PR?

1. `ci/ci-capabilities.yml` — the contract: 16 capabilities, one per CI job, `id` = job key. 11 portable, 5 engine-specific exceptions (`claude`, `copilot`, `pages-deploy`, `package-and-release`, `release`) each carrying `exception: {engine, evidence}`.
2. `docs/ci-reference-format.md` — the normative format (C1) + the **tested** `yq` extraction expressions (C2): GHA `'.jobs | keys'`; GitLab key-bound form (with an explicit warning against the malformed `contains([.])` form that leaks reserved keys); the reserved-name fallback (`pages`) read via `key | line_comment`, with the harvest = (keys − reserved) ∪ (reserved-named jobs bearing the annotation).
3. `docs/adr/0012-ci-reference-contract.md` — the design record.
4. F1: `.crewrig/core-paths.txt` (`ci/` strict root) + `docs/layers.md` (core-layer classification), same diff.
5. `docs/cli-matrix.md` — one **voluntary** cross-ref row (not a literally-triggered obligation; sub-spec A touches no trigger-surface path).
6. `docs/index.json` — regenerated for the two new published docs.

## How to test this PR?

```sh
markdownlint docs/ci-reference-format.md docs/adr/0012-ci-reference-contract.md   # exit 0
yq '.capabilities | length' ci/ci-capabilities.yml                                 # 16
yq '.jobs | keys' .github/workflows/build.yml                                      # ids match portable capabilities
bash scripts/check-core-paths.sh                                                   # ci/ resolves
bash scripts/build-docs-index.sh --check                                           # no drift
```

## Detailed description (for agents)

DEV of sub-spec A, implemented to PLAN v2 (issue #377) exactly; the non-blocking cold-review finding F3 was applied (correct GitLab key-bound `yq` expression pinned and tested; reserved-named jobs harvested via the fallback annotation so a `pages` deploy is never dropped as untraceable).

- **`ci/ci-capabilities.yml`** (new): C1 schema — `capabilities:` list, each `id` (= job key, C2), `name`, `trigger:` list (kinds ∈ {push, pull-request, tag, scheduled, manual} + portable filters branches/paths/tag-pattern), `portability`, conditional `exception`. `check-skill-versions`/`check-extension-version-bump` carry `pull-request`-only triggers matching their `if:` gate.
- **`docs/ci-reference-format.md`** (new): 8-section normative format, nav_order 60; pins tested extraction expressions; documents the `id≠job-key` reserved-name case (`pages-deploy`: GHA key `deploy`, GitLab reserves `pages`).
- **`docs/adr/0012-ci-reference-contract.md`** (new): ADR-0012, nav_order 120, house format + crewrig-doc sentinel.
- **`.crewrig/core-paths.txt`** + **`docs/layers.md`** (modified): F1 registration of `ci/` as a strict core-layer root.
- **`docs/cli-matrix.md`** (modified): one voluntary cross-ref row.
- **`docs/index.json`** (regenerated).

No version bump (no skill/agent source touched). No `build-components.sh` outputs (no `artifacts/`). Local verification: markdownlint exit 0 on all docs; `yq` parses the contract (16 unique ids, all 5 specific entries carry engine+evidence); the pinned GHA/GitLab/harvest expressions were run against a realistic fixture; `check-core-paths.sh` and `build-docs-index.sh --check` pass.

Closes #377
