### PR TITLE
📝 Reconcile ci-reference GHA-harvest claim with the reserved-name fallback

### DIFF
--- a/docs/ci-reference-format.md
+++ b/docs/ci-reference-format.md
@@ -310,9 +310,29 @@ $ yq '
 - pages-deploy
 ```
 
-On GitHub Actions the harvest is simply `.jobs | keys`; GHA imposes no
-reserved-name collision on the jobs CrewRig defines, so the fallback clause is
-needed only where a future engine forces a reserved job name.
+On GitHub Actions the harvest is the same primary ∪ fallback union, scoped
+under `.jobs`. Most job keys already equal their capability `id`, so the
+primary clause (`yq '.jobs | keys'`) attributes them directly. But where a
+descriptive `id` deliberately differs from the job key — the `pages-deploy`
+capability versus the `deploy` job in `.github/workflows/pages.yml` (see
+*Reserved-name fallback annotation* above) — that job carries a
+`# ci-capability: pages-deploy` trailing key-comment, and the fallback clause
+resolves it:
+
+```console
+$ yq '.jobs | (.[]
+        | select(key | line_comment | test("^ci-capability: "))
+        | key | line_comment | sub("^ci-capability: ", ""))' \
+    .github/workflows/pages.yml
+pages-deploy
+```
+
+The fallback clause is therefore exercised on GitHub Actions **today**, not
+only where a future engine forces a reserved job name: sub-spec C's harness
+applies the same primary ∪ fallback harvest to both engines. (Use the
+`select(key | line_comment | …)` form above, which binds the job **key**; the
+form `select(.value | key | line_comment …)` binds the job *body* and silently
+matches nothing.)
 
 ## Validity rules (judgeability)
 


### PR DESCRIPTION
Corrects an internal contradiction in `docs/ci-reference-format.md`: the GitHub Actions traceability harvest is now described as the same primary∪fallback union used for GitLab, consistent with the reserved-name-fallback section and the shipped spec-0049 harness.

## How to read this PR?

One file, one paragraph: `docs/ci-reference-format.md` → *The complete harvest* → the final "On GitHub Actions…" paragraph. Compare against the *Reserved-name fallback annotation* section earlier in the same doc (which the old paragraph contradicted) and against `.github/workflows/pages.yml`'s `deploy: # ci-capability: pages-deploy` job (annotated by spec 0049, PR #398).

## How to test this PR?

```sh
npx markdownlint-cli -c .markdownlintrc docs/ci-reference-format.md   # clean
# the documented yq example actually resolves:
yq '.jobs | (.[] | select(key | line_comment | test("^ci-capability: ")) | key | line_comment | sub("^ci-capability: ", ""))' .github/workflows/pages.yml
# → pages-deploy
```

## Detailed description (for agents)

The old paragraph claimed the GHA harvest was "simply `.jobs | keys`" and the fallback was "needed only where a future engine forces a reserved job name". This was false: the `pages-deploy` capability deliberately differs from the GHA `deploy` job key (per the same doc's fallback section), and spec 0049's harness now annotates `pages.yml`'s `deploy` job and harvests primary∪fallback on both engines. The paragraph is rewritten to describe the GHA harvest as the same primary∪fallback union, with a verified yq example and a note steering away from the broken `select(.value | key …)` form.

Documentation-only correction to a realization artifact of spec 0047 — no requirement of 0047 changes, hence no delta-spec (the delta-spec mechanism amends requirements; none are amended here). No code, no contract (`ci/ci-capabilities.yml`) change, no pipeline regeneration.

Closes #401