### PR TITLE
✨ Add 3-way CI drift harness (spec 0049)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Test check-core-paths regression (spec 0031)
         run: bash scripts/tests/test-check-core-paths.sh
 
+      - name: Test check-ci-parity regression (spec 0049)
+        run: bash scripts/tests/test-check-ci-parity.sh
+
       - name: Test assembly verification
         run: bash scripts/tests/test-assembly-verification.sh
 
@@ -227,3 +230,16 @@ jobs:
 
       - name: Verify the generated GitLab pipeline matches the contract (spec 0048)
         run: bash scripts/build-ci.sh --check
+
+  check-ci-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Verify the reference, GitHub Actions, and GitLab pipelines agree (spec 0049)
+        run: bash scripts/check-ci-parity.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  deploy: # ci-capability: pages-deploy
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ check-components:
     - "bash scripts/tests/test-sync-from-upstream.sh"
     - "bash scripts/check-core-paths.sh"
     - "bash scripts/tests/test-check-core-paths.sh"
+    - "bash scripts/tests/test-check-ci-parity.sh"
     - "bash scripts/tests/test-assembly-verification.sh"
     - "bash scripts/tests/test-artifact-build-install-scope.sh"
     - "bash scripts/build-docs-index.sh --check"
@@ -187,6 +188,18 @@ gitlab-ci-check:
     - chmod +x /usr/local/bin/yq
   script:
     - "bash scripts/build-ci.sh --check"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'
+
+check-ci-parity:
+  image: debian:stable-slim
+  before_script:
+    - apt-get update && apt-get install -y --no-install-recommends wget ca-certificates
+    - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+    - chmod +x /usr/local/bin/yq
+  script:
+    - "bash scripts/check-ci-parity.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -66,6 +66,7 @@ capabilities:
       - bash scripts/tests/test-sync-from-upstream.sh
       - bash scripts/check-core-paths.sh
       - bash scripts/tests/test-check-core-paths.sh
+      - bash scripts/tests/test-check-ci-parity.sh
       - bash scripts/tests/test-assembly-verification.sh
       - bash scripts/tests/test-artifact-build-install-scope.sh
       - bash scripts/build-docs-index.sh --check
@@ -242,6 +243,26 @@ capabilities:
       tools: [yq]
     command:
       - bash scripts/build-ci.sh --check
+
+  # check-ci-parity is the 3-way CI drift harness (spec 0049). It checks the
+  # reference against both engine pipelines on the portable capability set;
+  # registered as a portable capability (spec 0049 R11) so the verification
+  # surface is itself contract-described and parity-checked — symmetric with
+  # gitlab-ci-check above. It shells `yq` to read the reference and the
+  # pipelines, and composes `build-ci.sh --check` (which also needs yq) for the
+  # reference↔GitLab arm; hence `tools: [yq]` (delta-02 R12).
+  - id: check-ci-parity
+    name: "Verify the reference, GitHub Actions, and GitLab pipelines agree"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+      - on: push
+        branches: [main, "release/**"]
+    portability: portable
+    requires:
+      tools: [yq]
+    command:
+      - bash scripts/check-ci-parity.sh
 
   # --- Engine-specific: bot-mention assistants ----------------------------
   # A bot-mention trigger (an issue or review comment) is engine-specific,

