### PR TITLE
📝 Add spec 0047 delta-02 — engine-agnostic execution requirements

### DIFF
--- a/specs/0047-ci-capability-reference.delta-02.md
+++ b/specs/0047-ci-capability-reference.delta-02.md
@@ -1,0 +1,60 @@
+---
+id: "0047"
+slug: ci-capability-reference
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 389
+version: 1.2.0
+---
+
+# CI capability reference contract
+
+## ADDED
+
+One requirement extends the parent's `## Requirements` list (cumulative
+numbering R12):
+
+**R12.** Each capability marked portable SHALL declare its engine-agnostic
+execution requirements — the runtime and version, the additional tools, and
+the source-history depth needed to run its invocation command — such that a
+supported engine's pipeline for that capability can be derived from the
+reference alone. The execution requirements describe the need, not the
+mechanism: the engine-specific setup boilerplate that satisfies them is
+produced by the derivation, never stored in the reference.
+
+**Scenario:** A portable capability's execution need is satisfied per engine
+
+```text
+Given a portable capability declares an execution requirement (a runtime
+      version, a tool, a history depth)
+When a supported engine's pipeline for that capability is derived from the
+     reference
+Then the derived job sets up that engine's boilerplate satisfying the
+     declared requirement, with no execution need taken from any source
+     other than the reference
+```
+
+**Scenario:** A portable capability missing a needed execution requirement is rejected
+
+```text
+Given a portable capability whose invocation command needs a runtime or
+      tool that the capability does not declare as an execution requirement
+When the reference is judged against its format description
+Then it is rejected, requiring the execution requirement before the
+     capability is accepted as derivable
+```
+
+## MODIFIED
+
+_None of the parent's requirement text changes. This delta clarifies the
+boundary already implied by delta-01 R10 and the original R7 "Adding a
+further engine" rule: the "engine's setup boilerplate" produced by the
+derivation (delta-01 R10) is what satisfies the execution requirements this
+delta adds (R12). The boilerplate stays on the engine-mapping side (HOW);
+the requirement is the portable capability's own property (WHAT). No
+existing requirement is weakened or removed._
+
+## REMOVED
+
+_None._


### PR DESCRIPTION
Amends the CI capability reference contract (spec 0047) so each portable capability declares its engine-agnostic execution requirements — resolving the `class: spec` finding raised on sub-spec B's PLAN (#386), where the generator needed runtime/tools/history-depth data the frozen contract did not admit.

## How to read this PR?

One file: `specs/0047-ci-capability-reference.delta-02.md`. Three delta sections — `## ADDED` (R12 + two scenarios), `## MODIFIED` (none; a boundary clarification note), `## REMOVED` (none). Cumulative version 1.2.0.

## How to test this PR?

```sh
markdownlint specs/0047-ci-capability-reference.delta-02.md   # exit 0
task spec:lint
```

## Detailed description (for agents)

`spec`-class amendment. R12: each portable capability declares its engine-agnostic execution requirements (runtime+version, tools, source-history depth) so a pipeline is derivable from the reference alone. The requirement is the WHAT (a portable-capability property in the single source); the engine-specific setup boilerplate that satisfies it is HOW, produced by the derivation, never stored — which keeps the boundary consistent with delta-01 R10 and the original "Adding a further engine" rule (a new engine is a mapping only). Two scenarios cover per-engine satisfaction and rejection of a portable capability whose command needs an undeclared runtime/tool.

The original 0047 content and delta-01 on `main` are unchanged (append-only). Implementation (extending `ci/ci-capabilities.yml` + `docs/ci-reference-format.md`) is absorbed by sub-spec B's implementation-PR per the delta-spec cumulative rule.

Closes #389