### PR TITLE
📝 Transition spec 0047 to its implemented lifecycle state

### DIFF
--- a/specs/0047-ci-capability-reference.md
+++ b/specs/0047-ci-capability-reference.md
@@ -1,7 +1,7 @@
 ---
 id: "0047"
 slug: ci-capability-reference
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 371


### PR DESCRIPTION
Metadata-only `status: approved` → `implemented` on `specs/0047-ci-capability-reference.md`, recording that implementation-PR #380 merged. Lifecycle-metadata carve-out per docs/spec-format.md. Closes #381