--- a/scripts/check-ci-parity.sh
+++ b/scripts/check-ci-parity.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+# check-ci-parity.sh — 3-way CI drift harness (spec 0049).
+#
+# Treats ci/ci-capabilities.yml (contract C1, normatively described by
+# docs/ci-reference-format.md) as the source of truth and verifies that the
+# GitHub Actions workflows and the committed .gitlab-ci.yml both faithfully
+# exhibit its PORTABLE capability set. It re-derives nothing: the
+# reference↔GitLab arm composes `scripts/build-ci.sh --check` (the generator's
+# own drift gate, spec 0048), never re-implementing GitLab generation.
+#
+# Five concerns (spec 0049 R2–R8):
+#   1. Reference validity (R2) — fail closed on each docs/ci-reference-format.md
+#      validity-rule violation (unknown trigger kind/filter; engine-specific
+#      capability without evidence; missing/duplicate id; portable without
+#      command; portable whose command needs an undeclared runtime/tool).
+#   2. Traceability harvest (R7) — per-job attribution on BOTH engines: a job is
+#      traceable iff its key equals a capability id, or its `# ci-capability:`
+#      trailing key-comment maps to one (contract C2). Fail closed on any job
+#      that is neither.
+#   3. Arm 1 — reference↔GitHub Actions at the business-step level (R3/R4):
+#      each portable capability's `command:` must be exhibited by its attributed
+#      GHA job's business `run:` steps, and its `requires:` must be satisfied by
+#      that job's setup steps, judged by presence/equivalence not exact syntax.
+#   4. Arm 2 — reference↔GitLab (R5): compose `build-ci.sh --check`; propagate.
+#   5. Arm 3 — GitHub Actions↔GitLab portable-set parity (R6): both engines'
+#      exhibited portable sets must agree with the reference's portable set.
+#
+# Engine-specific capabilities are expected absent on the engines their
+# exception does not name (R8) — never demanded as generated jobs, their absence
+# is not a divergence. When one engine's pipeline artifacts are absent the
+# harness checks only the present arms (R11). The reference is always required.
+#
+# Exit: non-zero on ANY validity violation, divergence, evidence-less exception,
+# or untraceable job (R9); zero with an OK line on a clean pass.
+#
+# Usage:
+#   bash scripts/check-ci-parity.sh
+#
+# Override the repository root with CREWRIG_REPO_DIR (used by the self-test
+# against temporary fixtures).
+#
+# Prerequisites: yq (mikefarah v4).
+
+set -euo pipefail
+
+command -v yq >/dev/null 2>&1 || {
+  echo "Error: yq is required. Install with: brew install yq" >&2
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$SCRIPT_DIR/.." && pwd)"}"
+REFERENCE="$REPO_DIR/ci/ci-capabilities.yml"
+GITLAB_CI="$REPO_DIR/.gitlab-ci.yml"
+WORKFLOWS_DIR="$REPO_DIR/.github/workflows"
+
+if [ ! -f "$REFERENCE" ]; then
+  echo "Error: CI reference not found: $REFERENCE" >&2
+  exit 2
+fi
+
+# GitLab reserved top-level keywords (docs/ci-reference-format.md lines 237-243).
+# A job whose key is one of these is a keyword, not a capability, unless it
+# carries a `# ci-capability:` fallback annotation (reserved-name fallback).
+RESERVED="stages workflow default include variables image before_script after_script cache services pages"
+
+# Trigger vocabulary (docs/ci-reference-format.md — Neutral trigger vocabulary).
+TRIGGER_KINDS="push pull-request tag scheduled manual"
+FILTER_KEYS="on branches paths tag-pattern"
+
+# --- Failure accumulator ----------------------------------------------------
+
+FAILURES=()
+fail() {
+  echo "  DRIFT: $*" >&2
+  FAILURES+=("$*")
+}
+
+# --- Helpers ----------------------------------------------------------------
+
+# Normalize a command/step body for equivalence comparison: collapse every
+# whitespace run (including newlines) to a single space, trim the ends, and
+# strip a leading `sudo ` — so hand-authored boilerplate differences in
+# whitespace or a sudo prefix are not divergences (spec 0049 R4).
+normalize_cmd() {
+  printf '%s' "$1" \
+    | tr '\n\t' '  ' \
+    | sed -e 's/  */ /g' -e 's/^ //' -e 's/ $//' -e 's/^sudo //'
+}
+
+# Classify a normalized `run:` body as a known setup tool-install recipe,
+# echoing the tool it installs (empty if it is not a recognized install). The
+# recognized recipes mirror the exact closed tool vocabulary build-ci.sh knows
+# (tool_install_lines) and their hand-authored GHA forms, so the classifier
+# stays in lock-step with the generator (spec 0049 PLAN Risk R3).
+install_recipe_tool() {
+  case "$1" in
+    *yq_linux_amd64*|*mikefarah/yq*) echo yq ;;
+    *taskfile.dev*)                  echo task ;;
+    *markdownlint-cli*)              echo markdownlint-cli ;;
+    *apt-get*install*jq*|*install*-y*jq*) echo jq ;;
+    *) echo "" ;;
+  esac
+}
+
+# True if one of a portable capability's own command entries self-installs the
+# named tool (e.g. lint-markdown's `npm install -g markdownlint-cli`), so the
+# tool need not appear under requires.tools (validity rule 6).
+self_installs_tool() {
+  local cmds="$1" want="$2" line
+  while IFS= read -r line; do
+    [ "$(install_recipe_tool "$(normalize_cmd "$line")")" = "$want" ] && return 0
+  done <<< "$cmds"
+  return 1
+}
+
+in_list() { grep -qxF "$1" <<< "$2"; }
+
+# --- Concern 1: reference validity (R2) -------------------------------------
+
+validity_errors=()
+verr() { validity_errors+=("$*"); }
+
+cap_count=$(yq '.capabilities | length' "$REFERENCE")
+ids_seen=""
+for ((i = 0; i < cap_count; i++)); do
+  id=$(yq -r ".capabilities[$i].id // \"\"" "$REFERENCE")
+  port=$(yq -r ".capabilities[$i].portability // \"\"" "$REFERENCE")
+  label="capability index $i"
+  [ -n "$id" ] && [ "$id" != "null" ] && label="capability '$id'"
+
+  # Rule 4 — id present and unique.
+  if [ -z "$id" ] || [ "$id" = "null" ]; then
+    verr "$label: missing traceability id (validity rule 4)"
+  else
+    if in_list "$id" "$ids_seen"; then
+      verr "capability '$id': duplicate traceability id (validity rule 4)"
+    fi
+    ids_seen="${ids_seen}${id}"$'\n'
+  fi
+
+  # Rule 2 — trigger kinds and filters within the neutral vocabulary.
+  ntrig=$(yq ".capabilities[$i].trigger // [] | length" "$REFERENCE")
+  if [ "$ntrig" -eq 0 ]; then
+    verr "$label: declares no trigger (a trigger is mandatory)"
+  fi
+  for ((t = 0; t < ntrig; t++)); do
+    kind=$(yq -r ".capabilities[$i].trigger[$t].on // \"\"" "$REFERENCE")
+    case " $TRIGGER_KINDS " in
+      *" $kind "*) ;;
+      *) verr "$label: trigger kind '$kind' is outside the neutral vocabulary (validity rule 2)" ;;
+    esac
+    while IFS= read -r fk; do
+      [ -z "$fk" ] && continue
+      case " $FILTER_KEYS " in
+        *" $fk "*) ;;
+        *) verr "$label: trigger filter '$fk' is outside {branches, paths, tag-pattern} (validity rule 2)" ;;
+      esac
+    done < <(yq -r ".capabilities[$i].trigger[$t] | keys | .[]" "$REFERENCE")
+  done
+
+  # Rule 3 — engine-specific capability carries evidence-backed exception.
+  if [ "$port" = "specific" ]; then
+    eng=$(yq -r ".capabilities[$i].exception.engine // \"\"" "$REFERENCE")
+    ev=$(yq -r ".capabilities[$i].exception.evidence // \"\"" "$REFERENCE")
+    ev_trim=$(printf '%s' "$ev" | tr -d '[:space:]')
+    if [ -z "$eng" ] || [ "$eng" = "null" ]; then
+      verr "$label: engine-specific capability without exception.engine (validity rule 3)"
+    fi
+    if [ -z "$ev_trim" ] || [ "$ev" = "null" ]; then
+      verr "$label: engine-specific capability with empty exception.evidence (validity rule 3)"
+    fi
+  fi
+
+  # Rules 5 and 6 — portable capability declares a command, and its command
+  # invokes no runtime/tool it does not declare under requires (or self-install).
+  if [ "$port" = "portable" ]; then
+    ncmd=$(yq ".capabilities[$i].command // [] | length" "$REFERENCE")
+    if [ "$ncmd" -eq 0 ]; then
+      verr "$label: portable capability declares no command (validity rule 5)"
+    else
+      cmds=$(yq -r ".capabilities[$i].command[]" "$REFERENCE")
+      cmds_norm=" $(normalize_cmd "$cmds") "
+      runtime=$(yq -r ".capabilities[$i].requires.runtime // \"\"" "$REFERENCE")
+      req_tools=$(yq -r ".capabilities[$i].requires.tools // [] | .[]" "$REFERENCE")
+
+      # Runtime tokens — a command invoking node/npm or python needs the
+      # matching runtime declared.
+      case "$cmds_norm" in
+        *" npm "*|*" npx "*|*" node "*)
+          case "$runtime" in node@*) ;; *) verr "$label: command needs the node runtime but requires.runtime is '${runtime:-unset}' (validity rule 6)" ;; esac ;;
+      esac
+      case "$cmds_norm" in
+        *" python "*|*" python3 "*|*" pip "*|*" pip3 "*)
+          case "$runtime" in python@*) ;; *) verr "$label: command needs the python runtime but requires.runtime is '${runtime:-unset}' (validity rule 6)" ;; esac ;;
+      esac
+
+      # Tool tokens — a command invoking yq/jq/task/markdownlint needs the tool
+      # declared under requires.tools, unless the command self-installs it.
+      for probe in yq jq task markdownlint; do
+        case "$cmds_norm" in
+          *" $probe "*)
+            mapped="$probe"
+            [ "$probe" = markdownlint ] && mapped="markdownlint-cli"
+            if in_list "$mapped" "$req_tools"; then
+              :
+            elif self_installs_tool "$cmds" "$mapped"; then
+              :
+            else
+              verr "$label: command invokes '$probe' but does not declare '$mapped' under requires.tools (validity rule 6)"
+            fi
+            ;;
+        esac
+      done
+    fi
+  fi
+done
+
+if [ "${#validity_errors[@]}" -gt 0 ]; then
+  echo "FAILED: ${#validity_errors[@]} reference-validity violation(s) in $REFERENCE:" >&2
+  for e in "${validity_errors[@]}"; do
+    echo "  - $e" >&2
+  done
+  echo "" >&2
+  echo "The reference is the source of truth; refusing to check the engines against" >&2
+  echo "a malformed reference (spec 0049 R2)." >&2
+  exit 1
+fi
+
+# --- Reference id sets ------------------------------------------------------
+
+ALL_IDS=$(yq -r '.capabilities[].id' "$REFERENCE")
+PORTABLE_IDS=$(yq -r '.capabilities[] | select(.portability == "portable") | .id' "$REFERENCE")
+
+# --- Engine presence (R11 graceful degradation) -----------------------------
+
+GHA_PRESENT=false
+if [ -d "$WORKFLOWS_DIR" ]; then
+  for _wf in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
+    # An unmatched glob expands to the literal pattern, which is not a file.
+    [ -f "$_wf" ] && { GHA_PRESENT=true; break; }
+  done
+fi
+GITLAB_PRESENT=false
+[ -f "$GITLAB_CI" ] && GITLAB_PRESENT=true
+
+# --- Concern 2: traceability harvest, per-job attribution (R7) --------------
+
+# Attribute a job key to a capability id: the key itself when it equals an id
+# (C2 primary path), else the `# ci-capability:` annotation target when valid.
+# Echoes the attributed id, or empty if untraceable.
+attribute_job() {
+  local jk="$1" file="$2" sel="$3" cand lc
+  if in_list "$jk" "$ALL_IDS"; then
+    echo "$jk"
+    return
+  fi
+  lc=$(yq "$sel | key | line_comment" "$file")
+  case "$lc" in
+    "ci-capability: "*)
+      cand="${lc#ci-capability: }"
+      if in_list "$cand" "$ALL_IDS"; then echo "$cand"; return; fi
+      ;;
+  esac
+  echo ""
+}
+
+# GHA harvest — union across ALL workflow files. Records `id<TAB>file<TAB>jobkey`
+# triples so Arm 1 can locate each portable capability's job.
+GHA_JOBS=""
+GHA_EXHIBITED=""
+if $GHA_PRESENT; then
+  for wf in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
+    [ -f "$wf" ] || continue
+    yq -e '.jobs' "$wf" >/dev/null 2>&1 || continue
+    while IFS= read -r jk; do
+      [ -z "$jk" ] && continue
+      attributed=$(attribute_job "$jk" "$wf" ".jobs.\"$jk\"")
+      if [ -z "$attributed" ]; then
+        fail "untraceable job '$jk' in $(basename "$wf") (github-actions) — not a capability id and no valid '# ci-capability:' annotation (R7)"
+      else
+        GHA_JOBS="${GHA_JOBS}${attributed}	${wf}	${jk}"$'\n'
+        GHA_EXHIBITED="${GHA_EXHIBITED}${attributed}"$'\n'
+      fi
+    done < <(yq -r '.jobs | keys | .[]' "$wf")
+  done
+fi
+
+# GitLab harvest — top-level keys minus reserved keywords, plus reserved-named
+# jobs bearing a fallback annotation (the complete harvest, docs lines 287-315).
+GITLAB_EXHIBITED=""
+if $GITLAB_PRESENT; then
+  while IFS= read -r jk; do
+    [ -z "$jk" ] && continue
+    case " $RESERVED " in
+      *" $jk "*)
+        # Reserved keyword — a job only if it carries a fallback annotation.
+        lc=$(yq ".\"$jk\" | key | line_comment" "$GITLAB_CI")
+        case "$lc" in
+          "ci-capability: "*)
+            cand="${lc#ci-capability: }"
+            if in_list "$cand" "$ALL_IDS"; then
+              GITLAB_EXHIBITED="${GITLAB_EXHIBITED}${cand}"$'\n'
+            else
+              fail "untraceable job '$jk' in .gitlab-ci.yml (gitlab) — annotation '$cand' is not a capability id (R7)"
+            fi
+            ;;
+        esac
+        continue
+        ;;
+    esac
+    attributed=$(attribute_job "$jk" "$GITLAB_CI" ".\"$jk\"")
+    if [ -z "$attributed" ]; then
+      fail "untraceable job '$jk' in .gitlab-ci.yml (gitlab) — not a capability id and no valid '# ci-capability:' annotation (R7)"
+    else
+      GITLAB_EXHIBITED="${GITLAB_EXHIBITED}${attributed}"$'\n'
+    fi
+  done < <(yq -r 'keys | .[]' "$GITLAB_CI")
+fi
+
+# --- Arm 1: reference↔GitHub Actions business-step check (R3/R4) ------------
+
+# Verify one portable capability against its attributed GHA job. Aligns the
+# job's business `run:` steps against the capability's command list in order,
+# skipping `uses:` setup steps and recognized tool-install recipes; then checks
+# that requires is satisfied by the recorded setup (presence/equivalence).
+check_gha_job() {
+  local id="$1" wf="$2" jk="$3"
+  local ncmd runtime req_tools hist nsteps
+  ncmd=$(yq ".capabilities[] | select(.id == \"$id\") | .command | length" "$REFERENCE")
+  runtime=$(yq -r ".capabilities[] | select(.id == \"$id\") | .requires.runtime // \"\"" "$REFERENCE")
+  req_tools=$(yq -r ".capabilities[] | select(.id == \"$id\") | .requires.tools // [] | .[]" "$REFERENCE")
+  hist=$(yq -r ".capabilities[] | select(.id == \"$id\") | .requires.history-depth // \"\"" "$REFERENCE")
+  nsteps=$(yq ".jobs.\"$jk\".steps | length" "$wf")
+
+  local ci=0
+  local prov_node="" prov_python="" prov_fetch="" prov_tools=""
+  local s uses run nrun nextcmd rtool
+  for ((s = 0; s < nsteps; s++)); do
+    uses=$(yq -r ".jobs.\"$jk\".steps[$s].uses // \"\"" "$wf")
+    run=$(yq -r ".jobs.\"$jk\".steps[$s].run // \"\"" "$wf")
+
+    if [ -n "$uses" ] && [ "$uses" != "null" ]; then
+      case "$uses" in
+        */checkout@*)     prov_fetch=$(yq -r ".jobs.\"$jk\".steps[$s].with.fetch-depth // \"\"" "$wf") ;;
+        */setup-node@*)   prov_node=$(yq -r ".jobs.\"$jk\".steps[$s].with.node-version // \"\"" "$wf") ;;
+        */setup-python@*) prov_python=$(yq -r ".jobs.\"$jk\".steps[$s].with.python-version // \"\"" "$wf") ;;
+      esac
+      continue
+    fi
+
+    if [ -n "$run" ] && [ "$run" != "null" ]; then
+      nrun=$(normalize_cmd "$run")
+      # Business step iff it matches the next expected command entry, in order.
+      if [ "$ci" -lt "$ncmd" ]; then
+        nextcmd=$(normalize_cmd "$(yq -r ".capabilities[] | select(.id == \"$id\") | .command[$ci]" "$REFERENCE")")
+        if [ "$nrun" = "$nextcmd" ]; then
+          ci=$((ci + 1))
+          continue
+        fi
+      fi
+      # Otherwise it must be a recognized setup tool-install recipe.
+      rtool=$(install_recipe_tool "$nrun")
+      if [ -n "$rtool" ]; then
+        prov_tools="${prov_tools}${rtool}"$'\n'
+        continue
+      fi
+      fail "capability '$id' (github-actions): business step diverges from the declared command — unexpected step: '$nrun' (R3)"
+      return
+    fi
+  done
+
+  if [ "$ci" -ne "$ncmd" ]; then
+    fail "capability '$id' (github-actions): job '$jk' exhibits $ci of $ncmd declared business steps (R3)"
+  fi
+
+  # R4 — requires satisfied by setup, judged by presence/equivalence.
+  case "$runtime" in
+    node@*)
+      local want="${runtime#node@}"
+      [ "${prov_node%%.*}" = "${want%%.*}" ] || \
+        fail "capability '$id' (github-actions): requires runtime '$runtime' but setup provides node '${prov_node:-none}' (R4)"
+      ;;
+    python@*)
+      local want="${runtime#python@}"
+      case "$prov_python" in
+        "$want"*) ;;
+        *) fail "capability '$id' (github-actions): requires runtime '$runtime' but setup provides python '${prov_python:-none}' (R4)" ;;
+      esac
+      ;;
+  esac
+  while IFS= read -r rt; do
+    [ -z "$rt" ] && continue
+    in_list "$rt" "$prov_tools" || \
+      fail "capability '$id' (github-actions): requires tool '$rt' but no setup step installs it (R4)"
+  done <<< "$req_tools"
+  if [ "$hist" = "full" ]; then
+    [ "$prov_fetch" = "0" ] || \
+      fail "capability '$id' (github-actions): requires full source history but checkout fetch-depth is '${prov_fetch:-unset}' (R4)"
+  fi
+}
+
+if $GHA_PRESENT; then
+  while IFS= read -r pid; do
+    [ -z "$pid" ] && continue
+    triple=$(printf '%s' "$GHA_JOBS" | awk -F'\t' -v id="$pid" '$1 == id { print $2 "\t" $3; exit }')
+    # A portable capability with no GHA job is an Arm-3 omission, reported there.
+    [ -z "$triple" ] && continue
+    wf="${triple%%	*}"
+    jk="${triple#*	}"
+    check_gha_job "$pid" "$wf" "$jk"
+  done <<< "$PORTABLE_IDS"
+fi
+
+# --- Arm 2: reference↔GitLab (R5) -------------------------------------------
+
+if $GITLAB_PRESENT; then
+  if ! gitlab_out=$(REPO_DIR="$REPO_DIR" bash "$SCRIPT_DIR/build-ci.sh" --check 2>&1); then
+    fail "reference↔GitLab divergence (gitlab) — composed 'build-ci.sh --check' failed (R5):"
+    while IFS= read -r ln; do
+      echo "    $ln" >&2
+    done <<< "$gitlab_out"
+  fi
+fi
+
+# --- Arm 3: GitHub Actions↔GitLab portable-set parity (R6) ------------------
+
+# The portable ids each engine exhibits (specific capabilities excluded, R8).
+portable_subset() {
+  local exhibited="$1" x
+  while IFS= read -r x; do
+    [ -z "$x" ] && continue
+    in_list "$x" "$PORTABLE_IDS" && echo "$x"
+  done <<< "$exhibited" | sort -u
+}
+
+arm3_compare() {
+  local platform="$1" exhibited_portable="$2" pid
+  while IFS= read -r pid; do
+    [ -z "$pid" ] && continue
+    in_list "$pid" "$exhibited_portable" || \
+      fail "capability '$pid' is in the reference portable set but absent from $platform (R6)"
+  done <<< "$PORTABLE_IDS"
+}
+
+if $GHA_PRESENT; then
+  arm3_compare "github-actions" "$(portable_subset "$GHA_EXHIBITED")"
+fi
+if $GITLAB_PRESENT; then
+  arm3_compare "gitlab" "$(portable_subset "$GITLAB_EXHIBITED")"
+fi
+
+# Engine-specific capabilities (R8) need no check here: they are expected absent
+# on the engines their exception does not name, Arm 3 excludes them from the
+# portable comparison, and their absence is not a divergence.
+
+# --- Verdict (R9) -----------------------------------------------------------
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "FAILED: ${#FAILURES[@]} CI parity violation(s) detected (spec 0049)." >&2
+  exit 1
+fi
+
+arms="reference"
+$GHA_PRESENT && arms="$arms, GitHub Actions"
+$GITLAB_PRESENT && arms="$arms, GitLab"
+echo "OK: $arms agree on the portable capability set; every pipeline job is traceable."

