### PR TITLE
📝 Transition spec 0048 to its approved lifecycle state

### DIFF
--- a/specs/0048-ci-pipeline-generator.md
+++ b/specs/0048-ci-pipeline-generator.md
@@ -1,7 +1,7 @@
 ---
 id: "0048"
 slug: ci-pipeline-generator
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 372


### PR DESCRIPTION
Metadata-only `status: draft` → `approved` on `specs/0048-ci-pipeline-generator.md`, recording that spec-PR #385 merged. Closes #387