### PR TITLE
📝 Transition spec 0049 to its approved lifecycle state

### DIFF
--- a/specs/0049-ci-drift-harness.md
+++ b/specs/0049-ci-drift-harness.md
@@ -1,7 +1,7 @@
 ---
 id: "0049"
 slug: ci-drift-harness
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 373


### PR DESCRIPTION
Metadata-only `status: draft` → `approved` on `specs/0049-ci-drift-harness.md`, recording that spec-PR #394 merged. Closes #395