--- a/scripts/tests/test-check-ci-parity.sh
+++ b/scripts/tests/test-check-ci-parity.sh
@@ -1,0 +1,412 @@
+#!/bin/bash
+# test-check-ci-parity.sh — Regression tests for check-ci-parity.sh (spec 0049).
+#
+# check-ci-parity.sh is the 3-way CI drift harness: it treats
+# ci/ci-capabilities.yml as the source of truth and verifies that the GitHub
+# Actions workflows and the committed .gitlab-ci.yml both faithfully exhibit its
+# PORTABLE capability set, that the two engines agree, that no pipeline job is
+# untraceable, and that the reference is itself well-formed. This is the parity
+# sibling mandated by spec 0049 R10 and the repo convention "every check-*.sh
+# has a test-*.sh" (mirrors scripts/tests/test-check-core-paths.sh).
+#
+# Every fixture is a hermetic temp COPY of the real ci/, .github/, and
+# .gitlab-ci.yml tree; the real repo tree is never mutated. The harness composes
+# the real scripts/build-ci.sh for its reference↔GitLab arm (Arm 2), reading the
+# fixture via CREWRIG_REPO_DIR — so the copied ci/ + .gitlab-ci.yml are all Arm 2
+# needs from the fixture.
+#
+# Cases (each asserts the exit code AND that the message names the offending
+# capability + platform where applicable):
+#
+#   Positive:
+#     P1   Conforming tree → exit 0; OK line enumerates BOTH GitHub Actions
+#          AND GitLab (regression guard for the silent-skip bug — the OK line
+#          must prove every present engine was actually checked).
+#     P2a  Fallback resolution (PLAN Step 2a, load-bearing): the conforming
+#          fixture's GHA `deploy` job carries `# ci-capability: pages-deploy`;
+#          assert it resolves (no `untraceable job 'deploy'`) and exit 0.
+#     P2b  Negative twin: STRIP the annotation → `untraceable job 'deploy'`
+#          + exit 1.
+#     P3   Boilerplate tolerance (S2): an extra hand-authored setup step
+#          (uses:) → exit 0, no drift.
+#     P4a  Graceful degradation (S9/R11): missing .gitlab-ci.yml → exit 0
+#          (GHA-only; OK line omits GitLab).
+#     P4b  Graceful degradation (S9/R11): missing .github/ → exit 0
+#          (GitLab-only; OK line omits GitHub Actions).
+#
+#   Fail-closed (exit 1 each):
+#     S3   Drifted GHA business step → names github-actions.
+#     S4   Drifted committed .gitlab-ci.yml → names gitlab; surfaces the
+#          composed build-ci.sh --check.
+#     S5   An engine omits a portable capability → cross-engine parity (R6).
+#     S6   Untraceable job (key != id, no fallback annotation).
+#     S7   `specific` capability with empty evidence.
+#     S10a Reference validity: unknown trigger kind.
+#     S10b Reference validity: duplicate id.
+#     S10c Reference validity: portable without command.
+#     S10d Reference validity: portable with an unmet requirement.
+#     R4d  Missing fetch-depth: 0 where requires history-depth: full.
+#     R4t  Missing tool install (yq).
+#     R4r  Wrong runtime version (node-version).
+#
+# Usage:
+#   bash scripts/tests/test-check-ci-parity.sh
+
+# -e intentionally omitted: pass/fail counters control the harness; adding -e
+# would abort on the expected non-zero exits from the script under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-ci-parity.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "FATAL: yq (mikefarah v4) is required to run these tests" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ok()  { echo "PASS  $1"; pass=$((pass + 1)); }
+ko()  { echo "FAIL  $1"; fail=$((fail + 1)); }
+
+# make_fixture — print the path to a fresh hermetic copy of the conforming tree
+# (the real ci/, .github/, and .gitlab-ci.yml). Callers mutate the copy only.
+make_fixture() {
+  local fx
+  fx="$(mktemp -d "$TMP_ROOT/fx.XXXXXX")"
+  cp -R "$REPO_ROOT/ci"             "$fx/ci"
+  cp -R "$REPO_ROOT/.github"        "$fx/.github"
+  cp    "$REPO_ROOT/.gitlab-ci.yml" "$fx/.gitlab-ci.yml"
+  printf '%s' "$fx"
+}
+
+# run_check <fixture> — run the harness over the fixture, capturing exit/stdout/
+# stderr into CHECK_EXIT / CHECK_STDOUT / CHECK_STDERR.
+run_check() {
+  local repo="$1" out_file err_file
+  out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
+  err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
+  CHECK_EXIT=0
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  CHECK_STDOUT="$(cat "$out_file")"
+  CHECK_STDERR="$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+}
+
+# expect_exit <expected> <label>
+expect_exit() {
+  if [ "$CHECK_EXIT" -eq "$1" ]; then
+    ok "$2 (exit $1)"
+  else
+    ko "$2: expected exit $1, got $CHECK_EXIT"
+    echo "      stderr: $CHECK_STDERR"
+  fi
+}
+
+# expect_in <stream> <substring> <label> — assert the captured stream contains
+# the literal substring. <stream> is "out" or "err".
+expect_in() {
+  local stream="$1" needle="$2" label="$3" hay
+  case "$stream" in out) hay="$CHECK_STDOUT" ;; *) hay="$CHECK_STDERR" ;; esac
+  if printf '%s' "$hay" | grep -qF "$needle"; then
+    ok "$label"
+  else
+    ko "$label: $stream missing '$needle'"
+    echo "      $stream: $hay"
+  fi
+}
+
+# refute_in <stream> <substring> <label> — assert the stream does NOT contain it.
+refute_in() {
+  local stream="$1" needle="$2" label="$3" hay
+  case "$stream" in out) hay="$CHECK_STDOUT" ;; *) hay="$CHECK_STDERR" ;; esac
+  if printf '%s' "$hay" | grep -qF "$needle"; then
+    ko "$label: $stream unexpectedly contains '$needle'"
+    echo "      $stream: $hay"
+  else
+    ok "$label"
+  fi
+}
+
+# ===========================================================================
+# Positive cases
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# P1 + P2a — Conforming tree → exit 0; OK line enumerates BOTH engines; the
+# `deploy` fallback annotation resolves (no untraceable-job failure).
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  run_check "$f"
+
+  expect_exit 0 "P1: conforming tree passes"
+  expect_in out "OK:"            "P1: OK line emitted on stdout"
+  expect_in out "GitHub Actions" "P1: OK line enumerates GitHub Actions"
+  expect_in out "GitLab"         "P1: OK line enumerates GitLab"
+
+  # P2a — the load-bearing fallback-regression guard: `deploy` (key != id
+  # pages-deploy) must resolve via its `# ci-capability: pages-deploy`
+  # annotation, never surfacing as untraceable on the conforming repo.
+  refute_in err "untraceable job 'deploy'" "P2a: deploy fallback resolves (not untraceable)"
+}
+
+# ---------------------------------------------------------------------------
+# P2b — Negative twin: strip the `# ci-capability:` annotation from `deploy`
+# → untraceable job + exit 1.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # Drop the trailing key-comment so `deploy` is neither an id nor annotated.
+  sed -i.bak 's/^  deploy: # ci-capability: pages-deploy/  deploy:/' \
+    "$f/.github/workflows/pages.yml"
+  rm -f "$f/.github/workflows/pages.yml.bak"
+
+  run_check "$f"
+  expect_exit 1 "P2b: stripped fallback annotation fails closed"
+  expect_in err "untraceable job 'deploy'" "P2b: names the untraceable deploy job"
+  expect_in err "github-actions"           "P2b: names the github-actions platform"
+}
+
+# ---------------------------------------------------------------------------
+# P3 — Boilerplate tolerance (S2): an extra hand-authored setup step (a `uses:`
+# step) is not a divergence.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '.jobs.build.steps += [{"uses": "actions/cache@v4"}]' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 0 "P3: extra setup boilerplate is tolerated"
+  expect_in out "OK:" "P3: clean OK line on stdout"
+}
+
+# ---------------------------------------------------------------------------
+# P4a — Graceful degradation: missing .gitlab-ci.yml → exit 0, GHA-only.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  rm -f "$f/.gitlab-ci.yml"
+
+  run_check "$f"
+  expect_exit 0 "P4a: GHA-only repo passes (GitLab absent)"
+  expect_in out "GitHub Actions" "P4a: OK line names the present GitHub Actions arm"
+  refute_in out "GitLab"         "P4a: OK line omits the absent GitLab arm"
+}
+
+# ---------------------------------------------------------------------------
+# P4b — Graceful degradation: missing .github/ → exit 0, GitLab-only.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  rm -rf "$f/.github"
+
+  run_check "$f"
+  expect_exit 0 "P4b: GitLab-only repo passes (GitHub Actions absent)"
+  expect_in out "GitLab"          "P4b: OK line names the present GitLab arm"
+  refute_in out "GitHub Actions"  "P4b: OK line omits the absent GitHub Actions arm"
+}
+
+# ===========================================================================
+# Fail-closed cases
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# S3 — A drifted GHA business step → fail closed naming the capability + GHA.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # build job steps: [0] checkout, [1] setup-node, [2] `npm install`,
+  # [3] `npm run build …`. Break the business step at index 3.
+  yq -i '.jobs.build.steps[3].run = "npm run bogus"' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "S3: drifted GHA business step fails closed"
+  expect_in err "capability 'build' (github-actions)" "S3: names capability + github-actions"
+}
+
+# ---------------------------------------------------------------------------
+# S4 — A drifted committed .gitlab-ci.yml → fail closed naming GitLab via the
+# composed build-ci.sh --check.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # Any hand-edit makes the committed file differ from a fresh derivation.
+  printf '\n# hand-edited drift\n' >> "$f/.gitlab-ci.yml"
+
+  run_check "$f"
+  expect_exit 1 "S4: drifted .gitlab-ci.yml fails closed"
+  expect_in err "(gitlab)"             "S4: names the gitlab platform"
+  expect_in err "build-ci.sh --check"  "S4: surfaces the composed build-ci.sh --check"
+}
+
+# ---------------------------------------------------------------------------
+# S5 — An engine omits a portable capability → cross-engine parity (R6).
+# Removing check-agents-size from GHA leaves GitLab exhibiting it: Arm 3 flags
+# the github-actions omission (Arm 2 stays green — ci/ and .gitlab-ci.yml are
+# untouched, so build-ci.sh --check still passes).
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i 'del(.jobs.check-agents-size)' "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "S5: cross-engine portable-set mismatch fails closed"
+  expect_in err "check-agents-size" "S5: names the mismatched capability"
+  expect_in err "github-actions"    "S5: names the affected platform"
+  expect_in err "R6"                "S5: cites the parity rule R6"
+}
+
+# ---------------------------------------------------------------------------
+# S6 — An untraceable job (key != id, no fallback) → fail closed naming the job.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '.jobs."mystery" = {"runs-on": "ubuntu-latest", "steps": [{"run": "echo hi"}]}' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "S6: untraceable job fails closed"
+  expect_in err "untraceable job 'mystery'" "S6: names the untraceable job"
+  expect_in err "github-actions"            "S6: names the platform"
+}
+
+# ---------------------------------------------------------------------------
+# S7 — A `specific` capability with empty evidence → reference-validity (rule 3).
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '(.capabilities[] | select(.id == "pages-deploy") | .exception.evidence) = ""' \
+    "$f/ci/ci-capabilities.yml"
+
+  run_check "$f"
+  expect_exit 1 "S7: evidence-less engine-specific exception fails closed"
+  expect_in err "pages-deploy"  "S7: names the offending capability"
+  expect_in err "evidence"      "S7: names the empty evidence violation"
+}
+
+# ---------------------------------------------------------------------------
+# S10a — Reference validity: an unknown trigger kind.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '(.capabilities[] | select(.id == "build") | .trigger[0].on) = "bogus"' \
+    "$f/ci/ci-capabilities.yml"
+
+  run_check "$f"
+  expect_exit 1 "S10a: unknown trigger kind fails closed"
+  expect_in err "build"           "S10a: names the offending capability"
+  expect_in err "validity rule 2" "S10a: cites trigger-vocabulary rule 2"
+}
+
+# ---------------------------------------------------------------------------
+# S10b — Reference validity: a duplicate traceability id.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '(.capabilities[] | select(.id == "lint-specs") | .id) = "build"' \
+    "$f/ci/ci-capabilities.yml"
+
+  run_check "$f"
+  expect_exit 1 "S10b: duplicate id fails closed"
+  expect_in err "duplicate"       "S10b: names the duplicate-id violation"
+  expect_in err "validity rule 4" "S10b: cites id rule 4"
+}
+
+# ---------------------------------------------------------------------------
+# S10c — Reference validity: a portable capability without a command.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i 'del(.capabilities[] | select(.id == "build") | .command)' \
+    "$f/ci/ci-capabilities.yml"
+
+  run_check "$f"
+  expect_exit 1 "S10c: portable-without-command fails closed"
+  expect_in err "build"           "S10c: names the offending capability"
+  expect_in err "validity rule 5" "S10c: cites command rule 5"
+}
+
+# ---------------------------------------------------------------------------
+# S10d — Reference validity: a portable command needs a tool it does not declare.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # `build` declares runtime node@22 but no tools; add a jq invocation.
+  yq -i '(.capabilities[] | select(.id == "build") | .command) += ["jq ."]' \
+    "$f/ci/ci-capabilities.yml"
+
+  run_check "$f"
+  expect_exit 1 "S10d: portable-with-unmet-requirement fails closed"
+  expect_in err "jq"              "S10d: names the undeclared tool"
+  expect_in err "validity rule 6" "S10d: cites requirement rule 6"
+}
+
+# ---------------------------------------------------------------------------
+# R4d — Missing fetch-depth: 0 where the capability requires history-depth: full.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # check-skill-versions GHA job step[0] is the checkout carrying fetch-depth: 0.
+  yq -i 'del(.jobs.check-skill-versions.steps[0].with)' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "R4d: missing full-history checkout fails closed"
+  expect_in err "check-skill-versions" "R4d: names the capability"
+  expect_in err "fetch-depth"          "R4d: names the unmet history-depth requirement"
+}
+
+# ---------------------------------------------------------------------------
+# R4t — Missing tool install (yq) for a capability that requires it.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # check-feedback-routing GHA job step[1] is the "Install yq" recipe.
+  yq -i 'del(.jobs.check-feedback-routing.steps[1])' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "R4t: missing tool install fails closed"
+  expect_in err "check-feedback-routing" "R4t: names the capability"
+  expect_in err "requires tool 'yq'"     "R4t: names the unmet tool requirement"
+}
+
+# ---------------------------------------------------------------------------
+# R4r — Wrong runtime version (node-version) versus the declared runtime.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  # build requires node@22; downgrade the setup-node version to 20.
+  yq -i '(.jobs.build.steps[1].with.node-version) = 20' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "R4r: wrong runtime version fails closed"
+  expect_in err "capability 'build' (github-actions)" "R4r: names capability + platform"
+  expect_in err "node"                                "R4r: names the runtime mismatch"
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+echo "Results: $pass/$total passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Adds `check-ci-parity.sh`, a 3-way drift harness that treats `ci/ci-capabilities.yml` as the source of truth and fails closed when the GitHub Actions workflows or the committed `.gitlab-ci.yml` diverge from it. Implements spec 0049 (sub-spec C of EPIC #368).

