### PR TITLE
📝 Transition spec 0048 to its implemented lifecycle state

### DIFF
--- a/specs/0048-ci-pipeline-generator.md
+++ b/specs/0048-ci-pipeline-generator.md
@@ -1,7 +1,7 @@
 ---
 id: "0048"
 slug: ci-pipeline-generator
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 372


### PR DESCRIPTION
Metadata-only `status: approved` → `implemented` on `specs/0048-ci-pipeline-generator.md`, recording that implementation-PR #391 merged. Closes #392