### PR TITLE
📝 Transition spec 0050 to its approved lifecycle state

### DIFF
--- a/specs/0050-ci-agentic-surface.md
+++ b/specs/0050-ci-agentic-surface.md
@@ -1,7 +1,7 @@
 ---
 id: "0050"
 slug: ci-agentic-surface
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 374


### PR DESCRIPTION
Metadata-only `status: draft` → `approved` on `specs/0050-ci-agentic-surface.md`, recording that spec-PR #403 merged. Closes #404