## How to read this PR?

Read the changeset in this order:

1. **`scripts/check-ci-parity.sh`** — the harness, and the heart of the PR. The
   header comment (lines 1–42) states the contract; the body is organised as
   five labelled concerns: reference validity (R2), per-job traceability harvest
   (R7), then the three drift arms — reference↔GitHub Actions at the
   business-step level (R3/R4), reference↔GitLab via composed `build-ci.sh
   --check` (R5), and GitHub Actions↔GitLab portable-set parity (R6). It
   re-derives nothing: the GitLab arm composes the spec-0048 generator's own
   `--check` gate rather than re-implementing GitLab generation.
2. **`scripts/tests/test-check-ci-parity.sh`** — the self-test. The header
   (lines ~20–40) enumerates the scenarios P1–P4 / S5–S10 / R4; each builds a
   throwaway fixture tree under `CREWRIG_REPO_DIR` and asserts exit code and
   message. P1 is the regression guard for the silent-skip bug (see Detailed
   description).
3. **`ci/ci-capabilities.yml`** — the harness self-registers as a `portable`
   capability `check-ci-parity` (R11): the verification surface is itself
   contract-described and parity-checked. The same diff threads the self-test
   into the `check-components` capability command list.
4. **`.github/workflows/build.yml`**, **`.gitlab-ci.yml`** — the two engines now
   run the harness. The GitLab file is **generated** by `scripts/build-ci.sh`,
   not hand-edited; its diff is the mechanical projection of the capability
   added in (3).
