### PR TITLE
📝 Add spec 0047 delta-01 — invocation command for portable capabilities

### DIFF
--- a/specs/0047-ci-capability-reference.delta-01.md
+++ b/specs/0047-ci-capability-reference.delta-01.md
@@ -1,0 +1,57 @@
+---
+id: "0047"
+slug: ci-capability-reference
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 383
+version: 1.1.0
+---
+
+# CI capability reference contract
+
+## ADDED
+
+Two requirements extend the parent's `## Requirements` list (cumulative
+numbering R10–R11):
+
+**R10.** Each capability marked portable SHALL declare the business
+invocation command that realizes the job — the work the job performs,
+distinct from any engine-specific setup boilerplate (checkout, runtime
+setup) — such that a supported engine's pipeline for that capability can be
+derived from the reference alone, with no other source.
+
+**R11.** A capability marked engine-specific SHALL NOT be required to
+declare an invocation command; its body remains hand-authored under its
+evidence-backed exception.
+
+**Scenario:** A portable capability yields an executable job
+
+```text
+Given a portable capability declares its invocation command
+When a supported engine's pipeline for that capability is derived from the
+     reference
+Then the derived job runs that command wrapped in the engine's setup
+     boilerplate, using no source other than the reference
+```
+
+**Scenario:** A portable capability missing its command is rejected
+
+```text
+Given a capability is marked portable but declares no invocation command
+When the reference is judged against its format description
+Then it is rejected, requiring the command before the capability is
+     accepted as portable
+```
+
+## MODIFIED
+
+_None. This delta is purely additive: it introduces the invocation-command
+obligation for portable capabilities without changing any existing
+requirement. Requirement 1's job granularity is preserved — the invocation
+command is the job's business command, not step-level mechanics, which
+remain in the project's scripts outside the reference._
+
+## REMOVED
+
+_None._


### PR DESCRIPTION
Amends the CI capability reference contract (spec 0047) so each portable capability declares its business invocation command — the prerequisite that lets sub-spec B derive an executable `.gitlab-ci.yml` from the reference alone (parity by construction). Surfaced at B's kickoff.

## How to read this PR?

One file: `specs/0047-ci-capability-reference.delta-01.md`. Three delta sections — `## ADDED` (R10/R11 + two scenarios), `## MODIFIED` (none — purely additive), `## REMOVED` (none). Cumulative version 1.1.0.

## How to test this PR?

```sh
markdownlint specs/0047-ci-capability-reference.delta-01.md   # exit 0
task spec:lint                                                # delta sections present, in order
```

## Detailed description (for agents)

`spec`-class amendment originated by a design point at sub-spec B's kickoff: the contract described capabilities at job granularity without an invocation command, so B could not derive an executable portable pipeline from the reference alone.

- **R10** — each portable capability declares its business invocation command (e.g. `bash scripts/check-components.sh`), distinct from engine setup boilerplate; the generator wraps the boilerplate. Job granularity preserved (the invocation is the job's command, not step-level mechanics).
- **R11** — engine-specific capabilities need no command (body hand-authored under their evidence-backed exception).
- Two scenarios: a portable capability yields an executable job from the reference alone; a portable capability lacking its command is rejected.

The original 0047 normative content on `main` is unchanged (append-only); this delta accumulates per the delta-spec convention. Its implementation (extending `ci/ci-capabilities.yml` + `docs/ci-reference-format.md`) is the prerequisite consumed by sub-spec B.

Closes #383