### PR TITLE
📝 Transition spec 0049 to its implemented lifecycle state

### DIFF
--- a/specs/0049-ci-drift-harness.md
+++ b/specs/0049-ci-drift-harness.md
@@ -1,7 +1,7 @@
 ---
 id: "0049"
 slug: ci-drift-harness
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 373


### PR DESCRIPTION
Metadata-only `status: approved` → `implemented` on `specs/0049-ci-drift-harness.md`, recording that implementation-PR #398 merged. Closes #399