5. **`.github/workflows/pages.yml`** — a one-token annotation
   (`deploy: # ci-capability: pages-deploy`) so the existing C2 engine-specific
   fallback job is traceable under the new harvest.

## How to test this PR?

Prerequisite: `yq` (mikefarah v4) on `PATH`.

```sh
# 1. The harness passes on this tree; the OK line names both present engines.
bash scripts/check-ci-parity.sh
#    → exit 0
#    → "OK: reference, GitHub Actions, GitLab agree on the portable capability
#       set; every pipeline job is traceable."

# 2. The self-test (fixtures cover happy path, graceful degradation, every
#    fail-closed arm).
bash scripts/tests/test-check-ci-parity.sh
#    → exit 0, "Results: 52/52 passed"

# 3. The GitLab pipeline is in sync with the reference (spec-0048 gate, which
#    the harness composes for its reference↔GitLab arm).
bash scripts/build-ci.sh --check
#    → exit 0, clean
```

All three verified green locally.

## Detailed description (for agents)

Six files, all under existing roots — no new top-level paths.

### New files

- **`scripts/check-ci-parity.sh`** (new, 468 lines) — the harness. `set -euo
  pipefail`; requires `yq` (exits 2 if absent). Five concerns:
  - **Concern 1 — reference validity (R2):** fails closed on each
    `docs/ci-reference-format.md` validity-rule violation (unknown trigger
    kind/filter outside the neutral vocabulary; engine-specific capability
    without an evidence-backed exception; missing/duplicate `id`; portable
    capability without a `command`; portable whose command invokes an
    undeclared runtime/tool). Refuses to check the engines against a malformed
    reference.
  - **Concern 2 — traceability harvest (R7):** per-job attribution on **both**
    engines. A job is traceable iff its key equals a capability `id`, or its
    trailing `# ci-capability:` key-comment maps to one (contract C2). GitLab
    reserved keywords are skipped unless they carry a fallback annotation. Fails
    closed on any untraceable job.
  - **Arm 1 — reference↔GitHub Actions (R3/R4):** each portable capability's
    `command:` entries must be exhibited, in order, by its attributed GHA job's
    business `run:` steps, and its `requires:` (runtime / tools / full history)
    satisfied by that job's `uses:` setup steps — judged by presence/equivalence
    (whitespace-collapsed, leading `sudo` stripped), not exact syntax. A closed
    `install_recipe_tool` classifier keeps the recognised tool-install recipes
    in lock-step with `build-ci.sh`.
  - **Arm 2 — reference↔GitLab (R5):** composes `build-ci.sh --check` and
    propagates its verdict; never re-implements GitLab generation.
  - **Arm 3 — GitHub Actions↔GitLab portable-set parity (R6):** both engines'
    exhibited portable sets must agree with the reference's portable set;
    engine-specific capabilities (R8) are excluded from the comparison and their
    absence is not a divergence.
  - **Graceful degradation (R11):** when one engine's artifacts are absent the
    harness checks only the present arms; the reference is always required. The
    OK line enumerates exactly the arms that ran.
- **`scripts/tests/test-check-ci-parity.sh`** (new, 412 lines) — 52-assertion
  self-test (R10). Builds throwaway fixture trees under `CREWRIG_REPO_DIR` and
  asserts exit code + message for: conforming tree (exit 0), GHA-only and
  GitLab-only graceful degradation, cross-engine portable-set mismatch,
  untraceable job, evidence-less engine-specific exception, unknown trigger
  kind, duplicate id, portable-without-command, portable-with-unmet-requirement,
  and the R4 setup-requirement arms (missing full-history checkout, missing tool
  install, wrong runtime version).

### Modified files

- **`ci/ci-capabilities.yml`** (+21) — self-registers `check-ci-parity` as a
  `portable` capability (R11) with `requires.tools: [yq]`, triggered on
  pull-request and push to `main` / `release/**` — symmetric with the existing
  `gitlab-ci-check`. Also threads `bash scripts/tests/test-check-ci-parity.sh`
  into the `check-components` capability command list.
- **`.github/workflows/build.yml`** (+16) — adds the self-test as a step in the
  `check-components` job and a standalone `check-ci-parity` job (checkout +
  install yq + run the harness).
- **`.gitlab-ci.yml`** (+13) — **generated** by `scripts/build-ci.sh` from the
  reference change above (the self-test step in `check-components`, plus the new
  `check-ci-parity` job). Presented as generator output, not a hand edit.
- **`.github/workflows/pages.yml`** (+1/−1) — annotates the existing `deploy`
  job with `# ci-capability: pages-deploy` so the C2 engine-specific GitHub
  Pages fallback is traceable under the new per-job harvest.

### Notable DEV decisions

- **Silent-skip bug found and fixed.** An early GHA-presence probe used `ls
  *.yml *.yaml`, which returns non-zero when `*.yaml` matches nothing — silently
  skipping the **entire** GitHub Actions arm. Replaced with a glob loop guarded
  by `[ -f ]`. The self-test's P1 scenario now asserts the OK line **enumerates
  every present engine**, so a future regression that skips an arm fails the
  build instead of passing quietly.
- **Self-test wired into CI** via the `check-components` capability (mirroring
  `test-check-core-paths.sh`) after an initial gap left it unrun by either
  engine.
- **Per-job attribution over raw set-union.** The cold-review's Finding 5 was
  honoured over the literal plan body: traceability is established per job
  (key-equals-id or `# ci-capability:` annotation), not by a raw set-union of
  capability ids across the pipeline — so an untraceable job cannot be masked by
  an unrelated job that happens to carry its id.

### Process notes

- **No `artifacts/**` touched** → no skill/agent version bump, no
  `build-components.sh` run required.
- **No `docs/cli-matrix.md` trigger** — the changed paths are not in the matrix
  maintenance surface.
- **No new `.crewrig/core-paths.txt` entry** — every path lives under an
  existing core root.
- **Known deferred follow-up (class: spec).** The `docs/ci-reference-format.md`
  line-313 contradiction is a deliberately-deferred class:spec item, to be
  addressed by a separate 0047 delta-spec **after** this lands — not fixed here.

Closes #397.
