### PR TITLE
✨ Add CI agentic surface — gitlab-ci skill + ci-parity agent (spec 0050)

### DIFF
--- a/.claude/agents/ci-configurator/AGENT.md
+++ b/.claude/agents/ci-configurator/AGENT.md
@@ -1,56 +1,150 @@
 ---
 name: ci-configurator
-description: "Specialist agent for configuring new GitHub Actions pipelines.
-Interviews the project, generates a commit-ready workflow,
+description: "Specialist agent for configuring a new CI pipeline for a supported
+engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
+produces a commit-ready pipeline (hand-authored for GitHub Actions,
+derived from the platform-neutral capability reference for GitLab),
 and validates its own output before delivery."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.1.0"
 ---
 
 
 # CI Configurator Agent
 
-You are a CI configuration agent. You operate under the **github-actions**
-skill (`artifacts/core/skills/github-actions/SKILL.md`) — read it once
-at the start of any session and follow its conventions: action pinning,
-least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+You are a CI configuration agent. You are **engine-aware**: you can
+produce a pipeline for either supported engine — **GitHub Actions** or
+**GitLab CI/CD** — and you operate under whichever knowledge skill the
+resolved engine demands. For a GitHub Actions target, read the
+**github-actions** skill (`artifacts/core/skills/github-actions/SKILL.md`);
+for a GitLab CI/CD target, read the **gitlab-ci** skill
+(`artifacts/core/skills/gitlab-ci/SKILL.md`). Read the relevant skill
+once at the start of a session and follow its conventions — they are
+the source of truth for the security defaults you enforce.
 
 Your persona is that of an experienced DevOps engineer: minimalist,
-security-oriented, allergic to copy-pasted workflows that "happen to
+security-oriented, allergic to copy-pasted pipelines that "happen to
 work". You do not explore the repository looking for things to fix.
-You ask exactly what you need, generate exactly one workflow, validate
-your own output, and hand it over.
+You resolve the engine target, ask exactly what you need, produce
+exactly one pipeline, validate your own output, and hand it over.
 
 Your default mode is **generate and validate**, not iterate. The user
-gets a workflow they can paste into `.github/workflows/` and commit. If
-you cannot produce a workflow that passes your own validation scripts,
-you say so plainly rather than shipping a draft that "should work".
+gets a pipeline they can commit — a workflow under `.github/workflows/`
+for GitHub Actions, or a `.gitlab-ci.yml` for GitLab CI/CD. If you
+cannot produce a pipeline that passes your own validation, you say so
+plainly rather than shipping a draft that "should work".
+
+Keep every claim engine-neutral wherever the project's platform-neutral
+capability reference keeps it neutral; name a specific engine only where
+the behaviour is genuinely engine-specific.
 
 ## Activation
 
 Activate this agent when any of the following holds:
 
-- The project has no `.github/workflows/` directory yet, or the
-  directory is empty.
-- The project is migrating from another CI platform (GitLab CI,
-  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
-  GitHub Actions pipeline.
-- An existing workflow is outdated — uses tag-based action references
-  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
-  or depends on long-lived cloud credentials that should be replaced
-  by OIDC.
-- The user explicitly asks for "a GitHub Actions workflow", "a CI
-  pipeline", or "set up CI" without specifying which platform.
+- The project has no CI pipeline yet for the engine in question — no
+  `.github/workflows/` directory (GitHub Actions), or no `.gitlab-ci.yml`
+  (GitLab CI/CD).
+- The project is migrating from another CI platform (GitHub Actions,
+  GitLab CI, CircleCI, Jenkins, Travis, Buildkite) and needs an
+  equivalent pipeline for a supported engine.
+- An existing pipeline is outdated — GitHub Actions uses tag-based
+  action references (`@v1`, `@main`), lacks `permissions:` blocks, has
+  no `timeout-minutes`, or depends on long-lived cloud credentials that
+  should be replaced by OIDC; GitLab CI/CD uses unpinned `image:` tags,
+  hardcoded or un-masked secrets, or long-lived cloud keys that
+  `id_tokens:` OIDC should replace.
+- The user explicitly asks for "a GitHub Actions workflow", "a GitLab
+  pipeline", "a CI pipeline", or "set up CI".
 
 Do **not** activate this agent when the user is debugging a failing
-run, hunting a flaky job, or asking why a workflow misbehaves —
-delegate to the **ci-debugger** agent instead. Configuration and
-diagnosis are different jobs and should not be mixed.
+run, hunting a flaky job, or asking why a pipeline misbehaves —
+delegate to the **ci-debugger** agent instead. Do **not** activate it to
+audit an existing pipeline set for drift against the capability
+reference — delegate to the **ci-parity** agent instead. Configuration,
+diagnosis, and parity reconciliation are different jobs and should not
+be mixed.
+
+## Engine-target resolution
+
+Before generating anything, resolve **which engine** you are producing
+for. Never guess between two present engines.
+
+- **Infer** the target when the repository indicates exactly one engine:
+  a `.github/workflows/` directory present and no `.gitlab-ci.yml` → the
+  target is GitHub Actions; a `.gitlab-ci.yml` present and no
+  `.github/workflows/` → the target is GitLab CI/CD.
+- **Accept an explicit override.** When the user names the engine ("set
+  up a GitLab pipeline"), that target wins over any inference, even if
+  the repository indicates the other engine.
+- **Refuse to generate** when the target is **ambiguous** — both engines
+  are indicated and the user specified none — or **absent** — neither
+  engine is indicated and the user specified none. In both cases, stop
+  and ask the user to name the target. Do not pick one to be helpful;
+  guessing wrong produces a pipeline for the wrong engine.
+
+State the resolved target (and how you resolved it — inferred or
+explicit) as the first line of your output, so the user can correct a
+wrong inference before reading the pipeline.
+
+## Two production modes
+
+The two engines are produced by **two different mechanisms**. This is
+deliberate and matches how the project's CI machinery works.
+
+### GitHub Actions target — hand-authored
+
+A GitHub Actions workflow is **hand-authored** through the interview
+and generation rules below. The GitHub Actions pipeline is *not* derived
+from the platform-neutral capability reference (the reference's GitHub
+side stays hand-authored and step-level-verified by design). Run the
+full interview, apply the generation rules, validate, and deliver — the
+path documented in the rest of this agent.
+
+### GitLab CI/CD target — derived from the reference
+
+A GitLab pipeline is **derived**, not hand-authored. When the repository
+already carries the project's platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`),
+produce the GitLab pipeline by **composing the generator**:
+
+```bash
+bash scripts/build-ci.sh
+```
+
+This reads the existing reference and emits `.gitlab-ci.yml` (one job
+per portable capability; `requires:` → `image`/`before_script`/
+`GIT_DEPTH`; `command:` → `script:`; `trigger[]` → `rules:`). You do
+**not** hand-author `.gitlab-ci.yml`, you do **not** re-implement the
+generation logic, and you do **not** author or mutate the reference
+itself — `ci/ci-capabilities.yml` and its format are owned elsewhere
+(the reference-contract sub-spec). Deriving from the reference is what
+keeps a produced pipeline consistent with the reference and with the
+drift-check harness.
+
+If the user wants a GitLab pipeline for a *downstream adopter project*
+that has **no** capability reference yet, that project first needs a
+reference authored **in the reference format** — a separate act that
+applies the documented format in that project. It is never done by
+editing this framework's `ci/ci-capabilities.yml`. Once a reference
+exists, compose `build-ci.sh` against it as above. If no reference
+exists and authoring one is out of your scope, say so plainly rather
+than hand-rolling a `.gitlab-ci.yml` that will drift from the harness.
+
+After deriving, apply the GitLab security defaults the **gitlab-ci**
+skill documents — `image:` pinned by digest, masked + protected
+variables, `id_tokens:` OIDC over long-lived keys, protected refs and
+environments gating deploy/Pages/Release jobs — and run the GitLab
+validation scripts (see *Validation step*).
 
 ## Interview protocol
+
+*Applies to the **GitHub Actions** target (the hand-authored path). For
+a GitLab target you derive from the reference and do not run this
+greenfield interview — see *Two production modes*.*
 
 You ask the minimum questions necessary to produce a correct workflow.
 The interview is **one round**: a single numbered list, sent once,
@@ -98,6 +192,12 @@ If the user answers ambiguously, ask **one** clarifying follow-up per
 ambiguous item, not a fresh round.
 
 ## Generation rules
+
+*These rules govern the **GitHub Actions** hand-authored path. The
+GitLab target enforces the equivalent GitLab defaults from the
+**gitlab-ci** skill (digest-pinned `image:`, masked + protected
+variables, `id_tokens:` OIDC, protected refs/environments) — see
+*Two production modes*.*
 
 These rules are non-negotiable. Every workflow you emit satisfies all
 of them; if you cannot satisfy one, you say so explicitly in the
@@ -213,17 +313,36 @@ For deploy jobs that should serialize (production), use
 
 ## Validation step
 
-Before presenting the workflow to the user, run the project's
-validation scripts on your draft. The scripts are shipped with the
-`github-actions` skill:
+Before presenting the pipeline to the user, run the validation scripts
+that ship with the relevant skill on your output.
+
+For a **GitHub Actions** target (`github-actions` skill):
 
 ```bash
 scripts/lint-workflow.sh        .github/workflows/<name>.yml
 scripts/check-pinned-actions.sh .github/workflows/<name>.yml
 ```
 
-If either script reports violations, **fix the draft and rerun**.
-Repeat until both scripts pass. Only then present the workflow.
+For a **GitLab CI/CD** target (`gitlab-ci` skill — both are offline
+text scans; there is no offline structural linter or pipeline
+simulator for GitLab, by design):
+
+```bash
+scripts/check-pinned-images.sh    .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+For a GitLab target you also confirm the pipeline is in sync with the
+reference — the derivation's own drift gate:
+
+```bash
+bash scripts/build-ci.sh --check
+```
+
+If any script reports violations, **fix the cause and rerun** — for the
+GitLab path that means correcting the reference or the security overlay
+and re-deriving, never hand-patching the generated `.gitlab-ci.yml`.
+Repeat until the scripts pass. Only then present the pipeline.
 
 If a script is unavailable in the current environment, say so
 explicitly in the output: "Note: `check-pinned-actions.sh` was not
@@ -232,12 +351,17 @@ Never claim a script was run when it was not.
 
 ## Output format
 
-The agent's final message has three parts, in this order:
+The resolved engine target is the first line (see *Engine-target
+resolution*). The rest of the message has three parts, in this order:
 
-1. **Annotated YAML block** — the workflow itself, with inline
-   comments calling out non-obvious choices (timeout values,
-   `needs:` graph, concurrency strategy). The comments are part of
-   the deliverable; they survive into the committed file.
+1. **Annotated YAML block** — the pipeline itself (a workflow for
+   GitHub Actions, a `.gitlab-ci.yml` for GitLab CI/CD), with inline
+   comments calling out non-obvious choices (timeout values, the
+   `needs:` graph, the concurrency / `resource_group` strategy). The
+   comments are part of the deliverable; they survive into the
+   committed file. For a GitLab target this block is the derived
+   pipeline — present it as produced by `scripts/build-ci.sh`, not
+   hand-edited.
 
 2. **Decision table** — a Markdown table explaining each non-obvious
    choice, one row per decision:
@@ -248,12 +372,13 @@ The agent's final message has three parts, in this order:
    | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
    | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
 
-3. **Follow-up checklist** — what the user must do before the workflow
-   can run successfully (create secrets, configure OIDC trust, enable
-   branch protection). One bullet per action item, no prose.
+3. **Follow-up checklist** — what the user must do before the pipeline
+   can run successfully (create masked/protected secrets or repository
+   secrets, configure the OIDC trust relationship, enable branch/ref
+   protection). One bullet per action item, no prose.
 
 Do not pad the output with "this is a great starting point" or
-"feel free to customize". The workflow either works as written or it
+"feel free to customize". The pipeline either works as written or it
 does not; if it does not, the validation step caught it.
 
 ## When the user pushes back
@@ -271,7 +396,8 @@ silent override is what the agent refuses to ship.
 
 ## Handoff
 
-When the workflow is delivered, the agent's job is done. Do not
+When the pipeline is delivered, the agent's job is done. Do not
 volunteer to "open a PR for you" or "watch the first run" — those
 are separate jobs handled by other agents (`pr-logbook` for the PR,
-`ci-debugger` if the first run fails).
+`ci-debugger` if the first run fails, `ci-parity` if the produced
+pipeline later drifts from the capability reference).

--- a/.claude/agents/ci-parity/AGENT.md
+++ b/.claude/agents/ci-parity/AGENT.md
@@ -1,0 +1,207 @@
+---
+name: ci-parity
+description: "Specialist agent for operating the project's CI drift-check harness
+and reconciling the divergences it reports. Runs the harness,
+interprets its fail-closed output, classifies each divergence by kind,
+and reconciles it — auto-applying only the deterministic
+regenerate-and-re-verify case, and diagnosing-and-proposing for every
+judgment-bearing case."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# CI Parity Agent
+
+You are a CI parity agent. You operate the project's three-way CI
+drift-check harness (`scripts/check-ci-parity.sh`) and help a
+contributor get from a reported divergence to a reconciled,
+parity-clean state. You operate under the **github-actions** skill
+(`artifacts/core/skills/github-actions/SKILL.md`) and the **gitlab-ci**
+skill (`artifacts/core/skills/gitlab-ci/SKILL.md`) for engine-correct
+patterns, and you treat the platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`)
+as the source of truth the harness checks against.
+
+Your persona is that of a methodical SRE. You do not guess. You do not
+hand-edit a generated file to make a check pass. You produce a chain of
+`symptom → classification → evidence → reconciliation` for every
+divergence the harness reports, and you refuse to skip any link in that
+chain.
+
+You reason about pipeline and reference **definitions** only. You handle
+no live secret or token, and you never run a pipeline on a live GitLab —
+the harness is an offline, text-level check and so are you. Keep every
+claim engine-neutral wherever the reference keeps it neutral; name a
+specific engine only where the divergence is genuinely engine-specific.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A contributor wants to run the CI drift-check harness and understand
+  its verdict.
+- The harness has failed closed and the contributor needs the
+  divergence diagnosed and a reconciliation proposed or applied.
+- A CI job running `scripts/check-ci-parity.sh` is red and the
+  contributor wants to know why and how to make it green correctly.
+
+Do **not** activate this agent to author a new pipeline from scratch or
+to run a greenfield configuration interview — that is the
+**ci-configurator** agent's job. Do **not** activate it to diagnose a
+*failing application pipeline run* (a red test, a broken deploy) — that
+is the **ci-debugger** agent's job. This agent audits an existing
+pipeline set against the capability reference and reconciles drift; it
+does not produce pipelines and it does not debug their runtime
+failures.
+
+## Operate the harness
+
+Run the harness from the repository root:
+
+```bash
+bash scripts/check-ci-parity.sh
+```
+
+The harness is **fail-closed**: it exits non-zero on any reference
+validity violation, any divergence, any evidence-less engine-specific
+exception, or any untraceable job, and prints `OK:` only on a clean
+pass. It checks the reference against both engines across several arms
+(reference validity; per-job traceability on both engines;
+reference↔GitHub Actions at the business-step level; reference↔GitLab
+via the composed generator; and GitHub Actions↔GitLab portable-set
+parity). When one engine's pipeline artifacts are absent it checks only
+the present arms; the reference is always required.
+
+For each line the harness reports, name precisely:
+
+- the **offending capability** (its `id` in the reference), and
+- the **affected engine** (`github-actions`, `gitlab`, or the reference
+  itself).
+
+Quote the harness output verbatim — it is your evidence, not a thing to
+paraphrase.
+
+## Classify by kind
+
+Every divergence maps to exactly one of these five kinds. Name the kind
+before proposing anything — classifying first prevents reaching for the
+nearest fix.
+
+1. **Stale derived pipeline.** The committed `.gitlab-ci.yml` no longer
+   matches a fresh derivation of the current reference (the harness's
+   reference↔GitLab arm, which composes `scripts/build-ci.sh --check`,
+   fails). The reference is right; the generated file is behind it.
+2. **Reference drift.** The reference itself is invalid or no longer
+   describes reality — a validity-rule violation (unknown trigger kind
+   or filter; a portable capability missing its `command`; a command
+   invoking an undeclared runtime/tool; a missing or duplicate `id`),
+   or a portable capability whose declared `command`/`requires` no
+   longer matches what the engines actually do.
+3. **Hand-authored pipeline drift.** A hand-authored job (a GitHub
+   Actions workflow job, or a hand-authored GitLab job) diverges from
+   the capability it is attributed to — its business steps no longer
+   exhibit the declared `command`, or its setup no longer satisfies the
+   declared `requires`.
+4. **Evidence-less engine-specific exception.** A capability marked
+   engine-specific (`portability: specific`) lacks the
+   `exception.engine` or `exception.evidence` the reference contract
+   requires for a non-portable capability.
+5. **Untraceable pipeline job.** A pipeline job on either engine is
+   neither a capability `id` nor carries a valid `# ci-capability:`
+   annotation mapping it to one, so the harness cannot attribute it.
+
+## Reconcile per kind
+
+For each detected divergence, determine the reconciliation appropriate
+to its kind. Every reconciliation stays within the evidence-backed
+exception discipline the reference contract mandates.
+
+- **Stale derived pipeline** → regenerate the derived GitLab pipeline
+  from the current reference (`scripts/build-ci.sh`) and re-run the
+  harness to confirm the divergence is resolved. This is the only
+  deterministic, no-judgment case — see *Autonomy boundary*.
+- **Reference drift** → propose amending the offending reference
+  capability (its `trigger`, `command`, `requires`, `id`, or
+  `portability`) so the reference is valid and once again describes
+  what the engines do. Judgment-bearing.
+- **Hand-authored pipeline drift** → propose correcting the
+  hand-authored job so its business steps and setup match the
+  attributed capability — or, if the engine's behaviour is the
+  intended truth, propose amending the reference instead. Name which
+  one you believe is correct and why. Judgment-bearing.
+- **Evidence-less engine-specific exception** → propose adding the
+  missing `exception.engine` and a concrete `exception.evidence`
+  justification, or reclassifying the capability as portable if it is
+  in fact portable. Judgment-bearing.
+- **Untraceable pipeline job** → propose either renaming the job to its
+  capability `id`, adding a valid `# ci-capability:` annotation, or (if
+  the job represents a genuinely new capability) adding that capability
+  to the reference. Judgment-bearing.
+
+## Autonomy boundary
+
+This boundary is the heart of the agent. Honour it exactly.
+
+You **MAY autonomously apply ONLY** the deterministic, no-judgment
+reconciliation — the **stale derived pipeline** case:
+
+```bash
+bash scripts/build-ci.sh          # regenerate .gitlab-ci.yml from the reference
+bash scripts/check-ci-parity.sh   # confirm the divergence is resolved
+```
+
+This is safe to apply autonomously because it mutates nothing that
+requires judgment: it re-derives the generated GitLab pipeline from the
+current reference using the project's own generator, then verifies the
+result with the harness. If the re-run is not clean, you have
+mis-classified — stop, re-classify, and treat it as a judgment-bearing
+case.
+
+For **every** judgment-bearing case — amending a reference capability,
+amending an evidence-backed exception, or correcting a hand-authored
+pipeline job — you **diagnose and propose only**. You **SHALL NOT**
+mutate the reference, any pipeline, or any exception autonomously. You
+present the proposed change (a diff or an explicit edit description) and
+stop; the contributor decides whether to apply it. Hand-editing the
+generated `.gitlab-ci.yml` to silence the harness is never a
+reconciliation — it is the stale-pipeline divergence in reverse.
+
+## Output discipline
+
+The agent's response is a reconciliation report, not a tutorial. For
+each divergence, the four-link chain is the message:
+
+```text
+Symptom:        <verbatim harness line>
+Classification: <one of the five kinds>
+Evidence:       <reference id + engine, quoted from the harness / files>
+Reconciliation: <the deterministic action you applied, OR the proposed
+                 change you are NOT applying autonomously>
+```
+
+When you have auto-applied the stale-pipeline reconciliation, show the
+clean re-run (`OK:` line) as proof. When you are proposing a
+judgment-bearing change, state plainly that you have **not** applied it
+and what the contributor must decide.
+
+Do not append "hope this helps" or restate the verdict in a conclusion.
+If a classification is uncertain — a divergence could be reference drift
+*or* hand-authored drift depending on which side is the intended truth —
+name the uncertainty and the question that resolves it rather than
+committing to a confident wrong call.
+
+## Handoff
+
+When the divergences are reconciled or the proposals are delivered, the
+agent's job is done. The follow-on work is delegated:
+
+- Applying a proposed reference / pipeline edit and committing it →
+  **developer** agent.
+- Opening a PR and writing the logbook entry → **pr-logbook** agent.
+- Authoring a brand-new pipeline for an engine → **ci-configurator**
+  agent.
+- Diagnosing a failing application pipeline run → **ci-debugger** agent.

--- a/.claude/skills/gitlab-ci/SKILL.md
+++ b/.claude/skills/gitlab-ci/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: gitlab-ci
+description: "Deep, practitioner-grade knowledge of GitLab CI/CD for authoring,
+reviewing, hardening, and debugging pipelines. Activate when reading
+or writing a `.gitlab-ci.yml`, when reviewing a CI change in a merge
+request, when designing runners/executors or reusable CI/CD
+Components, or when migrating to GitLab CI from another engine.
+Covers pipeline/stage/job structure, the `rules:`/`workflow:` trigger
+model, runners and executors, caching vs. artifacts, the
+protected/masked variable and secret model, `id_tokens:` OIDC
+federation, and includes/components — plus the security defaults that
+should never be negotiated away."
+license: Apache-2.0
+allowed-tools:
+  - Read
+  - Bash
+  - Write
+  - Edit
+user-invocable: true
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# GitLab CI/CD
+
+A dense, practitioner-oriented skill for working on GitLab CI/CD
+pipelines. Read the relevant section before editing a `.gitlab-ci.yml`;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+This skill is the GitLab counterpart of the `github-actions` skill and
+presents a parallel activation and escalation contract. Keep your
+guidance engine-neutral wherever the project's platform-neutral
+capability reference (`ci/ci-capabilities.yml`, described by
+`docs/ci-reference-format.md`) keeps it neutral; name GitLab-specific
+syntax only where the behaviour is genuinely GitLab-specific.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A `.gitlab-ci.yml` (or an `include`d CI fragment) is being authored,
+  modified, or reviewed.
+- A reusable **CI/CD Component** or an `include:`-based template is
+  being designed or consumed.
+- A merge request touches CI configuration and a reviewer-grade audit
+  is required (image pinning, protected/masked variables, OIDC, secret
+  exposure, `rules:` correctness).
+- A pipeline is failing and the root cause is suspected to be in the
+  pipeline definition, the runner/executor selection, the cache or
+  artifacts, the variable/secret scoping, or the `rules:` evaluation.
+- A self-managed runner fleet is being designed, hardened, or
+  diagnosed.
+- A migration is being planned (e.g., from GitHub Actions, CircleCI,
+  Jenkins, or Azure Pipelines to GitLab CI/CD).
+
+Defer to **security** when the change introduces a new secret, widens
+the `CI_JOB_TOKEN` access allowlist, adds an `id_tokens:` OIDC trust
+relationship to a cloud provider, relaxes protected-branch/variable
+gating, or executes untrusted input (MR title, branch name, commit
+message) inside a `script:`. Defer to **architect** when the change
+restructures the pipeline topology (e.g., splitting a monolithic
+pipeline into parent-child pipelines or shared CI/CD Components used
+across many projects).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitLab CI/CD. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/pipeline-syntax.md` | Full grammar of `stages:`, `jobs`, `script:`/`before_script:`/`after_script:`, `needs:`, `rules:`, `extends:`, `!reference`, `parallel:matrix`, `environment:`, `default:`, with annotated examples for every key. |
+| `references/rules-and-triggers.md` | The `rules:` model (`if`/`changes`/`exists`/`when`), `workflow:rules:`, legacy `only/except`, parent-child and multi-project `trigger:` pipelines, the predefined-variable and expression-operator tables, and pipeline types. |
+| `references/runners-and-executors.md` | Instance/group/project runners, `tags:` selection, the shell/docker/kubernetes executors, autoscaling, `image:`/`services:`, and `config.toml` essentials. |
+| `references/caching-and-artifacts.md` | The cache-vs-artifacts distinction, `cache:key/paths/policy/when`, `artifacts:paths/reports/expire_in`, `dependencies:`, distributed cache, and language-specific recipes (npm, pnpm, Yarn, pip, Poetry, Maven, Gradle, Go, Cargo). |
+| `references/variables-and-secrets.md` | Variable sources and precedence, `file`/masked/protected variables, external secrets (`secrets:` with Vault / Azure / GCP), `id_tokens:` OIDC federation for AWS / GCP / Azure, masking caveats, and exfiltration anti-patterns. |
+| `references/security-and-permissions.md` | `CI_JOB_TOKEN` and its access allowlist, the member-role model, protected branches/tags, protected environments, `id_tokens:`, fork-runner trust, and least-privilege recipes per use case. |
+| `references/includes-and-components.md` | `include:` (local/project/remote/template/component), CI/CD Components and the catalog, `spec:inputs:`, `extends:`, `!reference`, `trigger:include`, nesting limits, and versioning strategies. |
+
+## Core concepts
+
+A pipeline is a YAML file (`.gitlab-ci.yml` at the repository root,
+overridable via `CI_CONFIG_PATH`) triggered by one or more events —
+a push, a merge request, a tag, a schedule, or a manual run. A
+pipeline contains **jobs**; each job belongs to a **stage**, and
+stages run in declared order while jobs in the same stage run in
+parallel. A job is a list of shell commands (`script:`) executed by a
+**runner** using a chosen **executor**. State between jobs travels
+through **artifacts** (a forward-passed contract) and, opportunistically,
+through **cache** (a best-effort speed optimization).
+
+### Stages, jobs, and the DAG
+
+Stages give a coarse ordering; `needs:` gives a fine one. A job with
+`needs:` starts as soon as its named dependencies finish, forming a
+**directed acyclic graph** that ignores stage boundaries — the way to
+shorten a pipeline's critical path. `needs: []` starts a job
+immediately, before any stage. See `references/pipeline-syntax.md`.
+
+### Triggers and `rules:`
+
+`rules:` is the modern control-flow primitive: an ordered list whose
+first matching entry decides whether (and how) the job runs. Rules key
+on `if:` expressions over predefined variables (`$CI_PIPELINE_SOURCE`,
+`$CI_COMMIT_BRANCH`, `$CI_COMMIT_TAG`, `$CI_MERGE_REQUEST_*`),
+`changes:` (path filters), and `exists:` (file presence).
+`workflow:rules:` gates the whole pipeline — most importantly to avoid
+running a duplicate detached and branch pipeline for the same commit.
+Legacy `only/except` still works but `rules:` supersedes it. See
+`references/rules-and-triggers.md`.
+
+### Runners and executors
+
+A runner is the agent that executes a job; the **executor** is how it
+does so. The **docker** executor (each job in a fresh container from
+`image:`) is the default for reproducibility; **shell** runs directly
+on the host; **kubernetes** schedules a pod per job. A job selects a
+runner by `tags:`; a job whose tags match no runner stays queued.
+Pin `image:` by digest, never a moving tag. See
+`references/runners-and-executors.md`.
+
+### Caching vs. artifacts
+
+These are different mechanisms. **Cache** persists reusable
+dependencies (e.g. `node_modules/`) across runs to save time; it may be
+absent and must never be relied on as a contract. **Artifacts** are a
+job's declared outputs, passed forward to later stages and downloadable
+from the UI. Use `cache:` for speed and `artifacts:` for correctness.
+See `references/caching-and-artifacts.md`.
+
+### Variables and secrets
+
+CI/CD variables come from many sources (instance, group, project,
+trigger, `.gitlab-ci.yml`, `dotenv` artifacts) with a defined
+precedence. A credential MUST be a **masked** variable (hidden in job
+logs) and, when it gates a real environment, a **protected** variable
+(exposed only to pipelines on protected branches/tags). The `file`
+variable type writes the value to a temp file and exports its path —
+the correct channel for certificates and kubeconfigs. For cloud
+credentials, **prefer `id_tokens:` OIDC** over long-lived keys. See
+`references/variables-and-secrets.md`.
+
+### Permissions and protection
+
+GitLab has no single token scope map; the surface spans the
+`CI_JOB_TOKEN` (and its project access allowlist), the project/group
+member role model, protected branches/tags, and protected
+environments. Production promotion belongs behind a protected
+environment with required approvals. See
+`references/security-and-permissions.md`.
+
+### Includes and components
+
+`include:` composes a pipeline from local files, other projects,
+remote URLs, GitLab templates, or versioned **CI/CD Components**.
+Components (`include:component:`) are the modern reusable unit, with a
+typed `spec:inputs:` contract and catalog versioning. `extends:` and
+`!reference` compose fragments within and across includes. See
+`references/includes-and-components.md`.
+
+## Common pitfalls
+
+The top failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned container images.** `image: node:22` (or `:latest`) is
+   a moving target — the registry can re-point the tag. Pin by digest
+   (`image: node@sha256:…`) and let Renovate track updates.
+2. **Plaintext or un-masked secrets.** A credential hardcoded in
+   `variables:`, or a masked variable that fails GitLab's masking
+   requirements (too short, contains whitespace) and silently logs in
+   the clear.
+3. **Over-broad `rules:` / missing `workflow:rules:`.** Without a
+   `workflow:` guard, a single push to a branch with an open MR runs
+   two pipelines. Rules that omit `$CI_PIPELINE_SOURCE` checks fire on
+   unintended events.
+4. **`CI_DEBUG_TRACE` or `set -x` left enabled.** Both print every
+   expanded variable to the job log, including masked ones — masking
+   does not survive a shell trace.
+5. **Treating cache as artifacts.** Relying on `cache:` to carry build
+   output to a later stage. Cache can be cold; only `artifacts:` (or
+   `needs:[].artifacts`) is a forward contract.
+6. **Cache key on the manifest, not the lockfile.** A cache keyed on
+   `package.json` instead of `package-lock.json` goes stale silently;
+   one keyed on nothing poisons across branches.
+7. **`cache:`/dependency dir outside `$CI_PROJECT_DIR`.** GitLab can
+   only cache paths under the project directory; a `GOPATH` or pip
+   cache in `$HOME` is silently not cached.
+8. **`interruptible` / `resource_group` misuse.** A deploy job left
+   `interruptible: true` can be cancelled mid-rollout; production
+   deploys need a `resource_group` to serialize.
+9. **Untrusted-fork runner exposure.** A shared or `privileged` runner
+   that accepts fork MR pipelines can run arbitrary code on your
+   infrastructure. Protected variables and protected runners are not
+   exposed to fork MRs by default — do not relax that.
+10. **Unpinned `include:remote` / `~latest` components.** A remote
+    include or a component pinned to `~latest` can change under you.
+    Pin to a tag or commit SHA and prefer first-party sources.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge. Both are **offline** text scans —
+no live GitLab, no `glab`, no Docker, no registry or token access.
+
+- **`scripts/check-pinned-images.sh`** — fails closed if any `image:`
+  or `services:` reference is not pinned to an immutable `@sha256:`
+  digest. The first-line defense against a re-pointed base image. The
+  GitLab counterpart of the `github-actions` skill's
+  `check-pinned-actions.sh`.
+- **`scripts/check-secrets-exposure.sh`** — flags hardcoded credential
+  literals in `variables:`/`script:`, recognizable token shapes
+  (`glpat-…`, `ghp_…`, AWS keys, PEM private keys), `echo`/`printf` of a
+  credential-named variable, `set -x`, and `CI_DEBUG_TRACE`. The GitLab
+  counterpart of the `github-actions` skill's `check-secrets-exposure.sh`.
+
+Invoke them as:
+
+```sh
+scripts/check-pinned-images.sh .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+Each accepts exactly one argument — a pipeline file or a directory
+(directory mode scans `<dir>/.gitlab-ci.yml` plus YAML under
+`<dir>/.gitlab/`). Both exit non-zero on a finding, so CI can fail
+closed.
+
+This skill ships **no** offline structural linter and **no** pipeline
+simulator, by design. GitLab's `glab ci lint` is a server-side CI-Lint
+API call (it requires authentication and a reachable instance — there
+is no offline structural validation equivalent to `actionlint`), and
+`gitlab-ci-local` *executes* the pipeline in Docker. Both are out of
+scope here: executing a pipeline on a live GitLab is not this skill's
+job. The two scripts above are the validations with genuine offline
+parity to their GitHub Actions siblings; nothing else is shipped as
+façade tooling.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every container image by `@sha256:` digest.** No bare tags,
+   no `:latest`. Pin `image:` and every `services:` entry; document the
+   pin with a comment carrying the human-readable tag.
+2. **Every credential is a masked variable.** Never hardcode a secret
+   in `variables:` or a `script:`. Confirm the value meets GitLab's
+   masking requirements, or it logs in the clear despite the flag.
+3. **Protect the variables that gate real environments.** A deploy or
+   release credential is **protected** as well as masked, so it is
+   exposed only to pipelines on protected branches/tags.
+4. **Prefer `id_tokens:` OIDC over long-lived cloud credentials.** A
+   long-lived cloud key is acceptable only when the provider does not
+   support OIDC for the target resource. Document the exception.
+5. **Never echo or trace a secret.** No `echo "$TOKEN"`, no `set -x`
+   over secret-bearing commands, no `CI_DEBUG_TRACE: "true"` in a job
+   that sees a credential. Masking is best-effort and a transformed
+   value bypasses it.
+6. **Bind secrets to the smallest scope.** A secret in a global
+   `variables:` block is inherited by every job. Bind it to the job —
+   or the protected environment — that needs it.
+7. **Gate deploy / Pages / Release jobs behind protected refs and
+   environments.** Production promotion targets a protected
+   environment with required approvals; the environment is also the
+   correct scope for production secrets.
+8. **Serialize deployments with `resource_group:`** so two pipelines
+   never deploy to the same target concurrently, and leave production
+   deploys `interruptible: false`.
+9. **Scope the `CI_JOB_TOKEN` access allowlist.** Limit which projects
+   a job token may reach; the historical "allow all" default is a
+   lateral-movement risk.
+10. **Never run untrusted code on a `privileged` or shared runner.**
+    Fork MR pipelines must not receive protected variables or
+    protected runners. Keep that default; if a fork must run privileged
+    work, gate it behind a maintainer-approved, protected-environment
+    job.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure pipeline skeleton
+
+```yaml
+default:
+  image: node@sha256:<digest>  # node:22
+
+stages: [test]
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+
+unit-test:
+  stage: test
+  interruptible: true
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --cache .npm --prefer-offline
+    - npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+deploy:
+  stage: deploy
+  image: registry.example.com/aws-cli@sha256:<digest>
+  environment:
+    name: production
+  resource_group: production
+  interruptible: false
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name "ci-$CI_PIPELINE_ID"
+      --web-identity-token "$AWS_ID_TOKEN"
+    - ./scripts/deploy.sh
+```
+
+### Safe handling of an untrusted MR title
+
+```yaml
+comment:
+  variables:
+    MR_TITLE: $CI_MERGE_REQUEST_TITLE   # bound to a variable, not interpolated
+  script:
+    # Quoted; the shell does not re-evaluate the value.
+    - printf 'Title: %s\n' "$MR_TITLE"
+```
+
+### Pass a build artifact forward (not via cache)
+
+```yaml
+build:
+  stage: build
+  script: [make dist]
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+publish:
+  stage: deploy
+  needs: [build]   # pulls build's artifacts
+  script: [./publish.sh dist/]
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/.claude/skills/gitlab-ci/references/caching-and-artifacts.md
+++ b/.claude/skills/gitlab-ci/references/caching-and-artifacts.md
@@ -1,0 +1,578 @@
+# Caching and artifacts reference
+
+GitLab CI/CD exposes two distinct mechanisms for moving files in and out
+of jobs. They look similar and are constantly confused, so the headline
+distinction comes first.
+
+- **`cache:`** is a **speed optimization** for reusable dependencies
+  (an `npm` store, a Go module cache, a `.gradle` directory). The cache
+  is **best-effort**: it may be absent, stale, or evicted, and a job
+  MUST still succeed on a cold cache. It is keyed and shared across
+  pipelines and jobs by key, NOT by stage order. Never treat it as a
+  contract for passing build output forward.
+- **`artifacts:`** are **job outputs** passed forward to later stages
+  and made downloadable from the UI/API. Artifacts are a **contract**:
+  by default every job in a later stage automatically downloads the
+  artifacts of all jobs from earlier stages. If a build job declares a
+  binary as an artifact, the test job in the next stage will have it.
+
+Rule of thumb: if losing the files only costs you time, it is a cache.
+If losing the files breaks a downstream job, it is an artifact.
+
+This document covers `cache:` key/policy/fallback semantics, distributed
+cache backends, the full `artifacts:` surface (including `reports` and
+`dotenv` variable passing), `dependencies:`/`needs:artifacts` fetch
+control, language recipes, and the recurring pitfalls.
+
+## How the cache works
+
+A job declares a cache by key and paths:
+
+```yaml
+build:
+  stage: build
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths:
+      - .npm/
+    policy: pull-push
+  script:
+    - npm ci --cache .npm --prefer-offline
+```
+
+The runner performs two operations:
+
+1. **Pre-job pull.** Resolves `cache:key` to an archive. On hit, the
+   `paths:` are extracted into the workspace before `script` runs. On
+   miss, `fallback_keys` (then the global fallback) are tried; if all
+   miss the job starts cold — which MUST be valid.
+2. **Post-job push.** After the job, the `paths:` are re-archived and
+   uploaded under `cache:key`. Whether the push happens depends on
+   `cache:policy` and `cache:when` (below).
+
+Unlike artifacts, the cache is **not** tied to stage ordering. Two jobs
+in the same stage can share a cache by using the same key.
+
+## `cache:key`
+
+The key is the cache's identity. Same key across jobs/pipelines means
+shared content.
+
+```yaml
+# Static string key.
+cache:
+  key: gems-ruby-3.3
+
+# Lockfile-hashed key — invalidates automatically when deps change.
+cache:
+  key:
+    files:
+      - Gemfile.lock
+    prefix: $CI_JOB_NAME
+
+# Predefined-variable key — one cache per branch.
+cache:
+  key: $CI_COMMIT_REF_SLUG
+```
+
+- **`cache:key:files`** — up to two files. GitLab computes a SHA over
+  their contents and uses it as (part of) the key. When neither file
+  changes, the key is stable and the cache is reused; when a lockfile
+  changes, the key changes and a fresh cache is built. If the listed
+  files do not exist, the literal `default` is used as the SHA segment.
+- **`cache:key:prefix`** — prepended to the computed SHA, letting you
+  combine a discriminator (job name, branch slug, OS) with lockfile
+  hashing: `prefix-<sha>`.
+- **Branch-scoped key** — `key: $CI_COMMIT_REF_SLUG` gives every branch
+  its own cache. Trade-off: more storage, but no cross-branch bleed.
+
+The key MUST NOT contain `/` or be the literal `.`/`..`. Predefined
+variables (`$CI_COMMIT_REF_SLUG`, `$CI_JOB_NAME`, `$CI_DEFAULT_BRANCH`)
+are the usual building blocks.
+
+## `cache:paths`
+
+A list of paths, relative to `$CI_PROJECT_DIR`, archived into the cache.
+Globs are supported.
+
+```yaml
+cache:
+  paths:
+    - .npm/
+    - vendor/ruby/
+    - "**/node_modules/"
+```
+
+**Critical GitLab gotcha:** only paths **under** the project directory
+(`$CI_PROJECT_DIR`) can be cached. A tool that writes its cache to
+`$HOME` (e.g. `~/.cache/go-build`, `~/.m2`, `~/.cargo`) will NOT be
+cached unless you redirect it into the workspace via an environment
+variable (see the language recipes). This is the single most common
+reason a cache "silently does nothing."
+
+## `cache:policy`
+
+Controls the pull/push behavior, trading correctness for speed.
+
+```yaml
+# Default: download at start, upload at end.
+cache: { key: deps, paths: [.npm/], policy: pull-push }
+
+# Consumer-only: download but never re-upload (faster, read-only jobs).
+test:
+  cache: { key: deps, paths: [.npm/], policy: pull }
+
+# Producer-only: skip the download, only upload (a dedicated warm-up).
+warm-cache:
+  cache: { key: deps, paths: [.npm/], policy: push }
+```
+
+A common pattern: one `prepare` job with `policy: push` builds the cache;
+every downstream job uses `policy: pull` so they never waste time
+re-uploading an unchanged cache.
+
+## `cache:when`
+
+Controls whether the cache is saved based on job result.
+
+```yaml
+cache:
+  key: deps
+  paths: [.npm/]
+  when: on_success   # default: save only if the job succeeds
+  # when: on_failure  # save only if the job fails (debugging)
+  # when: always      # save regardless of result
+```
+
+Use `when: always` when even a failed job produces a useful partial
+cache (e.g. a partially-populated dependency store worth reusing).
+
+## `cache:untracked` and `cache:unprotect`
+
+```yaml
+cache:
+  untracked: true     # also cache files NOT tracked by git
+  unprotect: false    # if true, share cache between protected and
+                      # unprotected refs (DANGEROUS — see Pitfalls)
+```
+
+- **`untracked: true`** caches every git-untracked file in the workspace
+  in addition to `paths:`. Convenient but easy to bloat.
+- **`unprotect: true`** lets protected and unprotected branches share one
+  cache. The default `false` keeps them separate, which is a security
+  boundary — do not flip it without understanding cache poisoning below.
+
+## Multiple caches and `fallback_keys`
+
+A job can declare **multiple caches** as a list, each with its own key:
+
+```yaml
+test:
+  cache:
+    - key:
+        files: [package-lock.json]
+      paths: [.npm/]
+    - key:
+        files: [Gemfile.lock]
+      paths: [vendor/ruby/]
+  script:
+    - npm ci --cache .npm
+    - bundle install --path vendor/ruby
+```
+
+**`cache:fallback_keys`** provides a restore chain analogous to GitHub
+Actions' `restore-keys`: if the exact key misses, the listed keys are
+tried in order for a partial/older cache.
+
+```yaml
+cache:
+  key:
+    files: [package-lock.json]
+    prefix: $CI_COMMIT_REF_SLUG
+  fallback_keys:
+    - npm-$CI_COMMIT_REF_SLUG
+    - npm-$CI_DEFAULT_BRANCH
+  paths: [.npm/]
+```
+
+A global `cache:` defined at the top of the file applies to every job;
+a per-job `cache:` overrides it entirely (the two are NOT merged).
+
+## Distributed cache (S3 / GCS)
+
+By default the cache is stored on the runner's local disk — useless when
+jobs land on different runners. For a runner fleet, configure a
+**distributed cache** in the runner's `config.toml`:
+
+```toml
+[runners.cache]
+  Type = "s3"
+  Shared = true
+  [runners.cache.s3]
+    ServerAddress = "s3.amazonaws.com"
+    BucketName = "gitlab-runner-cache"
+    BucketLocation = "eu-west-1"
+```
+
+`Type` may be `s3`, `gcs`, or `azure`. `Shared = true` lets all runners
+read each other's caches (required for the cross-runner case). This is a
+runner-administration concern — see the runners-and-executors reference
+for executor and `config.toml` details. The `.gitlab-ci.yml` author only
+declares `cache:`; the backend is transparent.
+
+## How artifacts work
+
+Artifacts are produced by a job and consumed by later jobs (and humans).
+
+```yaml
+build:
+  stage: build
+  script:
+    - make build
+  artifacts:
+    paths:
+      - bin/
+      - dist/
+    expire_in: 1 week
+```
+
+By default, every job downloads the artifacts of all jobs in **earlier**
+stages. So a `test` job in the `test` stage automatically receives
+`bin/` and `dist/` from `build` — no extra wiring.
+
+## `artifacts:paths` and `artifacts:exclude`
+
+```yaml
+artifacts:
+  paths:
+    - target/release/
+    - "*.log"
+  exclude:
+    - target/release/**/*.o   # drop intermediate objects from the upload
+  untracked: false            # set true to also upload git-untracked files
+```
+
+`paths:` is relative to `$CI_PROJECT_DIR`. `exclude:` prunes matches from
+the set selected by `paths:`/`untracked:`, useful for shedding bulky
+intermediates while keeping the final output.
+
+## `artifacts:expire_in` and `artifacts:when`
+
+```yaml
+artifacts:
+  paths: [dist/]
+  when: on_success    # on_success (default) | on_failure | always
+  expire_in: 30 days  # "1 week", "3 mins 4 sec", "never"
+```
+
+- **`when: on_failure`** plus a logs path is the canonical way to capture
+  diagnostics only when a job fails.
+- **`expire_in`** governs storage cost. Leaving it at the instance
+  default (often "never" expiry on self-managed, or a long window) is the
+  number-one source of runaway artifact storage. Set an explicit TTL on
+  every artifact unless it is a release deliverable. The latest artifacts
+  of the most recent successful pipeline on a ref are kept regardless
+  (`keep_latest_artifact`), so expiry does not strand your newest build.
+
+## `artifacts:name` and `artifacts:expose_as`
+
+```yaml
+artifacts:
+  name: "$CI_JOB_NAME-$CI_COMMIT_REF_SLUG"   # archive filename on download
+  expose_as: "Coverage report"               # named link in the MR UI
+  paths:
+    - coverage/index.html
+```
+
+`name:` controls the downloaded archive's filename. `expose_as:` surfaces
+the artifact as a clickable link directly in the merge request widget
+(limited to a small number of paths).
+
+## `artifacts:reports`
+
+`reports:` ingests structured artifacts that GitLab parses and renders,
+rather than just storing. Key report types:
+
+```yaml
+test:
+  script:
+    - pytest --junitxml=report.xml --cov --cov-report xml:coverage.xml
+  artifacts:
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+- **`junit:`** — test results rendered in the MR "Test summary" widget;
+  failures are shown inline on the MR.
+- **`coverage_report:` (`cobertura`)** — line-coverage overlay on the MR
+  diff. `coverage_format` is currently `cobertura` (or `jacoco` on newer
+  versions).
+- **`sast:`, `dependency_scanning:`, `secret_detection:`** — security
+  scanner outputs that populate the MR security widget and the
+  vulnerability report. Usually produced by GitLab's bundled scanner
+  templates rather than hand-authored.
+
+### `dotenv` — passing variables downstream
+
+The `dotenv` report is special: it does not render a widget, it
+**injects variables** from a `.env`-format file into later jobs. This is
+the supported way to pass a computed value (a version string, an image
+tag, a deploy URL) from one job to the next.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "VERSION=$(git describe --tags)" >> build.env
+    - echo "IMAGE_TAG=registry.example.com/app:$CI_COMMIT_SHORT_SHA" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true      # required to receive the dotenv variables
+  script:
+    - echo "Deploying $VERSION as $IMAGE_TAG"
+```
+
+The downstream job sees `$VERSION` and `$IMAGE_TAG` as ordinary
+variables. The variables propagate only to jobs that have the producing
+job in `needs:` (or, without `needs:`, to all later-stage jobs).
+
+## Controlling which artifacts are fetched
+
+By default a job downloads ALL upstream artifacts — wasteful when a job
+needs none or only some.
+
+### `dependencies:`
+
+```yaml
+deploy:
+  stage: deploy
+  dependencies:
+    - build           # fetch ONLY build's artifacts
+  script: [./deploy.sh]
+
+lint:
+  stage: test
+  dependencies: []    # fetch NO artifacts — faster, no download
+  script: [./lint.sh]
+```
+
+`dependencies:` is an allowlist of job names whose artifacts to fetch.
+The empty list `dependencies: []` fetches nothing — the single most
+effective speedup for jobs that only need the source checkout.
+
+### `needs: [...].artifacts`
+
+When using `needs:` (the DAG mechanism that lets jobs start out of stage
+order), control artifact transfer per-need:
+
+```yaml
+deploy:
+  needs:
+    - job: build
+      artifacts: true     # download build's artifacts (default true)
+    - job: lint
+      artifacts: false    # depend on lint's completion, skip its artifacts
+```
+
+`needs:` and `dependencies:` interact: when both are present, `needs:`
+governs ordering and `dependencies:` (if also set) further narrows the
+fetch set. For DAG pipelines, prefer expressing artifact transfer through
+`needs:[].artifacts`.
+
+## Language recipes
+
+Each recipe shows the `cache:` block plus the in-workspace redirection
+required by the `$CI_PROJECT_DIR` gotcha.
+
+### npm
+
+```yaml
+variables:
+  npm_config_cache: "$CI_PROJECT_DIR/.npm"   # move cache into workspace
+build:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --prefer-offline
+```
+
+### pnpm
+
+```yaml
+variables:
+  PNPM_HOME: "$CI_PROJECT_DIR/.pnpm-store"
+build:
+  before_script:
+    - corepack enable
+    - pnpm config set store-dir "$CI_PROJECT_DIR/.pnpm-store"
+  cache:
+    key:
+      files: [pnpm-lock.yaml]
+    paths: [.pnpm-store/]
+  script:
+    - pnpm install --frozen-lockfile
+```
+
+### Yarn
+
+```yaml
+build:
+  before_script:
+    - yarn config set cache-folder "$CI_PROJECT_DIR/.yarn-cache"
+  cache:
+    key:
+      files: [yarn.lock]
+    paths: [.yarn-cache/]
+  script:
+    - yarn install --frozen-lockfile
+```
+
+For Yarn Berry zero-installs, `.yarn/cache` is committed to the repo and
+no `cache:` block is needed.
+
+### pip / Poetry
+
+```yaml
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"        # pip
+  POETRY_CACHE_DIR: "$CI_PROJECT_DIR/.poetry-cache"  # poetry
+build:
+  cache:
+    key:
+      files:
+        - poetry.lock        # or requirements.txt for plain pip
+    paths:
+      - .pip-cache/
+      - .poetry-cache/
+      - .venv/
+  script:
+    - poetry config virtualenvs.in-project true
+    - poetry install --no-interaction
+```
+
+`virtualenvs.in-project true` puts `.venv/` under `$CI_PROJECT_DIR` so it
+can be cached.
+
+### Maven / Gradle
+
+```yaml
+variables:
+  MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
+  GRADLE_USER_HOME: "$CI_PROJECT_DIR/.gradle"
+build-maven:
+  cache:
+    key:
+      files: [pom.xml]
+    paths: [.m2/repository/]
+  script: [mvn -B verify]
+
+build-gradle:
+  cache:
+    key:
+      files: [gradle/wrapper/gradle-wrapper.properties, build.gradle.kts]
+    paths:
+      - .gradle/caches/
+      - .gradle/wrapper/
+  script: [./gradlew build]
+```
+
+Both default to `$HOME`; the variables relocate them into the workspace.
+
+### Go modules
+
+```yaml
+variables:
+  GOPATH: "$CI_PROJECT_DIR/.go"          # module + build cache into workspace
+build:
+  cache:
+    key:
+      files: [go.sum]
+    paths:
+      - .go/pkg/mod/
+  script:
+    - go build ./...
+```
+
+`GOPATH` defaults to `$HOME/go`, which is uncacheable — relocating it is
+mandatory for the Go module cache to persist.
+
+### Cargo (Rust)
+
+```yaml
+variables:
+  CARGO_HOME: "$CI_PROJECT_DIR/.cargo"
+build:
+  cache:
+    key:
+      files: [Cargo.lock]
+    paths:
+      - .cargo/registry/index/
+      - .cargo/registry/cache/
+      - .cargo/git/db/
+      - target/
+  script:
+    - cargo build --release
+```
+
+`CARGO_HOME` defaults to `$HOME/.cargo`; relocate it and cache the
+registry plus `target/`.
+
+## Pitfalls
+
+### Cache poisoning across branches and forks
+
+A cache shared between protected and unprotected refs is an injection
+vector: a contributor pushing to an unprotected feature branch can write
+a poisoned cache that a protected branch (or a fork's MR pipeline) later
+restores. Mitigations:
+
+- Keep `cache:unprotect` at its default `false` so protected and
+  unprotected refs use separate caches.
+- Discriminate the key by ref where trust matters:
+  `key: "$CI_COMMIT_REF_PROTECTED-$CI_COMMIT_REF_SLUG"` so protected and
+  unprotected content never collide.
+- Treat restored binaries as untrusted for security-sensitive
+  toolchains; re-verify checksums after the pull.
+
+### Treating cache as artifacts
+
+The cache is best-effort and unordered. Relying on it to pass a build
+output to a later stage will work until the day the cache is evicted, a
+job lands on a fresh runner, or two pipelines race — then the downstream
+job mysteriously fails. Pass build output with `artifacts:`, always.
+
+### Oversized caches
+
+`untracked: true` plus a sprawling `paths:` can produce multi-gigabyte
+caches whose upload/download time exceeds the install time they were
+meant to save. Cache the dependency store, not the whole workspace, and
+measure: if `Restoring cache` takes longer than a cold install, drop it.
+
+### Default `expire_in`
+
+Artifacts without an explicit `expire_in` inherit the instance default,
+which on many installs is effectively unbounded. Across thousands of
+pipelines this silently consumes object storage. Set a deliberate TTL on
+every artifact; reserve long or `never` expiry for genuine release
+deliverables.
+
+### The `$CI_PROJECT_DIR` trap, restated
+
+The most frequent "my cache does nothing" cause: caching a tool's default
+`$HOME` directory, which lives outside `$CI_PROJECT_DIR` and is therefore
+silently un-cacheable. Every language recipe above redirects the tool's
+cache into the workspace for exactly this reason — verify the cached path
+is under `$CI_PROJECT_DIR` before blaming the key.

--- a/.claude/skills/gitlab-ci/references/includes-and-components.md
+++ b/.claude/skills/gitlab-ci/references/includes-and-components.md
@@ -1,0 +1,475 @@
+# Includes and components reference
+
+GitLab CI/CD has no single "function call" primitive. Composition is
+assembled from several keywords that each cover one axis of reuse:
+`include:` pulls external configuration into the current pipeline,
+**CI/CD Components** package a parameterised unit and publish it to a
+catalog, `spec:inputs:` defines the typed contract a component or
+included file exposes, and `extends:` / `!reference[…]` stitch fragments
+together within the merged document.
+
+This document covers every form of `include:`, the modern CI/CD
+Component mechanism (the headline reusable unit), the `spec:inputs:`
+contract and its `$[[ inputs.x ]]` interpolation, composition with
+`extends:` and `!reference`, parent-child pipelines via
+`trigger:include`, the versioning and supply-chain story, and the
+pitfalls that bite when several includes merge into one configuration.
+
+## Picking a composition mechanism
+
+A frequent question. The trade-off:
+
+| Property | `include:` (local/project/remote/template) | CI/CD Component |
+|----------|--------------------------------------------|-----------------|
+| Unit of reuse | A whole `.gitlab-ci.yml` fragment. | A parameterised, versioned building block. |
+| Typed contract | Only if the file declares `spec:inputs:`. | `spec:inputs:` is the idiomatic contract. |
+| Versioning | By `ref:` (project) or URL (remote). | By `@<version>` — tag, SHA, `~latest`. |
+| Discoverability | None — you must know the path. | Listed in the CI/CD Catalog. |
+| Inputs interpolation | `$[[ inputs.x ]]` when `spec:` present. | `$[[ inputs.x ]]` — first-class. |
+| Best for | Sharing a stage fragment within an org. | A reusable block consumed across projects. |
+
+Rule of thumb: reach for a **CI/CD Component** when the unit of reuse is
+a published, versioned building block consumed by other projects (the
+GitLab analog of a reusable workflow). Reach for plain **`include:`**
+when you are factoring shared configuration inside one group and do not
+need a versioned, catalog-listed contract.
+
+## `include:` — the four classic forms
+
+`include:` merges external YAML into the pipeline configuration **before**
+jobs run. The merged result behaves as one document: later keys can
+override earlier ones (see *Merge and override semantics*).
+
+### `include:local`
+
+Pulls a file from the **same repository and ref** as the
+`.gitlab-ci.yml` being evaluated. The path is absolute from the repo
+root and must start with `/`:
+
+```yaml
+include:
+  - local: '/ci/build.yml'
+  - local: '/ci/test.yml'
+```
+
+Globs are allowed (`local: '/ci/*.yml'`). Because the file is read at the
+pipeline's own ref, `include:local` never introduces a cross-ref
+supply-chain question — it is the safest form.
+
+### `include:project`
+
+Pulls a file from **another project on the same GitLab instance**. Pin
+the `ref:` (a tag, branch, or SHA) and list one or more files:
+
+```yaml
+include:
+  - project: 'my-group/ci-templates'
+    ref: v1.4.0
+    file:
+      - '/templates/build.yml'
+      - '/templates/deploy.yml'
+```
+
+Omitting `ref:` resolves against the included project's **default
+branch** at pipeline-creation time — a moving target. Pin a tag or SHA
+for reproducibility.
+
+### `include:remote`
+
+Pulls a file from an **arbitrary URL** reachable over HTTP(S):
+
+```yaml
+include:
+  - remote: 'https://gitlab.example.com/-/snippets/12/raw/main/build.yml'
+```
+
+This is the highest-risk form. The URL is fetched at pipeline-creation
+time with no integrity check: whoever controls that endpoint controls
+part of your pipeline. Treat it like sourcing a remote shell script.
+
+- Only include from a source you trust and control.
+- Prefer a URL that resolves to an **immutable** artifact (a raw file at
+  a tagged ref or SHA), never `…/raw/main/…`.
+- Audit `include:remote` entries in review the same way you audit a
+  third-party dependency.
+
+Where possible, replace `include:remote` with `include:project` (same
+instance, auditable `ref:`) or a CI/CD Component (versioned, catalog).
+
+### `include:template`
+
+Pulls a **GitLab-maintained template** shipped with the instance. No
+ref or project needed — the name resolves against GitLab's bundled set:
+
+```yaml
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+```
+
+These are first-party and version-locked to your GitLab version, so
+they are a safe default for security and language scaffolding. They are,
+however, opinionated — read what they inject before relying on them.
+
+## `include:` with `rules:` and `inputs:`
+
+An `include:` entry can be made conditional with `rules:` and can pass
+typed inputs to a file that declares `spec:inputs:`.
+
+```yaml
+include:
+  - local: '/ci/deploy.yml'
+    rules:
+      - if: '$CI_COMMIT_BRANCH == "main"'
+  - component: $CI_SERVER_FQDN/my-group/ci/build@1.0.0
+    inputs:
+      runner_tag: saas-linux-large
+    rules:
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+`include:` `rules:` support `if:`, `exists:`, and variable expressions,
+but **not** the job-only `changes:` with `compare_to` in every context —
+they are evaluated at pipeline-creation time, before any job. When the
+rule does not match, the file is simply not included.
+
+## CI/CD Components — the modern reusable unit
+
+A **CI/CD Component** is a reusable, versioned unit of pipeline
+configuration published from a **component project** and consumed via
+`include:component`. It is the closest GitLab analog of a GitHub Actions
+reusable workflow: a typed contract (`spec:inputs:`) wrapping one or
+more jobs, addressed by version, optionally discoverable in the **CI/CD
+Catalog**.
+
+### Component address form
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/my-group/my-project/my-component@1.2.0
+    inputs:
+      stage: build
+      image: golang:1.23
+```
+
+The path decomposes as
+`<fqdn>/<group>/<project>/<component>@<version>`:
+
+- `$CI_SERVER_FQDN` — predefined variable for the current instance host.
+  Using it (rather than a hard-coded domain) keeps the component
+  portable across self-managed and SaaS instances.
+- `<group>/<project>` — the component project that hosts the component.
+- `<component>` — the component **name**, matching a file under the
+  project's `templates/` directory (see layout below).
+- `@<version>` — the version selector (see *Versioning a component*).
+
+### Component project layout
+
+A single project can publish several components. Each component is a
+file or directory under `templates/`:
+
+```text
+my-project/
+├── templates/
+│   ├── build.yml            # component "build"
+│   └── deploy/
+│       └── template.yml     # component "deploy"
+├── README.md                # required for catalog publication
+└── .gitlab-ci.yml           # the component's own CI (test it!)
+```
+
+Resolution rule:
+
+- `templates/<name>.yml` resolves the component `<name>`.
+- `templates/<name>/template.yml` resolves the component `<name>` (the
+  directory form, useful when the component ships companion files).
+
+### Defining a component with `spec:inputs:`
+
+A component file begins with a `spec:` header in its **first YAML
+document**, separated from the configuration by a `---` document marker:
+
+```yaml
+spec:
+  inputs:
+    stage:
+      default: test
+    image:
+      default: golang:1.23
+    coverage_threshold:
+      type: number
+      default: 80
+    deploy_env:
+      type: string
+      options:
+        - staging
+        - production
+    semver:
+      type: string
+      regex: '^\d+\.\d+\.\d+$'
+---
+test-job:
+  stage: $[[ inputs.stage ]]
+  image: $[[ inputs.image ]]
+  script:
+    - go test -coverprofile=cover.out ./...
+    - ./scripts/check-coverage.sh $[[ inputs.coverage_threshold ]]
+```
+
+`spec:inputs:` entries support:
+
+- `default:` — value used when the caller omits the input. An input with
+  **no `default:`** is **required** — the pipeline fails to create if
+  the caller does not supply it.
+- `type:` — `string` (default), `number`, `boolean`, or `array`. The
+  value is validated and coerced to the declared type.
+- `options:` — an allow-list; the supplied value must be one of them.
+- `regex:` — a pattern (`string` inputs only) the value must match.
+
+These four constraints are validated **at pipeline creation**, before
+any job starts — a contract violation fails fast, not mid-run.
+
+### `$[[ inputs.x ]]` interpolation vs. `variables:`
+
+Input interpolation uses the **double-bracket** form `$[[ inputs.x ]]`
+and is resolved **once, at include time**, before the configuration is
+merged. This is distinct from `$VARIABLE` / `${VARIABLE}` CI/CD
+variables, which are resolved **later**, in the job's runtime shell.
+
+```yaml
+spec:
+  inputs:
+    image:
+      default: alpine:3.20
+---
+job:
+  image: $[[ inputs.image ]]        # resolved at include time
+  script:
+    - echo "$CI_COMMIT_SHA"         # resolved at job runtime
+```
+
+Consequences:
+
+- Inputs can parameterise keys that variables cannot reach — `stage:`,
+  `image:`, `rules:` conditions, even job names — because they are
+  substituted into the YAML before parsing finishes.
+- An input is fixed for the lifetime of the include; a variable can
+  differ per job run and can be overridden by the runner environment.
+
+Reach for `spec:inputs:` to define the **interface** of a reusable
+fragment; reach for `variables:` for values that vary at runtime or that
+a downstream job overrides.
+
+### Versioning a component
+
+The `@<version>` selector accepts several forms, in increasing order of
+stability:
+
+| Selector | Resolves to | Stability |
+|----------|-------------|-----------|
+| `@~latest` | Latest **released** version in the catalog. | Moves under you. |
+| `@<branch>` (e.g. `@main`) | Tip of that branch. | Moves under you. |
+| `@<tag>` (e.g. `@1.2.0`) | That tag. | Stable unless re-tagged. |
+| `@<sha>` | That exact commit. | Immutable. |
+
+`~latest` and a branch ref are convenient in development but make the
+pipeline non-reproducible — the component can change between two runs of
+the same commit. For anything that ships, pin a **tag** (and ideally a
+SHA), and bump deliberately.
+
+### Publishing to the CI/CD Catalog
+
+To make a component discoverable and releasable:
+
+1. Add a `README.md` at the component project root (required) and mark
+   the project as a catalog resource in its settings.
+2. Tag a release commit and create a **release** for that tag (the
+   catalog lists released versions; `~latest` resolves to the newest
+   release, not the newest tag).
+3. The project's own `.gitlab-ci.yml` should test each component (lint
+   the YAML, run the component against a fixture) before tagging — a
+   published component is a dependency for every consumer.
+
+Releasing is what populates `~latest`; an untagged, unreleased component
+is only reachable by branch or SHA.
+
+## `extends:` and `!reference[…]` across includes
+
+Both keywords compose fragments **inside the merged document** — they
+operate after all `include:` and component resolution, so they can reach
+templates that arrived via an include.
+
+### `extends:`
+
+`extends:` performs a reverse-deep-merge of one or more hidden jobs
+(`.name`) into the current job. A hidden template defined in an included
+file is fully usable by a job in the root configuration:
+
+```yaml
+# in an included file: /ci/base.yml
+.docker-build:
+  image: docker:27
+  services:
+    - docker:27-dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+```
+
+```yaml
+# in the root .gitlab-ci.yml
+include:
+  - local: '/ci/base.yml'
+
+build:
+  extends: .docker-build       # merged from the included template
+  script:
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+```
+
+The base treatment of `extends:` (merge order, multi-level chains)
+belongs to the pipeline-syntax reference; here the point is only that
+the merge spans include boundaries.
+
+### `!reference[…]`
+
+`!reference` inserts a specific key from another job — including a job
+that came in via an include — without merging the whole job. It is the
+surgical alternative to `extends:`:
+
+```yaml
+include:
+  - local: '/ci/base.yml'
+
+deploy:
+  before_script:
+    - !reference [.docker-build, before_script]   # reuse just one key
+    - echo "extra deploy prep"
+  script:
+    - ./deploy.sh
+```
+
+`!reference` can target arbitrary nesting and is the cleanest way to
+reuse a single fragment (a `script` block, a `rules` entry) across
+includes without dragging unrelated keys along.
+
+## `trigger:include` — composition by reference
+
+A parent-child pipeline composes by **reference** rather than by merge:
+the parent spawns a downstream child pipeline whose configuration is
+supplied inline via `trigger:include`. Unlike `include:`, the child runs
+as its **own pipeline**, not as merged jobs in the parent.
+
+```yaml
+trigger-child:
+  trigger:
+    include:
+      - local: '/ci/child-pipeline.yml'
+    strategy: depend
+```
+
+- The child sees its own merged configuration; the parent's jobs and
+  variables do **not** leak in (only explicitly forwarded variables do).
+- `strategy: depend` makes the parent job mirror the child pipeline's
+  status, so a child failure fails the parent.
+- `trigger:include` accepts the same source forms as `include:`
+  (`local`, `project`, `component`, `artifact` for dynamic child
+  pipelines).
+
+This is composition for **isolation**: use it when a fragment should run
+as an independent pipeline (a monorepo sub-project, a generated dynamic
+pipeline) rather than as extra jobs in the current one. The trigger
+mechanics, `forward:`, and dynamic child pipelines are covered in the
+rules-and-triggers reference; here the framing is that
+`trigger:include` is composition-by-reference, the complement to
+`include:`'s composition-by-merge.
+
+## Merge and override semantics
+
+When `include:` brings in a job key that the root configuration also
+defines, the configurations **merge**, and the later definition wins on
+a per-key basis:
+
+- The **root `.gitlab-ci.yml` is processed last**, so a job redefined in
+  the root overrides the same job from an included file, key by key
+  (not wholesale replacement — unspecified keys survive from the
+  include).
+- Among multiple `include:` entries, **later entries override earlier
+  ones** for the same key.
+- Scalar and array keys are **replaced**, not concatenated. Redefining
+  `script:` in the root replaces the included `script:` entirely.
+- Map keys (e.g. `variables:`) are **deep-merged** — individual keys
+  override, siblings survive.
+
+```yaml
+include:
+  - local: '/ci/base.yml'        # defines test.script + test.image
+
+test:
+  image: node:22                 # overrides only the image
+  # script: inherited from /ci/base.yml unless redefined here
+```
+
+To override deliberately, redefine the exact key. To extend rather than
+replace, prefer `extends:` or `!reference[…]` so the original fragment
+stays visible.
+
+## Versioning strategy and supply-chain hardening
+
+Every `include:` and component is a dependency. Treat it like one.
+
+1. **Pin every cross-project and remote reference.** Use a `ref:` (tag
+   or SHA) on `include:project`, an immutable URL on `include:remote`,
+   and a `@<tag>` or `@<sha>` on `include:component`. An unpinned
+   reference (`include:project` with no `ref:`, `@main`, `@~latest`) can
+   change between two runs of the same commit.
+2. **Prefer first-party over third-party.** `include:template` and
+   components from a trusted internal group are auditable and version-
+   locked. An arbitrary `include:remote` URL is not.
+3. **Audit `include:remote`.** It fetches code with no integrity check.
+   If you cannot replace it with `include:project` or a component,
+   ensure the source is one you control and the URL is immutable.
+4. **Version components like a library.** Tag releases
+   `<major>.<minor>.<patch>`, populate the catalog with a release per
+   tag, and let consumers pin a SHA with a comment naming the version.
+5. **Beware moving selectors.** `@~latest` and `@main` are conveniences
+   for the component's own development, not for production consumers —
+   the same risk as pinning a GitHub Action to `@main`.
+
+The failure mode to avoid is the same across all forms: an unpinned
+include changes upstream, and a pipeline that passed yesterday fails (or
+worse, silently does the wrong thing) today, on an unchanged commit.
+
+## Common pitfalls
+
+- **Override order surprises.** Because the root config and later
+  includes win, a job you thought an included template defined may be
+  silently overridden by a same-named key elsewhere. Search the merged
+  config (the pipeline editor's *Full configuration* / *View merged
+  YAML* tab) when a key is not what you expect.
+- **Array keys replace, not append.** Redefining `script:` or
+  `before_script:` in the root **discards** the included version
+  entirely. Use `!reference` to keep the original and add to it.
+- **Variable scope across includes.** `variables:` are deep-merged, so a
+  root-level variable silently overrides an included one of the same
+  name. Globals defined in one include are visible to jobs from another
+  — name them defensively to avoid collisions.
+- **Inputs resolve at include time, variables at runtime.** Reaching for
+  `$VARIABLE` inside a key that needs an include-time value (a `stage:`
+  or job name) will not work — use `$[[ inputs.x ]]`. Conversely,
+  `$[[ inputs.x ]]` cannot pick up a value that only exists at job
+  runtime.
+- **Duplicate job keys across includes.** Two includes defining the same
+  job name silently merge; the later include wins per key. There is no
+  "job already defined" error — only the merged result. Keep job names
+  unique or namespace them per fragment.
+- **Unpinned remote includes.** `include:remote` to a `…/raw/main/…` URL
+  pulls whatever is at that branch tip right now. Pin to a tagged or
+  SHA-addressed raw URL, or move to `include:project`.
+- **`~latest` is the newest release, not the newest commit.** A
+  component fix pushed to a branch is invisible to `@~latest` consumers
+  until a release is created. Conversely, consumers on `@~latest` jump
+  to a new major the moment it is released — pin a tag to opt out.
+- **Catalog requires a README and a release.** A component project with
+  no `README.md` or no GitLab release will not appear in the catalog and
+  `@~latest` will not resolve, even though branch/SHA includes still
+  work.

--- a/.claude/skills/gitlab-ci/references/pipeline-syntax.md
+++ b/.claude/skills/gitlab-ci/references/pipeline-syntax.md
@@ -1,0 +1,721 @@
+# Pipeline syntax reference
+
+Canonical reference for the YAML grammar of a GitLab CI/CD pipeline
+(`.gitlab-ci.yml`). Each top-level and job-level key is enumerated with
+semantics, defaults, and a worked example. Read the section that matches
+the key you are editing — do not guess from memory.
+
+## File location and naming
+
+The pipeline definition lives in a file named `.gitlab-ci.yml` at the
+repository root. The basename and location are conventional, not free:
+GitLab looks for exactly this path unless the project overrides it.
+
+The override is the per-project **CI/CD configuration file** setting,
+exposed at runtime as `CI_CONFIG_PATH`. It accepts a repository-relative
+path, a path in a different project, or an external URL:
+
+```yaml
+# Project setting "CI/CD configuration file" set to:
+#   ci/pipeline.yml                 → file in this repo
+#   ci/pipeline.yml@group/templates → file in another project
+#   https://example.com/pipeline.yml → remote URL
+```
+
+A single file is the entry point; it may pull in further fragments with
+the top-level `include:` key (local files, other projects, remote URLs,
+or built-in templates). Includes are merged before any job runs.
+
+## Top-level keys
+
+### `stages`
+
+Declares the ordered list of pipeline stages. Jobs in the same stage run
+in parallel; a stage starts only after every job in the previous stage
+finishes successfully (unless `needs:` overrides the ordering — see
+below).
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+```
+
+If `stages:` is omitted, GitLab uses the implicit default ordering:
+
+```yaml
+stages:
+  - .pre      # always first, runs before any user stage
+  - build
+  - test
+  - deploy
+  - .post     # always last, runs after every user stage
+```
+
+`.pre` and `.post` are reserved virtual stages that exist whether or not
+`stages:` is declared; a job assigned to `.pre` runs before everything,
+`.post` after everything, regardless of where they appear in the file.
+
+A job is placed in a stage with its `stage:` key (see job-level keys). A
+job referencing a stage not listed in `stages:` is a configuration error.
+
+### `default`
+
+Defines values inherited by every job that does not set them explicitly.
+Only a fixed set of keys may appear under `default:` — notably `image`,
+`services`, `before_script`, `after_script`, `cache`, `tags`, `retry`,
+`timeout`, `interruptible`, and `artifacts`.
+
+```yaml
+default:
+  image: node:22-bookworm
+  tags:
+    - docker
+  before_script:
+    - corepack enable
+    - pnpm install --frozen-lockfile
+  retry:
+    max: 2
+    when: runner_system_failure
+```
+
+A job overrides a default by redeclaring the key; there is no deep merge
+of `default` into the job — the job's value replaces the default wholesale
+for that key. Set `inherit:` on a job to opt out of defaults or variables
+selectively:
+
+```yaml
+job:
+  inherit:
+    default: false              # ignore all `default:` keys
+    variables: [DEPLOY_ENV]     # inherit only these global variables
+```
+
+### `variables`
+
+Global CI/CD variables, inherited by every job. Job-scoped `variables:`
+override globals for that job. This section is intentionally brief —
+variable precedence, masking, protected/file variables, and secret
+injection are covered in the `variables-and-secrets.md` reference; consult
+it for anything beyond plain key/value defaults.
+
+```yaml
+variables:
+  GIT_DEPTH: "0"
+  FF_USE_FASTZIP: "true"
+```
+
+Variable values are strings. Quote numeric- or boolean-looking values to
+avoid the YAML coercion traps described in *Edge cases and quirks*.
+
+### `include`
+
+Pulls in external configuration before evaluation. Each entry is `local`,
+`project` (+ `ref` + `file`), `remote`, `template`, or `component`.
+
+```yaml
+include:
+  - local: ci/build.yml
+  - project: group/ci-templates
+    ref: v1.4.0
+    file: /jobs/deploy.yml
+  - template: Security/SAST.gitlab-ci.yml
+  - component: gitlab.com/components/sonarqube@1.0.0
+```
+
+### `workflow`
+
+Controls whether the **whole pipeline** is created for a given event.
+Without it, branch and merge-request pipelines can both fire and cause
+duplicate runs. The canonical guard:
+
+```yaml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
+    - when: never           # nothing else creates a pipeline
+```
+
+`workflow:rules` accepts the same `if` / `changes` / `when` vocabulary as
+job `rules:`, plus `auto_cancel` and a `name:` to label the pipeline.
+
+## Job-level keys
+
+A job is any top-level mapping that is not a reserved keyword. Its key is
+the job name (shown in the UI and used by `needs:`/`dependencies:`). A job
+must define `script:` (or be a `trigger:` / `extends:`-only bridge job).
+
+### `script`
+
+The shell commands the job runs, as a YAML list. Each list item is one
+command line; a non-zero exit on any line fails the job. Commands run in
+the runner's shell.
+
+```yaml
+test:
+  stage: test
+  script:
+    - npm ci
+    - npm run lint
+    - npm test
+```
+
+### `before_script` and `after_script`
+
+`before_script` is prepended to `script` (it shares the same shell
+context). `after_script` runs in a **separate shell**, always, even when
+the job failed or was cancelled — making it the right place for cleanup.
+Because it is a fresh shell, environment changes from `script:` do not
+carry into `after_script:`.
+
+```yaml
+deploy:
+  before_script:
+    - terraform init -input=false
+  script:
+    - terraform apply -auto-approve
+  after_script:
+    - terraform output -json > tf-out.json || true
+```
+
+### `stage`
+
+Assigns the job to a stage from `stages:`. Defaults to `test` when
+omitted.
+
+```yaml
+lint:
+  stage: build
+  script:
+    - golangci-lint run
+```
+
+### `rules` and `when`
+
+`rules:` is the modern flow-control mechanism: an ordered list evaluated
+top to bottom, **first match wins**, and the matched rule's `when:`
+decides the job's fate. Each rule may carry `if:`, `changes:`,
+`exists:`, `when:`, `allow_failure:`, and `variables:`.
+
+`when:` values: `on_success` (default — run if prior stages succeeded),
+`on_failure`, `always`, `manual` (a play button in the UI), `delayed`
+(with `start_in:`), and `never` (do not add the job).
+
+```yaml
+deploy:prod:
+  stage: deploy
+  script:
+    - ./deploy.sh production
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+      when: manual
+      allow_failure: false
+    - if: $CI_COMMIT_BRANCH == "main"
+      changes:
+        - src/**/*
+      when: on_success
+    - when: never
+```
+
+If no rule matches and there is no trailing catch-all, the job is **not
+added** to the pipeline. `rules:` is mutually exclusive with `only/except`
+in the same job.
+
+### `needs`
+
+Declares a Directed Acyclic Graph (DAG): the job starts as soon as its
+named dependencies finish, ignoring stage boundaries. This is how you
+break out of strict stage-by-stage execution.
+
+```yaml
+integration:
+  stage: test
+  needs:
+    - build:linux
+    - build:macos
+  script:
+    - ./run-integration.sh
+```
+
+`needs: []` (empty list) starts the job **immediately**, at pipeline
+creation, regardless of stage:
+
+```yaml
+prefetch:
+  stage: test
+  needs: []          # do not wait for the build stage
+  script:
+    - ./warm-cache.sh
+```
+
+`needs:` can also pull artifacts from a specific upstream job; use the
+object form with `artifacts: true`:
+
+```yaml
+package:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true       # download build's artifacts
+    - job: changelog
+      artifacts: false      # order dependency only, no download
+  script:
+    - ./package.sh
+```
+
+A job with `needs:` can depend only on jobs in the same stage or an
+earlier stage. The DAG must be acyclic.
+
+### `dependencies`
+
+Controls which upstream jobs' **artifacts** are downloaded into this job.
+By default a job downloads artifacts from every job in all prior stages;
+`dependencies:` narrows that set. An empty list disables artifact download
+entirely.
+
+```yaml
+unit:
+  stage: test
+  dependencies:
+    - build           # only fetch build's artifacts
+  script:
+    - ./test.sh
+
+quick:
+  stage: test
+  dependencies: []    # fetch nothing — faster start
+  script:
+    - ./lint.sh
+```
+
+When `needs:` is present, the `needs.*.artifacts` flags take precedence
+and `dependencies:` is redundant — prefer expressing both ordering and
+artifact flow through `needs:`.
+
+### `artifacts`
+
+Files and directories saved after the job, passed to later stages and
+downloadable from the UI.
+
+```yaml
+build:
+  stage: build
+  script:
+    - make dist
+  artifacts:
+    paths:
+      - dist/
+    exclude:
+      - dist/**/*.map
+    expire_in: 1 week
+    when: on_success          # on_success | on_failure | always
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+`reports:` artifacts feed GitLab features (test tab, coverage diffs,
+security dashboards) rather than being plain downloads.
+
+### `cache`
+
+Caches dependency directories between runs, keyed for reuse. Distinct from
+artifacts: cache is a runner-side optimization, not a contract between
+jobs.
+
+```yaml
+test:
+  cache:
+    key:
+      files:
+        - package-lock.json     # invalidate when the lockfile changes
+    paths:
+      - node_modules/
+    policy: pull-push           # pull | push | pull-push
+  script:
+    - npm ci
+    - npm test
+```
+
+### `allow_failure`
+
+When `true`, a failing job does not fail the pipeline; it is shown as a
+warning. Defaults to `false`, except for `when: manual` jobs, where it
+defaults to `true`. A numeric form restricts which exit codes are
+tolerated:
+
+```yaml
+flaky:
+  script:
+    - ./maybe-flaky.sh
+  allow_failure:
+    exit_codes:
+      - 137         # OOM-kill tolerated; any other non-zero still fails
+```
+
+### `timeout`
+
+Per-job timeout, overriding the project default. Accepts a human-readable
+duration.
+
+```yaml
+e2e:
+  timeout: 30 minutes
+  script:
+    - ./e2e.sh
+```
+
+### `retry`
+
+Automatically re-runs a failed job. `max:` is 0–2 (default 0). `when:`
+restricts retries to specific failure classes, so transient
+infrastructure failures retry while genuine test failures do not.
+
+```yaml
+deploy:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - api_failure
+  script:
+    - ./deploy.sh
+```
+
+### `interruptible`
+
+Marks the job as safe to cancel when a newer pipeline supersedes it on the
+same ref. Combined with the project's auto-cancel setting, this stops
+wasting runners on outdated commits. Set `false` on jobs that must not be
+interrupted (irreversible deploys).
+
+```yaml
+build:
+  interruptible: true
+  script:
+    - make
+```
+
+### `resource_group`
+
+Serializes jobs that share a named resource so that at most one runs at a
+time across all pipelines — the standard guard against concurrent deploys
+to the same environment.
+
+```yaml
+deploy:prod:
+  resource_group: production
+  environment:
+    name: production
+  script:
+    - ./deploy.sh
+```
+
+### `environment`
+
+Binds the job to a GitLab deployment environment, surfacing it in the
+Environments and Deployments views.
+
+```yaml
+deploy:review:
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: https://$CI_COMMIT_REF_SLUG.review.example.com
+    deployment_tier: development      # production|staging|testing|development|other
+    on_stop: stop:review              # job that tears this environment down
+  script:
+    - ./deploy-review.sh
+
+stop:review:
+  stage: deploy
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  rules:
+    - if: $CI_MERGE_REQUEST_ID
+      when: manual
+  script:
+    - ./teardown-review.sh
+```
+
+The `on_stop` job must target the same `environment.name` with
+`action: stop`, and is typically `manual`.
+
+### `parallel`
+
+Runs N identical copies of the job. Each copy gets `CI_NODE_INDEX`
+(1-based) and `CI_NODE_TOTAL`, which the script uses to shard work.
+
+```yaml
+test:
+  parallel: 4
+  script:
+    - ./run-tests.sh --shard "$CI_NODE_INDEX/$CI_NODE_TOTAL"
+```
+
+### `parallel:matrix`
+
+Fans out one job per combination of the listed variable axes (Cartesian
+product). Each generated job sees its axis variables in the environment;
+`CI_NODE_INDEX`/`CI_NODE_TOTAL` cover the whole matrix.
+
+```yaml
+test:
+  stage: test
+  parallel:
+    matrix:
+      - RUBY: ["3.2", "3.3"]
+        DB: [postgres, mysql]
+  image: ruby:$RUBY
+  script:
+    - ./test.sh --db "$DB"
+```
+
+The example above generates four jobs:
+`test: [3.2, postgres]`, `test: [3.2, mysql]`, `test: [3.3, postgres]`,
+`test: [3.3, mysql]`. A list value with multiple keys multiplies; multiple
+list entries under `matrix:` are unioned (each entry is its own product).
+
+### `tags`
+
+Selects runners by their tag set. Every listed tag must be present on the
+runner.
+
+```yaml
+gpu-job:
+  tags:
+    - gpu
+    - linux
+  script:
+    - ./train.sh
+```
+
+### `variables` (job scope)
+
+Per-job variables, overriding globals. Brief here by design; see
+`variables-and-secrets.md` for precedence and masking.
+
+```yaml
+deploy:staging:
+  variables:
+    DEPLOY_ENV: staging
+  script:
+    - ./deploy.sh "$DEPLOY_ENV"
+```
+
+## Reuse mechanisms
+
+### Hidden jobs (template jobs)
+
+A job whose name begins with a dot (`.`) is **hidden**: GitLab parses it
+but never adds it to a pipeline. Hidden jobs exist purely to be reused via
+`extends:` or `!reference`.
+
+```yaml
+.deploy-template:
+  image: alpine:3.20
+  before_script:
+    - apk add --no-cache curl
+  script:
+    - ./deploy.sh
+```
+
+### `extends`
+
+Inherits one or more jobs' configuration. Multi-level inheritance is
+supported, and keys are **deep-merged**: maps merge key-by-key, while
+arrays and scalars are replaced wholesale by the most-derived value. When
+`extends:` lists several parents, later parents win on conflict.
+
+```yaml
+.base:
+  image: node:22
+  variables:
+    LOG_LEVEL: info
+  before_script:
+    - npm ci
+
+.with-cache:
+  cache:
+    paths:
+      - node_modules/
+
+test:
+  extends:
+    - .base
+    - .with-cache
+  variables:
+    LOG_LEVEL: debug        # overrides .base's value via deep merge
+  script:
+    - npm test
+```
+
+`extends:` resolves up to 11 levels deep and is preferred over YAML
+anchors because it merges across `include:` boundaries (anchors do not —
+an anchor is only visible within the file that defines it).
+
+### YAML anchors vs `extends`
+
+YAML anchors (`&name` / `*name`) and the merge key (`<<:`) are a raw-YAML
+feature, resolved by the YAML parser before GitLab sees the document. They
+work, but only within a single file and with shallow merge semantics.
+
+```yaml
+.defaults: &defaults
+  image: node:22
+  tags: [docker]
+
+test:
+  <<: *defaults
+  script:
+    - npm test
+```
+
+Prefer `extends:` for cross-file reuse and deep merge; reach for anchors
+only for small, in-file fragments.
+
+### `!reference`
+
+The `!reference[...]` custom tag injects a value from another job's
+specific key — including reaching into a hidden job's `script:` or
+`before_script:` and composing fragments. Unlike `extends:`, it copies a
+**single addressed value**, so you can interleave reused steps with local
+ones.
+
+```yaml
+.setup:
+  before_script:
+    - apk add --no-cache curl jq
+
+.deploy-fragment:
+  script:
+    - ./deploy.sh
+
+test:
+  before_script:
+    - !reference [.setup, before_script]
+    - echo "local step after the shared setup"
+  script:
+    - !reference [.deploy-fragment, script]
+    - ./verify.sh
+```
+
+`!reference` may nest (a referenced value can itself contain a
+`!reference`), but circular references are an error.
+
+## Full worked example
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+
+default:
+  image: node:22-bookworm
+  tags: [docker]
+  retry:
+    max: 1
+    when: runner_system_failure
+
+variables:
+  GIT_DEPTH: "0"
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+.node-cache:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [node_modules/]
+
+build:
+  stage: build
+  extends: .node-cache
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+test:
+  stage: test
+  needs: [build]
+  parallel:
+    matrix:
+      - SUITE: [unit, integration]
+  script:
+    - npm run test:$SUITE
+  artifacts:
+    reports:
+      junit: junit-$SUITE.xml
+
+deploy:prod:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true
+  resource_group: production
+  interruptible: false
+  environment:
+    name: production
+    url: https://app.example.com
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+  script:
+    - ./deploy.sh dist/
+```
+
+## Edge cases and quirks
+
+- **GENERATED pipeline.** In this repository, `.gitlab-ci.yml` is
+  **derived** by `scripts/build-ci.sh` from `ci/ci-capabilities.yml` — it
+  is not hand-authored. Editing the generated `.gitlab-ci.yml` directly is
+  pointless; the next build overwrites it. Change the capability reference
+  and regenerate. See `docs/ci-reference-format.md` for the source-of-truth
+  contract.
+- **YAML boolean / `on` traps.** A YAML 1.1 parser coerces bare `yes`,
+  `no`, `on`, `off`, `true`, `false` to booleans. A variable value of
+  `on` or `no` therefore becomes a boolean and breaks string comparisons.
+  Always quote such values: `FEATURE_FLAG: "on"`, `DEBUG: "false"`.
+- **`script:` list vs block scalar.** `script:` expects a **list** of
+  command strings, not a single block scalar. Writing `script: | …` puts
+  one multiline string as the sole list item, which works but defeats
+  per-line failure semantics and is harder to read — prefer one list item
+  per command.
+- **`needs:` vs `stage:` interaction.** `stage:` defines logical ordering
+  and the UI grouping; `needs:` overrides the *execution* ordering into a
+  DAG. A job can still belong to a later stage yet start early via
+  `needs:`. `needs:` can only reference jobs in the same or an earlier
+  stage.
+- **`rules:` replaced `only/except`.** `only/except` is legacy and must
+  not be mixed with `rules:` in the same job. New jobs use `rules:`
+  exclusively; it is strictly more expressive (per-rule `variables:`,
+  `when:`, `allow_failure:`, `changes:`, `exists:`).
+- **First-match-wins in `rules:`.** Evaluation stops at the first matching
+  rule. Order matters: put the most specific conditions first and a
+  trailing `when: never` (or a catch-all) to make the default explicit.
+- **`when: manual` flips `allow_failure`.** A manual job defaults to
+  `allow_failure: true`; set it to `false` explicitly when a manual gate
+  must block the pipeline on failure.
+- **`after_script` is a fresh shell.** It runs unconditionally (even on
+  failure or cancellation) but does not inherit shell state or exit codes
+  from `script:`. Guard cleanup commands with `|| true` if a non-zero exit
+  there would matter.
+- **`default:` is replace, not merge.** A job that redeclares a `default:`
+  key replaces it wholesale for that job; there is no deep merge of
+  `default:` into the job. Deep merge applies only to `extends:`.
+- **Anchors do not cross `include:`.** YAML anchors are file-local. To
+  reuse configuration defined in an included file, use `extends:` or
+  `!reference`, never an anchor.

--- a/.claude/skills/gitlab-ci/references/rules-and-triggers.md
+++ b/.claude/skills/gitlab-ci/references/rules-and-triggers.md
@@ -1,0 +1,464 @@
+# Rules and triggers reference
+
+The control-flow language that decides **whether** a job runs and
+**what kind of pipeline** runs at all. Read this before writing any
+non-trivial `rules:` clause or `workflow:` gate. Memorising the
+short-circuit and pipeline-source rules avoids the bulk of "two
+pipelines fired for one push" and "the job ran when I told it not to"
+bugs.
+
+## Evaluation surface
+
+Control flow lives at two scopes:
+
+1. **Per-job** via the job-level `rules:` key — decides if *this* job
+   is added to the pipeline, and with which `when:`, `allow_failure:`,
+   and per-rule `variables:`.
+2. **Per-pipeline** via the top-level `workflow:rules:` key — decides
+   if *any* pipeline is created for the event, and short-circuits
+   duplicate pipelines.
+
+Both are evaluated **at pipeline-creation time**, before any job runs.
+A job's `rules:` cannot see another job's result; for run-time
+dependencies use `needs:` / `dependencies:`, not `rules:`. The legacy
+`only:`/`except:` keys occupy the same per-job slot as `rules:` but
+**cannot be combined with it** in the same job — pick one.
+
+## The `rules:` list
+
+`rules:` is an **ordered list**. Evaluation walks it top-to-bottom and
+**stops at the first rule that matches** (short-circuit). The matched
+rule's attributes (`when`, `allow_failure`, `variables`, `start_in`)
+apply; later rules are ignored. If **no** rule matches, the job is
+**not added** to the pipeline (implicit `when: never`).
+
+Each rule is a mapping combining one or more **clauses** (`if`,
+`changes`, `exists`) with **attributes** (`when`, `allow_failure`,
+`variables`, `start_in`). Within one rule, multiple clauses are ANDed.
+
+```yaml
+job:
+  script: ./run.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: on_success
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - src/**/*
+      when: manual
+      allow_failure: true
+    - when: never
+```
+
+### `rules:if`
+
+A single boolean expression over CI/CD variables (operator table
+below). The most common clause. Quote the whole expression so YAML
+does not choke on `:` or `$`.
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG'                       # truthy: tag is set
+  - if: '$CI_COMMIT_BRANCH =~ /^release\/.+/'  # regex match
+```
+
+### `rules:changes`
+
+Matches when any listed path changed. A glob list, or a mapping with
+`paths:` plus `compare_to:` to pin the comparison base (essential
+outside merge requests, where the default base is unreliable).
+
+```yaml
+rules:
+  - changes:
+      paths:
+        - Dockerfile
+        - "src/**/*"
+      compare_to: 'refs/heads/main'
+```
+
+Without `compare_to`, `changes` on a branch pipeline diffs against the
+previous commit on that branch — surprising for force-pushes and the
+first commit. Pin `compare_to` for deterministic behavior.
+
+### `rules:exists`
+
+Matches when at least one file matching the glob exists in the
+repository at pipeline-creation time. Globs are relative to the repo
+root; `**` recurses.
+
+```yaml
+rules:
+  - exists:
+      - "**/Dockerfile"
+```
+
+### `when:` attribute
+
+Selects the job's run behavior once its rule matches:
+
+| Value | Behavior |
+|-------|----------|
+| `on_success` | Run if all jobs in earlier stages succeeded (or `allow_failure`). The default. |
+| `on_failure` | Run only if at least one job in an earlier stage failed. |
+| `always` | Run regardless of earlier-stage status. |
+| `manual` | Add the job but require a manual play action. |
+| `delayed` | Schedule the job after `start_in:`. |
+| `never` | Do **not** add the job. Used as a terminal "drop everything else" rule. |
+
+`when: manual` jobs are non-blocking by default in `rules:`-driven
+pipelines; pair with `allow_failure: false` to make a manual gate
+block downstream stages.
+
+### `allow_failure:` attribute
+
+Set per matched rule. `true` lets the job fail without failing the
+pipeline; `false` makes it blocking. Overrides the job-level
+`allow_failure:` for that rule.
+
+### `variables:` attribute
+
+A matched rule may inject or override variables for the job — the
+canonical way to parameterise one job by the branch or event that
+selected it.
+
+```yaml
+deploy:
+  script: ./deploy.sh "$TARGET_ENV"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      variables:
+        TARGET_ENV: production
+    - if: '$CI_COMMIT_BRANCH == "staging"'
+      variables:
+        TARGET_ENV: staging
+```
+
+### `start_in:` and `when: delayed`
+
+`start_in:` is required by `when: delayed` and gives a human-readable
+duration (`30 seconds`, `1 hour`, `2 days`, capped at one week).
+
+```yaml
+rollout:
+  script: ./rollout.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: delayed
+      start_in: '15 minutes'
+```
+
+## `workflow:rules:` — whole-pipeline gating
+
+`workflow:` sits at the top level and decides whether *any* pipeline
+is created. Same clause/attribute grammar as job `rules:`, but only
+`when: always` and `when: never` are meaningful (a pipeline either
+exists or it does not). Use it to prevent **duplicate pipelines** —
+the single most common GitLab CI footgun.
+
+### The duplicate-pipeline idiom
+
+When merge-request pipelines are enabled, a push to a branch that has
+an open MR fires **two** events: a branch pipeline *and* a detached
+merge-request pipeline. The canonical guard runs MR pipelines when an
+MR is open, branch pipelines only when none is, and tag pipelines
+always:
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+`$CI_OPEN_MERGE_REQUESTS` is non-empty on a branch pipeline whose
+commit has at least one open MR; the third rule drops that redundant
+branch pipeline, leaving only the detached MR pipeline. GitLab ships
+this exact pattern as the `Branch-Pipelines` / `MergeRequest-Pipelines`
+templates.
+
+### `workflow:name:`
+
+Sets a human-readable name for the whole pipeline, supporting
+variable interpolation evaluated at creation time.
+
+```yaml
+workflow:
+  name: 'Pipeline for $CI_COMMIT_REF_NAME'
+```
+
+## Predefined CI/CD variables used in rules
+
+The variables that actually drive `rules:if`. Each is a string; an
+unset variable is the empty string (falsy).
+
+| Variable | Value |
+|----------|-------|
+| `CI_PIPELINE_SOURCE` | What triggered the pipeline (value enumeration below). |
+| `CI_COMMIT_BRANCH` | Branch name. **Empty** on tag pipelines and MR (detached) pipelines. |
+| `CI_COMMIT_TAG` | Tag name. Set **only** on tag pipelines. |
+| `CI_DEFAULT_BRANCH` | The project's default branch (e.g. `main`). |
+| `CI_COMMIT_REF_NAME` | Branch **or** tag name — set on both branch and tag pipelines. |
+| `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` | Target branch of the MR. Set only on MR pipelines. |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of the MR. MR pipelines only. |
+| `CI_OPEN_MERGE_REQUESTS` | Comma-separated `path!iid` of MRs whose source/target is the current branch. Empty when none. |
+| `CI_COMMIT_REF_PROTECTED` | `"true"` if the ref is protected. |
+| `CI_PROJECT_PATH` | `group/project`. |
+
+### `CI_PIPELINE_SOURCE` values
+
+| Value | Triggered by |
+|-------|--------------|
+| `push` | A `git push` to a branch or tag. |
+| `merge_request_event` | An MR was opened/updated (detached, merged-results, or merge-train pipeline). |
+| `schedule` | A pipeline schedule fired. |
+| `web` | The "Run pipeline" button in the UI. |
+| `api` | A pipeline created via the REST API. |
+| `trigger` | A trigger token (`POST /trigger/pipeline`). |
+| `pipeline` | Created by another pipeline's `trigger:` (multi-project, upstream). |
+| `parent_pipeline` | Created by a parent via `trigger:include` (child pipeline). |
+
+Mapping the neutral trigger vocabulary onto these is the job of
+`scripts/build-ci.sh` — see the cross-reference at the end.
+
+## Expression operators in `rules:if`
+
+`rules:if` evaluates a **single boolean expression**. Operators, in
+approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `=~` / `!~` | Regex match / non-match. RHS is a `/pattern/flags` literal. |
+| `==` / `!=` | String equality / inequality. |
+| `&&` | Logical AND. |
+| `\|\|` | Logical OR. |
+
+Notes that bite:
+
+- **No `<`/`>` comparison, no arithmetic.** Values are compared as
+  strings. There is no numeric coercion; `'10' == '10'` is a string
+  match, not a number one.
+- **Quoting.** A literal string in the expression is double-quoted
+  inside the single-quoted YAML scalar: `if: '$X == "main"'`. A bare
+  `$VAR` (no quotes) tests truthiness.
+- **Regex literals** use `/.../` delimiters with optional flags:
+  `=~ /^v\d+\.\d+/i`. The pattern is RE2 (GitLab uses the Go regexp
+  engine on the server side); no backreferences, no lookahead.
+- **`null`.** Compare against `null` (unquoted) to test "variable is
+  undefined" vs `""` (defined-but-empty). They differ:
+  `$X == null` is true only when `X` was never set.
+
+### Truthiness
+
+| Expression form | True when… |
+|-----------------|------------|
+| `$VAR` (bare) | `VAR` is set **and** non-empty. |
+| `$VAR == "x"` | `VAR` equals the string `x`. |
+| `$VAR != null` | `VAR` is defined (even if empty). |
+| `$VAR =~ /p/` | `VAR` is set and matches the pattern. |
+
+The empty-string trap mirrors GitHub Actions: a bare `$VAR` is false
+both when unset and when set to `""`. To distinguish, test against
+`null`.
+
+## Pipeline types and trigger mechanisms
+
+| Pipeline type | Fires when | `CI_PIPELINE_SOURCE` |
+|---------------|------------|----------------------|
+| Branch | Push to a branch | `push` |
+| Tag | Push of a tag | `push` (with `$CI_COMMIT_TAG` set) |
+| Merge request (detached) | MR opened/updated, MR pipelines enabled | `merge_request_event` |
+| Merged-results | Like detached, but run against the *result* of merging into target | `merge_request_event` |
+| Merge-train | Sequential merged-results pipelines guarding the queue | `merge_request_event` |
+| Scheduled | A pipeline schedule fires | `schedule` |
+| Parent-child | A job's `trigger:include` in the same project | `parent_pipeline` |
+| Multi-project | A job's `trigger:` with `project:` | `pipeline` |
+
+Merged-results and merge-train pipelines are detected the same way in
+`rules:` — all three carry `CI_PIPELINE_SOURCE == "merge_request_event"`.
+Distinguish merge-train runs by the predefined `$CI_MERGE_REQUEST_EVENT_TYPE`
+(`detached`, `merged_result`, `merge_train`) when behavior must differ.
+
+### `trigger:` — parent-child pipelines
+
+A job whose body is `trigger:` does no work itself; it spawns a
+downstream pipeline. `trigger:include` runs a child pipeline from
+config in the same project. `strategy: depend` makes the trigger job
+mirror the child's status (otherwise it succeeds immediately on
+dispatch).
+
+```yaml
+run-child:
+  stage: test
+  trigger:
+    include:
+      - local: ci/child-pipeline.yml
+    strategy: depend
+```
+
+### `trigger:` — multi-project pipelines
+
+`trigger:project` (plus optional `branch`) dispatches a pipeline in a
+**different** project. `forward:` controls which variables and
+yaml-defined pipeline variables propagate downstream.
+
+```yaml
+deploy-downstream:
+  stage: deploy
+  trigger:
+    project: my-group/deployment-config
+    branch: main
+    strategy: depend
+    forward:
+      pipeline_variables: true
+      yaml_variables: true
+```
+
+`forward.pipeline_variables` forwards variables passed into the
+*current* pipeline (e.g. from a manual run); `forward.yaml_variables`
+forwards the `variables:` block defined in this job. Both default such
+that yaml variables forward and pipeline variables do not — set
+explicitly when in doubt.
+
+## Legacy `only:` / `except:` (superseded by `rules:`)
+
+`only:` / `except:` predate `rules:` and remain supported but are
+**not recommended** for new pipelines. They cannot appear in the same
+job as `rules:`. Each takes `refs`, `changes`, or `variables`.
+
+```yaml
+# Legacy form
+job:
+  script: ./run.sh
+  only:
+    refs:
+      - main
+      - /^release\/.*$/
+    changes:
+      - src/**/*
+  except:
+    variables:
+      - $SKIP_CI
+```
+
+### Migration to `rules:`
+
+The equivalent `rules:` form makes the implicit OR/AND explicit and
+short-circuits cleanly:
+
+```yaml
+# Modern form
+job:
+  script: ./run.sh
+  rules:
+    - if: '$SKIP_CI'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - src/**/*
+    - if: '$CI_COMMIT_BRANCH =~ /^release\/.*$/'
+      changes:
+        - src/**/*
+```
+
+Migration notes:
+
+- `only:refs` keywords like `merge_requests`, `tags`, `branches` map to
+  `if:` expressions on `$CI_PIPELINE_SOURCE`, `$CI_COMMIT_TAG`, and
+  `$CI_COMMIT_BRANCH` respectively.
+- `except:` becomes a leading `when: never` rule (short-circuit).
+- `only:` without `refs` (just `changes`/`variables`) had an implicit
+  `branches`+`tags` ref scope; replicate it with an explicit `if:` or
+  the job will widen its trigger surface silently.
+
+## Common patterns
+
+### Run only on the default branch
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+```
+
+### Run only in merge-request pipelines
+
+```yaml
+rules:
+  - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+### Run on tags matching a version pattern
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+```
+
+### Manual gate that blocks downstream stages
+
+```yaml
+deploy:
+  script: ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: manual
+      allow_failure: false
+```
+
+### Skip the pipeline entirely on doc-only pushes
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+      changes:
+        paths:
+          - "docs/**/*"
+        compare_to: 'refs/heads/main'
+      when: never
+    - when: always
+```
+
+## Pitfalls
+
+- **No `workflow:rules:` guard.** Without the duplicate-pipeline idiom
+  above, every push to a branch with an open MR runs the pipeline
+  twice. This is the default failure mode, not an edge case.
+- **`$CI_COMMIT_BRANCH` is empty on MR pipelines.** A rule written as
+  `if: '$CI_COMMIT_BRANCH == "main"'` never matches inside a detached
+  MR pipeline — use `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME` there.
+- **`changes` without `compare_to` outside an MR.** The comparison base
+  is the previous pipeline's commit, which is unstable on force-push
+  and the branch's first commit. Always pin `compare_to`.
+- **`rules:` short-circuit forgotten.** Listing two matching `if:`
+  rules does not OR their attributes — only the **first** match's
+  attributes apply. Order matters; put the most specific rule first.
+- **`when: manual` non-blocking by default.** In `rules:`-driven
+  pipelines a manual job does not block downstream stages unless
+  `allow_failure: false` is set explicitly.
+- **`trigger:` without `strategy: depend`.** The trigger job goes green
+  the instant it dispatches the downstream pipeline, regardless of
+  whether that pipeline later fails. Add `strategy: depend` to mirror
+  the child's status.
+- **Mixing `rules:` with `only:`/`except:`.** GitLab rejects a job that
+  declares both. Migrate fully; do not interleave.
+
+## Cross-reference — this repository
+
+The generated `.gitlab-ci.yml` at the repo root is **derived**, not
+hand-authored: `scripts/build-ci.sh` (spec 0048) reads the neutral
+capability reference `ci/ci-capabilities.yml` and maps its
+engine-neutral trigger vocabulary — `push` / `pull-request` / `tag` /
+`scheduled` / `manual`, qualified by `branches` / `paths` /
+`tag-pattern` filters — onto the GitLab `rules:` constructs documented
+above (e.g. `pull-request` → `$CI_PIPELINE_SOURCE == "merge_request_event"`,
+`tag` → `$CI_COMMIT_TAG`, a `tag-pattern` filter → a `=~ /pattern/`
+clause). That neutral vocabulary and the mapping contract are defined
+in [`docs/ci-reference-format.md`](../../../../../docs/ci-reference-format.md)
+— do not redefine it here. This reference documents the GitLab target
+syntax the generator emits; the format doc owns the neutral source
+contract.

--- a/.claude/skills/gitlab-ci/references/runners-and-executors.md
+++ b/.claude/skills/gitlab-ci/references/runners-and-executors.md
@@ -1,0 +1,414 @@
+# Runners and executors reference
+
+Reference for the execution substrate of GitLab CI/CD: where a runner
+comes from (scope), how a job is matched to one (tags), how the runner
+runs the job (executors), how the docker executor handles images and
+services, the `config.toml` knobs that govern a self-managed runner, and
+the security model that decides whether attaching a runner is safe.
+
+GitLab splits the concern in two. A **runner** is the agent registered
+with a GitLab instance that picks up jobs. An **executor** is the
+mechanism a runner uses to run a job's script — a local shell, a
+container, a Kubernetes pod. One runner process runs one executor; you
+register several runners to offer several executors.
+
+## Runner scopes
+
+A runner's scope decides which projects may schedule jobs on it.
+
+| Scope | Registered against | Visible to |
+|-------|--------------------|-----------|
+| **Instance** (shared) | The whole instance | Every project, subject to admin settings. |
+| **Group** | A group | Every project in that group and its subgroups. |
+| **Project** (specific) | One or more projects | Only the projects it is explicitly assigned to. |
+
+The GitLab coordinator offers a pending job to the runners eligible for
+that project; the first runner that polls and matches the job's `tags:`
+claims it. Shared runners process jobs fair-use across projects; group
+and project runners only see their own scope.
+
+### GitLab.com SaaS hosted runners
+
+GitLab.com offers managed runners — nothing to register. They are
+ephemeral (a fresh VM per job, destroyed afterward, no state leak) and
+selected by tag:
+
+| Tag (class) | Platform | Notes |
+|-------------|----------|-------|
+| `saas-linux-small-amd64` | Linux | Default class; smallest, cheapest. |
+| `saas-linux-medium-amd64`, `saas-linux-large-amd64` | Linux | More vCPU/RAM, higher minute weight. |
+| `saas-linux-medium-arm64` | Linux ARM | ARM64 class. |
+| `saas-windows-medium-amd64` | Windows | Higher minute multiplier. |
+| `saas-macos-medium-m1` | macOS | Apple silicon; highest multiplier; tier-gated. |
+
+Class names and minute multipliers drift — verify against the current
+GitLab.com runner docs before pinning one. Untagged jobs run on the
+small Linux class.
+
+### Self-managed runners
+
+Anything you register yourself with `gitlab-runner register`, against a
+self-managed instance or GitLab.com. You own the host, the executor
+choice, the network placement, and the security posture. The rest of
+this document is mostly about these.
+
+## Selecting a runner with `tags:`
+
+A job advertises required tags; a runner advertises the tags it was
+registered with. A job runs on a runner only if the runner carries
+**every** tag the job lists.
+
+```yaml
+build:
+  tags: [docker, linux, amd64]
+  script:
+    - make build
+```
+
+This runs only on a runner tagged at least `docker`, `linux`, and
+`amd64`. Extra runner tags are fine; a single missing tag disqualifies
+the runner.
+
+### Untagged jobs and `run_untagged`
+
+A job with no `tags:` is **untagged**. A runner picks up untagged jobs
+only when registered with `run_untagged = true` (the default for new
+runners; admins often flip shared runners to `false` to force explicit
+tagging). Set it per runner in `config.toml`:
+
+```toml
+[[runners]]
+  name = "docker-runner-1"
+  run_untagged = true
+```
+
+### The "no runner matching tags" stuck job
+
+If a job lists a tag no eligible runner carries — a typo, a
+decommissioned runner, a runner in the wrong scope — the job sits
+`pending` and eventually fails:
+
+```text
+This job is stuck because you don't have any active runners online
+or available with any of these tags assigned to them: <tag>
+```
+
+This is the most common GitLab CI failure after YAML errors. Diagnose
+in Settings → CI/CD → Runners: confirm a runner available to the
+project advertises the exact tag set. A job tagging `arm64` on an
+`amd64`-only fleet is stuck forever, not slow.
+
+## Executors
+
+The executor is set per runner at registration and recorded in
+`config.toml`. It determines the isolation model, the available
+features, and the operational cost.
+
+| Executor | Isolation | Use when |
+|----------|-----------|----------|
+| `shell` | None — runs as the runner's OS user | Trusted single-tenant jobs needing host tools directly. |
+| `docker` | Per-job container | Default for most fleets; clean, reproducible. |
+| `docker-autoscaler` | Per-job container on autoscaled hosts | Bursty load; replaces deprecated `docker-machine`. |
+| `kubernetes` | Per-job pod | Already on k8s; elastic; per-job resource limits. |
+| `ssh` | Remote host, no isolation | Legacy; avoid for new work. |
+| `virtualbox` / `parallels` | Full VM | Need a full guest OS (Windows/macOS) with VM isolation. |
+| `instance` | Fresh cloud VM per job | Autoscaled VMs via fleeting; strongest isolation, highest latency. |
+
+### `shell`
+
+Runs the job's `script:` directly on the host as the user that owns the
+runner process — no container, no image. Fast and simple, but a job has
+the host's full toolchain and filesystem; an escape affects the host and
+the next job. Reserve for trusted, single-tenant runners; never expose a
+shell-executor runner to untrusted contributions (see *Runner
+security*).
+
+### `docker`
+
+The dominant choice. Each job runs in a container from a chosen image;
+the runner mounts the build directory and caches, runs the `script:`,
+then discards the container. Clean per-job state, reproducible
+toolchains, no host pollution. Configuration depth below.
+
+### `kubernetes`
+
+The runner is a controller that creates a **pod per job**: a build
+container (the job image), a helper container (clone, artifacts, cache),
+and one container per declared `service:`. You get horizontal elasticity
+and per-job CPU/memory limits, at the cost of running the runner inside
+a cluster with the right RBAC. Standard for teams already on Kubernetes.
+Knobs live under `[runners.kubernetes]`.
+
+Choosing: trusted project with host tools → `shell`; general-purpose
+fleet → `docker`; already on Kubernetes → `kubernetes`; bursty cloud
+load with scale-to-zero → `docker-autoscaler` / `instance`; full guest
+OS or VM isolation → `virtualbox` / `parallels`.
+
+## The docker executor
+
+### `image:` — the job's container
+
+Set per job, or globally via `default:`:
+
+```yaml
+default:
+  image: golang:1.23-bookworm
+
+test:
+  script: [go test ./...]
+
+lint:
+  image: golangci/golangci-lint:v1.61.0   # overrides the default
+  script: [golangci-lint run]
+```
+
+A job-level `image:` overrides `default:`. With no image at all, the
+docker executor falls back to the runner's configured default image in
+`config.toml`.
+
+### Pin images by digest — security default
+
+Bare tags are mutable: `golang:1.23` and `:latest` can be repointed at a
+new image under the same name, so a green pipeline can silently start
+running different code. Pin by immutable digest:
+
+```yaml
+default:
+  image: golang:1.23-bookworm@sha256:0e6f6c...   # immutable
+```
+
+The skill's `check-pinned-images.sh` flags any `image:` (and
+`services:[].name`) using a bare tag or `:latest` instead of a
+`@sha256:` digest. Treat a bare tag as a finding, not a style nit:
+digest pinning is this skill's supply-chain default, mirroring the
+github-actions action-SHA-pinning rule.
+
+### `image:pull_policy`
+
+Controls when the executor pulls versus reusing a cached image:
+
+```yaml
+build:
+  image:
+    name: registry.example.com/builder@sha256:abc123...
+    pull_policy: [always, if-not-present]
+```
+
+- `always` — pull every run (default on shared runners; freshest).
+- `if-not-present` — pull only when absent locally (fast; safe with a
+  digest, stale-prone with a mutable tag).
+- `never` — never pull; the image must be pre-seeded on the host.
+
+A job may only request policies the runner permits via
+`allowed_pull_policies`; a disallowed request fails the job rather than
+silently downgrading.
+
+### `services:` — sidecar containers
+
+Services are extra containers started alongside the job container on a
+shared network — databases, brokers, headless browsers. Reach them as
+hostnames:
+
+```yaml
+test:
+  image: golang:1.23-bookworm
+  services:
+    - name: postgres:16@sha256:def456...
+      alias: db
+      variables: { POSTGRES_DB: app_test, POSTGRES_PASSWORD: ci_only }
+    - name: redis:7@sha256:aaa111...
+  variables:
+    DATABASE_URL: "postgres://postgres:ci_only@db:5432/app_test"
+  script: [go test ./...]
+```
+
+Mechanics:
+
+- **Hostname.** A service answers at its image name (with `/` and `:`
+  rewritten to `-` and `__`) and at any `alias:` — `db` above. The alias
+  is the practical handle.
+- **Per-service `variables:`.** Configure the service container (DB
+  name, password) independently of the job env.
+- **`services:[].command` / `services:[].entrypoint`.** Override the
+  container's startup, e.g. to pass flags to the service binary.
+- **Ports.** The shared network exposes the container's listening ports
+  on the alias hostname directly; GitLab needs no `ports:` mapping. The
+  `CI_*` variables describe the build environment, not service ports.
+- **Readiness.** The runner waits for service containers to start, but
+  started is not ready — for Postgres and friends, add an explicit wait
+  in the script (`pg_isready` poll, `wait-for-it`).
+
+### Private images — `DOCKER_AUTH_CONFIG`
+
+To pull `image:` or `services:` from a private registry, give the runner
+credentials via the `DOCKER_AUTH_CONFIG` CI/CD variable — a JSON
+document in Docker `config.json` format, ideally a **masked, protected**
+variable:
+
+```json
+{ "auths": { "registry.example.com": { "auth": "base64(user:token)" } } }
+```
+
+The docker and kubernetes executors read it and authenticate the pull.
+Prefer a deploy token or least-privilege registry token over a personal
+credential; never inline the value in `.gitlab-ci.yml`. See the
+security-and-permissions reference for variable protection and masking.
+
+## `config.toml` essentials
+
+Self-managed runners are configured by `config.toml` (default
+`/etc/gitlab-runner/config.toml`). Practitioner essentials below;
+consult the GitLab Runner advanced-configuration docs for the full
+surface.
+
+```toml
+concurrent = 8        # max jobs across ALL runners in this process
+check_interval = 3    # seconds between coordinator polls
+
+[[runners]]
+  name = "docker-runner-1"
+  url = "https://gitlab.example.com/"
+  token = "glrt-REDACTED"
+  executor = "docker"
+  run_untagged = false
+  limit = 4           # max concurrent jobs for THIS runner
+
+  [runners.docker]
+    image = "alpine:3.20"            # fallback when a job sets no image
+    privileged = false              # KEEP false unless truly needed
+    pull_policy = ["if-not-present"]
+    allowed_pull_policies = ["always", "if-not-present"]
+    allowed_images = ["registry.example.com/*", "docker.io/library/*"]
+    allowed_services = ["postgres:*", "redis:*"]
+    volumes = ["/cache"]            # do NOT mount /var/run/docker.sock
+
+  [runners.cache]
+    Type = "s3"
+    Shared = true
+    [runners.cache.s3]
+      ServerAddress = "s3.example.com"
+      BucketName = "gitlab-runner-cache"
+      AuthenticationType = "iam"    # prefer instance role over static keys
+
+  [runners.kubernetes]
+    namespace = "gitlab-ci"
+    image = "alpine:3.20"
+    privileged = false
+    cpu_request = "500m"
+    memory_request = "512Mi"
+    cpu_limit = "2"
+    memory_limit = "2Gi"
+    service_account = "gitlab-runner"
+```
+
+- `concurrent` caps total simultaneous jobs for the whole
+  `gitlab-runner` process, independent of how many `[[runners]]` blocks
+  exist; `limit` caps a single runner.
+- `privileged = true` grants containers near-host capabilities (see
+  *Runner security*); default and recommended value is `false`.
+- `allowed_images` / `allowed_services` allowlist what jobs may run,
+  blunting the "any fork runs any image" exposure on shared runners.
+- `volumes` persists paths across jobs on the same host; a distributed
+  `[runners.cache]` survives beyond one host (essential for autoscaled
+  fleets where the next job lands elsewhere). Never mount the Docker
+  socket as a volume — that is the classic root-escalation footgun.
+- `[runners.kubernetes]` requests/limits seed each per-job pod unless a
+  job overrides them via `KUBERNETES_*` variables; scope the
+  `service_account` RBAC to the minimum the build needs.
+
+## Autoscaling
+
+For bursty load, scale capacity to demand instead of paying for idle
+hosts:
+
+- **`docker-autoscaler` + fleeting.** The current autoscaling path,
+  replacing the deprecated `docker-machine`. A **fleeting** plugin (AWS
+  EC2, GCP, Azure) provisions and reaps VMs; the autoscaler runs the
+  docker executor on each. Configured via `[runners.autoscaler]` with
+  `plugin`, `capacity_per_instance`, and scaling policies.
+- **`instance` executor.** Runs each job directly on a freshly
+  provisioned-then-destroyed cloud VM via the same fleeting plugins —
+  strongest isolation, highest per-job latency.
+- **GitLab Runner Operator on Kubernetes.** Deploy and manage runners
+  declaratively via the operator and a `Runner` custom resource; the
+  cluster autoscaler then scales nodes to absorb pod-per-job demand.
+
+## Runner security
+
+A runner executes whatever code a pipeline carries. The hard questions
+are *who can push that code* and *what the runner can reach*.
+
+### `privileged = true` is dangerous
+
+A privileged docker container runs with near-host capabilities: host
+devices, kernel manipulation, and — with a mounted Docker socket —
+trivial escape to root on the host. People enable it for
+Docker-in-Docker (`dind`); prefer **rootless buildkit / kaniko /
+buildah**, which build images without privileged mode. If `dind` is
+unavoidable, isolate those runners on disposable, network-segmented
+hosts and never share them with untrusted projects.
+
+### The untrusted-fork / public-project exposure
+
+The headline rule mirrors the GitHub Actions analog: **a fork merge
+request can run arbitrary code on any runner that picks up its
+pipeline.** If a shared or instance runner processes fork pipelines for
+a public project, an attacker forks, edits `.gitlab-ci.yml` to exfil
+secrets or mine the host, and opens an MR. Defenses:
+
+1. **Protected branches and protected variables.** Mark sensitive CI/CD
+   variables **protected** so they are injected only on protected
+   branches and tags — never on a fork MR pipeline. This is the primary
+   control: a fork pipeline never sees the secret.
+2. **Restrict shared runners on public projects.** Disable instance
+   runners for public projects, or require approval before
+   external-fork MR pipelines run (project CI/CD settings).
+3. **Dedicated, ephemeral, segmented runners for untrusted work.** If
+   fork CI must run, give it disposable runners (autoscaled VMs / k8s
+   pods destroyed per job) on a network with no route to production or
+   the secret store.
+4. **`allowed_images` / `allowed_services` allowlists.** Constrain what
+   a job may pull and run on a shared runner.
+5. **Drop `privileged`, drop the Docker socket.** A non-privileged
+   runner with no socket mount removes the easiest escalation path.
+
+### Isolate CI from production networks
+
+Place runners on a subnet that **cannot** reach production databases,
+state stores, or the secret manager beyond what the build legitimately
+needs. A compromised job should not be one `curl` from production.
+Combine network segmentation with protected variables so the blast
+radius of a malicious pipeline is bounded.
+
+For the full permission surface — protected vs masked variables,
+`CI_JOB_TOKEN` scoping, the GitLab security model — see the
+security-and-permissions reference.
+
+## Resource and concurrency controls
+
+Two job-level fields interact with the runner layer; full job-field
+semantics live in the pipeline-syntax reference, summarized here only
+for their runner-side effect:
+
+- **`resource_group`** — serializes jobs sharing the named group so
+  that, across pipelines, at most one runs at a time. The mechanism is
+  the coordinator's, not the runner's, but it is how you stop two deploy
+  jobs racing on the same environment regardless of free runner count.
+
+  ```yaml
+  deploy_prod:
+    resource_group: production
+    environment: production
+    script: ./deploy.sh
+  ```
+
+- **`interruptible`** — marks a job safe to auto-cancel when a newer
+  pipeline supersedes it on the same ref (with *Auto-cancel redundant
+  pipelines* enabled), freeing runner capacity. Full field detail in the
+  pipeline-syntax reference.
+
+  ```yaml
+  build:
+    interruptible: true
+    script: make build
+  ```

--- a/.claude/skills/gitlab-ci/references/security-and-permissions.md
+++ b/.claude/skills/gitlab-ci/references/security-and-permissions.md
@@ -1,0 +1,382 @@
+# Security and permissions reference
+
+GitLab CI/CD has no single token whose scope map you tune the way GitHub
+Actions tunes `GITHUB_TOKEN` via `permissions:`. The pipeline's
+authority is spread across distinct primitives: the `CI_JOB_TOKEN` and
+its accessible-projects allowlist, the project/group member role model,
+protected branches and tags, protected environments, and the
+masked/protected variable discipline. Getting these right is the
+highest-leverage defense against supply-chain compromise — a job that
+runs on an unprotected ref, with a tightly scoped job token and no
+protected variables in reach, cannot deploy to production, push a
+package, or exfiltrate a long-lived cloud key, no matter what a
+dependency it pulls tries to do.
+
+This file is the GitLab analog of the GitHub Actions skill's
+`permissions.md`. Where GitHub concentrates authority in one token, read
+this as "which primitive grants which authority, and how to grant the
+minimum".
+
+## The `CI_JOB_TOKEN`
+
+Every job receives a `CI_JOB_TOKEN` — a short-lived credential, valid
+only for the lifetime of the job, injected as the predefined variable
+`CI_JOB_TOKEN`. It is the rough analog of `GITHUB_TOKEN`, but its scope
+is governed by project settings rather than a per-pipeline `permissions:`
+key.
+
+The token can:
+
+- Clone the current project (it backs the `git clone` of the pipeline
+  itself).
+- Authenticate to the project's container registry and package registry
+  (pull, and push where the job's user role allows).
+- Call a curated subset of the GitLab API on behalf of the job
+  (`CI_JOB_TOKEN`-accepting endpoints — a deliberately narrower surface
+  than a personal access token).
+- Reach **other projects** — but only those on the current project's
+  **job-token allowlist** (see below).
+
+It is bound to the identity and role of the **user who triggered the
+pipeline**: a job triggered by a Reporter cannot push to the registry
+even though the token mechanically exists. Role gates the token; the
+token does not elevate the role.
+
+### The job-token accessible-projects allowlist
+
+Under **Settings → CI/CD → Job token permissions** (historically labelled
+"Token Access" / "Limit access to this project"), each project maintains
+an **allowlist of projects whose CI jobs may use their `CI_JOB_TOKEN`
+to access this project**.
+
+- **Historical over-broad default.** On older GitLab versions the token
+  was usable across *any* project the triggering user could see — an
+  implicit, organization-wide allowlist. That default is the classic
+  GitLab CI lateral-movement vector: a compromised job in a low-value
+  project could clone or push to a high-value sibling.
+- **The hardened posture.** Enable "Limit access to this project" (the
+  inbound allowlist), then add only the specific projects whose
+  pipelines legitimately need to reach this one. Newer GitLab versions
+  default to the restricted allowlist for new projects; audit existing
+  projects, which may still carry the legacy open setting.
+- **Direction matters.** The allowlist is **inbound**: project A's
+  allowlist names the projects *allowed to reach A*. To let project B's
+  pipeline clone A, add B to A's allowlist — not the reverse.
+
+An over-permissive allowlist (or the legacy open default) is a `high`
+finding: it converts any single pipeline compromise into a blast radius
+spanning every reachable project.
+
+## Member roles — who can run and edit pipelines
+
+GitLab gates pipeline authority through the project/group **member role**
+of the actor, not through a per-job permission map. The roles, in
+increasing authority:
+
+| Role | Relevant CI/CD authority |
+|------|--------------------------|
+| **Guest** | Cannot run pipelines on private projects; view-only on most CI surfaces. |
+| **Reporter** | View pipelines and job logs; cannot run or edit. |
+| **Developer** | Run pipelines, push to **unprotected** branches, run manual jobs on unprotected refs. Cannot push to protected branches or manage protected variables by default. |
+| **Maintainer** | Manage protected branches/tags, CI/CD variables (including protected/masked), runners, the job-token allowlist, and protected environments. |
+| **Owner** | All Maintainer authority plus project/group deletion and transfer. |
+
+The practical security lever: **what is gated behind Maintainer**.
+Protected variables, the job-token allowlist, runner registration, and
+protected-environment approver lists all sit at Maintainer. Keep the
+Maintainer/Owner set small; most contributors operate fine at Developer.
+
+## Protected branches and protected tags
+
+This is the central protection primitive — the GitLab equivalent of
+"this credential is only available on the trusted ref". A branch or tag
+is **protected** when it appears under **Settings → Repository →
+Protected branches / Protected tags**, with an "allowed to push" and
+"allowed to merge" role list.
+
+What protection unlocks for CI/CD:
+
+- **Protected variables** are exposed **only** to pipelines running on a
+  protected ref. On any other ref the variable is simply absent.
+- **Protected runners** accept jobs **only** from pipelines on a
+  protected ref.
+- It gates who may *create* a pipeline that runs on the protected ref at
+  all (the "allowed to push/merge" lists).
+
+Use `$CI_COMMIT_REF_PROTECTED` to gate sensitive jobs on the protection
+status of the running ref:
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH == "main"'
+```
+
+The job above runs only when the pipeline is on a protected `main` — so
+the protected deploy variables it relies on are actually present, and an
+attacker pushing to a feature branch never reaches the deploy path.
+
+## Protected environments
+
+Protected branches gate *where the secret lives*; **protected
+environments** gate *who may promote to a tier and with what approval* —
+the correct primitive for a production promotion gate, and the GitLab
+analog of GitHub Environments.
+
+Configured under **Settings → CI/CD → Protected environments**, an
+environment gains:
+
+- An **allowed-to-deploy** list (roles or specific users/groups) — only
+  these identities can run a job targeting the environment.
+- **Required approvals** — a deployment to the environment blocks until
+  N approvers from the allowed list sign off, independent of who
+  triggered the pipeline.
+- **Deployment-tier** semantics (`production`, `staging`, …) via the
+  `environment.deployment_tier` keyword, so the platform can reason about
+  tier ordering.
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+With `production` registered as a protected environment requiring two
+approvals, the job halts pending sign-off even when it sits on a
+protected ref. Layer protected environments on top of protected branches
+for production — neither alone is sufficient for a high-tier gate.
+
+## OIDC and `id_tokens:`
+
+The least-privilege default for cloud authentication is **federated
+OIDC**, not a long-lived access key stored in a variable. GitLab mints a
+short-lived JWT per job via the `id_tokens:` keyword; the cloud provider
+exchanges it for a temporary, narrowly-scoped credential against a trust
+policy keyed on claims like `project_path`, `ref`, and `ref_protected`.
+
+State the principle here; the full trust-policy snippets and per-cloud
+audience configuration live in the `variables-and-secrets` reference.
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./assume-role-with-web-identity.sh
+```
+
+Reach for OIDC whenever the target cloud supports it. A long-lived key in
+a CI/CD variable is acceptable only when the provider has no OIDC path
+for the resource — and that exception belongs in an ADR. Scope the
+cloud-side trust policy to `ref_protected:true` and the specific
+`project_path` so a fork or feature branch cannot assume the role.
+
+## Masked and protected variables
+
+The full treatment lives in the `variables-and-secrets` reference; the
+rule, stated once:
+
+- **Mask** every secret variable so its value is redacted from job logs.
+- **Protect** every secret variable so it is exposed only on protected
+  refs (see *Protected branches* above).
+- A secret that is masked but **not** protected leaks to any feature
+  branch pipeline; a secret that is protected but **not** masked leaks
+  into logs. Production secrets need both.
+
+## Fork and untrusted-contributor trust
+
+Merge requests from forks are the GitLab equivalent of GitHub's
+`pull_request` from a fork — the point where untrusted code meets your
+CI. GitLab's defense rests on the protection primitives above:
+
+- **Protected variables are NOT exposed** to pipelines triggered by an
+  external contributor's fork MR, because the fork branch is not a
+  protected ref of your project. The fork pipeline sees only unprotected
+  variables.
+- **Protected runners do NOT accept** fork-MR jobs for the same reason —
+  so a fork cannot land on a runner that has access to a privileged
+  network segment or a protected deploy credential.
+- **The danger of relaxing this.** Enabling "Run untrusted code" style
+  settings, marking fork-fed variables as available, or registering a
+  shared runner without protection so it picks up fork jobs, all collapse
+  this boundary. Treat any such relaxation as a `high` finding requiring
+  explicit justification.
+
+Gate fork-sensitive logic with the `CI_MERGE_REQUEST_*` predefined
+variables, which are populated only in merge-request pipelines:
+
+```yaml
+fork_safe_tests:
+  script: ./run-tests.sh
+  rules:
+    - if: '$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_MERGE_REQUEST_PROJECT_ID'
+      # MR originates from a fork — run only the sandboxed, secret-free job set
+    - if: '$CI_MERGE_REQUEST_ID'
+```
+
+Never run a deploy, a registry push, or a job that reads a protected
+variable on a fork MR pipeline. Keep untrusted-MR jobs on unprotected,
+non-`privileged` runners, restricted to read-only test and lint work.
+
+## Least-privilege recipes
+
+The minimum permission/protection configuration for each common job
+shape. These mirror the per-use-case recipes in the GitHub Actions
+`permissions.md`.
+
+### (a) Read-only test / lint job
+
+```yaml
+unit_tests:
+  stage: test
+  image: node:22@sha256:<digest>
+  script:
+    - npm ci
+    - npm test
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+No protected variables, no protected runner, no environment. The default
+`CI_JOB_TOKEN` (current-project clone only) is all it needs. The vast
+majority of CI jobs are this shape. Safe to run on fork MRs.
+
+### (b) Push to the container / package registry
+
+```yaml
+build_image:
+  stage: build
+  image: docker:27@sha256:<digest>
+  services:
+    - docker:27-dind
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA"
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+`CI_JOB_TOKEN` authenticates to `$CI_REGISTRY` for the current project's
+namespace; no separate credential is required. Gate the push on a
+protected ref so a fork or feature branch cannot publish an image under
+your namespace. The triggering user must hold at least Developer to push.
+
+### (c) Deploy to a cloud via OIDC
+
+```yaml
+deploy_cloud:
+  stage: deploy
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./federated-login.sh   # exchanges $GCP_ID_TOKEN for a short-lived token
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+No long-lived key in any variable. The cloud trust policy is scoped to
+`ref_protected:true` and this `project_path`. Layer the protected
+`production` environment on top for an approval gate. This is the
+preferred deploy shape.
+
+### (d) Create a Release / tag
+
+```yaml
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script:
+    - echo "Publishing release $CI_COMMIT_TAG"
+  release:
+    tag_name: '$CI_COMMIT_TAG'
+    description: 'Release $CI_COMMIT_TAG'
+  rules:
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+Releases are cut from tags; protect the release tags (under Protected
+tags) and gate the job on `$CI_COMMIT_TAG` plus
+`$CI_COMMIT_REF_PROTECTED`. The triggering user must be allowed to
+create the protected tag. The `release` keyword uses `CI_JOB_TOKEN`
+against the current project — no broader scope needed.
+
+### (e) Clone a sibling private repo (job-token allowlist)
+
+```yaml
+build_with_dep:
+  stage: build
+  script:
+    - git clone "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.example.com/group/private-dep.git"
+    - ./build.sh
+```
+
+The clone of `group/private-dep` succeeds **only** if `private-dep`'s
+**inbound job-token allowlist** names *this* project. Add this project to
+`private-dep`'s allowlist (Settings → CI/CD → Job token permissions);
+do not disable the allowlist wholesale. Grant the narrowest entry — the
+single consuming project — never a group-wide or open allowlist.
+
+## Security defaults
+
+These defaults are non-negotiable and consistent with the parent
+`gitlab-ci` SKILL.md. Treat every deviation as requiring an ADR.
+
+1. **Mask and protect every secret variable.** Masked redacts logs;
+   protected restricts exposure to protected refs. Production secrets
+   need both (see `variables-and-secrets`).
+2. **Prefer OIDC `id_tokens:` over long-lived cloud keys.** A long-lived
+   key in a CI/CD variable is acceptable only when the provider has no
+   OIDC path for the resource — document the exception.
+3. **Pin `image:` and `services:` by digest, not tag.** `node:22@sha256:…`,
+   not `node:22`. A mutable tag is a silent supply-chain entry point.
+4. **Gate every deploy, Pages, and Release job behind a protected ref**
+   (`$CI_COMMIT_REF_PROTECTED == "true"`) and, for production, a
+   protected environment with required approvals.
+5. **Scope the `CI_JOB_TOKEN` accessible-projects allowlist.** Enable
+   the inbound allowlist on every project and name only the specific
+   consuming projects; never rely on the legacy open default.
+6. **No `privileged` runners for untrusted code.** Never let a fork-MR
+   pipeline land on a privileged runner, a `docker:dind` privileged
+   executor, or a runner with access to a protected network segment.
+   Keep untrusted-MR jobs on unprotected, unprivileged runners doing
+   read-only work.
+7. **Never expose protected variables or protected runners to fork
+   MRs.** This boundary is the default — keep it. Branch fork-sensitive
+   logic on `CI_MERGE_REQUEST_SOURCE_PROJECT_ID` vs
+   `CI_MERGE_REQUEST_PROJECT_ID`.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Review each project's **Job token permissions** page: confirm the
+  inbound allowlist is enabled and lists only legitimate consumers.
+  Flag any project still on the legacy open default as `high`.
+- Confirm `production` (and equivalent high-tier environments) are
+  registered as **protected environments** with an allowed-to-deploy
+  list and required approvals.
+- Grep pipeline definitions for deploy/registry/release jobs lacking a
+  `$CI_COMMIT_REF_PROTECTED` (or protected-tag) guard in their `rules:`.
+- Confirm every secret CI/CD variable is both **masked** and
+  **protected**; flag any production secret missing either flag.
+- Verify OIDC trust policies on the cloud side are scoped to
+  `ref_protected:true` and the specific `project_path`, not a wildcard.
+- Confirm no shared/protected runner is configured to pick up fork-MR
+  jobs, and that no runner used by untrusted code runs `privileged`.

--- a/.claude/skills/gitlab-ci/references/variables-and-secrets.md
+++ b/.claude/skills/gitlab-ci/references/variables-and-secrets.md
@@ -1,0 +1,441 @@
+# Variables and secrets reference
+
+CI/CD variables are the channel GitLab offers for injecting
+configuration into a pipeline. There is no separate "secret" object as
+in some other systems: a variable becomes a secret by flipping two
+flags — **masked** and **protected** — and by binding it to the
+smallest scope that needs it. Get those flags wrong and you either leak
+a credential to a job log or expose it to an untrusted branch. For
+credentials that should never sit at rest in GitLab at all, the
+`secrets:` keyword pulls them from an external manager (Vault, Azure
+Key Vault, GCP Secret Manager) at job start, and `id_tokens:` federates
+to a cloud provider with a short-lived JWT instead of a long-lived key.
+
+## The variable model
+
+A pipeline sees a flattened set of environment variables assembled from
+several sources:
+
+- **Predefined variables.** Supplied by GitLab itself: `CI_COMMIT_REF_NAME`,
+  `CI_PROJECT_PATH`, `CI_PIPELINE_SOURCE`, `CI_JOB_TOKEN`, etc. Read-only.
+- **Instance variables.** Defined by an administrator; visible to every
+  project on the instance.
+- **Group variables.** `Group → Settings → CI/CD → Variables`. Inherited
+  by every project in the group (and subgroups).
+- **Project variables.** `Project → Settings → CI/CD → Variables`. The
+  most common place for credentials.
+- **Pipeline-trigger / scheduled variables.** Passed when a pipeline is
+  started via the trigger API, a pipeline schedule, or a manual `web`
+  run (the "Run pipeline" form, driven by `value`/`description`).
+- **`.gitlab-ci.yml` variables.** Declared in YAML, either globally
+  (top-level `variables:`) or per-job (`job.variables:`). Committed to
+  the repository — never a credential.
+- **`dotenv` artifacts.** A job exports a `*.env` file as a
+  `reports: dotenv:` artifact; downstream jobs inherit those keys as
+  variables. The channel for passing computed values between stages.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "BUILD_ID=$(date +%s)" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  script:
+    - echo "Deploying build $BUILD_ID"   # inherited from dotenv
+```
+
+## Scope and precedence
+
+When the same variable name is defined at several sources, GitLab
+resolves it by a fixed precedence. Highest priority wins:
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | Trigger variables, scheduled-pipeline variables, manual (`web`) run variables |
+| 2 | Project variables |
+| 3 | Group variables (nearest subgroup first, then parent groups) |
+| 4 | Instance variables |
+| 5 | `.gitlab-ci.yml` global `variables:` |
+| 6 (lowest) | `.gitlab-ci.yml` job `variables:` |
+
+The counter-intuitive part: a value set in the UI (project/group/
+instance) or via a trigger **overrides** the YAML. This is deliberate —
+it lets an operator override a committed default at run time without a
+commit. Predefined variables sit alongside this table and are generally
+not overridable.
+
+Group and project variables also carry an **environment scope**
+(`environment_scope`): a variable can be limited to `production`,
+`review/*`, or `*` (all). A job picks up only the variables whose scope
+matches its `environment:` name.
+
+## Variable types and flags
+
+### `variable` vs `file` type
+
+Every CI/CD variable has a **type**:
+
+- **`variable`** (default) — the value is exported as an environment
+  variable verbatim.
+- **`file`** — GitLab writes the value to a temporary file and exports
+  the **path** to that file as the environment variable. This is the
+  correct channel for anything a tool expects as a file: TLS
+  certificates, a `kubeconfig`, a GCP service-account JSON, an SSH key.
+
+```yaml
+deploy:
+  script:
+    # KUBECONFIG is a file-type variable: $KUBECONFIG is a path, not YAML.
+    - kubectl --kubeconfig "$KUBECONFIG" apply -f manifests/
+    # GOOGLE_APPLICATION_CREDENTIALS is a file-type variable too.
+    - gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+```
+
+Storing a certificate in a `variable`-type variable and then
+`echo`-ing it into a file inside `script:` defeats masking and risks
+trace leakage — use `file` type instead.
+
+### Masked variables
+
+A variable flagged **masked** has its value replaced with `[MASKED]` in
+job logs. GitLab enforces masking eligibility requirements on the value:
+
+- at least 8 characters long;
+- a single line (no newlines or whitespace);
+- drawn from a restricted character set (Base64 alphabet plus `@:.~`),
+  depending on GitLab version. Values with spaces, `$`, `"`, or `'`
+  cannot be masked.
+
+Masking caveats — treat masking as a safety net, not a guarantee:
+
+- Masking is **best-effort substring replacement** in the trace. A
+  secret that is split (`echo "${TOKEN:0:8}"`), transformed
+  (base64-decoded, uppercased, URL-encoded), or concatenated bypasses
+  the matcher and prints in clear.
+- Masking redacts **only the job log**. It does **not** redact
+  artifacts, caches, the dotenv report, or anything your job writes to
+  an external system. A masked secret printed into a file and uploaded
+  as an artifact is leaked in plaintext.
+- Masking does not stop a malicious `.gitlab-ci.yml` from exfiltrating
+  the value over the network. Masking defends against accidental
+  disclosure, not against a hostile pipeline author.
+
+### Protected variables
+
+A variable flagged **protected** is exposed **only** to pipelines
+running on a **protected branch** or **protected tag**. A pipeline for
+a regular feature branch or a fork merge request never receives it.
+This is the primary defense against a contributor reading production
+credentials by pushing a branch that echoes them.
+
+**Default discipline for any credential: masked + protected.** Mask it
+so an accidental `echo` does not print it; protect it so only trusted
+refs can run the job that consumes it. A credential missing either flag
+is a finding.
+
+### Raw vs expanded values
+
+By default GitLab performs **variable expansion**: a `$`-prefixed token
+inside a value is expanded against other variables. A secret containing
+a literal `$` (e.g. a bcrypt hash, some passwords) is corrupted by
+expansion. Flag the variable **raw** (`Expand variable reference` off,
+or `raw: true` in the API) to disable expansion and keep the literal
+value.
+
+### Manual-run prompts
+
+A top-level `variables:` entry can declare `value` and `description`;
+the `description` turns the variable into a prefilled, documented field
+on the manual "Run pipeline" form.
+
+```yaml
+variables:
+  DEPLOY_ENV:
+    value: "staging"
+    description: "Target environment for a manual deploy (staging|production)."
+```
+
+## External secrets (`secrets:`)
+
+The `secrets:` keyword fetches a value from an external manager at job
+start and exposes it as a `file`-type variable by default. The job
+never stores the secret in GitLab. It requires an `id_tokens:` JWT (see
+below) for the manager to authenticate the pipeline.
+
+### HashiCorp Vault
+
+```yaml
+deploy:
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  secrets:
+    DATABASE_PASSWORD:
+      vault: prod/db/password@ops      # secret path @ KV mount
+      token: $VAULT_ID_TOKEN           # JWT used to auth to Vault
+      file: false                      # export as a plain env var, not a file
+  script:
+    - psql "postgres://app:${DATABASE_PASSWORD}@db/app"
+```
+
+Vault is configured with the JWT auth method and a role whose
+`bound_audiences` and `bound_claims` (e.g. `project_id`, `ref`,
+`ref_type`) match the GitLab token. `secrets:[].file` controls whether
+the resolved value lands in a temp file (default `true`) or an env var;
+`secrets:[].token` names the `id_tokens:` entry used to authenticate.
+
+### Azure Key Vault
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: https://AzureADTokenExchange
+  secrets:
+    DB_PASSWORD:
+      azure_key_vault:
+        name: db-password
+        version: 00000000000000000000000000000000
+      token: $AZURE_ID_TOKEN
+```
+
+The project's CI/CD settings declare the vault server URL; the app
+registration carries a federated credential whose subject matches the
+pipeline.
+
+### GCP Secret Manager
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  secrets:
+    API_KEY:
+      gcp_secret_manager:
+        name: api-key
+        version: latest
+      token: $GCP_ID_TOKEN
+```
+
+GCP is configured with a Workload Identity Pool provider that trusts
+the GitLab issuer and maps the JWT claims to a service account that can
+read the secret.
+
+## OIDC federation (`id_tokens:`)
+
+For cloud credentials, **prefer OIDC over a long-lived access key stored
+as a CI/CD variable**. The runner mints a short-lived JWT signed by the
+GitLab instance's OIDC provider (issuer = the GitLab base URL, e.g.
+`https://gitlab.example.com`). The cloud side validates the token's
+claims and issues a temporary credential.
+
+Benefits, mirroring any OIDC story:
+
+- No long-lived secret to rotate, mask, or leak.
+- Per-project, per-ref scoping — a `main` deploy gets a token whose
+  `sub` includes `ref:main`.
+- An audit trail in both GitLab and the cloud provider.
+
+GitLab JWT claims you bind trust against include `iss` (the issuer
+URL), `aud` (set per `id_tokens:` entry), `project_path`,
+`namespace_path`, `ref`, `ref_type`, and a composite `sub` of the form:
+
+```text
+project_path:my-group/my-project:ref_type:branch:ref:main
+```
+
+### AWS
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com   # must match the OIDC provider audience
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name gitlab-$CI_PIPELINE_ID
+      --web-identity-token "$AWS_ID_TOKEN"
+      --duration-seconds 3600
+```
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/gitlab.example.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "gitlab.example.com:aud": "https://gitlab.example.com"
+      },
+      "StringLike": {
+        "gitlab.example.com:sub":
+          "project_path:my-group/my-project:ref_type:branch:ref:main"
+      }
+    }
+  }]
+}
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  script:
+    - echo "$GCP_ID_TOKEN" > token.jwt
+    - >
+      gcloud iam workload-identity-pools create-cred-config
+      projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+      --service-account="gitlab-deploy@my-project.iam.gserviceaccount.com"
+      --credential-source-file=token.jwt
+      --output-file=cred.json
+    - export GOOGLE_APPLICATION_CREDENTIALS=cred.json
+```
+
+The WIF provider declares an attribute mapping (e.g.
+`google.subject = assertion.sub`) and an attribute condition pinning
+the allowed `project_path` / `ref`.
+
+### Azure
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: api://AzureADTokenExchange
+  script:
+    - >
+      az login --service-principal
+      --username "$AZURE_CLIENT_ID"
+      --tenant "$AZURE_TENANT_ID"
+      --federated-token "$AZURE_ID_TOKEN"
+```
+
+The Azure side configures a **federated credential** on the app
+registration whose issuer is the GitLab URL and whose subject matches
+the pipeline's `sub` claim.
+
+## Exfiltration anti-patterns and common pitfalls
+
+### Hardcoded secret literals
+
+```yaml
+# BAD: the secret is committed to the repo, visible to anyone with read
+# access and to the full git history forever.
+variables:
+  API_TOKEN: "glpat-XXXXXXXXXXXXXXXXXXXX"
+```
+
+Define credentials as masked + protected CI/CD variables in project
+settings, never in `.gitlab-ci.yml`.
+
+### Secrets in a global `variables:`
+
+```yaml
+# BAD: a top-level variables: block is in scope for every job in the
+# pipeline — maximal blast radius.
+variables:
+  DEPLOY_KEY: "..."          # also a hardcoded literal — doubly wrong
+```
+
+Bind a credential to the single job that needs it via `job.variables:`,
+or scope the CI/CD variable to the deploy environment.
+
+### Echoing a variable to the log
+
+```yaml
+# BAD: even a masked variable can leak if transformed before printing,
+# and the value still reaches any artifact/cache written next.
+script:
+  - echo "$DEPLOY_TOKEN"
+  - echo "token is $DEPLOY_TOKEN"
+```
+
+Never debug by printing a secret. Print a length or a checksum instead:
+
+```yaml
+script:
+  - echo "Token length: ${#DEPLOY_TOKEN}"
+```
+
+### `set -x` shell trace
+
+```yaml
+# BAD: shell trace prints every expanded command, including the
+# resolved value of a secret variable, and masking may not catch it.
+script:
+  - set -x
+  - curl -H "Authorization: Bearer $TOKEN" https://api.example.com
+```
+
+Keep `set -x` (and `CI_DEBUG_TRACE: "true"`) out of jobs that touch
+credentials. `CI_DEBUG_TRACE` in particular dumps **all** variables,
+masked or not, and must never run on a job with protected secrets.
+
+### Structured JSON in one variable
+
+A single `CLOUD_CONFIG` variable holding a JSON blob is convenient for
+setup but defeats per-key rotation and per-key masking (the blob fails
+the no-whitespace masking rule anyway). Split into individual variables,
+or fetch the structured secret at runtime via `secrets:` so each key is
+resolved and handled independently.
+
+### A variable that should be masked or protected
+
+A CI/CD variable whose value is sensitive on inspection (a token, a
+URL embedding a token, a password) but is missing the **masked** or
+**protected** flag is a secret in disguise. If it is sensitive, set
+both flags.
+
+### Secrets reaching fork pipelines
+
+A merge request from a fork runs in the fork's context. **Protected**
+variables are withheld from such pipelines by design — which is exactly
+why every credential must be protected. Do not relax the
+"only-protected-branches-can-run-this-job" rules to make a fork MR
+pipeline "just work"; gate privileged work behind a protected branch
+and a manual approval instead.
+
+### Offline scan
+
+This skill ships `scripts/check-secrets-exposure.sh`, which scans a
+`.gitlab-ci.yml` offline for several of the patterns above — hardcoded
+secret literals, `echo $TOKEN`-style log leaks, `set -x` /
+`CI_DEBUG_TRACE` in credential jobs, and global `variables:` holding a
+likely secret. Run it before committing pipeline changes.
+
+## Auditing
+
+Periodic audit checklist:
+
+- Review every project, group, and instance CI/CD variable: confirm
+  every credential is flagged **masked** and **protected**. Flag any
+  sensitive value missing either flag.
+- Rotate long-lived tokens stored as variables on a schedule; prefer
+  migrating each to `secrets:` (external manager) or `id_tokens:`
+  (OIDC) so there is nothing long-lived to rotate.
+- Grep the `.gitlab-ci.yml` for hardcoded secret literals and for
+  `echo`/`set -x`/`CI_DEBUG_TRACE` on jobs that consume credentials
+  (the `check-secrets-exposure.sh` validator does this).
+- Confirm no credential lives in a global `variables:` block; bind each
+  to its job or environment scope.
+- For each cloud provider, audit the OIDC trust conditions: the `aud`
+  must match the configured audience and the `sub`/`project_path`/`ref`
+  bindings must pin the allowed projects and refs — no wildcard that
+  admits an unintended project.

--- a/.claude/skills/gitlab-ci/scripts/check-pinned-images.sh
+++ b/.claude/skills/gitlab-ci/scripts/check-pinned-images.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# check-pinned-images.sh — flag GitLab CI container references that are not
+# pinned to an immutable @sha256: digest.
+#
+# Usage: check-pinned-images.sh <pipeline-file-or-directory>
+#
+# Rationale: a `image: node:22` or `image: node:latest` reference is a moving
+# target — the registry can re-point the tag to a different image at any time,
+# silently changing what runs in your pipeline. Pinning to a digest
+# (`image: node@sha256:<64-hex>`) makes the reference immutable, exactly as
+# pinning a GitHub Action to a commit SHA does.
+#
+# Scanned surface (text scan; no registry call, no Docker, no live GitLab):
+#   - `image: <ref>`                       (job-level, global, and default:)
+#   - `image:` long form → its `name: <ref>`
+#   - `services:` list entries: `- <ref>`  and `- name: <ref>` / `name: <ref>`
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`
+# (the conventional local-include location). A bare variable reference with no
+# tag (e.g. `$CI_REGISTRY_IMAGE`) is skipped — there is nothing to evaluate
+# statically.
+#
+# Limitation: only inline forms (value on the same line) are matched. A `name:`
+# spread across multiple YAML lines is not detected.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# An immutable reference is digest-pinned: <name>@sha256:<64 hex chars>.
+digest_re='@sha256:[0-9a-fA-F]{64}$'
+
+# Strip surrounding quotes from a captured scalar.
+unquote() {
+    local v="$1"
+    v="${v%\"}"; v="${v#\"}"
+    v="${v%\'}"; v="${v#\'}"
+    printf '%s' "$v"
+}
+
+# Decide whether a container reference is acceptably pinned. Returns 0 (pinned
+# or not-applicable) or 1 (a finding). A pure variable expansion with no tag is
+# treated as not-applicable: there is no static digest to demand.
+check_ref() {
+    local value="$1" file="$2" lineno="$3"
+    value="$(unquote "$value")"
+    [ -z "$value" ] && return 0
+    case "$value" in
+        # Bare variable with no `:tag` and no digest — nothing to evaluate.
+        \$*)
+            case "$value" in
+                *:*|*@*) ;;          # has a tag/digest part — fall through to the check
+                *) return 0 ;;
+            esac
+            ;;
+    esac
+    if [[ "$value" =~ $digest_re ]]; then
+        return 0
+    fi
+    echo "${C_RED}[UNPINNED]${C_RESET} ${file}:${lineno}: ${value}"
+    return 1
+}
+
+for f in "${files[@]}"; do
+    lineno=0
+    in_image_block=0
+    in_services_block=0
+    block_indent=-1
+    # shellcheck disable=SC2094  # check_ref() only echoes; it does not write to "$f".
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Skip blank and comment-only lines (but they do not close a block).
+        case "$line" in
+            ''|'#'*|*[![:space:]]*'#') : ;;
+        esac
+
+        # Current line indentation (number of leading spaces).
+        stripped="${line#"${line%%[![:space:]]*}"}"
+        indent=$(( ${#line} - ${#stripped} ))
+
+        # Close an open block when indentation returns to/under the opener and
+        # the line carries content.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [ -n "$stripped" ] && [ "$indent" -le "$block_indent" ]; then
+            in_image_block=0
+            in_services_block=0
+            block_indent=-1
+        fi
+
+        # `image:` — short inline form, or open the long-form mapping block.
+        if [[ "$line" =~ ^[[:space:]]*image:[[:space:]]*(.*)$ ]]; then
+            val="${BASH_REMATCH[1]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            if [ -n "$val" ]; then
+                check_ref "$val" "$f" "$lineno" || violations=$((violations + 1))
+            else
+                in_image_block=1
+                in_services_block=0
+                block_indent=$indent
+            fi
+            continue
+        fi
+
+        # `services:` — open the list block (entries handled below).
+        if [[ "$line" =~ ^[[:space:]]*services:[[:space:]]*$ ]]; then
+            in_services_block=1
+            in_image_block=0
+            block_indent=$indent
+            continue
+        fi
+
+        # Inside an image: mapping or a services: entry — a `name:` scalar.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*name:[[:space:]]*([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+
+        # Inside services: — a bare list item `- <image-ref>`.
+        if [ "$in_services_block" -eq 1 ] \
+            && [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all image/service references are pinned to a @sha256: digest"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned image/service reference(s) found${C_RESET}" >&2
+exit 1

--- a/.claude/skills/gitlab-ci/scripts/check-secrets-exposure.sh
+++ b/.claude/skills/gitlab-ci/scripts/check-secrets-exposure.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in a GitLab CI pipeline that may
+# leak secrets into job logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <pipeline-file-or-directory>
+#
+# Patterns flagged (text scan; no live GitLab, no token read, no network):
+#   1. Hardcoded secret literal in `variables:` or a shell assignment
+#      (a key named like a credential set to an inline value, not a $VAR ref).
+#   2. A well-known token shape appearing as a literal anywhere
+#      (glpat-…, ghp_…, AWS AKIA…, a PEM private-key header).
+#   3. `echo`/`printf` of a credential-named variable — written to the job log.
+#   4. `set -x` / `set +x` in a `script:` — shell xtrace prints expanded values.
+#   5. `CI_DEBUG_TRACE: "true"` — turns on full pipeline trace, logging every
+#      variable including masked ones.
+#
+# Masking and protection are GitLab's real defenses (see the skill's
+# references/variables-and-secrets.md); this scan catches the hygiene mistakes
+# that defeat them before review.
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+# A key whose name marks it as a credential.
+secret_key='(SECRET|TOKEN|PASSWORD|PASSWD|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIAL|AUTH|PASSPHRASE)'
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Strip a leading YAML list dash so `- export TOKEN=…` is seen as a
+        # shell assignment too.
+        probe="${line#"${line%%[![:space:]]*}"}"
+        probe="${probe#- }"
+
+        # 1. Hardcoded literal: YAML `KEY: value` or shell `KEY=value` where the
+        #    key is credential-named and the value is an inline literal (not a
+        #    `$VAR` reference, not empty, not a masked/protected reference).
+        if [[ "$probe" =~ ^(export[[:space:]]+)?[A-Za-z0-9_]*${secret_key}[A-Za-z0-9_]*[[:space:]]*[:=][[:space:]]*(.+)$ ]]; then
+            val="${BASH_REMATCH[3]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            # Unquote.
+            val="${val%\"}"; val="${val#\"}"
+            val="${val%\'}"; val="${val#\'}"
+            case "$val" in
+                ''|\$*|'!reference'*|'&'*|'*'*) : ;;   # ref/anchor/empty — fine
+                *)
+                    report "$current_file" "$lineno" "hardcoded value for a credential-named key" \
+                        "a secret committed in the pipeline is readable by anyone with repo access — move it to a masked + protected CI/CD variable"
+                    ;;
+            esac
+        fi
+
+        # 2. Well-known token shapes as literals.
+        if [[ "$line" =~ glpat-[A-Za-z0-9_-]{20} ]] \
+            || [[ "$line" =~ (ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36} ]] \
+            || [[ "$line" =~ AKIA[0-9A-Z]{16} ]] \
+            || [[ "$line" =~ BEGIN[[:space:]].*PRIVATE[[:space:]]KEY ]]; then
+            report "$current_file" "$lineno" "literal access token / private key" \
+                "a recognizable credential literal is committed in the pipeline — revoke it and store it as a masked + protected CI/CD variable"
+        fi
+
+        # 3. echo / printf of a credential-named variable.
+        if [[ "$line" =~ (echo|printf)[[:space:]].*\$\{?[A-Za-z0-9_]*${secret_key} ]]; then
+            report "$current_file" "$lineno" "echo/printf of a credential-named variable" \
+                "printing a secret to the job log persists it in the log; masking is best-effort and a transformed value bypasses it"
+        fi
+
+        # 4. set -x / set +x — shell xtrace.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret variable values"
+        fi
+
+        # 5. CI_DEBUG_TRACE enabled.
+        if [[ "$line" =~ CI_DEBUG_TRACE[[:space:]]*:?=?[[:space:]]*[\"\']?(true|1)[\"\']? ]]; then
+            report "$current_file" "$lineno" "CI_DEBUG_TRACE enabled" \
+                "debug trace logs every variable in the job, including masked and protected ones"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/.gemini/agents/ci-configurator.md
+++ b/.gemini/agents/ci-configurator.md
@@ -1,51 +1,145 @@
 ---
 name: ci-configurator
-description: "Specialist agent for configuring new GitHub Actions pipelines.
-Interviews the project, generates a commit-ready workflow,
+description: "Specialist agent for configuring a new CI pipeline for a supported
+engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
+produces a commit-ready pipeline (hand-authored for GitHub Actions,
+derived from the platform-neutral capability reference for GitLab),
 and validates its own output before delivery."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # CI Configurator Agent
 
-You are a CI configuration agent. You operate under the **github-actions**
-skill (`artifacts/core/skills/github-actions/SKILL.md`) — read it once
-at the start of any session and follow its conventions: action pinning,
-least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+You are a CI configuration agent. You are **engine-aware**: you can
+produce a pipeline for either supported engine — **GitHub Actions** or
+**GitLab CI/CD** — and you operate under whichever knowledge skill the
+resolved engine demands. For a GitHub Actions target, read the
+**github-actions** skill (`artifacts/core/skills/github-actions/SKILL.md`);
+for a GitLab CI/CD target, read the **gitlab-ci** skill
+(`artifacts/core/skills/gitlab-ci/SKILL.md`). Read the relevant skill
+once at the start of a session and follow its conventions — they are
+the source of truth for the security defaults you enforce.
 
 Your persona is that of an experienced DevOps engineer: minimalist,
-security-oriented, allergic to copy-pasted workflows that "happen to
+security-oriented, allergic to copy-pasted pipelines that "happen to
 work". You do not explore the repository looking for things to fix.
-You ask exactly what you need, generate exactly one workflow, validate
-your own output, and hand it over.
+You resolve the engine target, ask exactly what you need, produce
+exactly one pipeline, validate your own output, and hand it over.
 
 Your default mode is **generate and validate**, not iterate. The user
-gets a workflow they can paste into `.github/workflows/` and commit. If
-you cannot produce a workflow that passes your own validation scripts,
-you say so plainly rather than shipping a draft that "should work".
+gets a pipeline they can commit — a workflow under `.github/workflows/`
+for GitHub Actions, or a `.gitlab-ci.yml` for GitLab CI/CD. If you
+cannot produce a pipeline that passes your own validation, you say so
+plainly rather than shipping a draft that "should work".
+
+Keep every claim engine-neutral wherever the project's platform-neutral
+capability reference keeps it neutral; name a specific engine only where
+the behaviour is genuinely engine-specific.
 
 ## Activation
 
 Activate this agent when any of the following holds:
 
-- The project has no `.github/workflows/` directory yet, or the
-  directory is empty.
-- The project is migrating from another CI platform (GitLab CI,
-  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
-  GitHub Actions pipeline.
-- An existing workflow is outdated — uses tag-based action references
-  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
-  or depends on long-lived cloud credentials that should be replaced
-  by OIDC.
-- The user explicitly asks for "a GitHub Actions workflow", "a CI
-  pipeline", or "set up CI" without specifying which platform.
+- The project has no CI pipeline yet for the engine in question — no
+  `.github/workflows/` directory (GitHub Actions), or no `.gitlab-ci.yml`
+  (GitLab CI/CD).
+- The project is migrating from another CI platform (GitHub Actions,
+  GitLab CI, CircleCI, Jenkins, Travis, Buildkite) and needs an
+  equivalent pipeline for a supported engine.
+- An existing pipeline is outdated — GitHub Actions uses tag-based
+  action references (`@v1`, `@main`), lacks `permissions:` blocks, has
+  no `timeout-minutes`, or depends on long-lived cloud credentials that
+  should be replaced by OIDC; GitLab CI/CD uses unpinned `image:` tags,
+  hardcoded or un-masked secrets, or long-lived cloud keys that
+  `id_tokens:` OIDC should replace.
+- The user explicitly asks for "a GitHub Actions workflow", "a GitLab
+  pipeline", "a CI pipeline", or "set up CI".
 
 Do **not** activate this agent when the user is debugging a failing
-run, hunting a flaky job, or asking why a workflow misbehaves —
-delegate to the **ci-debugger** agent instead. Configuration and
-diagnosis are different jobs and should not be mixed.
+run, hunting a flaky job, or asking why a pipeline misbehaves —
+delegate to the **ci-debugger** agent instead. Do **not** activate it to
+audit an existing pipeline set for drift against the capability
+reference — delegate to the **ci-parity** agent instead. Configuration,
+diagnosis, and parity reconciliation are different jobs and should not
+be mixed.
+
+## Engine-target resolution
+
+Before generating anything, resolve **which engine** you are producing
+for. Never guess between two present engines.
+
+- **Infer** the target when the repository indicates exactly one engine:
+  a `.github/workflows/` directory present and no `.gitlab-ci.yml` → the
+  target is GitHub Actions; a `.gitlab-ci.yml` present and no
+  `.github/workflows/` → the target is GitLab CI/CD.
+- **Accept an explicit override.** When the user names the engine ("set
+  up a GitLab pipeline"), that target wins over any inference, even if
+  the repository indicates the other engine.
+- **Refuse to generate** when the target is **ambiguous** — both engines
+  are indicated and the user specified none — or **absent** — neither
+  engine is indicated and the user specified none. In both cases, stop
+  and ask the user to name the target. Do not pick one to be helpful;
+  guessing wrong produces a pipeline for the wrong engine.
+
+State the resolved target (and how you resolved it — inferred or
+explicit) as the first line of your output, so the user can correct a
+wrong inference before reading the pipeline.
+
+## Two production modes
+
+The two engines are produced by **two different mechanisms**. This is
+deliberate and matches how the project's CI machinery works.
+
+### GitHub Actions target — hand-authored
+
+A GitHub Actions workflow is **hand-authored** through the interview
+and generation rules below. The GitHub Actions pipeline is *not* derived
+from the platform-neutral capability reference (the reference's GitHub
+side stays hand-authored and step-level-verified by design). Run the
+full interview, apply the generation rules, validate, and deliver — the
+path documented in the rest of this agent.
+
+### GitLab CI/CD target — derived from the reference
+
+A GitLab pipeline is **derived**, not hand-authored. When the repository
+already carries the project's platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`),
+produce the GitLab pipeline by **composing the generator**:
+
+```bash
+bash scripts/build-ci.sh
+```
+
+This reads the existing reference and emits `.gitlab-ci.yml` (one job
+per portable capability; `requires:` → `image`/`before_script`/
+`GIT_DEPTH`; `command:` → `script:`; `trigger[]` → `rules:`). You do
+**not** hand-author `.gitlab-ci.yml`, you do **not** re-implement the
+generation logic, and you do **not** author or mutate the reference
+itself — `ci/ci-capabilities.yml` and its format are owned elsewhere
+(the reference-contract sub-spec). Deriving from the reference is what
+keeps a produced pipeline consistent with the reference and with the
+drift-check harness.
+
+If the user wants a GitLab pipeline for a *downstream adopter project*
+that has **no** capability reference yet, that project first needs a
+reference authored **in the reference format** — a separate act that
+applies the documented format in that project. It is never done by
+editing this framework's `ci/ci-capabilities.yml`. Once a reference
+exists, compose `build-ci.sh` against it as above. If no reference
+exists and authoring one is out of your scope, say so plainly rather
+than hand-rolling a `.gitlab-ci.yml` that will drift from the harness.
+
+After deriving, apply the GitLab security defaults the **gitlab-ci**
+skill documents — `image:` pinned by digest, masked + protected
+variables, `id_tokens:` OIDC over long-lived keys, protected refs and
+environments gating deploy/Pages/Release jobs — and run the GitLab
+validation scripts (see *Validation step*).
 
 ## Interview protocol
+
+*Applies to the **GitHub Actions** target (the hand-authored path). For
+a GitLab target you derive from the reference and do not run this
+greenfield interview — see *Two production modes*.*
 
 You ask the minimum questions necessary to produce a correct workflow.
 The interview is **one round**: a single numbered list, sent once,
@@ -93,6 +187,12 @@ If the user answers ambiguously, ask **one** clarifying follow-up per
 ambiguous item, not a fresh round.
 
 ## Generation rules
+
+*These rules govern the **GitHub Actions** hand-authored path. The
+GitLab target enforces the equivalent GitLab defaults from the
+**gitlab-ci** skill (digest-pinned `image:`, masked + protected
+variables, `id_tokens:` OIDC, protected refs/environments) — see
+*Two production modes*.*
 
 These rules are non-negotiable. Every workflow you emit satisfies all
 of them; if you cannot satisfy one, you say so explicitly in the
@@ -208,17 +308,36 @@ For deploy jobs that should serialize (production), use
 
 ## Validation step
 
-Before presenting the workflow to the user, run the project's
-validation scripts on your draft. The scripts are shipped with the
-`github-actions` skill:
+Before presenting the pipeline to the user, run the validation scripts
+that ship with the relevant skill on your output.
+
+For a **GitHub Actions** target (`github-actions` skill):
 
 ```bash
 scripts/lint-workflow.sh        .github/workflows/<name>.yml
 scripts/check-pinned-actions.sh .github/workflows/<name>.yml
 ```
 
-If either script reports violations, **fix the draft and rerun**.
-Repeat until both scripts pass. Only then present the workflow.
+For a **GitLab CI/CD** target (`gitlab-ci` skill — both are offline
+text scans; there is no offline structural linter or pipeline
+simulator for GitLab, by design):
+
+```bash
+scripts/check-pinned-images.sh    .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+For a GitLab target you also confirm the pipeline is in sync with the
+reference — the derivation's own drift gate:
+
+```bash
+bash scripts/build-ci.sh --check
+```
+
+If any script reports violations, **fix the cause and rerun** — for the
+GitLab path that means correcting the reference or the security overlay
+and re-deriving, never hand-patching the generated `.gitlab-ci.yml`.
+Repeat until the scripts pass. Only then present the pipeline.
 
 If a script is unavailable in the current environment, say so
 explicitly in the output: "Note: `check-pinned-actions.sh` was not
@@ -227,12 +346,17 @@ Never claim a script was run when it was not.
 
 ## Output format
 
-The agent's final message has three parts, in this order:
+The resolved engine target is the first line (see *Engine-target
+resolution*). The rest of the message has three parts, in this order:
 
-1. **Annotated YAML block** — the workflow itself, with inline
-   comments calling out non-obvious choices (timeout values,
-   `needs:` graph, concurrency strategy). The comments are part of
-   the deliverable; they survive into the committed file.
+1. **Annotated YAML block** — the pipeline itself (a workflow for
+   GitHub Actions, a `.gitlab-ci.yml` for GitLab CI/CD), with inline
+   comments calling out non-obvious choices (timeout values, the
+   `needs:` graph, the concurrency / `resource_group` strategy). The
+   comments are part of the deliverable; they survive into the
+   committed file. For a GitLab target this block is the derived
+   pipeline — present it as produced by `scripts/build-ci.sh`, not
+   hand-edited.
 
 2. **Decision table** — a Markdown table explaining each non-obvious
    choice, one row per decision:
@@ -243,12 +367,13 @@ The agent's final message has three parts, in this order:
    | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
    | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
 
-3. **Follow-up checklist** — what the user must do before the workflow
-   can run successfully (create secrets, configure OIDC trust, enable
-   branch protection). One bullet per action item, no prose.
+3. **Follow-up checklist** — what the user must do before the pipeline
+   can run successfully (create masked/protected secrets or repository
+   secrets, configure the OIDC trust relationship, enable branch/ref
+   protection). One bullet per action item, no prose.
 
 Do not pad the output with "this is a great starting point" or
-"feel free to customize". The workflow either works as written or it
+"feel free to customize". The pipeline either works as written or it
 does not; if it does not, the validation step caught it.
 
 ## When the user pushes back
@@ -266,7 +391,8 @@ silent override is what the agent refuses to ship.
 
 ## Handoff
 
-When the workflow is delivered, the agent's job is done. Do not
+When the pipeline is delivered, the agent's job is done. Do not
 volunteer to "open a PR for you" or "watch the first run" — those
 are separate jobs handled by other agents (`pr-logbook` for the PR,
-`ci-debugger` if the first run fails).
+`ci-debugger` if the first run fails, `ci-parity` if the produced
+pipeline later drifts from the capability reference).

--- a/.gemini/agents/ci-parity.md
+++ b/.gemini/agents/ci-parity.md
@@ -1,0 +1,202 @@
+---
+name: ci-parity
+description: "Specialist agent for operating the project's CI drift-check harness
+and reconciling the divergences it reports. Runs the harness,
+interprets its fail-closed output, classifies each divergence by kind,
+and reconciles it — auto-applying only the deterministic
+regenerate-and-re-verify case, and diagnosing-and-proposing for every
+judgment-bearing case."
+---
+<!-- crewrig-provenance: version="1.0.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+
+# CI Parity Agent
+
+You are a CI parity agent. You operate the project's three-way CI
+drift-check harness (`scripts/check-ci-parity.sh`) and help a
+contributor get from a reported divergence to a reconciled,
+parity-clean state. You operate under the **github-actions** skill
+(`artifacts/core/skills/github-actions/SKILL.md`) and the **gitlab-ci**
+skill (`artifacts/core/skills/gitlab-ci/SKILL.md`) for engine-correct
+patterns, and you treat the platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`)
+as the source of truth the harness checks against.
+
+Your persona is that of a methodical SRE. You do not guess. You do not
+hand-edit a generated file to make a check pass. You produce a chain of
+`symptom → classification → evidence → reconciliation` for every
+divergence the harness reports, and you refuse to skip any link in that
+chain.
+
+You reason about pipeline and reference **definitions** only. You handle
+no live secret or token, and you never run a pipeline on a live GitLab —
+the harness is an offline, text-level check and so are you. Keep every
+claim engine-neutral wherever the reference keeps it neutral; name a
+specific engine only where the divergence is genuinely engine-specific.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A contributor wants to run the CI drift-check harness and understand
+  its verdict.
+- The harness has failed closed and the contributor needs the
+  divergence diagnosed and a reconciliation proposed or applied.
+- A CI job running `scripts/check-ci-parity.sh` is red and the
+  contributor wants to know why and how to make it green correctly.
+
+Do **not** activate this agent to author a new pipeline from scratch or
+to run a greenfield configuration interview — that is the
+**ci-configurator** agent's job. Do **not** activate it to diagnose a
+*failing application pipeline run* (a red test, a broken deploy) — that
+is the **ci-debugger** agent's job. This agent audits an existing
+pipeline set against the capability reference and reconciles drift; it
+does not produce pipelines and it does not debug their runtime
+failures.
+
+## Operate the harness
+
+Run the harness from the repository root:
+
+```bash
+bash scripts/check-ci-parity.sh
+```
+
+The harness is **fail-closed**: it exits non-zero on any reference
+validity violation, any divergence, any evidence-less engine-specific
+exception, or any untraceable job, and prints `OK:` only on a clean
+pass. It checks the reference against both engines across several arms
+(reference validity; per-job traceability on both engines;
+reference↔GitHub Actions at the business-step level; reference↔GitLab
+via the composed generator; and GitHub Actions↔GitLab portable-set
+parity). When one engine's pipeline artifacts are absent it checks only
+the present arms; the reference is always required.
+
+For each line the harness reports, name precisely:
+
+- the **offending capability** (its `id` in the reference), and
+- the **affected engine** (`github-actions`, `gitlab`, or the reference
+  itself).
+
+Quote the harness output verbatim — it is your evidence, not a thing to
+paraphrase.
+
+## Classify by kind
+
+Every divergence maps to exactly one of these five kinds. Name the kind
+before proposing anything — classifying first prevents reaching for the
+nearest fix.
+
+1. **Stale derived pipeline.** The committed `.gitlab-ci.yml` no longer
+   matches a fresh derivation of the current reference (the harness's
+   reference↔GitLab arm, which composes `scripts/build-ci.sh --check`,
+   fails). The reference is right; the generated file is behind it.
+2. **Reference drift.** The reference itself is invalid or no longer
+   describes reality — a validity-rule violation (unknown trigger kind
+   or filter; a portable capability missing its `command`; a command
+   invoking an undeclared runtime/tool; a missing or duplicate `id`),
+   or a portable capability whose declared `command`/`requires` no
+   longer matches what the engines actually do.
+3. **Hand-authored pipeline drift.** A hand-authored job (a GitHub
+   Actions workflow job, or a hand-authored GitLab job) diverges from
+   the capability it is attributed to — its business steps no longer
+   exhibit the declared `command`, or its setup no longer satisfies the
+   declared `requires`.
+4. **Evidence-less engine-specific exception.** A capability marked
+   engine-specific (`portability: specific`) lacks the
+   `exception.engine` or `exception.evidence` the reference contract
+   requires for a non-portable capability.
+5. **Untraceable pipeline job.** A pipeline job on either engine is
+   neither a capability `id` nor carries a valid `# ci-capability:`
+   annotation mapping it to one, so the harness cannot attribute it.
+
+## Reconcile per kind
+
+For each detected divergence, determine the reconciliation appropriate
+to its kind. Every reconciliation stays within the evidence-backed
+exception discipline the reference contract mandates.
+
+- **Stale derived pipeline** → regenerate the derived GitLab pipeline
+  from the current reference (`scripts/build-ci.sh`) and re-run the
+  harness to confirm the divergence is resolved. This is the only
+  deterministic, no-judgment case — see *Autonomy boundary*.
+- **Reference drift** → propose amending the offending reference
+  capability (its `trigger`, `command`, `requires`, `id`, or
+  `portability`) so the reference is valid and once again describes
+  what the engines do. Judgment-bearing.
+- **Hand-authored pipeline drift** → propose correcting the
+  hand-authored job so its business steps and setup match the
+  attributed capability — or, if the engine's behaviour is the
+  intended truth, propose amending the reference instead. Name which
+  one you believe is correct and why. Judgment-bearing.
+- **Evidence-less engine-specific exception** → propose adding the
+  missing `exception.engine` and a concrete `exception.evidence`
+  justification, or reclassifying the capability as portable if it is
+  in fact portable. Judgment-bearing.
+- **Untraceable pipeline job** → propose either renaming the job to its
+  capability `id`, adding a valid `# ci-capability:` annotation, or (if
+  the job represents a genuinely new capability) adding that capability
+  to the reference. Judgment-bearing.
+
+## Autonomy boundary
+
+This boundary is the heart of the agent. Honour it exactly.
+
+You **MAY autonomously apply ONLY** the deterministic, no-judgment
+reconciliation — the **stale derived pipeline** case:
+
+```bash
+bash scripts/build-ci.sh          # regenerate .gitlab-ci.yml from the reference
+bash scripts/check-ci-parity.sh   # confirm the divergence is resolved
+```
+
+This is safe to apply autonomously because it mutates nothing that
+requires judgment: it re-derives the generated GitLab pipeline from the
+current reference using the project's own generator, then verifies the
+result with the harness. If the re-run is not clean, you have
+mis-classified — stop, re-classify, and treat it as a judgment-bearing
+case.
+
+For **every** judgment-bearing case — amending a reference capability,
+amending an evidence-backed exception, or correcting a hand-authored
+pipeline job — you **diagnose and propose only**. You **SHALL NOT**
+mutate the reference, any pipeline, or any exception autonomously. You
+present the proposed change (a diff or an explicit edit description) and
+stop; the contributor decides whether to apply it. Hand-editing the
+generated `.gitlab-ci.yml` to silence the harness is never a
+reconciliation — it is the stale-pipeline divergence in reverse.
+
+## Output discipline
+
+The agent's response is a reconciliation report, not a tutorial. For
+each divergence, the four-link chain is the message:
+
+```text
+Symptom:        <verbatim harness line>
+Classification: <one of the five kinds>
+Evidence:       <reference id + engine, quoted from the harness / files>
+Reconciliation: <the deterministic action you applied, OR the proposed
+                 change you are NOT applying autonomously>
+```
+
+When you have auto-applied the stale-pipeline reconciliation, show the
+clean re-run (`OK:` line) as proof. When you are proposing a
+judgment-bearing change, state plainly that you have **not** applied it
+and what the contributor must decide.
+
+Do not append "hope this helps" or restate the verdict in a conclusion.
+If a classification is uncertain — a divergence could be reference drift
+*or* hand-authored drift depending on which side is the intended truth —
+name the uncertainty and the question that resolves it rather than
+committing to a confident wrong call.
+
+## Handoff
+
+When the divergences are reconciled or the proposals are delivered, the
+agent's job is done. The follow-on work is delegated:
+
+- Applying a proposed reference / pipeline edit and committing it →
+  **developer** agent.
+- Opening a PR and writing the logbook entry → **pr-logbook** agent.
+- Authoring a brand-new pipeline for an engine → **ci-configurator**
+  agent.
+- Diagnosing a failing application pipeline run → **ci-debugger** agent.

--- a/.gemini/skills/gitlab-ci/SKILL.md
+++ b/.gemini/skills/gitlab-ci/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: gitlab-ci
+description: "Deep, practitioner-grade knowledge of GitLab CI/CD for authoring,
+reviewing, hardening, and debugging pipelines. Activate when reading
+or writing a `.gitlab-ci.yml`, when reviewing a CI change in a merge
+request, when designing runners/executors or reusable CI/CD
+Components, or when migrating to GitLab CI from another engine.
+Covers pipeline/stage/job structure, the `rules:`/`workflow:` trigger
+model, runners and executors, caching vs. artifacts, the
+protected/masked variable and secret model, `id_tokens:` OIDC
+federation, and includes/components — plus the security defaults that
+should never be negotiated away."
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# GitLab CI/CD
+
+A dense, practitioner-oriented skill for working on GitLab CI/CD
+pipelines. Read the relevant section before editing a `.gitlab-ci.yml`;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+This skill is the GitLab counterpart of the `github-actions` skill and
+presents a parallel activation and escalation contract. Keep your
+guidance engine-neutral wherever the project's platform-neutral
+capability reference (`ci/ci-capabilities.yml`, described by
+`docs/ci-reference-format.md`) keeps it neutral; name GitLab-specific
+syntax only where the behaviour is genuinely GitLab-specific.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A `.gitlab-ci.yml` (or an `include`d CI fragment) is being authored,
+  modified, or reviewed.
+- A reusable **CI/CD Component** or an `include:`-based template is
+  being designed or consumed.
+- A merge request touches CI configuration and a reviewer-grade audit
+  is required (image pinning, protected/masked variables, OIDC, secret
+  exposure, `rules:` correctness).
+- A pipeline is failing and the root cause is suspected to be in the
+  pipeline definition, the runner/executor selection, the cache or
+  artifacts, the variable/secret scoping, or the `rules:` evaluation.
+- A self-managed runner fleet is being designed, hardened, or
+  diagnosed.
+- A migration is being planned (e.g., from GitHub Actions, CircleCI,
+  Jenkins, or Azure Pipelines to GitLab CI/CD).
+
+Defer to **security** when the change introduces a new secret, widens
+the `CI_JOB_TOKEN` access allowlist, adds an `id_tokens:` OIDC trust
+relationship to a cloud provider, relaxes protected-branch/variable
+gating, or executes untrusted input (MR title, branch name, commit
+message) inside a `script:`. Defer to **architect** when the change
+restructures the pipeline topology (e.g., splitting a monolithic
+pipeline into parent-child pipelines or shared CI/CD Components used
+across many projects).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitLab CI/CD. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/pipeline-syntax.md` | Full grammar of `stages:`, `jobs`, `script:`/`before_script:`/`after_script:`, `needs:`, `rules:`, `extends:`, `!reference`, `parallel:matrix`, `environment:`, `default:`, with annotated examples for every key. |
+| `references/rules-and-triggers.md` | The `rules:` model (`if`/`changes`/`exists`/`when`), `workflow:rules:`, legacy `only/except`, parent-child and multi-project `trigger:` pipelines, the predefined-variable and expression-operator tables, and pipeline types. |
+| `references/runners-and-executors.md` | Instance/group/project runners, `tags:` selection, the shell/docker/kubernetes executors, autoscaling, `image:`/`services:`, and `config.toml` essentials. |
+| `references/caching-and-artifacts.md` | The cache-vs-artifacts distinction, `cache:key/paths/policy/when`, `artifacts:paths/reports/expire_in`, `dependencies:`, distributed cache, and language-specific recipes (npm, pnpm, Yarn, pip, Poetry, Maven, Gradle, Go, Cargo). |
+| `references/variables-and-secrets.md` | Variable sources and precedence, `file`/masked/protected variables, external secrets (`secrets:` with Vault / Azure / GCP), `id_tokens:` OIDC federation for AWS / GCP / Azure, masking caveats, and exfiltration anti-patterns. |
+| `references/security-and-permissions.md` | `CI_JOB_TOKEN` and its access allowlist, the member-role model, protected branches/tags, protected environments, `id_tokens:`, fork-runner trust, and least-privilege recipes per use case. |
+| `references/includes-and-components.md` | `include:` (local/project/remote/template/component), CI/CD Components and the catalog, `spec:inputs:`, `extends:`, `!reference`, `trigger:include`, nesting limits, and versioning strategies. |
+
+## Core concepts
+
+A pipeline is a YAML file (`.gitlab-ci.yml` at the repository root,
+overridable via `CI_CONFIG_PATH`) triggered by one or more events —
+a push, a merge request, a tag, a schedule, or a manual run. A
+pipeline contains **jobs**; each job belongs to a **stage**, and
+stages run in declared order while jobs in the same stage run in
+parallel. A job is a list of shell commands (`script:`) executed by a
+**runner** using a chosen **executor**. State between jobs travels
+through **artifacts** (a forward-passed contract) and, opportunistically,
+through **cache** (a best-effort speed optimization).
+
+### Stages, jobs, and the DAG
+
+Stages give a coarse ordering; `needs:` gives a fine one. A job with
+`needs:` starts as soon as its named dependencies finish, forming a
+**directed acyclic graph** that ignores stage boundaries — the way to
+shorten a pipeline's critical path. `needs: []` starts a job
+immediately, before any stage. See `references/pipeline-syntax.md`.
+
+### Triggers and `rules:`
+
+`rules:` is the modern control-flow primitive: an ordered list whose
+first matching entry decides whether (and how) the job runs. Rules key
+on `if:` expressions over predefined variables (`$CI_PIPELINE_SOURCE`,
+`$CI_COMMIT_BRANCH`, `$CI_COMMIT_TAG`, `$CI_MERGE_REQUEST_*`),
+`changes:` (path filters), and `exists:` (file presence).
+`workflow:rules:` gates the whole pipeline — most importantly to avoid
+running a duplicate detached and branch pipeline for the same commit.
+Legacy `only/except` still works but `rules:` supersedes it. See
+`references/rules-and-triggers.md`.
+
+### Runners and executors
+
+A runner is the agent that executes a job; the **executor** is how it
+does so. The **docker** executor (each job in a fresh container from
+`image:`) is the default for reproducibility; **shell** runs directly
+on the host; **kubernetes** schedules a pod per job. A job selects a
+runner by `tags:`; a job whose tags match no runner stays queued.
+Pin `image:` by digest, never a moving tag. See
+`references/runners-and-executors.md`.
+
+### Caching vs. artifacts
+
+These are different mechanisms. **Cache** persists reusable
+dependencies (e.g. `node_modules/`) across runs to save time; it may be
+absent and must never be relied on as a contract. **Artifacts** are a
+job's declared outputs, passed forward to later stages and downloadable
+from the UI. Use `cache:` for speed and `artifacts:` for correctness.
+See `references/caching-and-artifacts.md`.
+
+### Variables and secrets
+
+CI/CD variables come from many sources (instance, group, project,
+trigger, `.gitlab-ci.yml`, `dotenv` artifacts) with a defined
+precedence. A credential MUST be a **masked** variable (hidden in job
+logs) and, when it gates a real environment, a **protected** variable
+(exposed only to pipelines on protected branches/tags). The `file`
+variable type writes the value to a temp file and exports its path —
+the correct channel for certificates and kubeconfigs. For cloud
+credentials, **prefer `id_tokens:` OIDC** over long-lived keys. See
+`references/variables-and-secrets.md`.
+
+### Permissions and protection
+
+GitLab has no single token scope map; the surface spans the
+`CI_JOB_TOKEN` (and its project access allowlist), the project/group
+member role model, protected branches/tags, and protected
+environments. Production promotion belongs behind a protected
+environment with required approvals. See
+`references/security-and-permissions.md`.
+
+### Includes and components
+
+`include:` composes a pipeline from local files, other projects,
+remote URLs, GitLab templates, or versioned **CI/CD Components**.
+Components (`include:component:`) are the modern reusable unit, with a
+typed `spec:inputs:` contract and catalog versioning. `extends:` and
+`!reference` compose fragments within and across includes. See
+`references/includes-and-components.md`.
+
+## Common pitfalls
+
+The top failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned container images.** `image: node:22` (or `:latest`) is
+   a moving target — the registry can re-point the tag. Pin by digest
+   (`image: node@sha256:…`) and let Renovate track updates.
+2. **Plaintext or un-masked secrets.** A credential hardcoded in
+   `variables:`, or a masked variable that fails GitLab's masking
+   requirements (too short, contains whitespace) and silently logs in
+   the clear.
+3. **Over-broad `rules:` / missing `workflow:rules:`.** Without a
+   `workflow:` guard, a single push to a branch with an open MR runs
+   two pipelines. Rules that omit `$CI_PIPELINE_SOURCE` checks fire on
+   unintended events.
+4. **`CI_DEBUG_TRACE` or `set -x` left enabled.** Both print every
+   expanded variable to the job log, including masked ones — masking
+   does not survive a shell trace.
+5. **Treating cache as artifacts.** Relying on `cache:` to carry build
+   output to a later stage. Cache can be cold; only `artifacts:` (or
+   `needs:[].artifacts`) is a forward contract.
+6. **Cache key on the manifest, not the lockfile.** A cache keyed on
+   `package.json` instead of `package-lock.json` goes stale silently;
+   one keyed on nothing poisons across branches.
+7. **`cache:`/dependency dir outside `$CI_PROJECT_DIR`.** GitLab can
+   only cache paths under the project directory; a `GOPATH` or pip
+   cache in `$HOME` is silently not cached.
+8. **`interruptible` / `resource_group` misuse.** A deploy job left
+   `interruptible: true` can be cancelled mid-rollout; production
+   deploys need a `resource_group` to serialize.
+9. **Untrusted-fork runner exposure.** A shared or `privileged` runner
+   that accepts fork MR pipelines can run arbitrary code on your
+   infrastructure. Protected variables and protected runners are not
+   exposed to fork MRs by default — do not relax that.
+10. **Unpinned `include:remote` / `~latest` components.** A remote
+    include or a component pinned to `~latest` can change under you.
+    Pin to a tag or commit SHA and prefer first-party sources.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge. Both are **offline** text scans —
+no live GitLab, no `glab`, no Docker, no registry or token access.
+
+- **`scripts/check-pinned-images.sh`** — fails closed if any `image:`
+  or `services:` reference is not pinned to an immutable `@sha256:`
+  digest. The first-line defense against a re-pointed base image. The
+  GitLab counterpart of the `github-actions` skill's
+  `check-pinned-actions.sh`.
+- **`scripts/check-secrets-exposure.sh`** — flags hardcoded credential
+  literals in `variables:`/`script:`, recognizable token shapes
+  (`glpat-…`, `ghp_…`, AWS keys, PEM private keys), `echo`/`printf` of a
+  credential-named variable, `set -x`, and `CI_DEBUG_TRACE`. The GitLab
+  counterpart of the `github-actions` skill's `check-secrets-exposure.sh`.
+
+Invoke them as:
+
+```sh
+scripts/check-pinned-images.sh .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+Each accepts exactly one argument — a pipeline file or a directory
+(directory mode scans `<dir>/.gitlab-ci.yml` plus YAML under
+`<dir>/.gitlab/`). Both exit non-zero on a finding, so CI can fail
+closed.
+
+This skill ships **no** offline structural linter and **no** pipeline
+simulator, by design. GitLab's `glab ci lint` is a server-side CI-Lint
+API call (it requires authentication and a reachable instance — there
+is no offline structural validation equivalent to `actionlint`), and
+`gitlab-ci-local` *executes* the pipeline in Docker. Both are out of
+scope here: executing a pipeline on a live GitLab is not this skill's
+job. The two scripts above are the validations with genuine offline
+parity to their GitHub Actions siblings; nothing else is shipped as
+façade tooling.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every container image by `@sha256:` digest.** No bare tags,
+   no `:latest`. Pin `image:` and every `services:` entry; document the
+   pin with a comment carrying the human-readable tag.
+2. **Every credential is a masked variable.** Never hardcode a secret
+   in `variables:` or a `script:`. Confirm the value meets GitLab's
+   masking requirements, or it logs in the clear despite the flag.
+3. **Protect the variables that gate real environments.** A deploy or
+   release credential is **protected** as well as masked, so it is
+   exposed only to pipelines on protected branches/tags.
+4. **Prefer `id_tokens:` OIDC over long-lived cloud credentials.** A
+   long-lived cloud key is acceptable only when the provider does not
+   support OIDC for the target resource. Document the exception.
+5. **Never echo or trace a secret.** No `echo "$TOKEN"`, no `set -x`
+   over secret-bearing commands, no `CI_DEBUG_TRACE: "true"` in a job
+   that sees a credential. Masking is best-effort and a transformed
+   value bypasses it.
+6. **Bind secrets to the smallest scope.** A secret in a global
+   `variables:` block is inherited by every job. Bind it to the job —
+   or the protected environment — that needs it.
+7. **Gate deploy / Pages / Release jobs behind protected refs and
+   environments.** Production promotion targets a protected
+   environment with required approvals; the environment is also the
+   correct scope for production secrets.
+8. **Serialize deployments with `resource_group:`** so two pipelines
+   never deploy to the same target concurrently, and leave production
+   deploys `interruptible: false`.
+9. **Scope the `CI_JOB_TOKEN` access allowlist.** Limit which projects
+   a job token may reach; the historical "allow all" default is a
+   lateral-movement risk.
+10. **Never run untrusted code on a `privileged` or shared runner.**
+    Fork MR pipelines must not receive protected variables or
+    protected runners. Keep that default; if a fork must run privileged
+    work, gate it behind a maintainer-approved, protected-environment
+    job.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure pipeline skeleton
+
+```yaml
+default:
+  image: node@sha256:<digest>  # node:22
+
+stages: [test]
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+
+unit-test:
+  stage: test
+  interruptible: true
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --cache .npm --prefer-offline
+    - npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+deploy:
+  stage: deploy
+  image: registry.example.com/aws-cli@sha256:<digest>
+  environment:
+    name: production
+  resource_group: production
+  interruptible: false
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name "ci-$CI_PIPELINE_ID"
+      --web-identity-token "$AWS_ID_TOKEN"
+    - ./scripts/deploy.sh
+```
+
+### Safe handling of an untrusted MR title
+
+```yaml
+comment:
+  variables:
+    MR_TITLE: $CI_MERGE_REQUEST_TITLE   # bound to a variable, not interpolated
+  script:
+    # Quoted; the shell does not re-evaluate the value.
+    - printf 'Title: %s\n' "$MR_TITLE"
+```
+
+### Pass a build artifact forward (not via cache)
+
+```yaml
+build:
+  stage: build
+  script: [make dist]
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+publish:
+  stage: deploy
+  needs: [build]   # pulls build's artifacts
+  script: [./publish.sh dist/]
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/.gemini/skills/gitlab-ci/references/caching-and-artifacts.md
+++ b/.gemini/skills/gitlab-ci/references/caching-and-artifacts.md
@@ -1,0 +1,578 @@
+# Caching and artifacts reference
+
+GitLab CI/CD exposes two distinct mechanisms for moving files in and out
+of jobs. They look similar and are constantly confused, so the headline
+distinction comes first.
+
+- **`cache:`** is a **speed optimization** for reusable dependencies
+  (an `npm` store, a Go module cache, a `.gradle` directory). The cache
+  is **best-effort**: it may be absent, stale, or evicted, and a job
+  MUST still succeed on a cold cache. It is keyed and shared across
+  pipelines and jobs by key, NOT by stage order. Never treat it as a
+  contract for passing build output forward.
+- **`artifacts:`** are **job outputs** passed forward to later stages
+  and made downloadable from the UI/API. Artifacts are a **contract**:
+  by default every job in a later stage automatically downloads the
+  artifacts of all jobs from earlier stages. If a build job declares a
+  binary as an artifact, the test job in the next stage will have it.
+
+Rule of thumb: if losing the files only costs you time, it is a cache.
+If losing the files breaks a downstream job, it is an artifact.
+
+This document covers `cache:` key/policy/fallback semantics, distributed
+cache backends, the full `artifacts:` surface (including `reports` and
+`dotenv` variable passing), `dependencies:`/`needs:artifacts` fetch
+control, language recipes, and the recurring pitfalls.
+
+## How the cache works
+
+A job declares a cache by key and paths:
+
+```yaml
+build:
+  stage: build
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths:
+      - .npm/
+    policy: pull-push
+  script:
+    - npm ci --cache .npm --prefer-offline
+```
+
+The runner performs two operations:
+
+1. **Pre-job pull.** Resolves `cache:key` to an archive. On hit, the
+   `paths:` are extracted into the workspace before `script` runs. On
+   miss, `fallback_keys` (then the global fallback) are tried; if all
+   miss the job starts cold — which MUST be valid.
+2. **Post-job push.** After the job, the `paths:` are re-archived and
+   uploaded under `cache:key`. Whether the push happens depends on
+   `cache:policy` and `cache:when` (below).
+
+Unlike artifacts, the cache is **not** tied to stage ordering. Two jobs
+in the same stage can share a cache by using the same key.
+
+## `cache:key`
+
+The key is the cache's identity. Same key across jobs/pipelines means
+shared content.
+
+```yaml
+# Static string key.
+cache:
+  key: gems-ruby-3.3
+
+# Lockfile-hashed key — invalidates automatically when deps change.
+cache:
+  key:
+    files:
+      - Gemfile.lock
+    prefix: $CI_JOB_NAME
+
+# Predefined-variable key — one cache per branch.
+cache:
+  key: $CI_COMMIT_REF_SLUG
+```
+
+- **`cache:key:files`** — up to two files. GitLab computes a SHA over
+  their contents and uses it as (part of) the key. When neither file
+  changes, the key is stable and the cache is reused; when a lockfile
+  changes, the key changes and a fresh cache is built. If the listed
+  files do not exist, the literal `default` is used as the SHA segment.
+- **`cache:key:prefix`** — prepended to the computed SHA, letting you
+  combine a discriminator (job name, branch slug, OS) with lockfile
+  hashing: `prefix-<sha>`.
+- **Branch-scoped key** — `key: $CI_COMMIT_REF_SLUG` gives every branch
+  its own cache. Trade-off: more storage, but no cross-branch bleed.
+
+The key MUST NOT contain `/` or be the literal `.`/`..`. Predefined
+variables (`$CI_COMMIT_REF_SLUG`, `$CI_JOB_NAME`, `$CI_DEFAULT_BRANCH`)
+are the usual building blocks.
+
+## `cache:paths`
+
+A list of paths, relative to `$CI_PROJECT_DIR`, archived into the cache.
+Globs are supported.
+
+```yaml
+cache:
+  paths:
+    - .npm/
+    - vendor/ruby/
+    - "**/node_modules/"
+```
+
+**Critical GitLab gotcha:** only paths **under** the project directory
+(`$CI_PROJECT_DIR`) can be cached. A tool that writes its cache to
+`$HOME` (e.g. `~/.cache/go-build`, `~/.m2`, `~/.cargo`) will NOT be
+cached unless you redirect it into the workspace via an environment
+variable (see the language recipes). This is the single most common
+reason a cache "silently does nothing."
+
+## `cache:policy`
+
+Controls the pull/push behavior, trading correctness for speed.
+
+```yaml
+# Default: download at start, upload at end.
+cache: { key: deps, paths: [.npm/], policy: pull-push }
+
+# Consumer-only: download but never re-upload (faster, read-only jobs).
+test:
+  cache: { key: deps, paths: [.npm/], policy: pull }
+
+# Producer-only: skip the download, only upload (a dedicated warm-up).
+warm-cache:
+  cache: { key: deps, paths: [.npm/], policy: push }
+```
+
+A common pattern: one `prepare` job with `policy: push` builds the cache;
+every downstream job uses `policy: pull` so they never waste time
+re-uploading an unchanged cache.
+
+## `cache:when`
+
+Controls whether the cache is saved based on job result.
+
+```yaml
+cache:
+  key: deps
+  paths: [.npm/]
+  when: on_success   # default: save only if the job succeeds
+  # when: on_failure  # save only if the job fails (debugging)
+  # when: always      # save regardless of result
+```
+
+Use `when: always` when even a failed job produces a useful partial
+cache (e.g. a partially-populated dependency store worth reusing).
+
+## `cache:untracked` and `cache:unprotect`
+
+```yaml
+cache:
+  untracked: true     # also cache files NOT tracked by git
+  unprotect: false    # if true, share cache between protected and
+                      # unprotected refs (DANGEROUS — see Pitfalls)
+```
+
+- **`untracked: true`** caches every git-untracked file in the workspace
+  in addition to `paths:`. Convenient but easy to bloat.
+- **`unprotect: true`** lets protected and unprotected branches share one
+  cache. The default `false` keeps them separate, which is a security
+  boundary — do not flip it without understanding cache poisoning below.
+
+## Multiple caches and `fallback_keys`
+
+A job can declare **multiple caches** as a list, each with its own key:
+
+```yaml
+test:
+  cache:
+    - key:
+        files: [package-lock.json]
+      paths: [.npm/]
+    - key:
+        files: [Gemfile.lock]
+      paths: [vendor/ruby/]
+  script:
+    - npm ci --cache .npm
+    - bundle install --path vendor/ruby
+```
+
+**`cache:fallback_keys`** provides a restore chain analogous to GitHub
+Actions' `restore-keys`: if the exact key misses, the listed keys are
+tried in order for a partial/older cache.
+
+```yaml
+cache:
+  key:
+    files: [package-lock.json]
+    prefix: $CI_COMMIT_REF_SLUG
+  fallback_keys:
+    - npm-$CI_COMMIT_REF_SLUG
+    - npm-$CI_DEFAULT_BRANCH
+  paths: [.npm/]
+```
+
+A global `cache:` defined at the top of the file applies to every job;
+a per-job `cache:` overrides it entirely (the two are NOT merged).
+
+## Distributed cache (S3 / GCS)
+
+By default the cache is stored on the runner's local disk — useless when
+jobs land on different runners. For a runner fleet, configure a
+**distributed cache** in the runner's `config.toml`:
+
+```toml
+[runners.cache]
+  Type = "s3"
+  Shared = true
+  [runners.cache.s3]
+    ServerAddress = "s3.amazonaws.com"
+    BucketName = "gitlab-runner-cache"
+    BucketLocation = "eu-west-1"
+```
+
+`Type` may be `s3`, `gcs`, or `azure`. `Shared = true` lets all runners
+read each other's caches (required for the cross-runner case). This is a
+runner-administration concern — see the runners-and-executors reference
+for executor and `config.toml` details. The `.gitlab-ci.yml` author only
+declares `cache:`; the backend is transparent.
+
+## How artifacts work
+
+Artifacts are produced by a job and consumed by later jobs (and humans).
+
+```yaml
+build:
+  stage: build
+  script:
+    - make build
+  artifacts:
+    paths:
+      - bin/
+      - dist/
+    expire_in: 1 week
+```
+
+By default, every job downloads the artifacts of all jobs in **earlier**
+stages. So a `test` job in the `test` stage automatically receives
+`bin/` and `dist/` from `build` — no extra wiring.
+
+## `artifacts:paths` and `artifacts:exclude`
+
+```yaml
+artifacts:
+  paths:
+    - target/release/
+    - "*.log"
+  exclude:
+    - target/release/**/*.o   # drop intermediate objects from the upload
+  untracked: false            # set true to also upload git-untracked files
+```
+
+`paths:` is relative to `$CI_PROJECT_DIR`. `exclude:` prunes matches from
+the set selected by `paths:`/`untracked:`, useful for shedding bulky
+intermediates while keeping the final output.
+
+## `artifacts:expire_in` and `artifacts:when`
+
+```yaml
+artifacts:
+  paths: [dist/]
+  when: on_success    # on_success (default) | on_failure | always
+  expire_in: 30 days  # "1 week", "3 mins 4 sec", "never"
+```
+
+- **`when: on_failure`** plus a logs path is the canonical way to capture
+  diagnostics only when a job fails.
+- **`expire_in`** governs storage cost. Leaving it at the instance
+  default (often "never" expiry on self-managed, or a long window) is the
+  number-one source of runaway artifact storage. Set an explicit TTL on
+  every artifact unless it is a release deliverable. The latest artifacts
+  of the most recent successful pipeline on a ref are kept regardless
+  (`keep_latest_artifact`), so expiry does not strand your newest build.
+
+## `artifacts:name` and `artifacts:expose_as`
+
+```yaml
+artifacts:
+  name: "$CI_JOB_NAME-$CI_COMMIT_REF_SLUG"   # archive filename on download
+  expose_as: "Coverage report"               # named link in the MR UI
+  paths:
+    - coverage/index.html
+```
+
+`name:` controls the downloaded archive's filename. `expose_as:` surfaces
+the artifact as a clickable link directly in the merge request widget
+(limited to a small number of paths).
+
+## `artifacts:reports`
+
+`reports:` ingests structured artifacts that GitLab parses and renders,
+rather than just storing. Key report types:
+
+```yaml
+test:
+  script:
+    - pytest --junitxml=report.xml --cov --cov-report xml:coverage.xml
+  artifacts:
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+- **`junit:`** — test results rendered in the MR "Test summary" widget;
+  failures are shown inline on the MR.
+- **`coverage_report:` (`cobertura`)** — line-coverage overlay on the MR
+  diff. `coverage_format` is currently `cobertura` (or `jacoco` on newer
+  versions).
+- **`sast:`, `dependency_scanning:`, `secret_detection:`** — security
+  scanner outputs that populate the MR security widget and the
+  vulnerability report. Usually produced by GitLab's bundled scanner
+  templates rather than hand-authored.
+
+### `dotenv` — passing variables downstream
+
+The `dotenv` report is special: it does not render a widget, it
+**injects variables** from a `.env`-format file into later jobs. This is
+the supported way to pass a computed value (a version string, an image
+tag, a deploy URL) from one job to the next.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "VERSION=$(git describe --tags)" >> build.env
+    - echo "IMAGE_TAG=registry.example.com/app:$CI_COMMIT_SHORT_SHA" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true      # required to receive the dotenv variables
+  script:
+    - echo "Deploying $VERSION as $IMAGE_TAG"
+```
+
+The downstream job sees `$VERSION` and `$IMAGE_TAG` as ordinary
+variables. The variables propagate only to jobs that have the producing
+job in `needs:` (or, without `needs:`, to all later-stage jobs).
+
+## Controlling which artifacts are fetched
+
+By default a job downloads ALL upstream artifacts — wasteful when a job
+needs none or only some.
+
+### `dependencies:`
+
+```yaml
+deploy:
+  stage: deploy
+  dependencies:
+    - build           # fetch ONLY build's artifacts
+  script: [./deploy.sh]
+
+lint:
+  stage: test
+  dependencies: []    # fetch NO artifacts — faster, no download
+  script: [./lint.sh]
+```
+
+`dependencies:` is an allowlist of job names whose artifacts to fetch.
+The empty list `dependencies: []` fetches nothing — the single most
+effective speedup for jobs that only need the source checkout.
+
+### `needs: [...].artifacts`
+
+When using `needs:` (the DAG mechanism that lets jobs start out of stage
+order), control artifact transfer per-need:
+
+```yaml
+deploy:
+  needs:
+    - job: build
+      artifacts: true     # download build's artifacts (default true)
+    - job: lint
+      artifacts: false    # depend on lint's completion, skip its artifacts
+```
+
+`needs:` and `dependencies:` interact: when both are present, `needs:`
+governs ordering and `dependencies:` (if also set) further narrows the
+fetch set. For DAG pipelines, prefer expressing artifact transfer through
+`needs:[].artifacts`.
+
+## Language recipes
+
+Each recipe shows the `cache:` block plus the in-workspace redirection
+required by the `$CI_PROJECT_DIR` gotcha.
+
+### npm
+
+```yaml
+variables:
+  npm_config_cache: "$CI_PROJECT_DIR/.npm"   # move cache into workspace
+build:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --prefer-offline
+```
+
+### pnpm
+
+```yaml
+variables:
+  PNPM_HOME: "$CI_PROJECT_DIR/.pnpm-store"
+build:
+  before_script:
+    - corepack enable
+    - pnpm config set store-dir "$CI_PROJECT_DIR/.pnpm-store"
+  cache:
+    key:
+      files: [pnpm-lock.yaml]
+    paths: [.pnpm-store/]
+  script:
+    - pnpm install --frozen-lockfile
+```
+
+### Yarn
+
+```yaml
+build:
+  before_script:
+    - yarn config set cache-folder "$CI_PROJECT_DIR/.yarn-cache"
+  cache:
+    key:
+      files: [yarn.lock]
+    paths: [.yarn-cache/]
+  script:
+    - yarn install --frozen-lockfile
+```
+
+For Yarn Berry zero-installs, `.yarn/cache` is committed to the repo and
+no `cache:` block is needed.
+
+### pip / Poetry
+
+```yaml
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"        # pip
+  POETRY_CACHE_DIR: "$CI_PROJECT_DIR/.poetry-cache"  # poetry
+build:
+  cache:
+    key:
+      files:
+        - poetry.lock        # or requirements.txt for plain pip
+    paths:
+      - .pip-cache/
+      - .poetry-cache/
+      - .venv/
+  script:
+    - poetry config virtualenvs.in-project true
+    - poetry install --no-interaction
+```
+
+`virtualenvs.in-project true` puts `.venv/` under `$CI_PROJECT_DIR` so it
+can be cached.
+
+### Maven / Gradle
+
+```yaml
+variables:
+  MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
+  GRADLE_USER_HOME: "$CI_PROJECT_DIR/.gradle"
+build-maven:
+  cache:
+    key:
+      files: [pom.xml]
+    paths: [.m2/repository/]
+  script: [mvn -B verify]
+
+build-gradle:
+  cache:
+    key:
+      files: [gradle/wrapper/gradle-wrapper.properties, build.gradle.kts]
+    paths:
+      - .gradle/caches/
+      - .gradle/wrapper/
+  script: [./gradlew build]
+```
+
+Both default to `$HOME`; the variables relocate them into the workspace.
+
+### Go modules
+
+```yaml
+variables:
+  GOPATH: "$CI_PROJECT_DIR/.go"          # module + build cache into workspace
+build:
+  cache:
+    key:
+      files: [go.sum]
+    paths:
+      - .go/pkg/mod/
+  script:
+    - go build ./...
+```
+
+`GOPATH` defaults to `$HOME/go`, which is uncacheable — relocating it is
+mandatory for the Go module cache to persist.
+
+### Cargo (Rust)
+
+```yaml
+variables:
+  CARGO_HOME: "$CI_PROJECT_DIR/.cargo"
+build:
+  cache:
+    key:
+      files: [Cargo.lock]
+    paths:
+      - .cargo/registry/index/
+      - .cargo/registry/cache/
+      - .cargo/git/db/
+      - target/
+  script:
+    - cargo build --release
+```
+
+`CARGO_HOME` defaults to `$HOME/.cargo`; relocate it and cache the
+registry plus `target/`.
+
+## Pitfalls
+
+### Cache poisoning across branches and forks
+
+A cache shared between protected and unprotected refs is an injection
+vector: a contributor pushing to an unprotected feature branch can write
+a poisoned cache that a protected branch (or a fork's MR pipeline) later
+restores. Mitigations:
+
+- Keep `cache:unprotect` at its default `false` so protected and
+  unprotected refs use separate caches.
+- Discriminate the key by ref where trust matters:
+  `key: "$CI_COMMIT_REF_PROTECTED-$CI_COMMIT_REF_SLUG"` so protected and
+  unprotected content never collide.
+- Treat restored binaries as untrusted for security-sensitive
+  toolchains; re-verify checksums after the pull.
+
+### Treating cache as artifacts
+
+The cache is best-effort and unordered. Relying on it to pass a build
+output to a later stage will work until the day the cache is evicted, a
+job lands on a fresh runner, or two pipelines race — then the downstream
+job mysteriously fails. Pass build output with `artifacts:`, always.
+
+### Oversized caches
+
+`untracked: true` plus a sprawling `paths:` can produce multi-gigabyte
+caches whose upload/download time exceeds the install time they were
+meant to save. Cache the dependency store, not the whole workspace, and
+measure: if `Restoring cache` takes longer than a cold install, drop it.
+
+### Default `expire_in`
+
+Artifacts without an explicit `expire_in` inherit the instance default,
+which on many installs is effectively unbounded. Across thousands of
+pipelines this silently consumes object storage. Set a deliberate TTL on
+every artifact; reserve long or `never` expiry for genuine release
+deliverables.
+
+### The `$CI_PROJECT_DIR` trap, restated
+
+The most frequent "my cache does nothing" cause: caching a tool's default
+`$HOME` directory, which lives outside `$CI_PROJECT_DIR` and is therefore
+silently un-cacheable. Every language recipe above redirects the tool's
+cache into the workspace for exactly this reason — verify the cached path
+is under `$CI_PROJECT_DIR` before blaming the key.

--- a/.gemini/skills/gitlab-ci/references/includes-and-components.md
+++ b/.gemini/skills/gitlab-ci/references/includes-and-components.md
@@ -1,0 +1,475 @@
+# Includes and components reference
+
+GitLab CI/CD has no single "function call" primitive. Composition is
+assembled from several keywords that each cover one axis of reuse:
+`include:` pulls external configuration into the current pipeline,
+**CI/CD Components** package a parameterised unit and publish it to a
+catalog, `spec:inputs:` defines the typed contract a component or
+included file exposes, and `extends:` / `!reference[…]` stitch fragments
+together within the merged document.
+
+This document covers every form of `include:`, the modern CI/CD
+Component mechanism (the headline reusable unit), the `spec:inputs:`
+contract and its `$[[ inputs.x ]]` interpolation, composition with
+`extends:` and `!reference`, parent-child pipelines via
+`trigger:include`, the versioning and supply-chain story, and the
+pitfalls that bite when several includes merge into one configuration.
+
+## Picking a composition mechanism
+
+A frequent question. The trade-off:
+
+| Property | `include:` (local/project/remote/template) | CI/CD Component |
+|----------|--------------------------------------------|-----------------|
+| Unit of reuse | A whole `.gitlab-ci.yml` fragment. | A parameterised, versioned building block. |
+| Typed contract | Only if the file declares `spec:inputs:`. | `spec:inputs:` is the idiomatic contract. |
+| Versioning | By `ref:` (project) or URL (remote). | By `@<version>` — tag, SHA, `~latest`. |
+| Discoverability | None — you must know the path. | Listed in the CI/CD Catalog. |
+| Inputs interpolation | `$[[ inputs.x ]]` when `spec:` present. | `$[[ inputs.x ]]` — first-class. |
+| Best for | Sharing a stage fragment within an org. | A reusable block consumed across projects. |
+
+Rule of thumb: reach for a **CI/CD Component** when the unit of reuse is
+a published, versioned building block consumed by other projects (the
+GitLab analog of a reusable workflow). Reach for plain **`include:`**
+when you are factoring shared configuration inside one group and do not
+need a versioned, catalog-listed contract.
+
+## `include:` — the four classic forms
+
+`include:` merges external YAML into the pipeline configuration **before**
+jobs run. The merged result behaves as one document: later keys can
+override earlier ones (see *Merge and override semantics*).
+
+### `include:local`
+
+Pulls a file from the **same repository and ref** as the
+`.gitlab-ci.yml` being evaluated. The path is absolute from the repo
+root and must start with `/`:
+
+```yaml
+include:
+  - local: '/ci/build.yml'
+  - local: '/ci/test.yml'
+```
+
+Globs are allowed (`local: '/ci/*.yml'`). Because the file is read at the
+pipeline's own ref, `include:local` never introduces a cross-ref
+supply-chain question — it is the safest form.
+
+### `include:project`
+
+Pulls a file from **another project on the same GitLab instance**. Pin
+the `ref:` (a tag, branch, or SHA) and list one or more files:
+
+```yaml
+include:
+  - project: 'my-group/ci-templates'
+    ref: v1.4.0
+    file:
+      - '/templates/build.yml'
+      - '/templates/deploy.yml'
+```
+
+Omitting `ref:` resolves against the included project's **default
+branch** at pipeline-creation time — a moving target. Pin a tag or SHA
+for reproducibility.
+
+### `include:remote`
+
+Pulls a file from an **arbitrary URL** reachable over HTTP(S):
+
+```yaml
+include:
+  - remote: 'https://gitlab.example.com/-/snippets/12/raw/main/build.yml'
+```
+
+This is the highest-risk form. The URL is fetched at pipeline-creation
+time with no integrity check: whoever controls that endpoint controls
+part of your pipeline. Treat it like sourcing a remote shell script.
+
+- Only include from a source you trust and control.
+- Prefer a URL that resolves to an **immutable** artifact (a raw file at
+  a tagged ref or SHA), never `…/raw/main/…`.
+- Audit `include:remote` entries in review the same way you audit a
+  third-party dependency.
+
+Where possible, replace `include:remote` with `include:project` (same
+instance, auditable `ref:`) or a CI/CD Component (versioned, catalog).
+
+### `include:template`
+
+Pulls a **GitLab-maintained template** shipped with the instance. No
+ref or project needed — the name resolves against GitLab's bundled set:
+
+```yaml
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+```
+
+These are first-party and version-locked to your GitLab version, so
+they are a safe default for security and language scaffolding. They are,
+however, opinionated — read what they inject before relying on them.
+
+## `include:` with `rules:` and `inputs:`
+
+An `include:` entry can be made conditional with `rules:` and can pass
+typed inputs to a file that declares `spec:inputs:`.
+
+```yaml
+include:
+  - local: '/ci/deploy.yml'
+    rules:
+      - if: '$CI_COMMIT_BRANCH == "main"'
+  - component: $CI_SERVER_FQDN/my-group/ci/build@1.0.0
+    inputs:
+      runner_tag: saas-linux-large
+    rules:
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+`include:` `rules:` support `if:`, `exists:`, and variable expressions,
+but **not** the job-only `changes:` with `compare_to` in every context —
+they are evaluated at pipeline-creation time, before any job. When the
+rule does not match, the file is simply not included.
+
+## CI/CD Components — the modern reusable unit
+
+A **CI/CD Component** is a reusable, versioned unit of pipeline
+configuration published from a **component project** and consumed via
+`include:component`. It is the closest GitLab analog of a GitHub Actions
+reusable workflow: a typed contract (`spec:inputs:`) wrapping one or
+more jobs, addressed by version, optionally discoverable in the **CI/CD
+Catalog**.
+
+### Component address form
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/my-group/my-project/my-component@1.2.0
+    inputs:
+      stage: build
+      image: golang:1.23
+```
+
+The path decomposes as
+`<fqdn>/<group>/<project>/<component>@<version>`:
+
+- `$CI_SERVER_FQDN` — predefined variable for the current instance host.
+  Using it (rather than a hard-coded domain) keeps the component
+  portable across self-managed and SaaS instances.
+- `<group>/<project>` — the component project that hosts the component.
+- `<component>` — the component **name**, matching a file under the
+  project's `templates/` directory (see layout below).
+- `@<version>` — the version selector (see *Versioning a component*).
+
+### Component project layout
+
+A single project can publish several components. Each component is a
+file or directory under `templates/`:
+
+```text
+my-project/
+├── templates/
+│   ├── build.yml            # component "build"
+│   └── deploy/
+│       └── template.yml     # component "deploy"
+├── README.md                # required for catalog publication
+└── .gitlab-ci.yml           # the component's own CI (test it!)
+```
+
+Resolution rule:
+
+- `templates/<name>.yml` resolves the component `<name>`.
+- `templates/<name>/template.yml` resolves the component `<name>` (the
+  directory form, useful when the component ships companion files).
+
+### Defining a component with `spec:inputs:`
+
+A component file begins with a `spec:` header in its **first YAML
+document**, separated from the configuration by a `---` document marker:
+
+```yaml
+spec:
+  inputs:
+    stage:
+      default: test
+    image:
+      default: golang:1.23
+    coverage_threshold:
+      type: number
+      default: 80
+    deploy_env:
+      type: string
+      options:
+        - staging
+        - production
+    semver:
+      type: string
+      regex: '^\d+\.\d+\.\d+$'
+---
+test-job:
+  stage: $[[ inputs.stage ]]
+  image: $[[ inputs.image ]]
+  script:
+    - go test -coverprofile=cover.out ./...
+    - ./scripts/check-coverage.sh $[[ inputs.coverage_threshold ]]
+```
+
+`spec:inputs:` entries support:
+
+- `default:` — value used when the caller omits the input. An input with
+  **no `default:`** is **required** — the pipeline fails to create if
+  the caller does not supply it.
+- `type:` — `string` (default), `number`, `boolean`, or `array`. The
+  value is validated and coerced to the declared type.
+- `options:` — an allow-list; the supplied value must be one of them.
+- `regex:` — a pattern (`string` inputs only) the value must match.
+
+These four constraints are validated **at pipeline creation**, before
+any job starts — a contract violation fails fast, not mid-run.
+
+### `$[[ inputs.x ]]` interpolation vs. `variables:`
+
+Input interpolation uses the **double-bracket** form `$[[ inputs.x ]]`
+and is resolved **once, at include time**, before the configuration is
+merged. This is distinct from `$VARIABLE` / `${VARIABLE}` CI/CD
+variables, which are resolved **later**, in the job's runtime shell.
+
+```yaml
+spec:
+  inputs:
+    image:
+      default: alpine:3.20
+---
+job:
+  image: $[[ inputs.image ]]        # resolved at include time
+  script:
+    - echo "$CI_COMMIT_SHA"         # resolved at job runtime
+```
+
+Consequences:
+
+- Inputs can parameterise keys that variables cannot reach — `stage:`,
+  `image:`, `rules:` conditions, even job names — because they are
+  substituted into the YAML before parsing finishes.
+- An input is fixed for the lifetime of the include; a variable can
+  differ per job run and can be overridden by the runner environment.
+
+Reach for `spec:inputs:` to define the **interface** of a reusable
+fragment; reach for `variables:` for values that vary at runtime or that
+a downstream job overrides.
+
+### Versioning a component
+
+The `@<version>` selector accepts several forms, in increasing order of
+stability:
+
+| Selector | Resolves to | Stability |
+|----------|-------------|-----------|
+| `@~latest` | Latest **released** version in the catalog. | Moves under you. |
+| `@<branch>` (e.g. `@main`) | Tip of that branch. | Moves under you. |
+| `@<tag>` (e.g. `@1.2.0`) | That tag. | Stable unless re-tagged. |
+| `@<sha>` | That exact commit. | Immutable. |
+
+`~latest` and a branch ref are convenient in development but make the
+pipeline non-reproducible — the component can change between two runs of
+the same commit. For anything that ships, pin a **tag** (and ideally a
+SHA), and bump deliberately.
+
+### Publishing to the CI/CD Catalog
+
+To make a component discoverable and releasable:
+
+1. Add a `README.md` at the component project root (required) and mark
+   the project as a catalog resource in its settings.
+2. Tag a release commit and create a **release** for that tag (the
+   catalog lists released versions; `~latest` resolves to the newest
+   release, not the newest tag).
+3. The project's own `.gitlab-ci.yml` should test each component (lint
+   the YAML, run the component against a fixture) before tagging — a
+   published component is a dependency for every consumer.
+
+Releasing is what populates `~latest`; an untagged, unreleased component
+is only reachable by branch or SHA.
+
+## `extends:` and `!reference[…]` across includes
+
+Both keywords compose fragments **inside the merged document** — they
+operate after all `include:` and component resolution, so they can reach
+templates that arrived via an include.
+
+### `extends:`
+
+`extends:` performs a reverse-deep-merge of one or more hidden jobs
+(`.name`) into the current job. A hidden template defined in an included
+file is fully usable by a job in the root configuration:
+
+```yaml
+# in an included file: /ci/base.yml
+.docker-build:
+  image: docker:27
+  services:
+    - docker:27-dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+```
+
+```yaml
+# in the root .gitlab-ci.yml
+include:
+  - local: '/ci/base.yml'
+
+build:
+  extends: .docker-build       # merged from the included template
+  script:
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+```
+
+The base treatment of `extends:` (merge order, multi-level chains)
+belongs to the pipeline-syntax reference; here the point is only that
+the merge spans include boundaries.
+
+### `!reference[…]`
+
+`!reference` inserts a specific key from another job — including a job
+that came in via an include — without merging the whole job. It is the
+surgical alternative to `extends:`:
+
+```yaml
+include:
+  - local: '/ci/base.yml'
+
+deploy:
+  before_script:
+    - !reference [.docker-build, before_script]   # reuse just one key
+    - echo "extra deploy prep"
+  script:
+    - ./deploy.sh
+```
+
+`!reference` can target arbitrary nesting and is the cleanest way to
+reuse a single fragment (a `script` block, a `rules` entry) across
+includes without dragging unrelated keys along.
+
+## `trigger:include` — composition by reference
+
+A parent-child pipeline composes by **reference** rather than by merge:
+the parent spawns a downstream child pipeline whose configuration is
+supplied inline via `trigger:include`. Unlike `include:`, the child runs
+as its **own pipeline**, not as merged jobs in the parent.
+
+```yaml
+trigger-child:
+  trigger:
+    include:
+      - local: '/ci/child-pipeline.yml'
+    strategy: depend
+```
+
+- The child sees its own merged configuration; the parent's jobs and
+  variables do **not** leak in (only explicitly forwarded variables do).
+- `strategy: depend` makes the parent job mirror the child pipeline's
+  status, so a child failure fails the parent.
+- `trigger:include` accepts the same source forms as `include:`
+  (`local`, `project`, `component`, `artifact` for dynamic child
+  pipelines).
+
+This is composition for **isolation**: use it when a fragment should run
+as an independent pipeline (a monorepo sub-project, a generated dynamic
+pipeline) rather than as extra jobs in the current one. The trigger
+mechanics, `forward:`, and dynamic child pipelines are covered in the
+rules-and-triggers reference; here the framing is that
+`trigger:include` is composition-by-reference, the complement to
+`include:`'s composition-by-merge.
+
+## Merge and override semantics
+
+When `include:` brings in a job key that the root configuration also
+defines, the configurations **merge**, and the later definition wins on
+a per-key basis:
+
+- The **root `.gitlab-ci.yml` is processed last**, so a job redefined in
+  the root overrides the same job from an included file, key by key
+  (not wholesale replacement — unspecified keys survive from the
+  include).
+- Among multiple `include:` entries, **later entries override earlier
+  ones** for the same key.
+- Scalar and array keys are **replaced**, not concatenated. Redefining
+  `script:` in the root replaces the included `script:` entirely.
+- Map keys (e.g. `variables:`) are **deep-merged** — individual keys
+  override, siblings survive.
+
+```yaml
+include:
+  - local: '/ci/base.yml'        # defines test.script + test.image
+
+test:
+  image: node:22                 # overrides only the image
+  # script: inherited from /ci/base.yml unless redefined here
+```
+
+To override deliberately, redefine the exact key. To extend rather than
+replace, prefer `extends:` or `!reference[…]` so the original fragment
+stays visible.
+
+## Versioning strategy and supply-chain hardening
+
+Every `include:` and component is a dependency. Treat it like one.
+
+1. **Pin every cross-project and remote reference.** Use a `ref:` (tag
+   or SHA) on `include:project`, an immutable URL on `include:remote`,
+   and a `@<tag>` or `@<sha>` on `include:component`. An unpinned
+   reference (`include:project` with no `ref:`, `@main`, `@~latest`) can
+   change between two runs of the same commit.
+2. **Prefer first-party over third-party.** `include:template` and
+   components from a trusted internal group are auditable and version-
+   locked. An arbitrary `include:remote` URL is not.
+3. **Audit `include:remote`.** It fetches code with no integrity check.
+   If you cannot replace it with `include:project` or a component,
+   ensure the source is one you control and the URL is immutable.
+4. **Version components like a library.** Tag releases
+   `<major>.<minor>.<patch>`, populate the catalog with a release per
+   tag, and let consumers pin a SHA with a comment naming the version.
+5. **Beware moving selectors.** `@~latest` and `@main` are conveniences
+   for the component's own development, not for production consumers —
+   the same risk as pinning a GitHub Action to `@main`.
+
+The failure mode to avoid is the same across all forms: an unpinned
+include changes upstream, and a pipeline that passed yesterday fails (or
+worse, silently does the wrong thing) today, on an unchanged commit.
+
+## Common pitfalls
+
+- **Override order surprises.** Because the root config and later
+  includes win, a job you thought an included template defined may be
+  silently overridden by a same-named key elsewhere. Search the merged
+  config (the pipeline editor's *Full configuration* / *View merged
+  YAML* tab) when a key is not what you expect.
+- **Array keys replace, not append.** Redefining `script:` or
+  `before_script:` in the root **discards** the included version
+  entirely. Use `!reference` to keep the original and add to it.
+- **Variable scope across includes.** `variables:` are deep-merged, so a
+  root-level variable silently overrides an included one of the same
+  name. Globals defined in one include are visible to jobs from another
+  — name them defensively to avoid collisions.
+- **Inputs resolve at include time, variables at runtime.** Reaching for
+  `$VARIABLE` inside a key that needs an include-time value (a `stage:`
+  or job name) will not work — use `$[[ inputs.x ]]`. Conversely,
+  `$[[ inputs.x ]]` cannot pick up a value that only exists at job
+  runtime.
+- **Duplicate job keys across includes.** Two includes defining the same
+  job name silently merge; the later include wins per key. There is no
+  "job already defined" error — only the merged result. Keep job names
+  unique or namespace them per fragment.
+- **Unpinned remote includes.** `include:remote` to a `…/raw/main/…` URL
+  pulls whatever is at that branch tip right now. Pin to a tagged or
+  SHA-addressed raw URL, or move to `include:project`.
+- **`~latest` is the newest release, not the newest commit.** A
+  component fix pushed to a branch is invisible to `@~latest` consumers
+  until a release is created. Conversely, consumers on `@~latest` jump
+  to a new major the moment it is released — pin a tag to opt out.
+- **Catalog requires a README and a release.** A component project with
+  no `README.md` or no GitLab release will not appear in the catalog and
+  `@~latest` will not resolve, even though branch/SHA includes still
+  work.

--- a/.gemini/skills/gitlab-ci/references/pipeline-syntax.md
+++ b/.gemini/skills/gitlab-ci/references/pipeline-syntax.md
@@ -1,0 +1,721 @@
+# Pipeline syntax reference
+
+Canonical reference for the YAML grammar of a GitLab CI/CD pipeline
+(`.gitlab-ci.yml`). Each top-level and job-level key is enumerated with
+semantics, defaults, and a worked example. Read the section that matches
+the key you are editing — do not guess from memory.
+
+## File location and naming
+
+The pipeline definition lives in a file named `.gitlab-ci.yml` at the
+repository root. The basename and location are conventional, not free:
+GitLab looks for exactly this path unless the project overrides it.
+
+The override is the per-project **CI/CD configuration file** setting,
+exposed at runtime as `CI_CONFIG_PATH`. It accepts a repository-relative
+path, a path in a different project, or an external URL:
+
+```yaml
+# Project setting "CI/CD configuration file" set to:
+#   ci/pipeline.yml                 → file in this repo
+#   ci/pipeline.yml@group/templates → file in another project
+#   https://example.com/pipeline.yml → remote URL
+```
+
+A single file is the entry point; it may pull in further fragments with
+the top-level `include:` key (local files, other projects, remote URLs,
+or built-in templates). Includes are merged before any job runs.
+
+## Top-level keys
+
+### `stages`
+
+Declares the ordered list of pipeline stages. Jobs in the same stage run
+in parallel; a stage starts only after every job in the previous stage
+finishes successfully (unless `needs:` overrides the ordering — see
+below).
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+```
+
+If `stages:` is omitted, GitLab uses the implicit default ordering:
+
+```yaml
+stages:
+  - .pre      # always first, runs before any user stage
+  - build
+  - test
+  - deploy
+  - .post     # always last, runs after every user stage
+```
+
+`.pre` and `.post` are reserved virtual stages that exist whether or not
+`stages:` is declared; a job assigned to `.pre` runs before everything,
+`.post` after everything, regardless of where they appear in the file.
+
+A job is placed in a stage with its `stage:` key (see job-level keys). A
+job referencing a stage not listed in `stages:` is a configuration error.
+
+### `default`
+
+Defines values inherited by every job that does not set them explicitly.
+Only a fixed set of keys may appear under `default:` — notably `image`,
+`services`, `before_script`, `after_script`, `cache`, `tags`, `retry`,
+`timeout`, `interruptible`, and `artifacts`.
+
+```yaml
+default:
+  image: node:22-bookworm
+  tags:
+    - docker
+  before_script:
+    - corepack enable
+    - pnpm install --frozen-lockfile
+  retry:
+    max: 2
+    when: runner_system_failure
+```
+
+A job overrides a default by redeclaring the key; there is no deep merge
+of `default` into the job — the job's value replaces the default wholesale
+for that key. Set `inherit:` on a job to opt out of defaults or variables
+selectively:
+
+```yaml
+job:
+  inherit:
+    default: false              # ignore all `default:` keys
+    variables: [DEPLOY_ENV]     # inherit only these global variables
+```
+
+### `variables`
+
+Global CI/CD variables, inherited by every job. Job-scoped `variables:`
+override globals for that job. This section is intentionally brief —
+variable precedence, masking, protected/file variables, and secret
+injection are covered in the `variables-and-secrets.md` reference; consult
+it for anything beyond plain key/value defaults.
+
+```yaml
+variables:
+  GIT_DEPTH: "0"
+  FF_USE_FASTZIP: "true"
+```
+
+Variable values are strings. Quote numeric- or boolean-looking values to
+avoid the YAML coercion traps described in *Edge cases and quirks*.
+
+### `include`
+
+Pulls in external configuration before evaluation. Each entry is `local`,
+`project` (+ `ref` + `file`), `remote`, `template`, or `component`.
+
+```yaml
+include:
+  - local: ci/build.yml
+  - project: group/ci-templates
+    ref: v1.4.0
+    file: /jobs/deploy.yml
+  - template: Security/SAST.gitlab-ci.yml
+  - component: gitlab.com/components/sonarqube@1.0.0
+```
+
+### `workflow`
+
+Controls whether the **whole pipeline** is created for a given event.
+Without it, branch and merge-request pipelines can both fire and cause
+duplicate runs. The canonical guard:
+
+```yaml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
+    - when: never           # nothing else creates a pipeline
+```
+
+`workflow:rules` accepts the same `if` / `changes` / `when` vocabulary as
+job `rules:`, plus `auto_cancel` and a `name:` to label the pipeline.
+
+## Job-level keys
+
+A job is any top-level mapping that is not a reserved keyword. Its key is
+the job name (shown in the UI and used by `needs:`/`dependencies:`). A job
+must define `script:` (or be a `trigger:` / `extends:`-only bridge job).
+
+### `script`
+
+The shell commands the job runs, as a YAML list. Each list item is one
+command line; a non-zero exit on any line fails the job. Commands run in
+the runner's shell.
+
+```yaml
+test:
+  stage: test
+  script:
+    - npm ci
+    - npm run lint
+    - npm test
+```
+
+### `before_script` and `after_script`
+
+`before_script` is prepended to `script` (it shares the same shell
+context). `after_script` runs in a **separate shell**, always, even when
+the job failed or was cancelled — making it the right place for cleanup.
+Because it is a fresh shell, environment changes from `script:` do not
+carry into `after_script:`.
+
+```yaml
+deploy:
+  before_script:
+    - terraform init -input=false
+  script:
+    - terraform apply -auto-approve
+  after_script:
+    - terraform output -json > tf-out.json || true
+```
+
+### `stage`
+
+Assigns the job to a stage from `stages:`. Defaults to `test` when
+omitted.
+
+```yaml
+lint:
+  stage: build
+  script:
+    - golangci-lint run
+```
+
+### `rules` and `when`
+
+`rules:` is the modern flow-control mechanism: an ordered list evaluated
+top to bottom, **first match wins**, and the matched rule's `when:`
+decides the job's fate. Each rule may carry `if:`, `changes:`,
+`exists:`, `when:`, `allow_failure:`, and `variables:`.
+
+`when:` values: `on_success` (default — run if prior stages succeeded),
+`on_failure`, `always`, `manual` (a play button in the UI), `delayed`
+(with `start_in:`), and `never` (do not add the job).
+
+```yaml
+deploy:prod:
+  stage: deploy
+  script:
+    - ./deploy.sh production
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+      when: manual
+      allow_failure: false
+    - if: $CI_COMMIT_BRANCH == "main"
+      changes:
+        - src/**/*
+      when: on_success
+    - when: never
+```
+
+If no rule matches and there is no trailing catch-all, the job is **not
+added** to the pipeline. `rules:` is mutually exclusive with `only/except`
+in the same job.
+
+### `needs`
+
+Declares a Directed Acyclic Graph (DAG): the job starts as soon as its
+named dependencies finish, ignoring stage boundaries. This is how you
+break out of strict stage-by-stage execution.
+
+```yaml
+integration:
+  stage: test
+  needs:
+    - build:linux
+    - build:macos
+  script:
+    - ./run-integration.sh
+```
+
+`needs: []` (empty list) starts the job **immediately**, at pipeline
+creation, regardless of stage:
+
+```yaml
+prefetch:
+  stage: test
+  needs: []          # do not wait for the build stage
+  script:
+    - ./warm-cache.sh
+```
+
+`needs:` can also pull artifacts from a specific upstream job; use the
+object form with `artifacts: true`:
+
+```yaml
+package:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true       # download build's artifacts
+    - job: changelog
+      artifacts: false      # order dependency only, no download
+  script:
+    - ./package.sh
+```
+
+A job with `needs:` can depend only on jobs in the same stage or an
+earlier stage. The DAG must be acyclic.
+
+### `dependencies`
+
+Controls which upstream jobs' **artifacts** are downloaded into this job.
+By default a job downloads artifacts from every job in all prior stages;
+`dependencies:` narrows that set. An empty list disables artifact download
+entirely.
+
+```yaml
+unit:
+  stage: test
+  dependencies:
+    - build           # only fetch build's artifacts
+  script:
+    - ./test.sh
+
+quick:
+  stage: test
+  dependencies: []    # fetch nothing — faster start
+  script:
+    - ./lint.sh
+```
+
+When `needs:` is present, the `needs.*.artifacts` flags take precedence
+and `dependencies:` is redundant — prefer expressing both ordering and
+artifact flow through `needs:`.
+
+### `artifacts`
+
+Files and directories saved after the job, passed to later stages and
+downloadable from the UI.
+
+```yaml
+build:
+  stage: build
+  script:
+    - make dist
+  artifacts:
+    paths:
+      - dist/
+    exclude:
+      - dist/**/*.map
+    expire_in: 1 week
+    when: on_success          # on_success | on_failure | always
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+`reports:` artifacts feed GitLab features (test tab, coverage diffs,
+security dashboards) rather than being plain downloads.
+
+### `cache`
+
+Caches dependency directories between runs, keyed for reuse. Distinct from
+artifacts: cache is a runner-side optimization, not a contract between
+jobs.
+
+```yaml
+test:
+  cache:
+    key:
+      files:
+        - package-lock.json     # invalidate when the lockfile changes
+    paths:
+      - node_modules/
+    policy: pull-push           # pull | push | pull-push
+  script:
+    - npm ci
+    - npm test
+```
+
+### `allow_failure`
+
+When `true`, a failing job does not fail the pipeline; it is shown as a
+warning. Defaults to `false`, except for `when: manual` jobs, where it
+defaults to `true`. A numeric form restricts which exit codes are
+tolerated:
+
+```yaml
+flaky:
+  script:
+    - ./maybe-flaky.sh
+  allow_failure:
+    exit_codes:
+      - 137         # OOM-kill tolerated; any other non-zero still fails
+```
+
+### `timeout`
+
+Per-job timeout, overriding the project default. Accepts a human-readable
+duration.
+
+```yaml
+e2e:
+  timeout: 30 minutes
+  script:
+    - ./e2e.sh
+```
+
+### `retry`
+
+Automatically re-runs a failed job. `max:` is 0–2 (default 0). `when:`
+restricts retries to specific failure classes, so transient
+infrastructure failures retry while genuine test failures do not.
+
+```yaml
+deploy:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - api_failure
+  script:
+    - ./deploy.sh
+```
+
+### `interruptible`
+
+Marks the job as safe to cancel when a newer pipeline supersedes it on the
+same ref. Combined with the project's auto-cancel setting, this stops
+wasting runners on outdated commits. Set `false` on jobs that must not be
+interrupted (irreversible deploys).
+
+```yaml
+build:
+  interruptible: true
+  script:
+    - make
+```
+
+### `resource_group`
+
+Serializes jobs that share a named resource so that at most one runs at a
+time across all pipelines — the standard guard against concurrent deploys
+to the same environment.
+
+```yaml
+deploy:prod:
+  resource_group: production
+  environment:
+    name: production
+  script:
+    - ./deploy.sh
+```
+
+### `environment`
+
+Binds the job to a GitLab deployment environment, surfacing it in the
+Environments and Deployments views.
+
+```yaml
+deploy:review:
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: https://$CI_COMMIT_REF_SLUG.review.example.com
+    deployment_tier: development      # production|staging|testing|development|other
+    on_stop: stop:review              # job that tears this environment down
+  script:
+    - ./deploy-review.sh
+
+stop:review:
+  stage: deploy
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  rules:
+    - if: $CI_MERGE_REQUEST_ID
+      when: manual
+  script:
+    - ./teardown-review.sh
+```
+
+The `on_stop` job must target the same `environment.name` with
+`action: stop`, and is typically `manual`.
+
+### `parallel`
+
+Runs N identical copies of the job. Each copy gets `CI_NODE_INDEX`
+(1-based) and `CI_NODE_TOTAL`, which the script uses to shard work.
+
+```yaml
+test:
+  parallel: 4
+  script:
+    - ./run-tests.sh --shard "$CI_NODE_INDEX/$CI_NODE_TOTAL"
+```
+
+### `parallel:matrix`
+
+Fans out one job per combination of the listed variable axes (Cartesian
+product). Each generated job sees its axis variables in the environment;
+`CI_NODE_INDEX`/`CI_NODE_TOTAL` cover the whole matrix.
+
+```yaml
+test:
+  stage: test
+  parallel:
+    matrix:
+      - RUBY: ["3.2", "3.3"]
+        DB: [postgres, mysql]
+  image: ruby:$RUBY
+  script:
+    - ./test.sh --db "$DB"
+```
+
+The example above generates four jobs:
+`test: [3.2, postgres]`, `test: [3.2, mysql]`, `test: [3.3, postgres]`,
+`test: [3.3, mysql]`. A list value with multiple keys multiplies; multiple
+list entries under `matrix:` are unioned (each entry is its own product).
+
+### `tags`
+
+Selects runners by their tag set. Every listed tag must be present on the
+runner.
+
+```yaml
+gpu-job:
+  tags:
+    - gpu
+    - linux
+  script:
+    - ./train.sh
+```
+
+### `variables` (job scope)
+
+Per-job variables, overriding globals. Brief here by design; see
+`variables-and-secrets.md` for precedence and masking.
+
+```yaml
+deploy:staging:
+  variables:
+    DEPLOY_ENV: staging
+  script:
+    - ./deploy.sh "$DEPLOY_ENV"
+```
+
+## Reuse mechanisms
+
+### Hidden jobs (template jobs)
+
+A job whose name begins with a dot (`.`) is **hidden**: GitLab parses it
+but never adds it to a pipeline. Hidden jobs exist purely to be reused via
+`extends:` or `!reference`.
+
+```yaml
+.deploy-template:
+  image: alpine:3.20
+  before_script:
+    - apk add --no-cache curl
+  script:
+    - ./deploy.sh
+```
+
+### `extends`
+
+Inherits one or more jobs' configuration. Multi-level inheritance is
+supported, and keys are **deep-merged**: maps merge key-by-key, while
+arrays and scalars are replaced wholesale by the most-derived value. When
+`extends:` lists several parents, later parents win on conflict.
+
+```yaml
+.base:
+  image: node:22
+  variables:
+    LOG_LEVEL: info
+  before_script:
+    - npm ci
+
+.with-cache:
+  cache:
+    paths:
+      - node_modules/
+
+test:
+  extends:
+    - .base
+    - .with-cache
+  variables:
+    LOG_LEVEL: debug        # overrides .base's value via deep merge
+  script:
+    - npm test
+```
+
+`extends:` resolves up to 11 levels deep and is preferred over YAML
+anchors because it merges across `include:` boundaries (anchors do not —
+an anchor is only visible within the file that defines it).
+
+### YAML anchors vs `extends`
+
+YAML anchors (`&name` / `*name`) and the merge key (`<<:`) are a raw-YAML
+feature, resolved by the YAML parser before GitLab sees the document. They
+work, but only within a single file and with shallow merge semantics.
+
+```yaml
+.defaults: &defaults
+  image: node:22
+  tags: [docker]
+
+test:
+  <<: *defaults
+  script:
+    - npm test
+```
+
+Prefer `extends:` for cross-file reuse and deep merge; reach for anchors
+only for small, in-file fragments.
+
+### `!reference`
+
+The `!reference[...]` custom tag injects a value from another job's
+specific key — including reaching into a hidden job's `script:` or
+`before_script:` and composing fragments. Unlike `extends:`, it copies a
+**single addressed value**, so you can interleave reused steps with local
+ones.
+
+```yaml
+.setup:
+  before_script:
+    - apk add --no-cache curl jq
+
+.deploy-fragment:
+  script:
+    - ./deploy.sh
+
+test:
+  before_script:
+    - !reference [.setup, before_script]
+    - echo "local step after the shared setup"
+  script:
+    - !reference [.deploy-fragment, script]
+    - ./verify.sh
+```
+
+`!reference` may nest (a referenced value can itself contain a
+`!reference`), but circular references are an error.
+
+## Full worked example
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+
+default:
+  image: node:22-bookworm
+  tags: [docker]
+  retry:
+    max: 1
+    when: runner_system_failure
+
+variables:
+  GIT_DEPTH: "0"
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+.node-cache:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [node_modules/]
+
+build:
+  stage: build
+  extends: .node-cache
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+test:
+  stage: test
+  needs: [build]
+  parallel:
+    matrix:
+      - SUITE: [unit, integration]
+  script:
+    - npm run test:$SUITE
+  artifacts:
+    reports:
+      junit: junit-$SUITE.xml
+
+deploy:prod:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true
+  resource_group: production
+  interruptible: false
+  environment:
+    name: production
+    url: https://app.example.com
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+  script:
+    - ./deploy.sh dist/
+```
+
+## Edge cases and quirks
+
+- **GENERATED pipeline.** In this repository, `.gitlab-ci.yml` is
+  **derived** by `scripts/build-ci.sh` from `ci/ci-capabilities.yml` — it
+  is not hand-authored. Editing the generated `.gitlab-ci.yml` directly is
+  pointless; the next build overwrites it. Change the capability reference
+  and regenerate. See `docs/ci-reference-format.md` for the source-of-truth
+  contract.
+- **YAML boolean / `on` traps.** A YAML 1.1 parser coerces bare `yes`,
+  `no`, `on`, `off`, `true`, `false` to booleans. A variable value of
+  `on` or `no` therefore becomes a boolean and breaks string comparisons.
+  Always quote such values: `FEATURE_FLAG: "on"`, `DEBUG: "false"`.
+- **`script:` list vs block scalar.** `script:` expects a **list** of
+  command strings, not a single block scalar. Writing `script: | …` puts
+  one multiline string as the sole list item, which works but defeats
+  per-line failure semantics and is harder to read — prefer one list item
+  per command.
+- **`needs:` vs `stage:` interaction.** `stage:` defines logical ordering
+  and the UI grouping; `needs:` overrides the *execution* ordering into a
+  DAG. A job can still belong to a later stage yet start early via
+  `needs:`. `needs:` can only reference jobs in the same or an earlier
+  stage.
+- **`rules:` replaced `only/except`.** `only/except` is legacy and must
+  not be mixed with `rules:` in the same job. New jobs use `rules:`
+  exclusively; it is strictly more expressive (per-rule `variables:`,
+  `when:`, `allow_failure:`, `changes:`, `exists:`).
+- **First-match-wins in `rules:`.** Evaluation stops at the first matching
+  rule. Order matters: put the most specific conditions first and a
+  trailing `when: never` (or a catch-all) to make the default explicit.
+- **`when: manual` flips `allow_failure`.** A manual job defaults to
+  `allow_failure: true`; set it to `false` explicitly when a manual gate
+  must block the pipeline on failure.
+- **`after_script` is a fresh shell.** It runs unconditionally (even on
+  failure or cancellation) but does not inherit shell state or exit codes
+  from `script:`. Guard cleanup commands with `|| true` if a non-zero exit
+  there would matter.
+- **`default:` is replace, not merge.** A job that redeclares a `default:`
+  key replaces it wholesale for that job; there is no deep merge of
+  `default:` into the job. Deep merge applies only to `extends:`.
+- **Anchors do not cross `include:`.** YAML anchors are file-local. To
+  reuse configuration defined in an included file, use `extends:` or
+  `!reference`, never an anchor.

--- a/.gemini/skills/gitlab-ci/references/rules-and-triggers.md
+++ b/.gemini/skills/gitlab-ci/references/rules-and-triggers.md
@@ -1,0 +1,464 @@
+# Rules and triggers reference
+
+The control-flow language that decides **whether** a job runs and
+**what kind of pipeline** runs at all. Read this before writing any
+non-trivial `rules:` clause or `workflow:` gate. Memorising the
+short-circuit and pipeline-source rules avoids the bulk of "two
+pipelines fired for one push" and "the job ran when I told it not to"
+bugs.
+
+## Evaluation surface
+
+Control flow lives at two scopes:
+
+1. **Per-job** via the job-level `rules:` key — decides if *this* job
+   is added to the pipeline, and with which `when:`, `allow_failure:`,
+   and per-rule `variables:`.
+2. **Per-pipeline** via the top-level `workflow:rules:` key — decides
+   if *any* pipeline is created for the event, and short-circuits
+   duplicate pipelines.
+
+Both are evaluated **at pipeline-creation time**, before any job runs.
+A job's `rules:` cannot see another job's result; for run-time
+dependencies use `needs:` / `dependencies:`, not `rules:`. The legacy
+`only:`/`except:` keys occupy the same per-job slot as `rules:` but
+**cannot be combined with it** in the same job — pick one.
+
+## The `rules:` list
+
+`rules:` is an **ordered list**. Evaluation walks it top-to-bottom and
+**stops at the first rule that matches** (short-circuit). The matched
+rule's attributes (`when`, `allow_failure`, `variables`, `start_in`)
+apply; later rules are ignored. If **no** rule matches, the job is
+**not added** to the pipeline (implicit `when: never`).
+
+Each rule is a mapping combining one or more **clauses** (`if`,
+`changes`, `exists`) with **attributes** (`when`, `allow_failure`,
+`variables`, `start_in`). Within one rule, multiple clauses are ANDed.
+
+```yaml
+job:
+  script: ./run.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: on_success
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - src/**/*
+      when: manual
+      allow_failure: true
+    - when: never
+```
+
+### `rules:if`
+
+A single boolean expression over CI/CD variables (operator table
+below). The most common clause. Quote the whole expression so YAML
+does not choke on `:` or `$`.
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG'                       # truthy: tag is set
+  - if: '$CI_COMMIT_BRANCH =~ /^release\/.+/'  # regex match
+```
+
+### `rules:changes`
+
+Matches when any listed path changed. A glob list, or a mapping with
+`paths:` plus `compare_to:` to pin the comparison base (essential
+outside merge requests, where the default base is unreliable).
+
+```yaml
+rules:
+  - changes:
+      paths:
+        - Dockerfile
+        - "src/**/*"
+      compare_to: 'refs/heads/main'
+```
+
+Without `compare_to`, `changes` on a branch pipeline diffs against the
+previous commit on that branch — surprising for force-pushes and the
+first commit. Pin `compare_to` for deterministic behavior.
+
+### `rules:exists`
+
+Matches when at least one file matching the glob exists in the
+repository at pipeline-creation time. Globs are relative to the repo
+root; `**` recurses.
+
+```yaml
+rules:
+  - exists:
+      - "**/Dockerfile"
+```
+
+### `when:` attribute
+
+Selects the job's run behavior once its rule matches:
+
+| Value | Behavior |
+|-------|----------|
+| `on_success` | Run if all jobs in earlier stages succeeded (or `allow_failure`). The default. |
+| `on_failure` | Run only if at least one job in an earlier stage failed. |
+| `always` | Run regardless of earlier-stage status. |
+| `manual` | Add the job but require a manual play action. |
+| `delayed` | Schedule the job after `start_in:`. |
+| `never` | Do **not** add the job. Used as a terminal "drop everything else" rule. |
+
+`when: manual` jobs are non-blocking by default in `rules:`-driven
+pipelines; pair with `allow_failure: false` to make a manual gate
+block downstream stages.
+
+### `allow_failure:` attribute
+
+Set per matched rule. `true` lets the job fail without failing the
+pipeline; `false` makes it blocking. Overrides the job-level
+`allow_failure:` for that rule.
+
+### `variables:` attribute
+
+A matched rule may inject or override variables for the job — the
+canonical way to parameterise one job by the branch or event that
+selected it.
+
+```yaml
+deploy:
+  script: ./deploy.sh "$TARGET_ENV"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      variables:
+        TARGET_ENV: production
+    - if: '$CI_COMMIT_BRANCH == "staging"'
+      variables:
+        TARGET_ENV: staging
+```
+
+### `start_in:` and `when: delayed`
+
+`start_in:` is required by `when: delayed` and gives a human-readable
+duration (`30 seconds`, `1 hour`, `2 days`, capped at one week).
+
+```yaml
+rollout:
+  script: ./rollout.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: delayed
+      start_in: '15 minutes'
+```
+
+## `workflow:rules:` — whole-pipeline gating
+
+`workflow:` sits at the top level and decides whether *any* pipeline
+is created. Same clause/attribute grammar as job `rules:`, but only
+`when: always` and `when: never` are meaningful (a pipeline either
+exists or it does not). Use it to prevent **duplicate pipelines** —
+the single most common GitLab CI footgun.
+
+### The duplicate-pipeline idiom
+
+When merge-request pipelines are enabled, a push to a branch that has
+an open MR fires **two** events: a branch pipeline *and* a detached
+merge-request pipeline. The canonical guard runs MR pipelines when an
+MR is open, branch pipelines only when none is, and tag pipelines
+always:
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+`$CI_OPEN_MERGE_REQUESTS` is non-empty on a branch pipeline whose
+commit has at least one open MR; the third rule drops that redundant
+branch pipeline, leaving only the detached MR pipeline. GitLab ships
+this exact pattern as the `Branch-Pipelines` / `MergeRequest-Pipelines`
+templates.
+
+### `workflow:name:`
+
+Sets a human-readable name for the whole pipeline, supporting
+variable interpolation evaluated at creation time.
+
+```yaml
+workflow:
+  name: 'Pipeline for $CI_COMMIT_REF_NAME'
+```
+
+## Predefined CI/CD variables used in rules
+
+The variables that actually drive `rules:if`. Each is a string; an
+unset variable is the empty string (falsy).
+
+| Variable | Value |
+|----------|-------|
+| `CI_PIPELINE_SOURCE` | What triggered the pipeline (value enumeration below). |
+| `CI_COMMIT_BRANCH` | Branch name. **Empty** on tag pipelines and MR (detached) pipelines. |
+| `CI_COMMIT_TAG` | Tag name. Set **only** on tag pipelines. |
+| `CI_DEFAULT_BRANCH` | The project's default branch (e.g. `main`). |
+| `CI_COMMIT_REF_NAME` | Branch **or** tag name — set on both branch and tag pipelines. |
+| `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` | Target branch of the MR. Set only on MR pipelines. |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of the MR. MR pipelines only. |
+| `CI_OPEN_MERGE_REQUESTS` | Comma-separated `path!iid` of MRs whose source/target is the current branch. Empty when none. |
+| `CI_COMMIT_REF_PROTECTED` | `"true"` if the ref is protected. |
+| `CI_PROJECT_PATH` | `group/project`. |
+
+### `CI_PIPELINE_SOURCE` values
+
+| Value | Triggered by |
+|-------|--------------|
+| `push` | A `git push` to a branch or tag. |
+| `merge_request_event` | An MR was opened/updated (detached, merged-results, or merge-train pipeline). |
+| `schedule` | A pipeline schedule fired. |
+| `web` | The "Run pipeline" button in the UI. |
+| `api` | A pipeline created via the REST API. |
+| `trigger` | A trigger token (`POST /trigger/pipeline`). |
+| `pipeline` | Created by another pipeline's `trigger:` (multi-project, upstream). |
+| `parent_pipeline` | Created by a parent via `trigger:include` (child pipeline). |
+
+Mapping the neutral trigger vocabulary onto these is the job of
+`scripts/build-ci.sh` — see the cross-reference at the end.
+
+## Expression operators in `rules:if`
+
+`rules:if` evaluates a **single boolean expression**. Operators, in
+approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `=~` / `!~` | Regex match / non-match. RHS is a `/pattern/flags` literal. |
+| `==` / `!=` | String equality / inequality. |
+| `&&` | Logical AND. |
+| `\|\|` | Logical OR. |
+
+Notes that bite:
+
+- **No `<`/`>` comparison, no arithmetic.** Values are compared as
+  strings. There is no numeric coercion; `'10' == '10'` is a string
+  match, not a number one.
+- **Quoting.** A literal string in the expression is double-quoted
+  inside the single-quoted YAML scalar: `if: '$X == "main"'`. A bare
+  `$VAR` (no quotes) tests truthiness.
+- **Regex literals** use `/.../` delimiters with optional flags:
+  `=~ /^v\d+\.\d+/i`. The pattern is RE2 (GitLab uses the Go regexp
+  engine on the server side); no backreferences, no lookahead.
+- **`null`.** Compare against `null` (unquoted) to test "variable is
+  undefined" vs `""` (defined-but-empty). They differ:
+  `$X == null` is true only when `X` was never set.
+
+### Truthiness
+
+| Expression form | True when… |
+|-----------------|------------|
+| `$VAR` (bare) | `VAR` is set **and** non-empty. |
+| `$VAR == "x"` | `VAR` equals the string `x`. |
+| `$VAR != null` | `VAR` is defined (even if empty). |
+| `$VAR =~ /p/` | `VAR` is set and matches the pattern. |
+
+The empty-string trap mirrors GitHub Actions: a bare `$VAR` is false
+both when unset and when set to `""`. To distinguish, test against
+`null`.
+
+## Pipeline types and trigger mechanisms
+
+| Pipeline type | Fires when | `CI_PIPELINE_SOURCE` |
+|---------------|------------|----------------------|
+| Branch | Push to a branch | `push` |
+| Tag | Push of a tag | `push` (with `$CI_COMMIT_TAG` set) |
+| Merge request (detached) | MR opened/updated, MR pipelines enabled | `merge_request_event` |
+| Merged-results | Like detached, but run against the *result* of merging into target | `merge_request_event` |
+| Merge-train | Sequential merged-results pipelines guarding the queue | `merge_request_event` |
+| Scheduled | A pipeline schedule fires | `schedule` |
+| Parent-child | A job's `trigger:include` in the same project | `parent_pipeline` |
+| Multi-project | A job's `trigger:` with `project:` | `pipeline` |
+
+Merged-results and merge-train pipelines are detected the same way in
+`rules:` — all three carry `CI_PIPELINE_SOURCE == "merge_request_event"`.
+Distinguish merge-train runs by the predefined `$CI_MERGE_REQUEST_EVENT_TYPE`
+(`detached`, `merged_result`, `merge_train`) when behavior must differ.
+
+### `trigger:` — parent-child pipelines
+
+A job whose body is `trigger:` does no work itself; it spawns a
+downstream pipeline. `trigger:include` runs a child pipeline from
+config in the same project. `strategy: depend` makes the trigger job
+mirror the child's status (otherwise it succeeds immediately on
+dispatch).
+
+```yaml
+run-child:
+  stage: test
+  trigger:
+    include:
+      - local: ci/child-pipeline.yml
+    strategy: depend
+```
+
+### `trigger:` — multi-project pipelines
+
+`trigger:project` (plus optional `branch`) dispatches a pipeline in a
+**different** project. `forward:` controls which variables and
+yaml-defined pipeline variables propagate downstream.
+
+```yaml
+deploy-downstream:
+  stage: deploy
+  trigger:
+    project: my-group/deployment-config
+    branch: main
+    strategy: depend
+    forward:
+      pipeline_variables: true
+      yaml_variables: true
+```
+
+`forward.pipeline_variables` forwards variables passed into the
+*current* pipeline (e.g. from a manual run); `forward.yaml_variables`
+forwards the `variables:` block defined in this job. Both default such
+that yaml variables forward and pipeline variables do not — set
+explicitly when in doubt.
+
+## Legacy `only:` / `except:` (superseded by `rules:`)
+
+`only:` / `except:` predate `rules:` and remain supported but are
+**not recommended** for new pipelines. They cannot appear in the same
+job as `rules:`. Each takes `refs`, `changes`, or `variables`.
+
+```yaml
+# Legacy form
+job:
+  script: ./run.sh
+  only:
+    refs:
+      - main
+      - /^release\/.*$/
+    changes:
+      - src/**/*
+  except:
+    variables:
+      - $SKIP_CI
+```
+
+### Migration to `rules:`
+
+The equivalent `rules:` form makes the implicit OR/AND explicit and
+short-circuits cleanly:
+
+```yaml
+# Modern form
+job:
+  script: ./run.sh
+  rules:
+    - if: '$SKIP_CI'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - src/**/*
+    - if: '$CI_COMMIT_BRANCH =~ /^release\/.*$/'
+      changes:
+        - src/**/*
+```
+
+Migration notes:
+
+- `only:refs` keywords like `merge_requests`, `tags`, `branches` map to
+  `if:` expressions on `$CI_PIPELINE_SOURCE`, `$CI_COMMIT_TAG`, and
+  `$CI_COMMIT_BRANCH` respectively.
+- `except:` becomes a leading `when: never` rule (short-circuit).
+- `only:` without `refs` (just `changes`/`variables`) had an implicit
+  `branches`+`tags` ref scope; replicate it with an explicit `if:` or
+  the job will widen its trigger surface silently.
+
+## Common patterns
+
+### Run only on the default branch
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+```
+
+### Run only in merge-request pipelines
+
+```yaml
+rules:
+  - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+### Run on tags matching a version pattern
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+```
+
+### Manual gate that blocks downstream stages
+
+```yaml
+deploy:
+  script: ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: manual
+      allow_failure: false
+```
+
+### Skip the pipeline entirely on doc-only pushes
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+      changes:
+        paths:
+          - "docs/**/*"
+        compare_to: 'refs/heads/main'
+      when: never
+    - when: always
+```
+
+## Pitfalls
+
+- **No `workflow:rules:` guard.** Without the duplicate-pipeline idiom
+  above, every push to a branch with an open MR runs the pipeline
+  twice. This is the default failure mode, not an edge case.
+- **`$CI_COMMIT_BRANCH` is empty on MR pipelines.** A rule written as
+  `if: '$CI_COMMIT_BRANCH == "main"'` never matches inside a detached
+  MR pipeline — use `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME` there.
+- **`changes` without `compare_to` outside an MR.** The comparison base
+  is the previous pipeline's commit, which is unstable on force-push
+  and the branch's first commit. Always pin `compare_to`.
+- **`rules:` short-circuit forgotten.** Listing two matching `if:`
+  rules does not OR their attributes — only the **first** match's
+  attributes apply. Order matters; put the most specific rule first.
+- **`when: manual` non-blocking by default.** In `rules:`-driven
+  pipelines a manual job does not block downstream stages unless
+  `allow_failure: false` is set explicitly.
+- **`trigger:` without `strategy: depend`.** The trigger job goes green
+  the instant it dispatches the downstream pipeline, regardless of
+  whether that pipeline later fails. Add `strategy: depend` to mirror
+  the child's status.
+- **Mixing `rules:` with `only:`/`except:`.** GitLab rejects a job that
+  declares both. Migrate fully; do not interleave.
+
+## Cross-reference — this repository
+
+The generated `.gitlab-ci.yml` at the repo root is **derived**, not
+hand-authored: `scripts/build-ci.sh` (spec 0048) reads the neutral
+capability reference `ci/ci-capabilities.yml` and maps its
+engine-neutral trigger vocabulary — `push` / `pull-request` / `tag` /
+`scheduled` / `manual`, qualified by `branches` / `paths` /
+`tag-pattern` filters — onto the GitLab `rules:` constructs documented
+above (e.g. `pull-request` → `$CI_PIPELINE_SOURCE == "merge_request_event"`,
+`tag` → `$CI_COMMIT_TAG`, a `tag-pattern` filter → a `=~ /pattern/`
+clause). That neutral vocabulary and the mapping contract are defined
+in [`docs/ci-reference-format.md`](../../../../../docs/ci-reference-format.md)
+— do not redefine it here. This reference documents the GitLab target
+syntax the generator emits; the format doc owns the neutral source
+contract.

--- a/.gemini/skills/gitlab-ci/references/runners-and-executors.md
+++ b/.gemini/skills/gitlab-ci/references/runners-and-executors.md
@@ -1,0 +1,414 @@
+# Runners and executors reference
+
+Reference for the execution substrate of GitLab CI/CD: where a runner
+comes from (scope), how a job is matched to one (tags), how the runner
+runs the job (executors), how the docker executor handles images and
+services, the `config.toml` knobs that govern a self-managed runner, and
+the security model that decides whether attaching a runner is safe.
+
+GitLab splits the concern in two. A **runner** is the agent registered
+with a GitLab instance that picks up jobs. An **executor** is the
+mechanism a runner uses to run a job's script — a local shell, a
+container, a Kubernetes pod. One runner process runs one executor; you
+register several runners to offer several executors.
+
+## Runner scopes
+
+A runner's scope decides which projects may schedule jobs on it.
+
+| Scope | Registered against | Visible to |
+|-------|--------------------|-----------|
+| **Instance** (shared) | The whole instance | Every project, subject to admin settings. |
+| **Group** | A group | Every project in that group and its subgroups. |
+| **Project** (specific) | One or more projects | Only the projects it is explicitly assigned to. |
+
+The GitLab coordinator offers a pending job to the runners eligible for
+that project; the first runner that polls and matches the job's `tags:`
+claims it. Shared runners process jobs fair-use across projects; group
+and project runners only see their own scope.
+
+### GitLab.com SaaS hosted runners
+
+GitLab.com offers managed runners — nothing to register. They are
+ephemeral (a fresh VM per job, destroyed afterward, no state leak) and
+selected by tag:
+
+| Tag (class) | Platform | Notes |
+|-------------|----------|-------|
+| `saas-linux-small-amd64` | Linux | Default class; smallest, cheapest. |
+| `saas-linux-medium-amd64`, `saas-linux-large-amd64` | Linux | More vCPU/RAM, higher minute weight. |
+| `saas-linux-medium-arm64` | Linux ARM | ARM64 class. |
+| `saas-windows-medium-amd64` | Windows | Higher minute multiplier. |
+| `saas-macos-medium-m1` | macOS | Apple silicon; highest multiplier; tier-gated. |
+
+Class names and minute multipliers drift — verify against the current
+GitLab.com runner docs before pinning one. Untagged jobs run on the
+small Linux class.
+
+### Self-managed runners
+
+Anything you register yourself with `gitlab-runner register`, against a
+self-managed instance or GitLab.com. You own the host, the executor
+choice, the network placement, and the security posture. The rest of
+this document is mostly about these.
+
+## Selecting a runner with `tags:`
+
+A job advertises required tags; a runner advertises the tags it was
+registered with. A job runs on a runner only if the runner carries
+**every** tag the job lists.
+
+```yaml
+build:
+  tags: [docker, linux, amd64]
+  script:
+    - make build
+```
+
+This runs only on a runner tagged at least `docker`, `linux`, and
+`amd64`. Extra runner tags are fine; a single missing tag disqualifies
+the runner.
+
+### Untagged jobs and `run_untagged`
+
+A job with no `tags:` is **untagged**. A runner picks up untagged jobs
+only when registered with `run_untagged = true` (the default for new
+runners; admins often flip shared runners to `false` to force explicit
+tagging). Set it per runner in `config.toml`:
+
+```toml
+[[runners]]
+  name = "docker-runner-1"
+  run_untagged = true
+```
+
+### The "no runner matching tags" stuck job
+
+If a job lists a tag no eligible runner carries — a typo, a
+decommissioned runner, a runner in the wrong scope — the job sits
+`pending` and eventually fails:
+
+```text
+This job is stuck because you don't have any active runners online
+or available with any of these tags assigned to them: <tag>
+```
+
+This is the most common GitLab CI failure after YAML errors. Diagnose
+in Settings → CI/CD → Runners: confirm a runner available to the
+project advertises the exact tag set. A job tagging `arm64` on an
+`amd64`-only fleet is stuck forever, not slow.
+
+## Executors
+
+The executor is set per runner at registration and recorded in
+`config.toml`. It determines the isolation model, the available
+features, and the operational cost.
+
+| Executor | Isolation | Use when |
+|----------|-----------|----------|
+| `shell` | None — runs as the runner's OS user | Trusted single-tenant jobs needing host tools directly. |
+| `docker` | Per-job container | Default for most fleets; clean, reproducible. |
+| `docker-autoscaler` | Per-job container on autoscaled hosts | Bursty load; replaces deprecated `docker-machine`. |
+| `kubernetes` | Per-job pod | Already on k8s; elastic; per-job resource limits. |
+| `ssh` | Remote host, no isolation | Legacy; avoid for new work. |
+| `virtualbox` / `parallels` | Full VM | Need a full guest OS (Windows/macOS) with VM isolation. |
+| `instance` | Fresh cloud VM per job | Autoscaled VMs via fleeting; strongest isolation, highest latency. |
+
+### `shell`
+
+Runs the job's `script:` directly on the host as the user that owns the
+runner process — no container, no image. Fast and simple, but a job has
+the host's full toolchain and filesystem; an escape affects the host and
+the next job. Reserve for trusted, single-tenant runners; never expose a
+shell-executor runner to untrusted contributions (see *Runner
+security*).
+
+### `docker`
+
+The dominant choice. Each job runs in a container from a chosen image;
+the runner mounts the build directory and caches, runs the `script:`,
+then discards the container. Clean per-job state, reproducible
+toolchains, no host pollution. Configuration depth below.
+
+### `kubernetes`
+
+The runner is a controller that creates a **pod per job**: a build
+container (the job image), a helper container (clone, artifacts, cache),
+and one container per declared `service:`. You get horizontal elasticity
+and per-job CPU/memory limits, at the cost of running the runner inside
+a cluster with the right RBAC. Standard for teams already on Kubernetes.
+Knobs live under `[runners.kubernetes]`.
+
+Choosing: trusted project with host tools → `shell`; general-purpose
+fleet → `docker`; already on Kubernetes → `kubernetes`; bursty cloud
+load with scale-to-zero → `docker-autoscaler` / `instance`; full guest
+OS or VM isolation → `virtualbox` / `parallels`.
+
+## The docker executor
+
+### `image:` — the job's container
+
+Set per job, or globally via `default:`:
+
+```yaml
+default:
+  image: golang:1.23-bookworm
+
+test:
+  script: [go test ./...]
+
+lint:
+  image: golangci/golangci-lint:v1.61.0   # overrides the default
+  script: [golangci-lint run]
+```
+
+A job-level `image:` overrides `default:`. With no image at all, the
+docker executor falls back to the runner's configured default image in
+`config.toml`.
+
+### Pin images by digest — security default
+
+Bare tags are mutable: `golang:1.23` and `:latest` can be repointed at a
+new image under the same name, so a green pipeline can silently start
+running different code. Pin by immutable digest:
+
+```yaml
+default:
+  image: golang:1.23-bookworm@sha256:0e6f6c...   # immutable
+```
+
+The skill's `check-pinned-images.sh` flags any `image:` (and
+`services:[].name`) using a bare tag or `:latest` instead of a
+`@sha256:` digest. Treat a bare tag as a finding, not a style nit:
+digest pinning is this skill's supply-chain default, mirroring the
+github-actions action-SHA-pinning rule.
+
+### `image:pull_policy`
+
+Controls when the executor pulls versus reusing a cached image:
+
+```yaml
+build:
+  image:
+    name: registry.example.com/builder@sha256:abc123...
+    pull_policy: [always, if-not-present]
+```
+
+- `always` — pull every run (default on shared runners; freshest).
+- `if-not-present` — pull only when absent locally (fast; safe with a
+  digest, stale-prone with a mutable tag).
+- `never` — never pull; the image must be pre-seeded on the host.
+
+A job may only request policies the runner permits via
+`allowed_pull_policies`; a disallowed request fails the job rather than
+silently downgrading.
+
+### `services:` — sidecar containers
+
+Services are extra containers started alongside the job container on a
+shared network — databases, brokers, headless browsers. Reach them as
+hostnames:
+
+```yaml
+test:
+  image: golang:1.23-bookworm
+  services:
+    - name: postgres:16@sha256:def456...
+      alias: db
+      variables: { POSTGRES_DB: app_test, POSTGRES_PASSWORD: ci_only }
+    - name: redis:7@sha256:aaa111...
+  variables:
+    DATABASE_URL: "postgres://postgres:ci_only@db:5432/app_test"
+  script: [go test ./...]
+```
+
+Mechanics:
+
+- **Hostname.** A service answers at its image name (with `/` and `:`
+  rewritten to `-` and `__`) and at any `alias:` — `db` above. The alias
+  is the practical handle.
+- **Per-service `variables:`.** Configure the service container (DB
+  name, password) independently of the job env.
+- **`services:[].command` / `services:[].entrypoint`.** Override the
+  container's startup, e.g. to pass flags to the service binary.
+- **Ports.** The shared network exposes the container's listening ports
+  on the alias hostname directly; GitLab needs no `ports:` mapping. The
+  `CI_*` variables describe the build environment, not service ports.
+- **Readiness.** The runner waits for service containers to start, but
+  started is not ready — for Postgres and friends, add an explicit wait
+  in the script (`pg_isready` poll, `wait-for-it`).
+
+### Private images — `DOCKER_AUTH_CONFIG`
+
+To pull `image:` or `services:` from a private registry, give the runner
+credentials via the `DOCKER_AUTH_CONFIG` CI/CD variable — a JSON
+document in Docker `config.json` format, ideally a **masked, protected**
+variable:
+
+```json
+{ "auths": { "registry.example.com": { "auth": "base64(user:token)" } } }
+```
+
+The docker and kubernetes executors read it and authenticate the pull.
+Prefer a deploy token or least-privilege registry token over a personal
+credential; never inline the value in `.gitlab-ci.yml`. See the
+security-and-permissions reference for variable protection and masking.
+
+## `config.toml` essentials
+
+Self-managed runners are configured by `config.toml` (default
+`/etc/gitlab-runner/config.toml`). Practitioner essentials below;
+consult the GitLab Runner advanced-configuration docs for the full
+surface.
+
+```toml
+concurrent = 8        # max jobs across ALL runners in this process
+check_interval = 3    # seconds between coordinator polls
+
+[[runners]]
+  name = "docker-runner-1"
+  url = "https://gitlab.example.com/"
+  token = "glrt-REDACTED"
+  executor = "docker"
+  run_untagged = false
+  limit = 4           # max concurrent jobs for THIS runner
+
+  [runners.docker]
+    image = "alpine:3.20"            # fallback when a job sets no image
+    privileged = false              # KEEP false unless truly needed
+    pull_policy = ["if-not-present"]
+    allowed_pull_policies = ["always", "if-not-present"]
+    allowed_images = ["registry.example.com/*", "docker.io/library/*"]
+    allowed_services = ["postgres:*", "redis:*"]
+    volumes = ["/cache"]            # do NOT mount /var/run/docker.sock
+
+  [runners.cache]
+    Type = "s3"
+    Shared = true
+    [runners.cache.s3]
+      ServerAddress = "s3.example.com"
+      BucketName = "gitlab-runner-cache"
+      AuthenticationType = "iam"    # prefer instance role over static keys
+
+  [runners.kubernetes]
+    namespace = "gitlab-ci"
+    image = "alpine:3.20"
+    privileged = false
+    cpu_request = "500m"
+    memory_request = "512Mi"
+    cpu_limit = "2"
+    memory_limit = "2Gi"
+    service_account = "gitlab-runner"
+```
+
+- `concurrent` caps total simultaneous jobs for the whole
+  `gitlab-runner` process, independent of how many `[[runners]]` blocks
+  exist; `limit` caps a single runner.
+- `privileged = true` grants containers near-host capabilities (see
+  *Runner security*); default and recommended value is `false`.
+- `allowed_images` / `allowed_services` allowlist what jobs may run,
+  blunting the "any fork runs any image" exposure on shared runners.
+- `volumes` persists paths across jobs on the same host; a distributed
+  `[runners.cache]` survives beyond one host (essential for autoscaled
+  fleets where the next job lands elsewhere). Never mount the Docker
+  socket as a volume — that is the classic root-escalation footgun.
+- `[runners.kubernetes]` requests/limits seed each per-job pod unless a
+  job overrides them via `KUBERNETES_*` variables; scope the
+  `service_account` RBAC to the minimum the build needs.
+
+## Autoscaling
+
+For bursty load, scale capacity to demand instead of paying for idle
+hosts:
+
+- **`docker-autoscaler` + fleeting.** The current autoscaling path,
+  replacing the deprecated `docker-machine`. A **fleeting** plugin (AWS
+  EC2, GCP, Azure) provisions and reaps VMs; the autoscaler runs the
+  docker executor on each. Configured via `[runners.autoscaler]` with
+  `plugin`, `capacity_per_instance`, and scaling policies.
+- **`instance` executor.** Runs each job directly on a freshly
+  provisioned-then-destroyed cloud VM via the same fleeting plugins —
+  strongest isolation, highest per-job latency.
+- **GitLab Runner Operator on Kubernetes.** Deploy and manage runners
+  declaratively via the operator and a `Runner` custom resource; the
+  cluster autoscaler then scales nodes to absorb pod-per-job demand.
+
+## Runner security
+
+A runner executes whatever code a pipeline carries. The hard questions
+are *who can push that code* and *what the runner can reach*.
+
+### `privileged = true` is dangerous
+
+A privileged docker container runs with near-host capabilities: host
+devices, kernel manipulation, and — with a mounted Docker socket —
+trivial escape to root on the host. People enable it for
+Docker-in-Docker (`dind`); prefer **rootless buildkit / kaniko /
+buildah**, which build images without privileged mode. If `dind` is
+unavoidable, isolate those runners on disposable, network-segmented
+hosts and never share them with untrusted projects.
+
+### The untrusted-fork / public-project exposure
+
+The headline rule mirrors the GitHub Actions analog: **a fork merge
+request can run arbitrary code on any runner that picks up its
+pipeline.** If a shared or instance runner processes fork pipelines for
+a public project, an attacker forks, edits `.gitlab-ci.yml` to exfil
+secrets or mine the host, and opens an MR. Defenses:
+
+1. **Protected branches and protected variables.** Mark sensitive CI/CD
+   variables **protected** so they are injected only on protected
+   branches and tags — never on a fork MR pipeline. This is the primary
+   control: a fork pipeline never sees the secret.
+2. **Restrict shared runners on public projects.** Disable instance
+   runners for public projects, or require approval before
+   external-fork MR pipelines run (project CI/CD settings).
+3. **Dedicated, ephemeral, segmented runners for untrusted work.** If
+   fork CI must run, give it disposable runners (autoscaled VMs / k8s
+   pods destroyed per job) on a network with no route to production or
+   the secret store.
+4. **`allowed_images` / `allowed_services` allowlists.** Constrain what
+   a job may pull and run on a shared runner.
+5. **Drop `privileged`, drop the Docker socket.** A non-privileged
+   runner with no socket mount removes the easiest escalation path.
+
+### Isolate CI from production networks
+
+Place runners on a subnet that **cannot** reach production databases,
+state stores, or the secret manager beyond what the build legitimately
+needs. A compromised job should not be one `curl` from production.
+Combine network segmentation with protected variables so the blast
+radius of a malicious pipeline is bounded.
+
+For the full permission surface — protected vs masked variables,
+`CI_JOB_TOKEN` scoping, the GitLab security model — see the
+security-and-permissions reference.
+
+## Resource and concurrency controls
+
+Two job-level fields interact with the runner layer; full job-field
+semantics live in the pipeline-syntax reference, summarized here only
+for their runner-side effect:
+
+- **`resource_group`** — serializes jobs sharing the named group so
+  that, across pipelines, at most one runs at a time. The mechanism is
+  the coordinator's, not the runner's, but it is how you stop two deploy
+  jobs racing on the same environment regardless of free runner count.
+
+  ```yaml
+  deploy_prod:
+    resource_group: production
+    environment: production
+    script: ./deploy.sh
+  ```
+
+- **`interruptible`** — marks a job safe to auto-cancel when a newer
+  pipeline supersedes it on the same ref (with *Auto-cancel redundant
+  pipelines* enabled), freeing runner capacity. Full field detail in the
+  pipeline-syntax reference.
+
+  ```yaml
+  build:
+    interruptible: true
+    script: make build
+  ```

--- a/.gemini/skills/gitlab-ci/references/security-and-permissions.md
+++ b/.gemini/skills/gitlab-ci/references/security-and-permissions.md
@@ -1,0 +1,382 @@
+# Security and permissions reference
+
+GitLab CI/CD has no single token whose scope map you tune the way GitHub
+Actions tunes `GITHUB_TOKEN` via `permissions:`. The pipeline's
+authority is spread across distinct primitives: the `CI_JOB_TOKEN` and
+its accessible-projects allowlist, the project/group member role model,
+protected branches and tags, protected environments, and the
+masked/protected variable discipline. Getting these right is the
+highest-leverage defense against supply-chain compromise — a job that
+runs on an unprotected ref, with a tightly scoped job token and no
+protected variables in reach, cannot deploy to production, push a
+package, or exfiltrate a long-lived cloud key, no matter what a
+dependency it pulls tries to do.
+
+This file is the GitLab analog of the GitHub Actions skill's
+`permissions.md`. Where GitHub concentrates authority in one token, read
+this as "which primitive grants which authority, and how to grant the
+minimum".
+
+## The `CI_JOB_TOKEN`
+
+Every job receives a `CI_JOB_TOKEN` — a short-lived credential, valid
+only for the lifetime of the job, injected as the predefined variable
+`CI_JOB_TOKEN`. It is the rough analog of `GITHUB_TOKEN`, but its scope
+is governed by project settings rather than a per-pipeline `permissions:`
+key.
+
+The token can:
+
+- Clone the current project (it backs the `git clone` of the pipeline
+  itself).
+- Authenticate to the project's container registry and package registry
+  (pull, and push where the job's user role allows).
+- Call a curated subset of the GitLab API on behalf of the job
+  (`CI_JOB_TOKEN`-accepting endpoints — a deliberately narrower surface
+  than a personal access token).
+- Reach **other projects** — but only those on the current project's
+  **job-token allowlist** (see below).
+
+It is bound to the identity and role of the **user who triggered the
+pipeline**: a job triggered by a Reporter cannot push to the registry
+even though the token mechanically exists. Role gates the token; the
+token does not elevate the role.
+
+### The job-token accessible-projects allowlist
+
+Under **Settings → CI/CD → Job token permissions** (historically labelled
+"Token Access" / "Limit access to this project"), each project maintains
+an **allowlist of projects whose CI jobs may use their `CI_JOB_TOKEN`
+to access this project**.
+
+- **Historical over-broad default.** On older GitLab versions the token
+  was usable across *any* project the triggering user could see — an
+  implicit, organization-wide allowlist. That default is the classic
+  GitLab CI lateral-movement vector: a compromised job in a low-value
+  project could clone or push to a high-value sibling.
+- **The hardened posture.** Enable "Limit access to this project" (the
+  inbound allowlist), then add only the specific projects whose
+  pipelines legitimately need to reach this one. Newer GitLab versions
+  default to the restricted allowlist for new projects; audit existing
+  projects, which may still carry the legacy open setting.
+- **Direction matters.** The allowlist is **inbound**: project A's
+  allowlist names the projects *allowed to reach A*. To let project B's
+  pipeline clone A, add B to A's allowlist — not the reverse.
+
+An over-permissive allowlist (or the legacy open default) is a `high`
+finding: it converts any single pipeline compromise into a blast radius
+spanning every reachable project.
+
+## Member roles — who can run and edit pipelines
+
+GitLab gates pipeline authority through the project/group **member role**
+of the actor, not through a per-job permission map. The roles, in
+increasing authority:
+
+| Role | Relevant CI/CD authority |
+|------|--------------------------|
+| **Guest** | Cannot run pipelines on private projects; view-only on most CI surfaces. |
+| **Reporter** | View pipelines and job logs; cannot run or edit. |
+| **Developer** | Run pipelines, push to **unprotected** branches, run manual jobs on unprotected refs. Cannot push to protected branches or manage protected variables by default. |
+| **Maintainer** | Manage protected branches/tags, CI/CD variables (including protected/masked), runners, the job-token allowlist, and protected environments. |
+| **Owner** | All Maintainer authority plus project/group deletion and transfer. |
+
+The practical security lever: **what is gated behind Maintainer**.
+Protected variables, the job-token allowlist, runner registration, and
+protected-environment approver lists all sit at Maintainer. Keep the
+Maintainer/Owner set small; most contributors operate fine at Developer.
+
+## Protected branches and protected tags
+
+This is the central protection primitive — the GitLab equivalent of
+"this credential is only available on the trusted ref". A branch or tag
+is **protected** when it appears under **Settings → Repository →
+Protected branches / Protected tags**, with an "allowed to push" and
+"allowed to merge" role list.
+
+What protection unlocks for CI/CD:
+
+- **Protected variables** are exposed **only** to pipelines running on a
+  protected ref. On any other ref the variable is simply absent.
+- **Protected runners** accept jobs **only** from pipelines on a
+  protected ref.
+- It gates who may *create* a pipeline that runs on the protected ref at
+  all (the "allowed to push/merge" lists).
+
+Use `$CI_COMMIT_REF_PROTECTED` to gate sensitive jobs on the protection
+status of the running ref:
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH == "main"'
+```
+
+The job above runs only when the pipeline is on a protected `main` — so
+the protected deploy variables it relies on are actually present, and an
+attacker pushing to a feature branch never reaches the deploy path.
+
+## Protected environments
+
+Protected branches gate *where the secret lives*; **protected
+environments** gate *who may promote to a tier and with what approval* —
+the correct primitive for a production promotion gate, and the GitLab
+analog of GitHub Environments.
+
+Configured under **Settings → CI/CD → Protected environments**, an
+environment gains:
+
+- An **allowed-to-deploy** list (roles or specific users/groups) — only
+  these identities can run a job targeting the environment.
+- **Required approvals** — a deployment to the environment blocks until
+  N approvers from the allowed list sign off, independent of who
+  triggered the pipeline.
+- **Deployment-tier** semantics (`production`, `staging`, …) via the
+  `environment.deployment_tier` keyword, so the platform can reason about
+  tier ordering.
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+With `production` registered as a protected environment requiring two
+approvals, the job halts pending sign-off even when it sits on a
+protected ref. Layer protected environments on top of protected branches
+for production — neither alone is sufficient for a high-tier gate.
+
+## OIDC and `id_tokens:`
+
+The least-privilege default for cloud authentication is **federated
+OIDC**, not a long-lived access key stored in a variable. GitLab mints a
+short-lived JWT per job via the `id_tokens:` keyword; the cloud provider
+exchanges it for a temporary, narrowly-scoped credential against a trust
+policy keyed on claims like `project_path`, `ref`, and `ref_protected`.
+
+State the principle here; the full trust-policy snippets and per-cloud
+audience configuration live in the `variables-and-secrets` reference.
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./assume-role-with-web-identity.sh
+```
+
+Reach for OIDC whenever the target cloud supports it. A long-lived key in
+a CI/CD variable is acceptable only when the provider has no OIDC path
+for the resource — and that exception belongs in an ADR. Scope the
+cloud-side trust policy to `ref_protected:true` and the specific
+`project_path` so a fork or feature branch cannot assume the role.
+
+## Masked and protected variables
+
+The full treatment lives in the `variables-and-secrets` reference; the
+rule, stated once:
+
+- **Mask** every secret variable so its value is redacted from job logs.
+- **Protect** every secret variable so it is exposed only on protected
+  refs (see *Protected branches* above).
+- A secret that is masked but **not** protected leaks to any feature
+  branch pipeline; a secret that is protected but **not** masked leaks
+  into logs. Production secrets need both.
+
+## Fork and untrusted-contributor trust
+
+Merge requests from forks are the GitLab equivalent of GitHub's
+`pull_request` from a fork — the point where untrusted code meets your
+CI. GitLab's defense rests on the protection primitives above:
+
+- **Protected variables are NOT exposed** to pipelines triggered by an
+  external contributor's fork MR, because the fork branch is not a
+  protected ref of your project. The fork pipeline sees only unprotected
+  variables.
+- **Protected runners do NOT accept** fork-MR jobs for the same reason —
+  so a fork cannot land on a runner that has access to a privileged
+  network segment or a protected deploy credential.
+- **The danger of relaxing this.** Enabling "Run untrusted code" style
+  settings, marking fork-fed variables as available, or registering a
+  shared runner without protection so it picks up fork jobs, all collapse
+  this boundary. Treat any such relaxation as a `high` finding requiring
+  explicit justification.
+
+Gate fork-sensitive logic with the `CI_MERGE_REQUEST_*` predefined
+variables, which are populated only in merge-request pipelines:
+
+```yaml
+fork_safe_tests:
+  script: ./run-tests.sh
+  rules:
+    - if: '$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_MERGE_REQUEST_PROJECT_ID'
+      # MR originates from a fork — run only the sandboxed, secret-free job set
+    - if: '$CI_MERGE_REQUEST_ID'
+```
+
+Never run a deploy, a registry push, or a job that reads a protected
+variable on a fork MR pipeline. Keep untrusted-MR jobs on unprotected,
+non-`privileged` runners, restricted to read-only test and lint work.
+
+## Least-privilege recipes
+
+The minimum permission/protection configuration for each common job
+shape. These mirror the per-use-case recipes in the GitHub Actions
+`permissions.md`.
+
+### (a) Read-only test / lint job
+
+```yaml
+unit_tests:
+  stage: test
+  image: node:22@sha256:<digest>
+  script:
+    - npm ci
+    - npm test
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+No protected variables, no protected runner, no environment. The default
+`CI_JOB_TOKEN` (current-project clone only) is all it needs. The vast
+majority of CI jobs are this shape. Safe to run on fork MRs.
+
+### (b) Push to the container / package registry
+
+```yaml
+build_image:
+  stage: build
+  image: docker:27@sha256:<digest>
+  services:
+    - docker:27-dind
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA"
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+`CI_JOB_TOKEN` authenticates to `$CI_REGISTRY` for the current project's
+namespace; no separate credential is required. Gate the push on a
+protected ref so a fork or feature branch cannot publish an image under
+your namespace. The triggering user must hold at least Developer to push.
+
+### (c) Deploy to a cloud via OIDC
+
+```yaml
+deploy_cloud:
+  stage: deploy
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./federated-login.sh   # exchanges $GCP_ID_TOKEN for a short-lived token
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+No long-lived key in any variable. The cloud trust policy is scoped to
+`ref_protected:true` and this `project_path`. Layer the protected
+`production` environment on top for an approval gate. This is the
+preferred deploy shape.
+
+### (d) Create a Release / tag
+
+```yaml
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script:
+    - echo "Publishing release $CI_COMMIT_TAG"
+  release:
+    tag_name: '$CI_COMMIT_TAG'
+    description: 'Release $CI_COMMIT_TAG'
+  rules:
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+Releases are cut from tags; protect the release tags (under Protected
+tags) and gate the job on `$CI_COMMIT_TAG` plus
+`$CI_COMMIT_REF_PROTECTED`. The triggering user must be allowed to
+create the protected tag. The `release` keyword uses `CI_JOB_TOKEN`
+against the current project — no broader scope needed.
+
+### (e) Clone a sibling private repo (job-token allowlist)
+
+```yaml
+build_with_dep:
+  stage: build
+  script:
+    - git clone "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.example.com/group/private-dep.git"
+    - ./build.sh
+```
+
+The clone of `group/private-dep` succeeds **only** if `private-dep`'s
+**inbound job-token allowlist** names *this* project. Add this project to
+`private-dep`'s allowlist (Settings → CI/CD → Job token permissions);
+do not disable the allowlist wholesale. Grant the narrowest entry — the
+single consuming project — never a group-wide or open allowlist.
+
+## Security defaults
+
+These defaults are non-negotiable and consistent with the parent
+`gitlab-ci` SKILL.md. Treat every deviation as requiring an ADR.
+
+1. **Mask and protect every secret variable.** Masked redacts logs;
+   protected restricts exposure to protected refs. Production secrets
+   need both (see `variables-and-secrets`).
+2. **Prefer OIDC `id_tokens:` over long-lived cloud keys.** A long-lived
+   key in a CI/CD variable is acceptable only when the provider has no
+   OIDC path for the resource — document the exception.
+3. **Pin `image:` and `services:` by digest, not tag.** `node:22@sha256:…`,
+   not `node:22`. A mutable tag is a silent supply-chain entry point.
+4. **Gate every deploy, Pages, and Release job behind a protected ref**
+   (`$CI_COMMIT_REF_PROTECTED == "true"`) and, for production, a
+   protected environment with required approvals.
+5. **Scope the `CI_JOB_TOKEN` accessible-projects allowlist.** Enable
+   the inbound allowlist on every project and name only the specific
+   consuming projects; never rely on the legacy open default.
+6. **No `privileged` runners for untrusted code.** Never let a fork-MR
+   pipeline land on a privileged runner, a `docker:dind` privileged
+   executor, or a runner with access to a protected network segment.
+   Keep untrusted-MR jobs on unprotected, unprivileged runners doing
+   read-only work.
+7. **Never expose protected variables or protected runners to fork
+   MRs.** This boundary is the default — keep it. Branch fork-sensitive
+   logic on `CI_MERGE_REQUEST_SOURCE_PROJECT_ID` vs
+   `CI_MERGE_REQUEST_PROJECT_ID`.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Review each project's **Job token permissions** page: confirm the
+  inbound allowlist is enabled and lists only legitimate consumers.
+  Flag any project still on the legacy open default as `high`.
+- Confirm `production` (and equivalent high-tier environments) are
+  registered as **protected environments** with an allowed-to-deploy
+  list and required approvals.
+- Grep pipeline definitions for deploy/registry/release jobs lacking a
+  `$CI_COMMIT_REF_PROTECTED` (or protected-tag) guard in their `rules:`.
+- Confirm every secret CI/CD variable is both **masked** and
+  **protected**; flag any production secret missing either flag.
+- Verify OIDC trust policies on the cloud side are scoped to
+  `ref_protected:true` and the specific `project_path`, not a wildcard.
+- Confirm no shared/protected runner is configured to pick up fork-MR
+  jobs, and that no runner used by untrusted code runs `privileged`.

--- a/.gemini/skills/gitlab-ci/references/variables-and-secrets.md
+++ b/.gemini/skills/gitlab-ci/references/variables-and-secrets.md
@@ -1,0 +1,441 @@
+# Variables and secrets reference
+
+CI/CD variables are the channel GitLab offers for injecting
+configuration into a pipeline. There is no separate "secret" object as
+in some other systems: a variable becomes a secret by flipping two
+flags — **masked** and **protected** — and by binding it to the
+smallest scope that needs it. Get those flags wrong and you either leak
+a credential to a job log or expose it to an untrusted branch. For
+credentials that should never sit at rest in GitLab at all, the
+`secrets:` keyword pulls them from an external manager (Vault, Azure
+Key Vault, GCP Secret Manager) at job start, and `id_tokens:` federates
+to a cloud provider with a short-lived JWT instead of a long-lived key.
+
+## The variable model
+
+A pipeline sees a flattened set of environment variables assembled from
+several sources:
+
+- **Predefined variables.** Supplied by GitLab itself: `CI_COMMIT_REF_NAME`,
+  `CI_PROJECT_PATH`, `CI_PIPELINE_SOURCE`, `CI_JOB_TOKEN`, etc. Read-only.
+- **Instance variables.** Defined by an administrator; visible to every
+  project on the instance.
+- **Group variables.** `Group → Settings → CI/CD → Variables`. Inherited
+  by every project in the group (and subgroups).
+- **Project variables.** `Project → Settings → CI/CD → Variables`. The
+  most common place for credentials.
+- **Pipeline-trigger / scheduled variables.** Passed when a pipeline is
+  started via the trigger API, a pipeline schedule, or a manual `web`
+  run (the "Run pipeline" form, driven by `value`/`description`).
+- **`.gitlab-ci.yml` variables.** Declared in YAML, either globally
+  (top-level `variables:`) or per-job (`job.variables:`). Committed to
+  the repository — never a credential.
+- **`dotenv` artifacts.** A job exports a `*.env` file as a
+  `reports: dotenv:` artifact; downstream jobs inherit those keys as
+  variables. The channel for passing computed values between stages.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "BUILD_ID=$(date +%s)" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  script:
+    - echo "Deploying build $BUILD_ID"   # inherited from dotenv
+```
+
+## Scope and precedence
+
+When the same variable name is defined at several sources, GitLab
+resolves it by a fixed precedence. Highest priority wins:
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | Trigger variables, scheduled-pipeline variables, manual (`web`) run variables |
+| 2 | Project variables |
+| 3 | Group variables (nearest subgroup first, then parent groups) |
+| 4 | Instance variables |
+| 5 | `.gitlab-ci.yml` global `variables:` |
+| 6 (lowest) | `.gitlab-ci.yml` job `variables:` |
+
+The counter-intuitive part: a value set in the UI (project/group/
+instance) or via a trigger **overrides** the YAML. This is deliberate —
+it lets an operator override a committed default at run time without a
+commit. Predefined variables sit alongside this table and are generally
+not overridable.
+
+Group and project variables also carry an **environment scope**
+(`environment_scope`): a variable can be limited to `production`,
+`review/*`, or `*` (all). A job picks up only the variables whose scope
+matches its `environment:` name.
+
+## Variable types and flags
+
+### `variable` vs `file` type
+
+Every CI/CD variable has a **type**:
+
+- **`variable`** (default) — the value is exported as an environment
+  variable verbatim.
+- **`file`** — GitLab writes the value to a temporary file and exports
+  the **path** to that file as the environment variable. This is the
+  correct channel for anything a tool expects as a file: TLS
+  certificates, a `kubeconfig`, a GCP service-account JSON, an SSH key.
+
+```yaml
+deploy:
+  script:
+    # KUBECONFIG is a file-type variable: $KUBECONFIG is a path, not YAML.
+    - kubectl --kubeconfig "$KUBECONFIG" apply -f manifests/
+    # GOOGLE_APPLICATION_CREDENTIALS is a file-type variable too.
+    - gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+```
+
+Storing a certificate in a `variable`-type variable and then
+`echo`-ing it into a file inside `script:` defeats masking and risks
+trace leakage — use `file` type instead.
+
+### Masked variables
+
+A variable flagged **masked** has its value replaced with `[MASKED]` in
+job logs. GitLab enforces masking eligibility requirements on the value:
+
+- at least 8 characters long;
+- a single line (no newlines or whitespace);
+- drawn from a restricted character set (Base64 alphabet plus `@:.~`),
+  depending on GitLab version. Values with spaces, `$`, `"`, or `'`
+  cannot be masked.
+
+Masking caveats — treat masking as a safety net, not a guarantee:
+
+- Masking is **best-effort substring replacement** in the trace. A
+  secret that is split (`echo "${TOKEN:0:8}"`), transformed
+  (base64-decoded, uppercased, URL-encoded), or concatenated bypasses
+  the matcher and prints in clear.
+- Masking redacts **only the job log**. It does **not** redact
+  artifacts, caches, the dotenv report, or anything your job writes to
+  an external system. A masked secret printed into a file and uploaded
+  as an artifact is leaked in plaintext.
+- Masking does not stop a malicious `.gitlab-ci.yml` from exfiltrating
+  the value over the network. Masking defends against accidental
+  disclosure, not against a hostile pipeline author.
+
+### Protected variables
+
+A variable flagged **protected** is exposed **only** to pipelines
+running on a **protected branch** or **protected tag**. A pipeline for
+a regular feature branch or a fork merge request never receives it.
+This is the primary defense against a contributor reading production
+credentials by pushing a branch that echoes them.
+
+**Default discipline for any credential: masked + protected.** Mask it
+so an accidental `echo` does not print it; protect it so only trusted
+refs can run the job that consumes it. A credential missing either flag
+is a finding.
+
+### Raw vs expanded values
+
+By default GitLab performs **variable expansion**: a `$`-prefixed token
+inside a value is expanded against other variables. A secret containing
+a literal `$` (e.g. a bcrypt hash, some passwords) is corrupted by
+expansion. Flag the variable **raw** (`Expand variable reference` off,
+or `raw: true` in the API) to disable expansion and keep the literal
+value.
+
+### Manual-run prompts
+
+A top-level `variables:` entry can declare `value` and `description`;
+the `description` turns the variable into a prefilled, documented field
+on the manual "Run pipeline" form.
+
+```yaml
+variables:
+  DEPLOY_ENV:
+    value: "staging"
+    description: "Target environment for a manual deploy (staging|production)."
+```
+
+## External secrets (`secrets:`)
+
+The `secrets:` keyword fetches a value from an external manager at job
+start and exposes it as a `file`-type variable by default. The job
+never stores the secret in GitLab. It requires an `id_tokens:` JWT (see
+below) for the manager to authenticate the pipeline.
+
+### HashiCorp Vault
+
+```yaml
+deploy:
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  secrets:
+    DATABASE_PASSWORD:
+      vault: prod/db/password@ops      # secret path @ KV mount
+      token: $VAULT_ID_TOKEN           # JWT used to auth to Vault
+      file: false                      # export as a plain env var, not a file
+  script:
+    - psql "postgres://app:${DATABASE_PASSWORD}@db/app"
+```
+
+Vault is configured with the JWT auth method and a role whose
+`bound_audiences` and `bound_claims` (e.g. `project_id`, `ref`,
+`ref_type`) match the GitLab token. `secrets:[].file` controls whether
+the resolved value lands in a temp file (default `true`) or an env var;
+`secrets:[].token` names the `id_tokens:` entry used to authenticate.
+
+### Azure Key Vault
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: https://AzureADTokenExchange
+  secrets:
+    DB_PASSWORD:
+      azure_key_vault:
+        name: db-password
+        version: 00000000000000000000000000000000
+      token: $AZURE_ID_TOKEN
+```
+
+The project's CI/CD settings declare the vault server URL; the app
+registration carries a federated credential whose subject matches the
+pipeline.
+
+### GCP Secret Manager
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  secrets:
+    API_KEY:
+      gcp_secret_manager:
+        name: api-key
+        version: latest
+      token: $GCP_ID_TOKEN
+```
+
+GCP is configured with a Workload Identity Pool provider that trusts
+the GitLab issuer and maps the JWT claims to a service account that can
+read the secret.
+
+## OIDC federation (`id_tokens:`)
+
+For cloud credentials, **prefer OIDC over a long-lived access key stored
+as a CI/CD variable**. The runner mints a short-lived JWT signed by the
+GitLab instance's OIDC provider (issuer = the GitLab base URL, e.g.
+`https://gitlab.example.com`). The cloud side validates the token's
+claims and issues a temporary credential.
+
+Benefits, mirroring any OIDC story:
+
+- No long-lived secret to rotate, mask, or leak.
+- Per-project, per-ref scoping — a `main` deploy gets a token whose
+  `sub` includes `ref:main`.
+- An audit trail in both GitLab and the cloud provider.
+
+GitLab JWT claims you bind trust against include `iss` (the issuer
+URL), `aud` (set per `id_tokens:` entry), `project_path`,
+`namespace_path`, `ref`, `ref_type`, and a composite `sub` of the form:
+
+```text
+project_path:my-group/my-project:ref_type:branch:ref:main
+```
+
+### AWS
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com   # must match the OIDC provider audience
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name gitlab-$CI_PIPELINE_ID
+      --web-identity-token "$AWS_ID_TOKEN"
+      --duration-seconds 3600
+```
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/gitlab.example.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "gitlab.example.com:aud": "https://gitlab.example.com"
+      },
+      "StringLike": {
+        "gitlab.example.com:sub":
+          "project_path:my-group/my-project:ref_type:branch:ref:main"
+      }
+    }
+  }]
+}
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  script:
+    - echo "$GCP_ID_TOKEN" > token.jwt
+    - >
+      gcloud iam workload-identity-pools create-cred-config
+      projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+      --service-account="gitlab-deploy@my-project.iam.gserviceaccount.com"
+      --credential-source-file=token.jwt
+      --output-file=cred.json
+    - export GOOGLE_APPLICATION_CREDENTIALS=cred.json
+```
+
+The WIF provider declares an attribute mapping (e.g.
+`google.subject = assertion.sub`) and an attribute condition pinning
+the allowed `project_path` / `ref`.
+
+### Azure
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: api://AzureADTokenExchange
+  script:
+    - >
+      az login --service-principal
+      --username "$AZURE_CLIENT_ID"
+      --tenant "$AZURE_TENANT_ID"
+      --federated-token "$AZURE_ID_TOKEN"
+```
+
+The Azure side configures a **federated credential** on the app
+registration whose issuer is the GitLab URL and whose subject matches
+the pipeline's `sub` claim.
+
+## Exfiltration anti-patterns and common pitfalls
+
+### Hardcoded secret literals
+
+```yaml
+# BAD: the secret is committed to the repo, visible to anyone with read
+# access and to the full git history forever.
+variables:
+  API_TOKEN: "glpat-XXXXXXXXXXXXXXXXXXXX"
+```
+
+Define credentials as masked + protected CI/CD variables in project
+settings, never in `.gitlab-ci.yml`.
+
+### Secrets in a global `variables:`
+
+```yaml
+# BAD: a top-level variables: block is in scope for every job in the
+# pipeline — maximal blast radius.
+variables:
+  DEPLOY_KEY: "..."          # also a hardcoded literal — doubly wrong
+```
+
+Bind a credential to the single job that needs it via `job.variables:`,
+or scope the CI/CD variable to the deploy environment.
+
+### Echoing a variable to the log
+
+```yaml
+# BAD: even a masked variable can leak if transformed before printing,
+# and the value still reaches any artifact/cache written next.
+script:
+  - echo "$DEPLOY_TOKEN"
+  - echo "token is $DEPLOY_TOKEN"
+```
+
+Never debug by printing a secret. Print a length or a checksum instead:
+
+```yaml
+script:
+  - echo "Token length: ${#DEPLOY_TOKEN}"
+```
+
+### `set -x` shell trace
+
+```yaml
+# BAD: shell trace prints every expanded command, including the
+# resolved value of a secret variable, and masking may not catch it.
+script:
+  - set -x
+  - curl -H "Authorization: Bearer $TOKEN" https://api.example.com
+```
+
+Keep `set -x` (and `CI_DEBUG_TRACE: "true"`) out of jobs that touch
+credentials. `CI_DEBUG_TRACE` in particular dumps **all** variables,
+masked or not, and must never run on a job with protected secrets.
+
+### Structured JSON in one variable
+
+A single `CLOUD_CONFIG` variable holding a JSON blob is convenient for
+setup but defeats per-key rotation and per-key masking (the blob fails
+the no-whitespace masking rule anyway). Split into individual variables,
+or fetch the structured secret at runtime via `secrets:` so each key is
+resolved and handled independently.
+
+### A variable that should be masked or protected
+
+A CI/CD variable whose value is sensitive on inspection (a token, a
+URL embedding a token, a password) but is missing the **masked** or
+**protected** flag is a secret in disguise. If it is sensitive, set
+both flags.
+
+### Secrets reaching fork pipelines
+
+A merge request from a fork runs in the fork's context. **Protected**
+variables are withheld from such pipelines by design — which is exactly
+why every credential must be protected. Do not relax the
+"only-protected-branches-can-run-this-job" rules to make a fork MR
+pipeline "just work"; gate privileged work behind a protected branch
+and a manual approval instead.
+
+### Offline scan
+
+This skill ships `scripts/check-secrets-exposure.sh`, which scans a
+`.gitlab-ci.yml` offline for several of the patterns above — hardcoded
+secret literals, `echo $TOKEN`-style log leaks, `set -x` /
+`CI_DEBUG_TRACE` in credential jobs, and global `variables:` holding a
+likely secret. Run it before committing pipeline changes.
+
+## Auditing
+
+Periodic audit checklist:
+
+- Review every project, group, and instance CI/CD variable: confirm
+  every credential is flagged **masked** and **protected**. Flag any
+  sensitive value missing either flag.
+- Rotate long-lived tokens stored as variables on a schedule; prefer
+  migrating each to `secrets:` (external manager) or `id_tokens:`
+  (OIDC) so there is nothing long-lived to rotate.
+- Grep the `.gitlab-ci.yml` for hardcoded secret literals and for
+  `echo`/`set -x`/`CI_DEBUG_TRACE` on jobs that consume credentials
+  (the `check-secrets-exposure.sh` validator does this).
+- Confirm no credential lives in a global `variables:` block; bind each
+  to its job or environment scope.
+- For each cloud provider, audit the OIDC trust conditions: the `aud`
+  must match the configured audience and the `sub`/`project_path`/`ref`
+  bindings must pin the allowed projects and refs — no wildcard that
+  admits an unintended project.

--- a/.gemini/skills/gitlab-ci/scripts/check-pinned-images.sh
+++ b/.gemini/skills/gitlab-ci/scripts/check-pinned-images.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# check-pinned-images.sh — flag GitLab CI container references that are not
+# pinned to an immutable @sha256: digest.
+#
+# Usage: check-pinned-images.sh <pipeline-file-or-directory>
+#
+# Rationale: a `image: node:22` or `image: node:latest` reference is a moving
+# target — the registry can re-point the tag to a different image at any time,
+# silently changing what runs in your pipeline. Pinning to a digest
+# (`image: node@sha256:<64-hex>`) makes the reference immutable, exactly as
+# pinning a GitHub Action to a commit SHA does.
+#
+# Scanned surface (text scan; no registry call, no Docker, no live GitLab):
+#   - `image: <ref>`                       (job-level, global, and default:)
+#   - `image:` long form → its `name: <ref>`
+#   - `services:` list entries: `- <ref>`  and `- name: <ref>` / `name: <ref>`
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`
+# (the conventional local-include location). A bare variable reference with no
+# tag (e.g. `$CI_REGISTRY_IMAGE`) is skipped — there is nothing to evaluate
+# statically.
+#
+# Limitation: only inline forms (value on the same line) are matched. A `name:`
+# spread across multiple YAML lines is not detected.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# An immutable reference is digest-pinned: <name>@sha256:<64 hex chars>.
+digest_re='@sha256:[0-9a-fA-F]{64}$'
+
+# Strip surrounding quotes from a captured scalar.
+unquote() {
+    local v="$1"
+    v="${v%\"}"; v="${v#\"}"
+    v="${v%\'}"; v="${v#\'}"
+    printf '%s' "$v"
+}
+
+# Decide whether a container reference is acceptably pinned. Returns 0 (pinned
+# or not-applicable) or 1 (a finding). A pure variable expansion with no tag is
+# treated as not-applicable: there is no static digest to demand.
+check_ref() {
+    local value="$1" file="$2" lineno="$3"
+    value="$(unquote "$value")"
+    [ -z "$value" ] && return 0
+    case "$value" in
+        # Bare variable with no `:tag` and no digest — nothing to evaluate.
+        \$*)
+            case "$value" in
+                *:*|*@*) ;;          # has a tag/digest part — fall through to the check
+                *) return 0 ;;
+            esac
+            ;;
+    esac
+    if [[ "$value" =~ $digest_re ]]; then
+        return 0
+    fi
+    echo "${C_RED}[UNPINNED]${C_RESET} ${file}:${lineno}: ${value}"
+    return 1
+}
+
+for f in "${files[@]}"; do
+    lineno=0
+    in_image_block=0
+    in_services_block=0
+    block_indent=-1
+    # shellcheck disable=SC2094  # check_ref() only echoes; it does not write to "$f".
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Skip blank and comment-only lines (but they do not close a block).
+        case "$line" in
+            ''|'#'*|*[![:space:]]*'#') : ;;
+        esac
+
+        # Current line indentation (number of leading spaces).
+        stripped="${line#"${line%%[![:space:]]*}"}"
+        indent=$(( ${#line} - ${#stripped} ))
+
+        # Close an open block when indentation returns to/under the opener and
+        # the line carries content.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [ -n "$stripped" ] && [ "$indent" -le "$block_indent" ]; then
+            in_image_block=0
+            in_services_block=0
+            block_indent=-1
+        fi
+
+        # `image:` — short inline form, or open the long-form mapping block.
+        if [[ "$line" =~ ^[[:space:]]*image:[[:space:]]*(.*)$ ]]; then
+            val="${BASH_REMATCH[1]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            if [ -n "$val" ]; then
+                check_ref "$val" "$f" "$lineno" || violations=$((violations + 1))
+            else
+                in_image_block=1
+                in_services_block=0
+                block_indent=$indent
+            fi
+            continue
+        fi
+
+        # `services:` — open the list block (entries handled below).
+        if [[ "$line" =~ ^[[:space:]]*services:[[:space:]]*$ ]]; then
+            in_services_block=1
+            in_image_block=0
+            block_indent=$indent
+            continue
+        fi
+
+        # Inside an image: mapping or a services: entry — a `name:` scalar.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*name:[[:space:]]*([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+
+        # Inside services: — a bare list item `- <image-ref>`.
+        if [ "$in_services_block" -eq 1 ] \
+            && [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all image/service references are pinned to a @sha256: digest"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned image/service reference(s) found${C_RESET}" >&2
+exit 1

--- a/.gemini/skills/gitlab-ci/scripts/check-secrets-exposure.sh
+++ b/.gemini/skills/gitlab-ci/scripts/check-secrets-exposure.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in a GitLab CI pipeline that may
+# leak secrets into job logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <pipeline-file-or-directory>
+#
+# Patterns flagged (text scan; no live GitLab, no token read, no network):
+#   1. Hardcoded secret literal in `variables:` or a shell assignment
+#      (a key named like a credential set to an inline value, not a $VAR ref).
+#   2. A well-known token shape appearing as a literal anywhere
+#      (glpat-…, ghp_…, AWS AKIA…, a PEM private-key header).
+#   3. `echo`/`printf` of a credential-named variable — written to the job log.
+#   4. `set -x` / `set +x` in a `script:` — shell xtrace prints expanded values.
+#   5. `CI_DEBUG_TRACE: "true"` — turns on full pipeline trace, logging every
+#      variable including masked ones.
+#
+# Masking and protection are GitLab's real defenses (see the skill's
+# references/variables-and-secrets.md); this scan catches the hygiene mistakes
+# that defeat them before review.
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+# A key whose name marks it as a credential.
+secret_key='(SECRET|TOKEN|PASSWORD|PASSWD|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIAL|AUTH|PASSPHRASE)'
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Strip a leading YAML list dash so `- export TOKEN=…` is seen as a
+        # shell assignment too.
+        probe="${line#"${line%%[![:space:]]*}"}"
+        probe="${probe#- }"
+
+        # 1. Hardcoded literal: YAML `KEY: value` or shell `KEY=value` where the
+        #    key is credential-named and the value is an inline literal (not a
+        #    `$VAR` reference, not empty, not a masked/protected reference).
+        if [[ "$probe" =~ ^(export[[:space:]]+)?[A-Za-z0-9_]*${secret_key}[A-Za-z0-9_]*[[:space:]]*[:=][[:space:]]*(.+)$ ]]; then
+            val="${BASH_REMATCH[3]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            # Unquote.
+            val="${val%\"}"; val="${val#\"}"
+            val="${val%\'}"; val="${val#\'}"
+            case "$val" in
+                ''|\$*|'!reference'*|'&'*|'*'*) : ;;   # ref/anchor/empty — fine
+                *)
+                    report "$current_file" "$lineno" "hardcoded value for a credential-named key" \
+                        "a secret committed in the pipeline is readable by anyone with repo access — move it to a masked + protected CI/CD variable"
+                    ;;
+            esac
+        fi
+
+        # 2. Well-known token shapes as literals.
+        if [[ "$line" =~ glpat-[A-Za-z0-9_-]{20} ]] \
+            || [[ "$line" =~ (ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36} ]] \
+            || [[ "$line" =~ AKIA[0-9A-Z]{16} ]] \
+            || [[ "$line" =~ BEGIN[[:space:]].*PRIVATE[[:space:]]KEY ]]; then
+            report "$current_file" "$lineno" "literal access token / private key" \
+                "a recognizable credential literal is committed in the pipeline — revoke it and store it as a masked + protected CI/CD variable"
+        fi
+
+        # 3. echo / printf of a credential-named variable.
+        if [[ "$line" =~ (echo|printf)[[:space:]].*\$\{?[A-Za-z0-9_]*${secret_key} ]]; then
+            report "$current_file" "$lineno" "echo/printf of a credential-named variable" \
+                "printing a secret to the job log persists it in the log; masking is best-effort and a transformed value bypasses it"
+        fi
+
+        # 4. set -x / set +x — shell xtrace.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret variable values"
+        fi
+
+        # 5. CI_DEBUG_TRACE enabled.
+        if [[ "$line" =~ CI_DEBUG_TRACE[[:space:]]*:?=?[[:space:]]*[\"\']?(true|1)[\"\']? ]]; then
+            report "$current_file" "$lineno" "CI_DEBUG_TRACE enabled" \
+                "debug trace logs every variable in the job, including masked and protected ones"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/.github/agents/ci-configurator.md
+++ b/.github/agents/ci-configurator.md
@@ -1,56 +1,150 @@
 ---
 name: ci-configurator
-description: "Specialist agent for configuring new GitHub Actions pipelines.
-Interviews the project, generates a commit-ready workflow,
+description: "Specialist agent for configuring a new CI pipeline for a supported
+engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
+produces a commit-ready pipeline (hand-authored for GitHub Actions,
+derived from the platform-neutral capability reference for GitLab),
 and validates its own output before delivery."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.1.0"
 ---
 
 
 # CI Configurator Agent
 
-You are a CI configuration agent. You operate under the **github-actions**
-skill (`artifacts/core/skills/github-actions/SKILL.md`) — read it once
-at the start of any session and follow its conventions: action pinning,
-least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+You are a CI configuration agent. You are **engine-aware**: you can
+produce a pipeline for either supported engine — **GitHub Actions** or
+**GitLab CI/CD** — and you operate under whichever knowledge skill the
+resolved engine demands. For a GitHub Actions target, read the
+**github-actions** skill (`artifacts/core/skills/github-actions/SKILL.md`);
+for a GitLab CI/CD target, read the **gitlab-ci** skill
+(`artifacts/core/skills/gitlab-ci/SKILL.md`). Read the relevant skill
+once at the start of a session and follow its conventions — they are
+the source of truth for the security defaults you enforce.
 
 Your persona is that of an experienced DevOps engineer: minimalist,
-security-oriented, allergic to copy-pasted workflows that "happen to
+security-oriented, allergic to copy-pasted pipelines that "happen to
 work". You do not explore the repository looking for things to fix.
-You ask exactly what you need, generate exactly one workflow, validate
-your own output, and hand it over.
+You resolve the engine target, ask exactly what you need, produce
+exactly one pipeline, validate your own output, and hand it over.
 
 Your default mode is **generate and validate**, not iterate. The user
-gets a workflow they can paste into `.github/workflows/` and commit. If
-you cannot produce a workflow that passes your own validation scripts,
-you say so plainly rather than shipping a draft that "should work".
+gets a pipeline they can commit — a workflow under `.github/workflows/`
+for GitHub Actions, or a `.gitlab-ci.yml` for GitLab CI/CD. If you
+cannot produce a pipeline that passes your own validation, you say so
+plainly rather than shipping a draft that "should work".
+
+Keep every claim engine-neutral wherever the project's platform-neutral
+capability reference keeps it neutral; name a specific engine only where
+the behaviour is genuinely engine-specific.
 
 ## Activation
 
 Activate this agent when any of the following holds:
 
-- The project has no `.github/workflows/` directory yet, or the
-  directory is empty.
-- The project is migrating from another CI platform (GitLab CI,
-  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
-  GitHub Actions pipeline.
-- An existing workflow is outdated — uses tag-based action references
-  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
-  or depends on long-lived cloud credentials that should be replaced
-  by OIDC.
-- The user explicitly asks for "a GitHub Actions workflow", "a CI
-  pipeline", or "set up CI" without specifying which platform.
+- The project has no CI pipeline yet for the engine in question — no
+  `.github/workflows/` directory (GitHub Actions), or no `.gitlab-ci.yml`
+  (GitLab CI/CD).
+- The project is migrating from another CI platform (GitHub Actions,
+  GitLab CI, CircleCI, Jenkins, Travis, Buildkite) and needs an
+  equivalent pipeline for a supported engine.
+- An existing pipeline is outdated — GitHub Actions uses tag-based
+  action references (`@v1`, `@main`), lacks `permissions:` blocks, has
+  no `timeout-minutes`, or depends on long-lived cloud credentials that
+  should be replaced by OIDC; GitLab CI/CD uses unpinned `image:` tags,
+  hardcoded or un-masked secrets, or long-lived cloud keys that
+  `id_tokens:` OIDC should replace.
+- The user explicitly asks for "a GitHub Actions workflow", "a GitLab
+  pipeline", "a CI pipeline", or "set up CI".
 
 Do **not** activate this agent when the user is debugging a failing
-run, hunting a flaky job, or asking why a workflow misbehaves —
-delegate to the **ci-debugger** agent instead. Configuration and
-diagnosis are different jobs and should not be mixed.
+run, hunting a flaky job, or asking why a pipeline misbehaves —
+delegate to the **ci-debugger** agent instead. Do **not** activate it to
+audit an existing pipeline set for drift against the capability
+reference — delegate to the **ci-parity** agent instead. Configuration,
+diagnosis, and parity reconciliation are different jobs and should not
+be mixed.
+
+## Engine-target resolution
+
+Before generating anything, resolve **which engine** you are producing
+for. Never guess between two present engines.
+
+- **Infer** the target when the repository indicates exactly one engine:
+  a `.github/workflows/` directory present and no `.gitlab-ci.yml` → the
+  target is GitHub Actions; a `.gitlab-ci.yml` present and no
+  `.github/workflows/` → the target is GitLab CI/CD.
+- **Accept an explicit override.** When the user names the engine ("set
+  up a GitLab pipeline"), that target wins over any inference, even if
+  the repository indicates the other engine.
+- **Refuse to generate** when the target is **ambiguous** — both engines
+  are indicated and the user specified none — or **absent** — neither
+  engine is indicated and the user specified none. In both cases, stop
+  and ask the user to name the target. Do not pick one to be helpful;
+  guessing wrong produces a pipeline for the wrong engine.
+
+State the resolved target (and how you resolved it — inferred or
+explicit) as the first line of your output, so the user can correct a
+wrong inference before reading the pipeline.
+
+## Two production modes
+
+The two engines are produced by **two different mechanisms**. This is
+deliberate and matches how the project's CI machinery works.
+
+### GitHub Actions target — hand-authored
+
+A GitHub Actions workflow is **hand-authored** through the interview
+and generation rules below. The GitHub Actions pipeline is *not* derived
+from the platform-neutral capability reference (the reference's GitHub
+side stays hand-authored and step-level-verified by design). Run the
+full interview, apply the generation rules, validate, and deliver — the
+path documented in the rest of this agent.
+
+### GitLab CI/CD target — derived from the reference
+
+A GitLab pipeline is **derived**, not hand-authored. When the repository
+already carries the project's platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`),
+produce the GitLab pipeline by **composing the generator**:
+
+```bash
+bash scripts/build-ci.sh
+```
+
+This reads the existing reference and emits `.gitlab-ci.yml` (one job
+per portable capability; `requires:` → `image`/`before_script`/
+`GIT_DEPTH`; `command:` → `script:`; `trigger[]` → `rules:`). You do
+**not** hand-author `.gitlab-ci.yml`, you do **not** re-implement the
+generation logic, and you do **not** author or mutate the reference
+itself — `ci/ci-capabilities.yml` and its format are owned elsewhere
+(the reference-contract sub-spec). Deriving from the reference is what
+keeps a produced pipeline consistent with the reference and with the
+drift-check harness.
+
+If the user wants a GitLab pipeline for a *downstream adopter project*
+that has **no** capability reference yet, that project first needs a
+reference authored **in the reference format** — a separate act that
+applies the documented format in that project. It is never done by
+editing this framework's `ci/ci-capabilities.yml`. Once a reference
+exists, compose `build-ci.sh` against it as above. If no reference
+exists and authoring one is out of your scope, say so plainly rather
+than hand-rolling a `.gitlab-ci.yml` that will drift from the harness.
+
+After deriving, apply the GitLab security defaults the **gitlab-ci**
+skill documents — `image:` pinned by digest, masked + protected
+variables, `id_tokens:` OIDC over long-lived keys, protected refs and
+environments gating deploy/Pages/Release jobs — and run the GitLab
+validation scripts (see *Validation step*).
 
 ## Interview protocol
+
+*Applies to the **GitHub Actions** target (the hand-authored path). For
+a GitLab target you derive from the reference and do not run this
+greenfield interview — see *Two production modes*.*
 
 You ask the minimum questions necessary to produce a correct workflow.
 The interview is **one round**: a single numbered list, sent once,
@@ -98,6 +192,12 @@ If the user answers ambiguously, ask **one** clarifying follow-up per
 ambiguous item, not a fresh round.
 
 ## Generation rules
+
+*These rules govern the **GitHub Actions** hand-authored path. The
+GitLab target enforces the equivalent GitLab defaults from the
+**gitlab-ci** skill (digest-pinned `image:`, masked + protected
+variables, `id_tokens:` OIDC, protected refs/environments) — see
+*Two production modes*.*
 
 These rules are non-negotiable. Every workflow you emit satisfies all
 of them; if you cannot satisfy one, you say so explicitly in the
@@ -213,17 +313,36 @@ For deploy jobs that should serialize (production), use
 
 ## Validation step
 
-Before presenting the workflow to the user, run the project's
-validation scripts on your draft. The scripts are shipped with the
-`github-actions` skill:
+Before presenting the pipeline to the user, run the validation scripts
+that ship with the relevant skill on your output.
+
+For a **GitHub Actions** target (`github-actions` skill):
 
 ```bash
 scripts/lint-workflow.sh        .github/workflows/<name>.yml
 scripts/check-pinned-actions.sh .github/workflows/<name>.yml
 ```
 
-If either script reports violations, **fix the draft and rerun**.
-Repeat until both scripts pass. Only then present the workflow.
+For a **GitLab CI/CD** target (`gitlab-ci` skill — both are offline
+text scans; there is no offline structural linter or pipeline
+simulator for GitLab, by design):
+
+```bash
+scripts/check-pinned-images.sh    .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+For a GitLab target you also confirm the pipeline is in sync with the
+reference — the derivation's own drift gate:
+
+```bash
+bash scripts/build-ci.sh --check
+```
+
+If any script reports violations, **fix the cause and rerun** — for the
+GitLab path that means correcting the reference or the security overlay
+and re-deriving, never hand-patching the generated `.gitlab-ci.yml`.
+Repeat until the scripts pass. Only then present the pipeline.
 
 If a script is unavailable in the current environment, say so
 explicitly in the output: "Note: `check-pinned-actions.sh` was not
@@ -232,12 +351,17 @@ Never claim a script was run when it was not.
 
 ## Output format
 
-The agent's final message has three parts, in this order:
+The resolved engine target is the first line (see *Engine-target
+resolution*). The rest of the message has three parts, in this order:
 
-1. **Annotated YAML block** — the workflow itself, with inline
-   comments calling out non-obvious choices (timeout values,
-   `needs:` graph, concurrency strategy). The comments are part of
-   the deliverable; they survive into the committed file.
+1. **Annotated YAML block** — the pipeline itself (a workflow for
+   GitHub Actions, a `.gitlab-ci.yml` for GitLab CI/CD), with inline
+   comments calling out non-obvious choices (timeout values, the
+   `needs:` graph, the concurrency / `resource_group` strategy). The
+   comments are part of the deliverable; they survive into the
+   committed file. For a GitLab target this block is the derived
+   pipeline — present it as produced by `scripts/build-ci.sh`, not
+   hand-edited.
 
 2. **Decision table** — a Markdown table explaining each non-obvious
    choice, one row per decision:
@@ -248,12 +372,13 @@ The agent's final message has three parts, in this order:
    | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
    | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
 
-3. **Follow-up checklist** — what the user must do before the workflow
-   can run successfully (create secrets, configure OIDC trust, enable
-   branch protection). One bullet per action item, no prose.
+3. **Follow-up checklist** — what the user must do before the pipeline
+   can run successfully (create masked/protected secrets or repository
+   secrets, configure the OIDC trust relationship, enable branch/ref
+   protection). One bullet per action item, no prose.
 
 Do not pad the output with "this is a great starting point" or
-"feel free to customize". The workflow either works as written or it
+"feel free to customize". The pipeline either works as written or it
 does not; if it does not, the validation step caught it.
 
 ## When the user pushes back
@@ -271,7 +396,8 @@ silent override is what the agent refuses to ship.
 
 ## Handoff
 
-When the workflow is delivered, the agent's job is done. Do not
+When the pipeline is delivered, the agent's job is done. Do not
 volunteer to "open a PR for you" or "watch the first run" — those
 are separate jobs handled by other agents (`pr-logbook` for the PR,
-`ci-debugger` if the first run fails).
+`ci-debugger` if the first run fails, `ci-parity` if the produced
+pipeline later drifts from the capability reference).

--- a/.github/agents/ci-parity.md
+++ b/.github/agents/ci-parity.md
@@ -1,0 +1,207 @@
+---
+name: ci-parity
+description: "Specialist agent for operating the project's CI drift-check harness
+and reconciling the divergences it reports. Runs the harness,
+interprets its fail-closed output, classifies each divergence by kind,
+and reconciles it — auto-applying only the deterministic
+regenerate-and-re-verify case, and diagnosing-and-proposing for every
+judgment-bearing case."
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# CI Parity Agent
+
+You are a CI parity agent. You operate the project's three-way CI
+drift-check harness (`scripts/check-ci-parity.sh`) and help a
+contributor get from a reported divergence to a reconciled,
+parity-clean state. You operate under the **github-actions** skill
+(`artifacts/core/skills/github-actions/SKILL.md`) and the **gitlab-ci**
+skill (`artifacts/core/skills/gitlab-ci/SKILL.md`) for engine-correct
+patterns, and you treat the platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`)
+as the source of truth the harness checks against.
+
+Your persona is that of a methodical SRE. You do not guess. You do not
+hand-edit a generated file to make a check pass. You produce a chain of
+`symptom → classification → evidence → reconciliation` for every
+divergence the harness reports, and you refuse to skip any link in that
+chain.
+
+You reason about pipeline and reference **definitions** only. You handle
+no live secret or token, and you never run a pipeline on a live GitLab —
+the harness is an offline, text-level check and so are you. Keep every
+claim engine-neutral wherever the reference keeps it neutral; name a
+specific engine only where the divergence is genuinely engine-specific.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A contributor wants to run the CI drift-check harness and understand
+  its verdict.
+- The harness has failed closed and the contributor needs the
+  divergence diagnosed and a reconciliation proposed or applied.
+- A CI job running `scripts/check-ci-parity.sh` is red and the
+  contributor wants to know why and how to make it green correctly.
+
+Do **not** activate this agent to author a new pipeline from scratch or
+to run a greenfield configuration interview — that is the
+**ci-configurator** agent's job. Do **not** activate it to diagnose a
+*failing application pipeline run* (a red test, a broken deploy) — that
+is the **ci-debugger** agent's job. This agent audits an existing
+pipeline set against the capability reference and reconciles drift; it
+does not produce pipelines and it does not debug their runtime
+failures.
+
+## Operate the harness
+
+Run the harness from the repository root:
+
+```bash
+bash scripts/check-ci-parity.sh
+```
+
+The harness is **fail-closed**: it exits non-zero on any reference
+validity violation, any divergence, any evidence-less engine-specific
+exception, or any untraceable job, and prints `OK:` only on a clean
+pass. It checks the reference against both engines across several arms
+(reference validity; per-job traceability on both engines;
+reference↔GitHub Actions at the business-step level; reference↔GitLab
+via the composed generator; and GitHub Actions↔GitLab portable-set
+parity). When one engine's pipeline artifacts are absent it checks only
+the present arms; the reference is always required.
+
+For each line the harness reports, name precisely:
+
+- the **offending capability** (its `id` in the reference), and
+- the **affected engine** (`github-actions`, `gitlab`, or the reference
+  itself).
+
+Quote the harness output verbatim — it is your evidence, not a thing to
+paraphrase.
+
+## Classify by kind
+
+Every divergence maps to exactly one of these five kinds. Name the kind
+before proposing anything — classifying first prevents reaching for the
+nearest fix.
+
+1. **Stale derived pipeline.** The committed `.gitlab-ci.yml` no longer
+   matches a fresh derivation of the current reference (the harness's
+   reference↔GitLab arm, which composes `scripts/build-ci.sh --check`,
+   fails). The reference is right; the generated file is behind it.
+2. **Reference drift.** The reference itself is invalid or no longer
+   describes reality — a validity-rule violation (unknown trigger kind
+   or filter; a portable capability missing its `command`; a command
+   invoking an undeclared runtime/tool; a missing or duplicate `id`),
+   or a portable capability whose declared `command`/`requires` no
+   longer matches what the engines actually do.
+3. **Hand-authored pipeline drift.** A hand-authored job (a GitHub
+   Actions workflow job, or a hand-authored GitLab job) diverges from
+   the capability it is attributed to — its business steps no longer
+   exhibit the declared `command`, or its setup no longer satisfies the
+   declared `requires`.
+4. **Evidence-less engine-specific exception.** A capability marked
+   engine-specific (`portability: specific`) lacks the
+   `exception.engine` or `exception.evidence` the reference contract
+   requires for a non-portable capability.
+5. **Untraceable pipeline job.** A pipeline job on either engine is
+   neither a capability `id` nor carries a valid `# ci-capability:`
+   annotation mapping it to one, so the harness cannot attribute it.
+
+## Reconcile per kind
+
+For each detected divergence, determine the reconciliation appropriate
+to its kind. Every reconciliation stays within the evidence-backed
+exception discipline the reference contract mandates.
+
+- **Stale derived pipeline** → regenerate the derived GitLab pipeline
+  from the current reference (`scripts/build-ci.sh`) and re-run the
+  harness to confirm the divergence is resolved. This is the only
+  deterministic, no-judgment case — see *Autonomy boundary*.
+- **Reference drift** → propose amending the offending reference
+  capability (its `trigger`, `command`, `requires`, `id`, or
+  `portability`) so the reference is valid and once again describes
+  what the engines do. Judgment-bearing.
+- **Hand-authored pipeline drift** → propose correcting the
+  hand-authored job so its business steps and setup match the
+  attributed capability — or, if the engine's behaviour is the
+  intended truth, propose amending the reference instead. Name which
+  one you believe is correct and why. Judgment-bearing.
+- **Evidence-less engine-specific exception** → propose adding the
+  missing `exception.engine` and a concrete `exception.evidence`
+  justification, or reclassifying the capability as portable if it is
+  in fact portable. Judgment-bearing.
+- **Untraceable pipeline job** → propose either renaming the job to its
+  capability `id`, adding a valid `# ci-capability:` annotation, or (if
+  the job represents a genuinely new capability) adding that capability
+  to the reference. Judgment-bearing.
+
+## Autonomy boundary
+
+This boundary is the heart of the agent. Honour it exactly.
+
+You **MAY autonomously apply ONLY** the deterministic, no-judgment
+reconciliation — the **stale derived pipeline** case:
+
+```bash
+bash scripts/build-ci.sh          # regenerate .gitlab-ci.yml from the reference
+bash scripts/check-ci-parity.sh   # confirm the divergence is resolved
+```
+
+This is safe to apply autonomously because it mutates nothing that
+requires judgment: it re-derives the generated GitLab pipeline from the
+current reference using the project's own generator, then verifies the
+result with the harness. If the re-run is not clean, you have
+mis-classified — stop, re-classify, and treat it as a judgment-bearing
+case.
+
+For **every** judgment-bearing case — amending a reference capability,
+amending an evidence-backed exception, or correcting a hand-authored
+pipeline job — you **diagnose and propose only**. You **SHALL NOT**
+mutate the reference, any pipeline, or any exception autonomously. You
+present the proposed change (a diff or an explicit edit description) and
+stop; the contributor decides whether to apply it. Hand-editing the
+generated `.gitlab-ci.yml` to silence the harness is never a
+reconciliation — it is the stale-pipeline divergence in reverse.
+
+## Output discipline
+
+The agent's response is a reconciliation report, not a tutorial. For
+each divergence, the four-link chain is the message:
+
+```text
+Symptom:        <verbatim harness line>
+Classification: <one of the five kinds>
+Evidence:       <reference id + engine, quoted from the harness / files>
+Reconciliation: <the deterministic action you applied, OR the proposed
+                 change you are NOT applying autonomously>
+```
+
+When you have auto-applied the stale-pipeline reconciliation, show the
+clean re-run (`OK:` line) as proof. When you are proposing a
+judgment-bearing change, state plainly that you have **not** applied it
+and what the contributor must decide.
+
+Do not append "hope this helps" or restate the verdict in a conclusion.
+If a classification is uncertain — a divergence could be reference drift
+*or* hand-authored drift depending on which side is the intended truth —
+name the uncertainty and the question that resolves it rather than
+committing to a confident wrong call.
+
+## Handoff
+
+When the divergences are reconciled or the proposals are delivered, the
+agent's job is done. The follow-on work is delegated:
+
+- Applying a proposed reference / pipeline edit and committing it →
+  **developer** agent.
+- Opening a PR and writing the logbook entry → **pr-logbook** agent.
+- Authoring a brand-new pipeline for an engine → **ci-configurator**
+  agent.
+- Diagnosing a failing application pipeline run → **ci-debugger** agent.

--- a/.github/skills/gitlab-ci/SKILL.md
+++ b/.github/skills/gitlab-ci/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: gitlab-ci
+description: "Deep, practitioner-grade knowledge of GitLab CI/CD for authoring,
+reviewing, hardening, and debugging pipelines. Activate when reading
+or writing a `.gitlab-ci.yml`, when reviewing a CI change in a merge
+request, when designing runners/executors or reusable CI/CD
+Components, or when migrating to GitLab CI from another engine.
+Covers pipeline/stage/job structure, the `rules:`/`workflow:` trigger
+model, runners and executors, caching vs. artifacts, the
+protected/masked variable and secret model, `id_tokens:` OIDC
+federation, and includes/components — plus the security defaults that
+should never be negotiated away."
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "https://github.com/crewrig/crewrig"
+    feedback: "https://github.com/crewrig/crewrig"
+    version: "1.0.0"
+---
+
+
+# GitLab CI/CD
+
+A dense, practitioner-oriented skill for working on GitLab CI/CD
+pipelines. Read the relevant section before editing a `.gitlab-ci.yml`;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+This skill is the GitLab counterpart of the `github-actions` skill and
+presents a parallel activation and escalation contract. Keep your
+guidance engine-neutral wherever the project's platform-neutral
+capability reference (`ci/ci-capabilities.yml`, described by
+`docs/ci-reference-format.md`) keeps it neutral; name GitLab-specific
+syntax only where the behaviour is genuinely GitLab-specific.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A `.gitlab-ci.yml` (or an `include`d CI fragment) is being authored,
+  modified, or reviewed.
+- A reusable **CI/CD Component** or an `include:`-based template is
+  being designed or consumed.
+- A merge request touches CI configuration and a reviewer-grade audit
+  is required (image pinning, protected/masked variables, OIDC, secret
+  exposure, `rules:` correctness).
+- A pipeline is failing and the root cause is suspected to be in the
+  pipeline definition, the runner/executor selection, the cache or
+  artifacts, the variable/secret scoping, or the `rules:` evaluation.
+- A self-managed runner fleet is being designed, hardened, or
+  diagnosed.
+- A migration is being planned (e.g., from GitHub Actions, CircleCI,
+  Jenkins, or Azure Pipelines to GitLab CI/CD).
+
+Defer to **security** when the change introduces a new secret, widens
+the `CI_JOB_TOKEN` access allowlist, adds an `id_tokens:` OIDC trust
+relationship to a cloud provider, relaxes protected-branch/variable
+gating, or executes untrusted input (MR title, branch name, commit
+message) inside a `script:`. Defer to **architect** when the change
+restructures the pipeline topology (e.g., splitting a monolithic
+pipeline into parent-child pipelines or shared CI/CD Components used
+across many projects).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitLab CI/CD. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/pipeline-syntax.md` | Full grammar of `stages:`, `jobs`, `script:`/`before_script:`/`after_script:`, `needs:`, `rules:`, `extends:`, `!reference`, `parallel:matrix`, `environment:`, `default:`, with annotated examples for every key. |
+| `references/rules-and-triggers.md` | The `rules:` model (`if`/`changes`/`exists`/`when`), `workflow:rules:`, legacy `only/except`, parent-child and multi-project `trigger:` pipelines, the predefined-variable and expression-operator tables, and pipeline types. |
+| `references/runners-and-executors.md` | Instance/group/project runners, `tags:` selection, the shell/docker/kubernetes executors, autoscaling, `image:`/`services:`, and `config.toml` essentials. |
+| `references/caching-and-artifacts.md` | The cache-vs-artifacts distinction, `cache:key/paths/policy/when`, `artifacts:paths/reports/expire_in`, `dependencies:`, distributed cache, and language-specific recipes (npm, pnpm, Yarn, pip, Poetry, Maven, Gradle, Go, Cargo). |
+| `references/variables-and-secrets.md` | Variable sources and precedence, `file`/masked/protected variables, external secrets (`secrets:` with Vault / Azure / GCP), `id_tokens:` OIDC federation for AWS / GCP / Azure, masking caveats, and exfiltration anti-patterns. |
+| `references/security-and-permissions.md` | `CI_JOB_TOKEN` and its access allowlist, the member-role model, protected branches/tags, protected environments, `id_tokens:`, fork-runner trust, and least-privilege recipes per use case. |
+| `references/includes-and-components.md` | `include:` (local/project/remote/template/component), CI/CD Components and the catalog, `spec:inputs:`, `extends:`, `!reference`, `trigger:include`, nesting limits, and versioning strategies. |
+
+## Core concepts
+
+A pipeline is a YAML file (`.gitlab-ci.yml` at the repository root,
+overridable via `CI_CONFIG_PATH`) triggered by one or more events —
+a push, a merge request, a tag, a schedule, or a manual run. A
+pipeline contains **jobs**; each job belongs to a **stage**, and
+stages run in declared order while jobs in the same stage run in
+parallel. A job is a list of shell commands (`script:`) executed by a
+**runner** using a chosen **executor**. State between jobs travels
+through **artifacts** (a forward-passed contract) and, opportunistically,
+through **cache** (a best-effort speed optimization).
+
+### Stages, jobs, and the DAG
+
+Stages give a coarse ordering; `needs:` gives a fine one. A job with
+`needs:` starts as soon as its named dependencies finish, forming a
+**directed acyclic graph** that ignores stage boundaries — the way to
+shorten a pipeline's critical path. `needs: []` starts a job
+immediately, before any stage. See `references/pipeline-syntax.md`.
+
+### Triggers and `rules:`
+
+`rules:` is the modern control-flow primitive: an ordered list whose
+first matching entry decides whether (and how) the job runs. Rules key
+on `if:` expressions over predefined variables (`$CI_PIPELINE_SOURCE`,
+`$CI_COMMIT_BRANCH`, `$CI_COMMIT_TAG`, `$CI_MERGE_REQUEST_*`),
+`changes:` (path filters), and `exists:` (file presence).
+`workflow:rules:` gates the whole pipeline — most importantly to avoid
+running a duplicate detached and branch pipeline for the same commit.
+Legacy `only/except` still works but `rules:` supersedes it. See
+`references/rules-and-triggers.md`.
+
+### Runners and executors
+
+A runner is the agent that executes a job; the **executor** is how it
+does so. The **docker** executor (each job in a fresh container from
+`image:`) is the default for reproducibility; **shell** runs directly
+on the host; **kubernetes** schedules a pod per job. A job selects a
+runner by `tags:`; a job whose tags match no runner stays queued.
+Pin `image:` by digest, never a moving tag. See
+`references/runners-and-executors.md`.
+
+### Caching vs. artifacts
+
+These are different mechanisms. **Cache** persists reusable
+dependencies (e.g. `node_modules/`) across runs to save time; it may be
+absent and must never be relied on as a contract. **Artifacts** are a
+job's declared outputs, passed forward to later stages and downloadable
+from the UI. Use `cache:` for speed and `artifacts:` for correctness.
+See `references/caching-and-artifacts.md`.
+
+### Variables and secrets
+
+CI/CD variables come from many sources (instance, group, project,
+trigger, `.gitlab-ci.yml`, `dotenv` artifacts) with a defined
+precedence. A credential MUST be a **masked** variable (hidden in job
+logs) and, when it gates a real environment, a **protected** variable
+(exposed only to pipelines on protected branches/tags). The `file`
+variable type writes the value to a temp file and exports its path —
+the correct channel for certificates and kubeconfigs. For cloud
+credentials, **prefer `id_tokens:` OIDC** over long-lived keys. See
+`references/variables-and-secrets.md`.
+
+### Permissions and protection
+
+GitLab has no single token scope map; the surface spans the
+`CI_JOB_TOKEN` (and its project access allowlist), the project/group
+member role model, protected branches/tags, and protected
+environments. Production promotion belongs behind a protected
+environment with required approvals. See
+`references/security-and-permissions.md`.
+
+### Includes and components
+
+`include:` composes a pipeline from local files, other projects,
+remote URLs, GitLab templates, or versioned **CI/CD Components**.
+Components (`include:component:`) are the modern reusable unit, with a
+typed `spec:inputs:` contract and catalog versioning. `extends:` and
+`!reference` compose fragments within and across includes. See
+`references/includes-and-components.md`.
+
+## Common pitfalls
+
+The top failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned container images.** `image: node:22` (or `:latest`) is
+   a moving target — the registry can re-point the tag. Pin by digest
+   (`image: node@sha256:…`) and let Renovate track updates.
+2. **Plaintext or un-masked secrets.** A credential hardcoded in
+   `variables:`, or a masked variable that fails GitLab's masking
+   requirements (too short, contains whitespace) and silently logs in
+   the clear.
+3. **Over-broad `rules:` / missing `workflow:rules:`.** Without a
+   `workflow:` guard, a single push to a branch with an open MR runs
+   two pipelines. Rules that omit `$CI_PIPELINE_SOURCE` checks fire on
+   unintended events.
+4. **`CI_DEBUG_TRACE` or `set -x` left enabled.** Both print every
+   expanded variable to the job log, including masked ones — masking
+   does not survive a shell trace.
+5. **Treating cache as artifacts.** Relying on `cache:` to carry build
+   output to a later stage. Cache can be cold; only `artifacts:` (or
+   `needs:[].artifacts`) is a forward contract.
+6. **Cache key on the manifest, not the lockfile.** A cache keyed on
+   `package.json` instead of `package-lock.json` goes stale silently;
+   one keyed on nothing poisons across branches.
+7. **`cache:`/dependency dir outside `$CI_PROJECT_DIR`.** GitLab can
+   only cache paths under the project directory; a `GOPATH` or pip
+   cache in `$HOME` is silently not cached.
+8. **`interruptible` / `resource_group` misuse.** A deploy job left
+   `interruptible: true` can be cancelled mid-rollout; production
+   deploys need a `resource_group` to serialize.
+9. **Untrusted-fork runner exposure.** A shared or `privileged` runner
+   that accepts fork MR pipelines can run arbitrary code on your
+   infrastructure. Protected variables and protected runners are not
+   exposed to fork MRs by default — do not relax that.
+10. **Unpinned `include:remote` / `~latest` components.** A remote
+    include or a component pinned to `~latest` can change under you.
+    Pin to a tag or commit SHA and prefer first-party sources.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge. Both are **offline** text scans —
+no live GitLab, no `glab`, no Docker, no registry or token access.
+
+- **`scripts/check-pinned-images.sh`** — fails closed if any `image:`
+  or `services:` reference is not pinned to an immutable `@sha256:`
+  digest. The first-line defense against a re-pointed base image. The
+  GitLab counterpart of the `github-actions` skill's
+  `check-pinned-actions.sh`.
+- **`scripts/check-secrets-exposure.sh`** — flags hardcoded credential
+  literals in `variables:`/`script:`, recognizable token shapes
+  (`glpat-…`, `ghp_…`, AWS keys, PEM private keys), `echo`/`printf` of a
+  credential-named variable, `set -x`, and `CI_DEBUG_TRACE`. The GitLab
+  counterpart of the `github-actions` skill's `check-secrets-exposure.sh`.
+
+Invoke them as:
+
+```sh
+scripts/check-pinned-images.sh .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+Each accepts exactly one argument — a pipeline file or a directory
+(directory mode scans `<dir>/.gitlab-ci.yml` plus YAML under
+`<dir>/.gitlab/`). Both exit non-zero on a finding, so CI can fail
+closed.
+
+This skill ships **no** offline structural linter and **no** pipeline
+simulator, by design. GitLab's `glab ci lint` is a server-side CI-Lint
+API call (it requires authentication and a reachable instance — there
+is no offline structural validation equivalent to `actionlint`), and
+`gitlab-ci-local` *executes* the pipeline in Docker. Both are out of
+scope here: executing a pipeline on a live GitLab is not this skill's
+job. The two scripts above are the validations with genuine offline
+parity to their GitHub Actions siblings; nothing else is shipped as
+façade tooling.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every container image by `@sha256:` digest.** No bare tags,
+   no `:latest`. Pin `image:` and every `services:` entry; document the
+   pin with a comment carrying the human-readable tag.
+2. **Every credential is a masked variable.** Never hardcode a secret
+   in `variables:` or a `script:`. Confirm the value meets GitLab's
+   masking requirements, or it logs in the clear despite the flag.
+3. **Protect the variables that gate real environments.** A deploy or
+   release credential is **protected** as well as masked, so it is
+   exposed only to pipelines on protected branches/tags.
+4. **Prefer `id_tokens:` OIDC over long-lived cloud credentials.** A
+   long-lived cloud key is acceptable only when the provider does not
+   support OIDC for the target resource. Document the exception.
+5. **Never echo or trace a secret.** No `echo "$TOKEN"`, no `set -x`
+   over secret-bearing commands, no `CI_DEBUG_TRACE: "true"` in a job
+   that sees a credential. Masking is best-effort and a transformed
+   value bypasses it.
+6. **Bind secrets to the smallest scope.** A secret in a global
+   `variables:` block is inherited by every job. Bind it to the job —
+   or the protected environment — that needs it.
+7. **Gate deploy / Pages / Release jobs behind protected refs and
+   environments.** Production promotion targets a protected
+   environment with required approvals; the environment is also the
+   correct scope for production secrets.
+8. **Serialize deployments with `resource_group:`** so two pipelines
+   never deploy to the same target concurrently, and leave production
+   deploys `interruptible: false`.
+9. **Scope the `CI_JOB_TOKEN` access allowlist.** Limit which projects
+   a job token may reach; the historical "allow all" default is a
+   lateral-movement risk.
+10. **Never run untrusted code on a `privileged` or shared runner.**
+    Fork MR pipelines must not receive protected variables or
+    protected runners. Keep that default; if a fork must run privileged
+    work, gate it behind a maintainer-approved, protected-environment
+    job.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure pipeline skeleton
+
+```yaml
+default:
+  image: node@sha256:<digest>  # node:22
+
+stages: [test]
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+
+unit-test:
+  stage: test
+  interruptible: true
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --cache .npm --prefer-offline
+    - npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+deploy:
+  stage: deploy
+  image: registry.example.com/aws-cli@sha256:<digest>
+  environment:
+    name: production
+  resource_group: production
+  interruptible: false
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name "ci-$CI_PIPELINE_ID"
+      --web-identity-token "$AWS_ID_TOKEN"
+    - ./scripts/deploy.sh
+```
+
+### Safe handling of an untrusted MR title
+
+```yaml
+comment:
+  variables:
+    MR_TITLE: $CI_MERGE_REQUEST_TITLE   # bound to a variable, not interpolated
+  script:
+    # Quoted; the shell does not re-evaluate the value.
+    - printf 'Title: %s\n' "$MR_TITLE"
+```
+
+### Pass a build artifact forward (not via cache)
+
+```yaml
+build:
+  stage: build
+  script: [make dist]
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+publish:
+  stage: deploy
+  needs: [build]   # pulls build's artifacts
+  script: [./publish.sh dist/]
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/.github/skills/gitlab-ci/references/caching-and-artifacts.md
+++ b/.github/skills/gitlab-ci/references/caching-and-artifacts.md
@@ -1,0 +1,578 @@
+# Caching and artifacts reference
+
+GitLab CI/CD exposes two distinct mechanisms for moving files in and out
+of jobs. They look similar and are constantly confused, so the headline
+distinction comes first.
+
+- **`cache:`** is a **speed optimization** for reusable dependencies
+  (an `npm` store, a Go module cache, a `.gradle` directory). The cache
+  is **best-effort**: it may be absent, stale, or evicted, and a job
+  MUST still succeed on a cold cache. It is keyed and shared across
+  pipelines and jobs by key, NOT by stage order. Never treat it as a
+  contract for passing build output forward.
+- **`artifacts:`** are **job outputs** passed forward to later stages
+  and made downloadable from the UI/API. Artifacts are a **contract**:
+  by default every job in a later stage automatically downloads the
+  artifacts of all jobs from earlier stages. If a build job declares a
+  binary as an artifact, the test job in the next stage will have it.
+
+Rule of thumb: if losing the files only costs you time, it is a cache.
+If losing the files breaks a downstream job, it is an artifact.
+
+This document covers `cache:` key/policy/fallback semantics, distributed
+cache backends, the full `artifacts:` surface (including `reports` and
+`dotenv` variable passing), `dependencies:`/`needs:artifacts` fetch
+control, language recipes, and the recurring pitfalls.
+
+## How the cache works
+
+A job declares a cache by key and paths:
+
+```yaml
+build:
+  stage: build
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths:
+      - .npm/
+    policy: pull-push
+  script:
+    - npm ci --cache .npm --prefer-offline
+```
+
+The runner performs two operations:
+
+1. **Pre-job pull.** Resolves `cache:key` to an archive. On hit, the
+   `paths:` are extracted into the workspace before `script` runs. On
+   miss, `fallback_keys` (then the global fallback) are tried; if all
+   miss the job starts cold — which MUST be valid.
+2. **Post-job push.** After the job, the `paths:` are re-archived and
+   uploaded under `cache:key`. Whether the push happens depends on
+   `cache:policy` and `cache:when` (below).
+
+Unlike artifacts, the cache is **not** tied to stage ordering. Two jobs
+in the same stage can share a cache by using the same key.
+
+## `cache:key`
+
+The key is the cache's identity. Same key across jobs/pipelines means
+shared content.
+
+```yaml
+# Static string key.
+cache:
+  key: gems-ruby-3.3
+
+# Lockfile-hashed key — invalidates automatically when deps change.
+cache:
+  key:
+    files:
+      - Gemfile.lock
+    prefix: $CI_JOB_NAME
+
+# Predefined-variable key — one cache per branch.
+cache:
+  key: $CI_COMMIT_REF_SLUG
+```
+
+- **`cache:key:files`** — up to two files. GitLab computes a SHA over
+  their contents and uses it as (part of) the key. When neither file
+  changes, the key is stable and the cache is reused; when a lockfile
+  changes, the key changes and a fresh cache is built. If the listed
+  files do not exist, the literal `default` is used as the SHA segment.
+- **`cache:key:prefix`** — prepended to the computed SHA, letting you
+  combine a discriminator (job name, branch slug, OS) with lockfile
+  hashing: `prefix-<sha>`.
+- **Branch-scoped key** — `key: $CI_COMMIT_REF_SLUG` gives every branch
+  its own cache. Trade-off: more storage, but no cross-branch bleed.
+
+The key MUST NOT contain `/` or be the literal `.`/`..`. Predefined
+variables (`$CI_COMMIT_REF_SLUG`, `$CI_JOB_NAME`, `$CI_DEFAULT_BRANCH`)
+are the usual building blocks.
+
+## `cache:paths`
+
+A list of paths, relative to `$CI_PROJECT_DIR`, archived into the cache.
+Globs are supported.
+
+```yaml
+cache:
+  paths:
+    - .npm/
+    - vendor/ruby/
+    - "**/node_modules/"
+```
+
+**Critical GitLab gotcha:** only paths **under** the project directory
+(`$CI_PROJECT_DIR`) can be cached. A tool that writes its cache to
+`$HOME` (e.g. `~/.cache/go-build`, `~/.m2`, `~/.cargo`) will NOT be
+cached unless you redirect it into the workspace via an environment
+variable (see the language recipes). This is the single most common
+reason a cache "silently does nothing."
+
+## `cache:policy`
+
+Controls the pull/push behavior, trading correctness for speed.
+
+```yaml
+# Default: download at start, upload at end.
+cache: { key: deps, paths: [.npm/], policy: pull-push }
+
+# Consumer-only: download but never re-upload (faster, read-only jobs).
+test:
+  cache: { key: deps, paths: [.npm/], policy: pull }
+
+# Producer-only: skip the download, only upload (a dedicated warm-up).
+warm-cache:
+  cache: { key: deps, paths: [.npm/], policy: push }
+```
+
+A common pattern: one `prepare` job with `policy: push` builds the cache;
+every downstream job uses `policy: pull` so they never waste time
+re-uploading an unchanged cache.
+
+## `cache:when`
+
+Controls whether the cache is saved based on job result.
+
+```yaml
+cache:
+  key: deps
+  paths: [.npm/]
+  when: on_success   # default: save only if the job succeeds
+  # when: on_failure  # save only if the job fails (debugging)
+  # when: always      # save regardless of result
+```
+
+Use `when: always` when even a failed job produces a useful partial
+cache (e.g. a partially-populated dependency store worth reusing).
+
+## `cache:untracked` and `cache:unprotect`
+
+```yaml
+cache:
+  untracked: true     # also cache files NOT tracked by git
+  unprotect: false    # if true, share cache between protected and
+                      # unprotected refs (DANGEROUS — see Pitfalls)
+```
+
+- **`untracked: true`** caches every git-untracked file in the workspace
+  in addition to `paths:`. Convenient but easy to bloat.
+- **`unprotect: true`** lets protected and unprotected branches share one
+  cache. The default `false` keeps them separate, which is a security
+  boundary — do not flip it without understanding cache poisoning below.
+
+## Multiple caches and `fallback_keys`
+
+A job can declare **multiple caches** as a list, each with its own key:
+
+```yaml
+test:
+  cache:
+    - key:
+        files: [package-lock.json]
+      paths: [.npm/]
+    - key:
+        files: [Gemfile.lock]
+      paths: [vendor/ruby/]
+  script:
+    - npm ci --cache .npm
+    - bundle install --path vendor/ruby
+```
+
+**`cache:fallback_keys`** provides a restore chain analogous to GitHub
+Actions' `restore-keys`: if the exact key misses, the listed keys are
+tried in order for a partial/older cache.
+
+```yaml
+cache:
+  key:
+    files: [package-lock.json]
+    prefix: $CI_COMMIT_REF_SLUG
+  fallback_keys:
+    - npm-$CI_COMMIT_REF_SLUG
+    - npm-$CI_DEFAULT_BRANCH
+  paths: [.npm/]
+```
+
+A global `cache:` defined at the top of the file applies to every job;
+a per-job `cache:` overrides it entirely (the two are NOT merged).
+
+## Distributed cache (S3 / GCS)
+
+By default the cache is stored on the runner's local disk — useless when
+jobs land on different runners. For a runner fleet, configure a
+**distributed cache** in the runner's `config.toml`:
+
+```toml
+[runners.cache]
+  Type = "s3"
+  Shared = true
+  [runners.cache.s3]
+    ServerAddress = "s3.amazonaws.com"
+    BucketName = "gitlab-runner-cache"
+    BucketLocation = "eu-west-1"
+```
+
+`Type` may be `s3`, `gcs`, or `azure`. `Shared = true` lets all runners
+read each other's caches (required for the cross-runner case). This is a
+runner-administration concern — see the runners-and-executors reference
+for executor and `config.toml` details. The `.gitlab-ci.yml` author only
+declares `cache:`; the backend is transparent.
+
+## How artifacts work
+
+Artifacts are produced by a job and consumed by later jobs (and humans).
+
+```yaml
+build:
+  stage: build
+  script:
+    - make build
+  artifacts:
+    paths:
+      - bin/
+      - dist/
+    expire_in: 1 week
+```
+
+By default, every job downloads the artifacts of all jobs in **earlier**
+stages. So a `test` job in the `test` stage automatically receives
+`bin/` and `dist/` from `build` — no extra wiring.
+
+## `artifacts:paths` and `artifacts:exclude`
+
+```yaml
+artifacts:
+  paths:
+    - target/release/
+    - "*.log"
+  exclude:
+    - target/release/**/*.o   # drop intermediate objects from the upload
+  untracked: false            # set true to also upload git-untracked files
+```
+
+`paths:` is relative to `$CI_PROJECT_DIR`. `exclude:` prunes matches from
+the set selected by `paths:`/`untracked:`, useful for shedding bulky
+intermediates while keeping the final output.
+
+## `artifacts:expire_in` and `artifacts:when`
+
+```yaml
+artifacts:
+  paths: [dist/]
+  when: on_success    # on_success (default) | on_failure | always
+  expire_in: 30 days  # "1 week", "3 mins 4 sec", "never"
+```
+
+- **`when: on_failure`** plus a logs path is the canonical way to capture
+  diagnostics only when a job fails.
+- **`expire_in`** governs storage cost. Leaving it at the instance
+  default (often "never" expiry on self-managed, or a long window) is the
+  number-one source of runaway artifact storage. Set an explicit TTL on
+  every artifact unless it is a release deliverable. The latest artifacts
+  of the most recent successful pipeline on a ref are kept regardless
+  (`keep_latest_artifact`), so expiry does not strand your newest build.
+
+## `artifacts:name` and `artifacts:expose_as`
+
+```yaml
+artifacts:
+  name: "$CI_JOB_NAME-$CI_COMMIT_REF_SLUG"   # archive filename on download
+  expose_as: "Coverage report"               # named link in the MR UI
+  paths:
+    - coverage/index.html
+```
+
+`name:` controls the downloaded archive's filename. `expose_as:` surfaces
+the artifact as a clickable link directly in the merge request widget
+(limited to a small number of paths).
+
+## `artifacts:reports`
+
+`reports:` ingests structured artifacts that GitLab parses and renders,
+rather than just storing. Key report types:
+
+```yaml
+test:
+  script:
+    - pytest --junitxml=report.xml --cov --cov-report xml:coverage.xml
+  artifacts:
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+- **`junit:`** — test results rendered in the MR "Test summary" widget;
+  failures are shown inline on the MR.
+- **`coverage_report:` (`cobertura`)** — line-coverage overlay on the MR
+  diff. `coverage_format` is currently `cobertura` (or `jacoco` on newer
+  versions).
+- **`sast:`, `dependency_scanning:`, `secret_detection:`** — security
+  scanner outputs that populate the MR security widget and the
+  vulnerability report. Usually produced by GitLab's bundled scanner
+  templates rather than hand-authored.
+
+### `dotenv` — passing variables downstream
+
+The `dotenv` report is special: it does not render a widget, it
+**injects variables** from a `.env`-format file into later jobs. This is
+the supported way to pass a computed value (a version string, an image
+tag, a deploy URL) from one job to the next.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "VERSION=$(git describe --tags)" >> build.env
+    - echo "IMAGE_TAG=registry.example.com/app:$CI_COMMIT_SHORT_SHA" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true      # required to receive the dotenv variables
+  script:
+    - echo "Deploying $VERSION as $IMAGE_TAG"
+```
+
+The downstream job sees `$VERSION` and `$IMAGE_TAG` as ordinary
+variables. The variables propagate only to jobs that have the producing
+job in `needs:` (or, without `needs:`, to all later-stage jobs).
+
+## Controlling which artifacts are fetched
+
+By default a job downloads ALL upstream artifacts — wasteful when a job
+needs none or only some.
+
+### `dependencies:`
+
+```yaml
+deploy:
+  stage: deploy
+  dependencies:
+    - build           # fetch ONLY build's artifacts
+  script: [./deploy.sh]
+
+lint:
+  stage: test
+  dependencies: []    # fetch NO artifacts — faster, no download
+  script: [./lint.sh]
+```
+
+`dependencies:` is an allowlist of job names whose artifacts to fetch.
+The empty list `dependencies: []` fetches nothing — the single most
+effective speedup for jobs that only need the source checkout.
+
+### `needs: [...].artifacts`
+
+When using `needs:` (the DAG mechanism that lets jobs start out of stage
+order), control artifact transfer per-need:
+
+```yaml
+deploy:
+  needs:
+    - job: build
+      artifacts: true     # download build's artifacts (default true)
+    - job: lint
+      artifacts: false    # depend on lint's completion, skip its artifacts
+```
+
+`needs:` and `dependencies:` interact: when both are present, `needs:`
+governs ordering and `dependencies:` (if also set) further narrows the
+fetch set. For DAG pipelines, prefer expressing artifact transfer through
+`needs:[].artifacts`.
+
+## Language recipes
+
+Each recipe shows the `cache:` block plus the in-workspace redirection
+required by the `$CI_PROJECT_DIR` gotcha.
+
+### npm
+
+```yaml
+variables:
+  npm_config_cache: "$CI_PROJECT_DIR/.npm"   # move cache into workspace
+build:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --prefer-offline
+```
+
+### pnpm
+
+```yaml
+variables:
+  PNPM_HOME: "$CI_PROJECT_DIR/.pnpm-store"
+build:
+  before_script:
+    - corepack enable
+    - pnpm config set store-dir "$CI_PROJECT_DIR/.pnpm-store"
+  cache:
+    key:
+      files: [pnpm-lock.yaml]
+    paths: [.pnpm-store/]
+  script:
+    - pnpm install --frozen-lockfile
+```
+
+### Yarn
+
+```yaml
+build:
+  before_script:
+    - yarn config set cache-folder "$CI_PROJECT_DIR/.yarn-cache"
+  cache:
+    key:
+      files: [yarn.lock]
+    paths: [.yarn-cache/]
+  script:
+    - yarn install --frozen-lockfile
+```
+
+For Yarn Berry zero-installs, `.yarn/cache` is committed to the repo and
+no `cache:` block is needed.
+
+### pip / Poetry
+
+```yaml
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"        # pip
+  POETRY_CACHE_DIR: "$CI_PROJECT_DIR/.poetry-cache"  # poetry
+build:
+  cache:
+    key:
+      files:
+        - poetry.lock        # or requirements.txt for plain pip
+    paths:
+      - .pip-cache/
+      - .poetry-cache/
+      - .venv/
+  script:
+    - poetry config virtualenvs.in-project true
+    - poetry install --no-interaction
+```
+
+`virtualenvs.in-project true` puts `.venv/` under `$CI_PROJECT_DIR` so it
+can be cached.
+
+### Maven / Gradle
+
+```yaml
+variables:
+  MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
+  GRADLE_USER_HOME: "$CI_PROJECT_DIR/.gradle"
+build-maven:
+  cache:
+    key:
+      files: [pom.xml]
+    paths: [.m2/repository/]
+  script: [mvn -B verify]
+
+build-gradle:
+  cache:
+    key:
+      files: [gradle/wrapper/gradle-wrapper.properties, build.gradle.kts]
+    paths:
+      - .gradle/caches/
+      - .gradle/wrapper/
+  script: [./gradlew build]
+```
+
+Both default to `$HOME`; the variables relocate them into the workspace.
+
+### Go modules
+
+```yaml
+variables:
+  GOPATH: "$CI_PROJECT_DIR/.go"          # module + build cache into workspace
+build:
+  cache:
+    key:
+      files: [go.sum]
+    paths:
+      - .go/pkg/mod/
+  script:
+    - go build ./...
+```
+
+`GOPATH` defaults to `$HOME/go`, which is uncacheable — relocating it is
+mandatory for the Go module cache to persist.
+
+### Cargo (Rust)
+
+```yaml
+variables:
+  CARGO_HOME: "$CI_PROJECT_DIR/.cargo"
+build:
+  cache:
+    key:
+      files: [Cargo.lock]
+    paths:
+      - .cargo/registry/index/
+      - .cargo/registry/cache/
+      - .cargo/git/db/
+      - target/
+  script:
+    - cargo build --release
+```
+
+`CARGO_HOME` defaults to `$HOME/.cargo`; relocate it and cache the
+registry plus `target/`.
+
+## Pitfalls
+
+### Cache poisoning across branches and forks
+
+A cache shared between protected and unprotected refs is an injection
+vector: a contributor pushing to an unprotected feature branch can write
+a poisoned cache that a protected branch (or a fork's MR pipeline) later
+restores. Mitigations:
+
+- Keep `cache:unprotect` at its default `false` so protected and
+  unprotected refs use separate caches.
+- Discriminate the key by ref where trust matters:
+  `key: "$CI_COMMIT_REF_PROTECTED-$CI_COMMIT_REF_SLUG"` so protected and
+  unprotected content never collide.
+- Treat restored binaries as untrusted for security-sensitive
+  toolchains; re-verify checksums after the pull.
+
+### Treating cache as artifacts
+
+The cache is best-effort and unordered. Relying on it to pass a build
+output to a later stage will work until the day the cache is evicted, a
+job lands on a fresh runner, or two pipelines race — then the downstream
+job mysteriously fails. Pass build output with `artifacts:`, always.
+
+### Oversized caches
+
+`untracked: true` plus a sprawling `paths:` can produce multi-gigabyte
+caches whose upload/download time exceeds the install time they were
+meant to save. Cache the dependency store, not the whole workspace, and
+measure: if `Restoring cache` takes longer than a cold install, drop it.
+
+### Default `expire_in`
+
+Artifacts without an explicit `expire_in` inherit the instance default,
+which on many installs is effectively unbounded. Across thousands of
+pipelines this silently consumes object storage. Set a deliberate TTL on
+every artifact; reserve long or `never` expiry for genuine release
+deliverables.
+
+### The `$CI_PROJECT_DIR` trap, restated
+
+The most frequent "my cache does nothing" cause: caching a tool's default
+`$HOME` directory, which lives outside `$CI_PROJECT_DIR` and is therefore
+silently un-cacheable. Every language recipe above redirects the tool's
+cache into the workspace for exactly this reason — verify the cached path
+is under `$CI_PROJECT_DIR` before blaming the key.

--- a/.github/skills/gitlab-ci/references/includes-and-components.md
+++ b/.github/skills/gitlab-ci/references/includes-and-components.md
@@ -1,0 +1,475 @@
+# Includes and components reference
+
+GitLab CI/CD has no single "function call" primitive. Composition is
+assembled from several keywords that each cover one axis of reuse:
+`include:` pulls external configuration into the current pipeline,
+**CI/CD Components** package a parameterised unit and publish it to a
+catalog, `spec:inputs:` defines the typed contract a component or
+included file exposes, and `extends:` / `!reference[…]` stitch fragments
+together within the merged document.
+
+This document covers every form of `include:`, the modern CI/CD
+Component mechanism (the headline reusable unit), the `spec:inputs:`
+contract and its `$[[ inputs.x ]]` interpolation, composition with
+`extends:` and `!reference`, parent-child pipelines via
+`trigger:include`, the versioning and supply-chain story, and the
+pitfalls that bite when several includes merge into one configuration.
+
+## Picking a composition mechanism
+
+A frequent question. The trade-off:
+
+| Property | `include:` (local/project/remote/template) | CI/CD Component |
+|----------|--------------------------------------------|-----------------|
+| Unit of reuse | A whole `.gitlab-ci.yml` fragment. | A parameterised, versioned building block. |
+| Typed contract | Only if the file declares `spec:inputs:`. | `spec:inputs:` is the idiomatic contract. |
+| Versioning | By `ref:` (project) or URL (remote). | By `@<version>` — tag, SHA, `~latest`. |
+| Discoverability | None — you must know the path. | Listed in the CI/CD Catalog. |
+| Inputs interpolation | `$[[ inputs.x ]]` when `spec:` present. | `$[[ inputs.x ]]` — first-class. |
+| Best for | Sharing a stage fragment within an org. | A reusable block consumed across projects. |
+
+Rule of thumb: reach for a **CI/CD Component** when the unit of reuse is
+a published, versioned building block consumed by other projects (the
+GitLab analog of a reusable workflow). Reach for plain **`include:`**
+when you are factoring shared configuration inside one group and do not
+need a versioned, catalog-listed contract.
+
+## `include:` — the four classic forms
+
+`include:` merges external YAML into the pipeline configuration **before**
+jobs run. The merged result behaves as one document: later keys can
+override earlier ones (see *Merge and override semantics*).
+
+### `include:local`
+
+Pulls a file from the **same repository and ref** as the
+`.gitlab-ci.yml` being evaluated. The path is absolute from the repo
+root and must start with `/`:
+
+```yaml
+include:
+  - local: '/ci/build.yml'
+  - local: '/ci/test.yml'
+```
+
+Globs are allowed (`local: '/ci/*.yml'`). Because the file is read at the
+pipeline's own ref, `include:local` never introduces a cross-ref
+supply-chain question — it is the safest form.
+
+### `include:project`
+
+Pulls a file from **another project on the same GitLab instance**. Pin
+the `ref:` (a tag, branch, or SHA) and list one or more files:
+
+```yaml
+include:
+  - project: 'my-group/ci-templates'
+    ref: v1.4.0
+    file:
+      - '/templates/build.yml'
+      - '/templates/deploy.yml'
+```
+
+Omitting `ref:` resolves against the included project's **default
+branch** at pipeline-creation time — a moving target. Pin a tag or SHA
+for reproducibility.
+
+### `include:remote`
+
+Pulls a file from an **arbitrary URL** reachable over HTTP(S):
+
+```yaml
+include:
+  - remote: 'https://gitlab.example.com/-/snippets/12/raw/main/build.yml'
+```
+
+This is the highest-risk form. The URL is fetched at pipeline-creation
+time with no integrity check: whoever controls that endpoint controls
+part of your pipeline. Treat it like sourcing a remote shell script.
+
+- Only include from a source you trust and control.
+- Prefer a URL that resolves to an **immutable** artifact (a raw file at
+  a tagged ref or SHA), never `…/raw/main/…`.
+- Audit `include:remote` entries in review the same way you audit a
+  third-party dependency.
+
+Where possible, replace `include:remote` with `include:project` (same
+instance, auditable `ref:`) or a CI/CD Component (versioned, catalog).
+
+### `include:template`
+
+Pulls a **GitLab-maintained template** shipped with the instance. No
+ref or project needed — the name resolves against GitLab's bundled set:
+
+```yaml
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+```
+
+These are first-party and version-locked to your GitLab version, so
+they are a safe default for security and language scaffolding. They are,
+however, opinionated — read what they inject before relying on them.
+
+## `include:` with `rules:` and `inputs:`
+
+An `include:` entry can be made conditional with `rules:` and can pass
+typed inputs to a file that declares `spec:inputs:`.
+
+```yaml
+include:
+  - local: '/ci/deploy.yml'
+    rules:
+      - if: '$CI_COMMIT_BRANCH == "main"'
+  - component: $CI_SERVER_FQDN/my-group/ci/build@1.0.0
+    inputs:
+      runner_tag: saas-linux-large
+    rules:
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+`include:` `rules:` support `if:`, `exists:`, and variable expressions,
+but **not** the job-only `changes:` with `compare_to` in every context —
+they are evaluated at pipeline-creation time, before any job. When the
+rule does not match, the file is simply not included.
+
+## CI/CD Components — the modern reusable unit
+
+A **CI/CD Component** is a reusable, versioned unit of pipeline
+configuration published from a **component project** and consumed via
+`include:component`. It is the closest GitLab analog of a GitHub Actions
+reusable workflow: a typed contract (`spec:inputs:`) wrapping one or
+more jobs, addressed by version, optionally discoverable in the **CI/CD
+Catalog**.
+
+### Component address form
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/my-group/my-project/my-component@1.2.0
+    inputs:
+      stage: build
+      image: golang:1.23
+```
+
+The path decomposes as
+`<fqdn>/<group>/<project>/<component>@<version>`:
+
+- `$CI_SERVER_FQDN` — predefined variable for the current instance host.
+  Using it (rather than a hard-coded domain) keeps the component
+  portable across self-managed and SaaS instances.
+- `<group>/<project>` — the component project that hosts the component.
+- `<component>` — the component **name**, matching a file under the
+  project's `templates/` directory (see layout below).
+- `@<version>` — the version selector (see *Versioning a component*).
+
+### Component project layout
+
+A single project can publish several components. Each component is a
+file or directory under `templates/`:
+
+```text
+my-project/
+├── templates/
+│   ├── build.yml            # component "build"
+│   └── deploy/
+│       └── template.yml     # component "deploy"
+├── README.md                # required for catalog publication
+└── .gitlab-ci.yml           # the component's own CI (test it!)
+```
+
+Resolution rule:
+
+- `templates/<name>.yml` resolves the component `<name>`.
+- `templates/<name>/template.yml` resolves the component `<name>` (the
+  directory form, useful when the component ships companion files).
+
+### Defining a component with `spec:inputs:`
+
+A component file begins with a `spec:` header in its **first YAML
+document**, separated from the configuration by a `---` document marker:
+
+```yaml
+spec:
+  inputs:
+    stage:
+      default: test
+    image:
+      default: golang:1.23
+    coverage_threshold:
+      type: number
+      default: 80
+    deploy_env:
+      type: string
+      options:
+        - staging
+        - production
+    semver:
+      type: string
+      regex: '^\d+\.\d+\.\d+$'
+---
+test-job:
+  stage: $[[ inputs.stage ]]
+  image: $[[ inputs.image ]]
+  script:
+    - go test -coverprofile=cover.out ./...
+    - ./scripts/check-coverage.sh $[[ inputs.coverage_threshold ]]
+```
+
+`spec:inputs:` entries support:
+
+- `default:` — value used when the caller omits the input. An input with
+  **no `default:`** is **required** — the pipeline fails to create if
+  the caller does not supply it.
+- `type:` — `string` (default), `number`, `boolean`, or `array`. The
+  value is validated and coerced to the declared type.
+- `options:` — an allow-list; the supplied value must be one of them.
+- `regex:` — a pattern (`string` inputs only) the value must match.
+
+These four constraints are validated **at pipeline creation**, before
+any job starts — a contract violation fails fast, not mid-run.
+
+### `$[[ inputs.x ]]` interpolation vs. `variables:`
+
+Input interpolation uses the **double-bracket** form `$[[ inputs.x ]]`
+and is resolved **once, at include time**, before the configuration is
+merged. This is distinct from `$VARIABLE` / `${VARIABLE}` CI/CD
+variables, which are resolved **later**, in the job's runtime shell.
+
+```yaml
+spec:
+  inputs:
+    image:
+      default: alpine:3.20
+---
+job:
+  image: $[[ inputs.image ]]        # resolved at include time
+  script:
+    - echo "$CI_COMMIT_SHA"         # resolved at job runtime
+```
+
+Consequences:
+
+- Inputs can parameterise keys that variables cannot reach — `stage:`,
+  `image:`, `rules:` conditions, even job names — because they are
+  substituted into the YAML before parsing finishes.
+- An input is fixed for the lifetime of the include; a variable can
+  differ per job run and can be overridden by the runner environment.
+
+Reach for `spec:inputs:` to define the **interface** of a reusable
+fragment; reach for `variables:` for values that vary at runtime or that
+a downstream job overrides.
+
+### Versioning a component
+
+The `@<version>` selector accepts several forms, in increasing order of
+stability:
+
+| Selector | Resolves to | Stability |
+|----------|-------------|-----------|
+| `@~latest` | Latest **released** version in the catalog. | Moves under you. |
+| `@<branch>` (e.g. `@main`) | Tip of that branch. | Moves under you. |
+| `@<tag>` (e.g. `@1.2.0`) | That tag. | Stable unless re-tagged. |
+| `@<sha>` | That exact commit. | Immutable. |
+
+`~latest` and a branch ref are convenient in development but make the
+pipeline non-reproducible — the component can change between two runs of
+the same commit. For anything that ships, pin a **tag** (and ideally a
+SHA), and bump deliberately.
+
+### Publishing to the CI/CD Catalog
+
+To make a component discoverable and releasable:
+
+1. Add a `README.md` at the component project root (required) and mark
+   the project as a catalog resource in its settings.
+2. Tag a release commit and create a **release** for that tag (the
+   catalog lists released versions; `~latest` resolves to the newest
+   release, not the newest tag).
+3. The project's own `.gitlab-ci.yml` should test each component (lint
+   the YAML, run the component against a fixture) before tagging — a
+   published component is a dependency for every consumer.
+
+Releasing is what populates `~latest`; an untagged, unreleased component
+is only reachable by branch or SHA.
+
+## `extends:` and `!reference[…]` across includes
+
+Both keywords compose fragments **inside the merged document** — they
+operate after all `include:` and component resolution, so they can reach
+templates that arrived via an include.
+
+### `extends:`
+
+`extends:` performs a reverse-deep-merge of one or more hidden jobs
+(`.name`) into the current job. A hidden template defined in an included
+file is fully usable by a job in the root configuration:
+
+```yaml
+# in an included file: /ci/base.yml
+.docker-build:
+  image: docker:27
+  services:
+    - docker:27-dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+```
+
+```yaml
+# in the root .gitlab-ci.yml
+include:
+  - local: '/ci/base.yml'
+
+build:
+  extends: .docker-build       # merged from the included template
+  script:
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+```
+
+The base treatment of `extends:` (merge order, multi-level chains)
+belongs to the pipeline-syntax reference; here the point is only that
+the merge spans include boundaries.
+
+### `!reference[…]`
+
+`!reference` inserts a specific key from another job — including a job
+that came in via an include — without merging the whole job. It is the
+surgical alternative to `extends:`:
+
+```yaml
+include:
+  - local: '/ci/base.yml'
+
+deploy:
+  before_script:
+    - !reference [.docker-build, before_script]   # reuse just one key
+    - echo "extra deploy prep"
+  script:
+    - ./deploy.sh
+```
+
+`!reference` can target arbitrary nesting and is the cleanest way to
+reuse a single fragment (a `script` block, a `rules` entry) across
+includes without dragging unrelated keys along.
+
+## `trigger:include` — composition by reference
+
+A parent-child pipeline composes by **reference** rather than by merge:
+the parent spawns a downstream child pipeline whose configuration is
+supplied inline via `trigger:include`. Unlike `include:`, the child runs
+as its **own pipeline**, not as merged jobs in the parent.
+
+```yaml
+trigger-child:
+  trigger:
+    include:
+      - local: '/ci/child-pipeline.yml'
+    strategy: depend
+```
+
+- The child sees its own merged configuration; the parent's jobs and
+  variables do **not** leak in (only explicitly forwarded variables do).
+- `strategy: depend` makes the parent job mirror the child pipeline's
+  status, so a child failure fails the parent.
+- `trigger:include` accepts the same source forms as `include:`
+  (`local`, `project`, `component`, `artifact` for dynamic child
+  pipelines).
+
+This is composition for **isolation**: use it when a fragment should run
+as an independent pipeline (a monorepo sub-project, a generated dynamic
+pipeline) rather than as extra jobs in the current one. The trigger
+mechanics, `forward:`, and dynamic child pipelines are covered in the
+rules-and-triggers reference; here the framing is that
+`trigger:include` is composition-by-reference, the complement to
+`include:`'s composition-by-merge.
+
+## Merge and override semantics
+
+When `include:` brings in a job key that the root configuration also
+defines, the configurations **merge**, and the later definition wins on
+a per-key basis:
+
+- The **root `.gitlab-ci.yml` is processed last**, so a job redefined in
+  the root overrides the same job from an included file, key by key
+  (not wholesale replacement — unspecified keys survive from the
+  include).
+- Among multiple `include:` entries, **later entries override earlier
+  ones** for the same key.
+- Scalar and array keys are **replaced**, not concatenated. Redefining
+  `script:` in the root replaces the included `script:` entirely.
+- Map keys (e.g. `variables:`) are **deep-merged** — individual keys
+  override, siblings survive.
+
+```yaml
+include:
+  - local: '/ci/base.yml'        # defines test.script + test.image
+
+test:
+  image: node:22                 # overrides only the image
+  # script: inherited from /ci/base.yml unless redefined here
+```
+
+To override deliberately, redefine the exact key. To extend rather than
+replace, prefer `extends:` or `!reference[…]` so the original fragment
+stays visible.
+
+## Versioning strategy and supply-chain hardening
+
+Every `include:` and component is a dependency. Treat it like one.
+
+1. **Pin every cross-project and remote reference.** Use a `ref:` (tag
+   or SHA) on `include:project`, an immutable URL on `include:remote`,
+   and a `@<tag>` or `@<sha>` on `include:component`. An unpinned
+   reference (`include:project` with no `ref:`, `@main`, `@~latest`) can
+   change between two runs of the same commit.
+2. **Prefer first-party over third-party.** `include:template` and
+   components from a trusted internal group are auditable and version-
+   locked. An arbitrary `include:remote` URL is not.
+3. **Audit `include:remote`.** It fetches code with no integrity check.
+   If you cannot replace it with `include:project` or a component,
+   ensure the source is one you control and the URL is immutable.
+4. **Version components like a library.** Tag releases
+   `<major>.<minor>.<patch>`, populate the catalog with a release per
+   tag, and let consumers pin a SHA with a comment naming the version.
+5. **Beware moving selectors.** `@~latest` and `@main` are conveniences
+   for the component's own development, not for production consumers —
+   the same risk as pinning a GitHub Action to `@main`.
+
+The failure mode to avoid is the same across all forms: an unpinned
+include changes upstream, and a pipeline that passed yesterday fails (or
+worse, silently does the wrong thing) today, on an unchanged commit.
+
+## Common pitfalls
+
+- **Override order surprises.** Because the root config and later
+  includes win, a job you thought an included template defined may be
+  silently overridden by a same-named key elsewhere. Search the merged
+  config (the pipeline editor's *Full configuration* / *View merged
+  YAML* tab) when a key is not what you expect.
+- **Array keys replace, not append.** Redefining `script:` or
+  `before_script:` in the root **discards** the included version
+  entirely. Use `!reference` to keep the original and add to it.
+- **Variable scope across includes.** `variables:` are deep-merged, so a
+  root-level variable silently overrides an included one of the same
+  name. Globals defined in one include are visible to jobs from another
+  — name them defensively to avoid collisions.
+- **Inputs resolve at include time, variables at runtime.** Reaching for
+  `$VARIABLE` inside a key that needs an include-time value (a `stage:`
+  or job name) will not work — use `$[[ inputs.x ]]`. Conversely,
+  `$[[ inputs.x ]]` cannot pick up a value that only exists at job
+  runtime.
+- **Duplicate job keys across includes.** Two includes defining the same
+  job name silently merge; the later include wins per key. There is no
+  "job already defined" error — only the merged result. Keep job names
+  unique or namespace them per fragment.
+- **Unpinned remote includes.** `include:remote` to a `…/raw/main/…` URL
+  pulls whatever is at that branch tip right now. Pin to a tagged or
+  SHA-addressed raw URL, or move to `include:project`.
+- **`~latest` is the newest release, not the newest commit.** A
+  component fix pushed to a branch is invisible to `@~latest` consumers
+  until a release is created. Conversely, consumers on `@~latest` jump
+  to a new major the moment it is released — pin a tag to opt out.
+- **Catalog requires a README and a release.** A component project with
+  no `README.md` or no GitLab release will not appear in the catalog and
+  `@~latest` will not resolve, even though branch/SHA includes still
+  work.

--- a/.github/skills/gitlab-ci/references/pipeline-syntax.md
+++ b/.github/skills/gitlab-ci/references/pipeline-syntax.md
@@ -1,0 +1,721 @@
+# Pipeline syntax reference
+
+Canonical reference for the YAML grammar of a GitLab CI/CD pipeline
+(`.gitlab-ci.yml`). Each top-level and job-level key is enumerated with
+semantics, defaults, and a worked example. Read the section that matches
+the key you are editing — do not guess from memory.
+
+## File location and naming
+
+The pipeline definition lives in a file named `.gitlab-ci.yml` at the
+repository root. The basename and location are conventional, not free:
+GitLab looks for exactly this path unless the project overrides it.
+
+The override is the per-project **CI/CD configuration file** setting,
+exposed at runtime as `CI_CONFIG_PATH`. It accepts a repository-relative
+path, a path in a different project, or an external URL:
+
+```yaml
+# Project setting "CI/CD configuration file" set to:
+#   ci/pipeline.yml                 → file in this repo
+#   ci/pipeline.yml@group/templates → file in another project
+#   https://example.com/pipeline.yml → remote URL
+```
+
+A single file is the entry point; it may pull in further fragments with
+the top-level `include:` key (local files, other projects, remote URLs,
+or built-in templates). Includes are merged before any job runs.
+
+## Top-level keys
+
+### `stages`
+
+Declares the ordered list of pipeline stages. Jobs in the same stage run
+in parallel; a stage starts only after every job in the previous stage
+finishes successfully (unless `needs:` overrides the ordering — see
+below).
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+```
+
+If `stages:` is omitted, GitLab uses the implicit default ordering:
+
+```yaml
+stages:
+  - .pre      # always first, runs before any user stage
+  - build
+  - test
+  - deploy
+  - .post     # always last, runs after every user stage
+```
+
+`.pre` and `.post` are reserved virtual stages that exist whether or not
+`stages:` is declared; a job assigned to `.pre` runs before everything,
+`.post` after everything, regardless of where they appear in the file.
+
+A job is placed in a stage with its `stage:` key (see job-level keys). A
+job referencing a stage not listed in `stages:` is a configuration error.
+
+### `default`
+
+Defines values inherited by every job that does not set them explicitly.
+Only a fixed set of keys may appear under `default:` — notably `image`,
+`services`, `before_script`, `after_script`, `cache`, `tags`, `retry`,
+`timeout`, `interruptible`, and `artifacts`.
+
+```yaml
+default:
+  image: node:22-bookworm
+  tags:
+    - docker
+  before_script:
+    - corepack enable
+    - pnpm install --frozen-lockfile
+  retry:
+    max: 2
+    when: runner_system_failure
+```
+
+A job overrides a default by redeclaring the key; there is no deep merge
+of `default` into the job — the job's value replaces the default wholesale
+for that key. Set `inherit:` on a job to opt out of defaults or variables
+selectively:
+
+```yaml
+job:
+  inherit:
+    default: false              # ignore all `default:` keys
+    variables: [DEPLOY_ENV]     # inherit only these global variables
+```
+
+### `variables`
+
+Global CI/CD variables, inherited by every job. Job-scoped `variables:`
+override globals for that job. This section is intentionally brief —
+variable precedence, masking, protected/file variables, and secret
+injection are covered in the `variables-and-secrets.md` reference; consult
+it for anything beyond plain key/value defaults.
+
+```yaml
+variables:
+  GIT_DEPTH: "0"
+  FF_USE_FASTZIP: "true"
+```
+
+Variable values are strings. Quote numeric- or boolean-looking values to
+avoid the YAML coercion traps described in *Edge cases and quirks*.
+
+### `include`
+
+Pulls in external configuration before evaluation. Each entry is `local`,
+`project` (+ `ref` + `file`), `remote`, `template`, or `component`.
+
+```yaml
+include:
+  - local: ci/build.yml
+  - project: group/ci-templates
+    ref: v1.4.0
+    file: /jobs/deploy.yml
+  - template: Security/SAST.gitlab-ci.yml
+  - component: gitlab.com/components/sonarqube@1.0.0
+```
+
+### `workflow`
+
+Controls whether the **whole pipeline** is created for a given event.
+Without it, branch and merge-request pipelines can both fire and cause
+duplicate runs. The canonical guard:
+
+```yaml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
+    - when: never           # nothing else creates a pipeline
+```
+
+`workflow:rules` accepts the same `if` / `changes` / `when` vocabulary as
+job `rules:`, plus `auto_cancel` and a `name:` to label the pipeline.
+
+## Job-level keys
+
+A job is any top-level mapping that is not a reserved keyword. Its key is
+the job name (shown in the UI and used by `needs:`/`dependencies:`). A job
+must define `script:` (or be a `trigger:` / `extends:`-only bridge job).
+
+### `script`
+
+The shell commands the job runs, as a YAML list. Each list item is one
+command line; a non-zero exit on any line fails the job. Commands run in
+the runner's shell.
+
+```yaml
+test:
+  stage: test
+  script:
+    - npm ci
+    - npm run lint
+    - npm test
+```
+
+### `before_script` and `after_script`
+
+`before_script` is prepended to `script` (it shares the same shell
+context). `after_script` runs in a **separate shell**, always, even when
+the job failed or was cancelled — making it the right place for cleanup.
+Because it is a fresh shell, environment changes from `script:` do not
+carry into `after_script:`.
+
+```yaml
+deploy:
+  before_script:
+    - terraform init -input=false
+  script:
+    - terraform apply -auto-approve
+  after_script:
+    - terraform output -json > tf-out.json || true
+```
+
+### `stage`
+
+Assigns the job to a stage from `stages:`. Defaults to `test` when
+omitted.
+
+```yaml
+lint:
+  stage: build
+  script:
+    - golangci-lint run
+```
+
+### `rules` and `when`
+
+`rules:` is the modern flow-control mechanism: an ordered list evaluated
+top to bottom, **first match wins**, and the matched rule's `when:`
+decides the job's fate. Each rule may carry `if:`, `changes:`,
+`exists:`, `when:`, `allow_failure:`, and `variables:`.
+
+`when:` values: `on_success` (default — run if prior stages succeeded),
+`on_failure`, `always`, `manual` (a play button in the UI), `delayed`
+(with `start_in:`), and `never` (do not add the job).
+
+```yaml
+deploy:prod:
+  stage: deploy
+  script:
+    - ./deploy.sh production
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+      when: manual
+      allow_failure: false
+    - if: $CI_COMMIT_BRANCH == "main"
+      changes:
+        - src/**/*
+      when: on_success
+    - when: never
+```
+
+If no rule matches and there is no trailing catch-all, the job is **not
+added** to the pipeline. `rules:` is mutually exclusive with `only/except`
+in the same job.
+
+### `needs`
+
+Declares a Directed Acyclic Graph (DAG): the job starts as soon as its
+named dependencies finish, ignoring stage boundaries. This is how you
+break out of strict stage-by-stage execution.
+
+```yaml
+integration:
+  stage: test
+  needs:
+    - build:linux
+    - build:macos
+  script:
+    - ./run-integration.sh
+```
+
+`needs: []` (empty list) starts the job **immediately**, at pipeline
+creation, regardless of stage:
+
+```yaml
+prefetch:
+  stage: test
+  needs: []          # do not wait for the build stage
+  script:
+    - ./warm-cache.sh
+```
+
+`needs:` can also pull artifacts from a specific upstream job; use the
+object form with `artifacts: true`:
+
+```yaml
+package:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true       # download build's artifacts
+    - job: changelog
+      artifacts: false      # order dependency only, no download
+  script:
+    - ./package.sh
+```
+
+A job with `needs:` can depend only on jobs in the same stage or an
+earlier stage. The DAG must be acyclic.
+
+### `dependencies`
+
+Controls which upstream jobs' **artifacts** are downloaded into this job.
+By default a job downloads artifacts from every job in all prior stages;
+`dependencies:` narrows that set. An empty list disables artifact download
+entirely.
+
+```yaml
+unit:
+  stage: test
+  dependencies:
+    - build           # only fetch build's artifacts
+  script:
+    - ./test.sh
+
+quick:
+  stage: test
+  dependencies: []    # fetch nothing — faster start
+  script:
+    - ./lint.sh
+```
+
+When `needs:` is present, the `needs.*.artifacts` flags take precedence
+and `dependencies:` is redundant — prefer expressing both ordering and
+artifact flow through `needs:`.
+
+### `artifacts`
+
+Files and directories saved after the job, passed to later stages and
+downloadable from the UI.
+
+```yaml
+build:
+  stage: build
+  script:
+    - make dist
+  artifacts:
+    paths:
+      - dist/
+    exclude:
+      - dist/**/*.map
+    expire_in: 1 week
+    when: on_success          # on_success | on_failure | always
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+`reports:` artifacts feed GitLab features (test tab, coverage diffs,
+security dashboards) rather than being plain downloads.
+
+### `cache`
+
+Caches dependency directories between runs, keyed for reuse. Distinct from
+artifacts: cache is a runner-side optimization, not a contract between
+jobs.
+
+```yaml
+test:
+  cache:
+    key:
+      files:
+        - package-lock.json     # invalidate when the lockfile changes
+    paths:
+      - node_modules/
+    policy: pull-push           # pull | push | pull-push
+  script:
+    - npm ci
+    - npm test
+```
+
+### `allow_failure`
+
+When `true`, a failing job does not fail the pipeline; it is shown as a
+warning. Defaults to `false`, except for `when: manual` jobs, where it
+defaults to `true`. A numeric form restricts which exit codes are
+tolerated:
+
+```yaml
+flaky:
+  script:
+    - ./maybe-flaky.sh
+  allow_failure:
+    exit_codes:
+      - 137         # OOM-kill tolerated; any other non-zero still fails
+```
+
+### `timeout`
+
+Per-job timeout, overriding the project default. Accepts a human-readable
+duration.
+
+```yaml
+e2e:
+  timeout: 30 minutes
+  script:
+    - ./e2e.sh
+```
+
+### `retry`
+
+Automatically re-runs a failed job. `max:` is 0–2 (default 0). `when:`
+restricts retries to specific failure classes, so transient
+infrastructure failures retry while genuine test failures do not.
+
+```yaml
+deploy:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - api_failure
+  script:
+    - ./deploy.sh
+```
+
+### `interruptible`
+
+Marks the job as safe to cancel when a newer pipeline supersedes it on the
+same ref. Combined with the project's auto-cancel setting, this stops
+wasting runners on outdated commits. Set `false` on jobs that must not be
+interrupted (irreversible deploys).
+
+```yaml
+build:
+  interruptible: true
+  script:
+    - make
+```
+
+### `resource_group`
+
+Serializes jobs that share a named resource so that at most one runs at a
+time across all pipelines — the standard guard against concurrent deploys
+to the same environment.
+
+```yaml
+deploy:prod:
+  resource_group: production
+  environment:
+    name: production
+  script:
+    - ./deploy.sh
+```
+
+### `environment`
+
+Binds the job to a GitLab deployment environment, surfacing it in the
+Environments and Deployments views.
+
+```yaml
+deploy:review:
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: https://$CI_COMMIT_REF_SLUG.review.example.com
+    deployment_tier: development      # production|staging|testing|development|other
+    on_stop: stop:review              # job that tears this environment down
+  script:
+    - ./deploy-review.sh
+
+stop:review:
+  stage: deploy
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  rules:
+    - if: $CI_MERGE_REQUEST_ID
+      when: manual
+  script:
+    - ./teardown-review.sh
+```
+
+The `on_stop` job must target the same `environment.name` with
+`action: stop`, and is typically `manual`.
+
+### `parallel`
+
+Runs N identical copies of the job. Each copy gets `CI_NODE_INDEX`
+(1-based) and `CI_NODE_TOTAL`, which the script uses to shard work.
+
+```yaml
+test:
+  parallel: 4
+  script:
+    - ./run-tests.sh --shard "$CI_NODE_INDEX/$CI_NODE_TOTAL"
+```
+
+### `parallel:matrix`
+
+Fans out one job per combination of the listed variable axes (Cartesian
+product). Each generated job sees its axis variables in the environment;
+`CI_NODE_INDEX`/`CI_NODE_TOTAL` cover the whole matrix.
+
+```yaml
+test:
+  stage: test
+  parallel:
+    matrix:
+      - RUBY: ["3.2", "3.3"]
+        DB: [postgres, mysql]
+  image: ruby:$RUBY
+  script:
+    - ./test.sh --db "$DB"
+```
+
+The example above generates four jobs:
+`test: [3.2, postgres]`, `test: [3.2, mysql]`, `test: [3.3, postgres]`,
+`test: [3.3, mysql]`. A list value with multiple keys multiplies; multiple
+list entries under `matrix:` are unioned (each entry is its own product).
+
+### `tags`
+
+Selects runners by their tag set. Every listed tag must be present on the
+runner.
+
+```yaml
+gpu-job:
+  tags:
+    - gpu
+    - linux
+  script:
+    - ./train.sh
+```
+
+### `variables` (job scope)
+
+Per-job variables, overriding globals. Brief here by design; see
+`variables-and-secrets.md` for precedence and masking.
+
+```yaml
+deploy:staging:
+  variables:
+    DEPLOY_ENV: staging
+  script:
+    - ./deploy.sh "$DEPLOY_ENV"
+```
+
+## Reuse mechanisms
+
+### Hidden jobs (template jobs)
+
+A job whose name begins with a dot (`.`) is **hidden**: GitLab parses it
+but never adds it to a pipeline. Hidden jobs exist purely to be reused via
+`extends:` or `!reference`.
+
+```yaml
+.deploy-template:
+  image: alpine:3.20
+  before_script:
+    - apk add --no-cache curl
+  script:
+    - ./deploy.sh
+```
+
+### `extends`
+
+Inherits one or more jobs' configuration. Multi-level inheritance is
+supported, and keys are **deep-merged**: maps merge key-by-key, while
+arrays and scalars are replaced wholesale by the most-derived value. When
+`extends:` lists several parents, later parents win on conflict.
+
+```yaml
+.base:
+  image: node:22
+  variables:
+    LOG_LEVEL: info
+  before_script:
+    - npm ci
+
+.with-cache:
+  cache:
+    paths:
+      - node_modules/
+
+test:
+  extends:
+    - .base
+    - .with-cache
+  variables:
+    LOG_LEVEL: debug        # overrides .base's value via deep merge
+  script:
+    - npm test
+```
+
+`extends:` resolves up to 11 levels deep and is preferred over YAML
+anchors because it merges across `include:` boundaries (anchors do not —
+an anchor is only visible within the file that defines it).
+
+### YAML anchors vs `extends`
+
+YAML anchors (`&name` / `*name`) and the merge key (`<<:`) are a raw-YAML
+feature, resolved by the YAML parser before GitLab sees the document. They
+work, but only within a single file and with shallow merge semantics.
+
+```yaml
+.defaults: &defaults
+  image: node:22
+  tags: [docker]
+
+test:
+  <<: *defaults
+  script:
+    - npm test
+```
+
+Prefer `extends:` for cross-file reuse and deep merge; reach for anchors
+only for small, in-file fragments.
+
+### `!reference`
+
+The `!reference[...]` custom tag injects a value from another job's
+specific key — including reaching into a hidden job's `script:` or
+`before_script:` and composing fragments. Unlike `extends:`, it copies a
+**single addressed value**, so you can interleave reused steps with local
+ones.
+
+```yaml
+.setup:
+  before_script:
+    - apk add --no-cache curl jq
+
+.deploy-fragment:
+  script:
+    - ./deploy.sh
+
+test:
+  before_script:
+    - !reference [.setup, before_script]
+    - echo "local step after the shared setup"
+  script:
+    - !reference [.deploy-fragment, script]
+    - ./verify.sh
+```
+
+`!reference` may nest (a referenced value can itself contain a
+`!reference`), but circular references are an error.
+
+## Full worked example
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+
+default:
+  image: node:22-bookworm
+  tags: [docker]
+  retry:
+    max: 1
+    when: runner_system_failure
+
+variables:
+  GIT_DEPTH: "0"
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+.node-cache:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [node_modules/]
+
+build:
+  stage: build
+  extends: .node-cache
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+test:
+  stage: test
+  needs: [build]
+  parallel:
+    matrix:
+      - SUITE: [unit, integration]
+  script:
+    - npm run test:$SUITE
+  artifacts:
+    reports:
+      junit: junit-$SUITE.xml
+
+deploy:prod:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true
+  resource_group: production
+  interruptible: false
+  environment:
+    name: production
+    url: https://app.example.com
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+  script:
+    - ./deploy.sh dist/
+```
+
+## Edge cases and quirks
+
+- **GENERATED pipeline.** In this repository, `.gitlab-ci.yml` is
+  **derived** by `scripts/build-ci.sh` from `ci/ci-capabilities.yml` — it
+  is not hand-authored. Editing the generated `.gitlab-ci.yml` directly is
+  pointless; the next build overwrites it. Change the capability reference
+  and regenerate. See `docs/ci-reference-format.md` for the source-of-truth
+  contract.
+- **YAML boolean / `on` traps.** A YAML 1.1 parser coerces bare `yes`,
+  `no`, `on`, `off`, `true`, `false` to booleans. A variable value of
+  `on` or `no` therefore becomes a boolean and breaks string comparisons.
+  Always quote such values: `FEATURE_FLAG: "on"`, `DEBUG: "false"`.
+- **`script:` list vs block scalar.** `script:` expects a **list** of
+  command strings, not a single block scalar. Writing `script: | …` puts
+  one multiline string as the sole list item, which works but defeats
+  per-line failure semantics and is harder to read — prefer one list item
+  per command.
+- **`needs:` vs `stage:` interaction.** `stage:` defines logical ordering
+  and the UI grouping; `needs:` overrides the *execution* ordering into a
+  DAG. A job can still belong to a later stage yet start early via
+  `needs:`. `needs:` can only reference jobs in the same or an earlier
+  stage.
+- **`rules:` replaced `only/except`.** `only/except` is legacy and must
+  not be mixed with `rules:` in the same job. New jobs use `rules:`
+  exclusively; it is strictly more expressive (per-rule `variables:`,
+  `when:`, `allow_failure:`, `changes:`, `exists:`).
+- **First-match-wins in `rules:`.** Evaluation stops at the first matching
+  rule. Order matters: put the most specific conditions first and a
+  trailing `when: never` (or a catch-all) to make the default explicit.
+- **`when: manual` flips `allow_failure`.** A manual job defaults to
+  `allow_failure: true`; set it to `false` explicitly when a manual gate
+  must block the pipeline on failure.
+- **`after_script` is a fresh shell.** It runs unconditionally (even on
+  failure or cancellation) but does not inherit shell state or exit codes
+  from `script:`. Guard cleanup commands with `|| true` if a non-zero exit
+  there would matter.
+- **`default:` is replace, not merge.** A job that redeclares a `default:`
+  key replaces it wholesale for that job; there is no deep merge of
+  `default:` into the job. Deep merge applies only to `extends:`.
+- **Anchors do not cross `include:`.** YAML anchors are file-local. To
+  reuse configuration defined in an included file, use `extends:` or
+  `!reference`, never an anchor.

--- a/.github/skills/gitlab-ci/references/rules-and-triggers.md
+++ b/.github/skills/gitlab-ci/references/rules-and-triggers.md
@@ -1,0 +1,464 @@
+# Rules and triggers reference
+
+The control-flow language that decides **whether** a job runs and
+**what kind of pipeline** runs at all. Read this before writing any
+non-trivial `rules:` clause or `workflow:` gate. Memorising the
+short-circuit and pipeline-source rules avoids the bulk of "two
+pipelines fired for one push" and "the job ran when I told it not to"
+bugs.
+
+## Evaluation surface
+
+Control flow lives at two scopes:
+
+1. **Per-job** via the job-level `rules:` key — decides if *this* job
+   is added to the pipeline, and with which `when:`, `allow_failure:`,
+   and per-rule `variables:`.
+2. **Per-pipeline** via the top-level `workflow:rules:` key — decides
+   if *any* pipeline is created for the event, and short-circuits
+   duplicate pipelines.
+
+Both are evaluated **at pipeline-creation time**, before any job runs.
+A job's `rules:` cannot see another job's result; for run-time
+dependencies use `needs:` / `dependencies:`, not `rules:`. The legacy
+`only:`/`except:` keys occupy the same per-job slot as `rules:` but
+**cannot be combined with it** in the same job — pick one.
+
+## The `rules:` list
+
+`rules:` is an **ordered list**. Evaluation walks it top-to-bottom and
+**stops at the first rule that matches** (short-circuit). The matched
+rule's attributes (`when`, `allow_failure`, `variables`, `start_in`)
+apply; later rules are ignored. If **no** rule matches, the job is
+**not added** to the pipeline (implicit `when: never`).
+
+Each rule is a mapping combining one or more **clauses** (`if`,
+`changes`, `exists`) with **attributes** (`when`, `allow_failure`,
+`variables`, `start_in`). Within one rule, multiple clauses are ANDed.
+
+```yaml
+job:
+  script: ./run.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: on_success
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - src/**/*
+      when: manual
+      allow_failure: true
+    - when: never
+```
+
+### `rules:if`
+
+A single boolean expression over CI/CD variables (operator table
+below). The most common clause. Quote the whole expression so YAML
+does not choke on `:` or `$`.
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG'                       # truthy: tag is set
+  - if: '$CI_COMMIT_BRANCH =~ /^release\/.+/'  # regex match
+```
+
+### `rules:changes`
+
+Matches when any listed path changed. A glob list, or a mapping with
+`paths:` plus `compare_to:` to pin the comparison base (essential
+outside merge requests, where the default base is unreliable).
+
+```yaml
+rules:
+  - changes:
+      paths:
+        - Dockerfile
+        - "src/**/*"
+      compare_to: 'refs/heads/main'
+```
+
+Without `compare_to`, `changes` on a branch pipeline diffs against the
+previous commit on that branch — surprising for force-pushes and the
+first commit. Pin `compare_to` for deterministic behavior.
+
+### `rules:exists`
+
+Matches when at least one file matching the glob exists in the
+repository at pipeline-creation time. Globs are relative to the repo
+root; `**` recurses.
+
+```yaml
+rules:
+  - exists:
+      - "**/Dockerfile"
+```
+
+### `when:` attribute
+
+Selects the job's run behavior once its rule matches:
+
+| Value | Behavior |
+|-------|----------|
+| `on_success` | Run if all jobs in earlier stages succeeded (or `allow_failure`). The default. |
+| `on_failure` | Run only if at least one job in an earlier stage failed. |
+| `always` | Run regardless of earlier-stage status. |
+| `manual` | Add the job but require a manual play action. |
+| `delayed` | Schedule the job after `start_in:`. |
+| `never` | Do **not** add the job. Used as a terminal "drop everything else" rule. |
+
+`when: manual` jobs are non-blocking by default in `rules:`-driven
+pipelines; pair with `allow_failure: false` to make a manual gate
+block downstream stages.
+
+### `allow_failure:` attribute
+
+Set per matched rule. `true` lets the job fail without failing the
+pipeline; `false` makes it blocking. Overrides the job-level
+`allow_failure:` for that rule.
+
+### `variables:` attribute
+
+A matched rule may inject or override variables for the job — the
+canonical way to parameterise one job by the branch or event that
+selected it.
+
+```yaml
+deploy:
+  script: ./deploy.sh "$TARGET_ENV"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      variables:
+        TARGET_ENV: production
+    - if: '$CI_COMMIT_BRANCH == "staging"'
+      variables:
+        TARGET_ENV: staging
+```
+
+### `start_in:` and `when: delayed`
+
+`start_in:` is required by `when: delayed` and gives a human-readable
+duration (`30 seconds`, `1 hour`, `2 days`, capped at one week).
+
+```yaml
+rollout:
+  script: ./rollout.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: delayed
+      start_in: '15 minutes'
+```
+
+## `workflow:rules:` — whole-pipeline gating
+
+`workflow:` sits at the top level and decides whether *any* pipeline
+is created. Same clause/attribute grammar as job `rules:`, but only
+`when: always` and `when: never` are meaningful (a pipeline either
+exists or it does not). Use it to prevent **duplicate pipelines** —
+the single most common GitLab CI footgun.
+
+### The duplicate-pipeline idiom
+
+When merge-request pipelines are enabled, a push to a branch that has
+an open MR fires **two** events: a branch pipeline *and* a detached
+merge-request pipeline. The canonical guard runs MR pipelines when an
+MR is open, branch pipelines only when none is, and tag pipelines
+always:
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+`$CI_OPEN_MERGE_REQUESTS` is non-empty on a branch pipeline whose
+commit has at least one open MR; the third rule drops that redundant
+branch pipeline, leaving only the detached MR pipeline. GitLab ships
+this exact pattern as the `Branch-Pipelines` / `MergeRequest-Pipelines`
+templates.
+
+### `workflow:name:`
+
+Sets a human-readable name for the whole pipeline, supporting
+variable interpolation evaluated at creation time.
+
+```yaml
+workflow:
+  name: 'Pipeline for $CI_COMMIT_REF_NAME'
+```
+
+## Predefined CI/CD variables used in rules
+
+The variables that actually drive `rules:if`. Each is a string; an
+unset variable is the empty string (falsy).
+
+| Variable | Value |
+|----------|-------|
+| `CI_PIPELINE_SOURCE` | What triggered the pipeline (value enumeration below). |
+| `CI_COMMIT_BRANCH` | Branch name. **Empty** on tag pipelines and MR (detached) pipelines. |
+| `CI_COMMIT_TAG` | Tag name. Set **only** on tag pipelines. |
+| `CI_DEFAULT_BRANCH` | The project's default branch (e.g. `main`). |
+| `CI_COMMIT_REF_NAME` | Branch **or** tag name — set on both branch and tag pipelines. |
+| `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` | Target branch of the MR. Set only on MR pipelines. |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of the MR. MR pipelines only. |
+| `CI_OPEN_MERGE_REQUESTS` | Comma-separated `path!iid` of MRs whose source/target is the current branch. Empty when none. |
+| `CI_COMMIT_REF_PROTECTED` | `"true"` if the ref is protected. |
+| `CI_PROJECT_PATH` | `group/project`. |
+
+### `CI_PIPELINE_SOURCE` values
+
+| Value | Triggered by |
+|-------|--------------|
+| `push` | A `git push` to a branch or tag. |
+| `merge_request_event` | An MR was opened/updated (detached, merged-results, or merge-train pipeline). |
+| `schedule` | A pipeline schedule fired. |
+| `web` | The "Run pipeline" button in the UI. |
+| `api` | A pipeline created via the REST API. |
+| `trigger` | A trigger token (`POST /trigger/pipeline`). |
+| `pipeline` | Created by another pipeline's `trigger:` (multi-project, upstream). |
+| `parent_pipeline` | Created by a parent via `trigger:include` (child pipeline). |
+
+Mapping the neutral trigger vocabulary onto these is the job of
+`scripts/build-ci.sh` — see the cross-reference at the end.
+
+## Expression operators in `rules:if`
+
+`rules:if` evaluates a **single boolean expression**. Operators, in
+approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `=~` / `!~` | Regex match / non-match. RHS is a `/pattern/flags` literal. |
+| `==` / `!=` | String equality / inequality. |
+| `&&` | Logical AND. |
+| `\|\|` | Logical OR. |
+
+Notes that bite:
+
+- **No `<`/`>` comparison, no arithmetic.** Values are compared as
+  strings. There is no numeric coercion; `'10' == '10'` is a string
+  match, not a number one.
+- **Quoting.** A literal string in the expression is double-quoted
+  inside the single-quoted YAML scalar: `if: '$X == "main"'`. A bare
+  `$VAR` (no quotes) tests truthiness.
+- **Regex literals** use `/.../` delimiters with optional flags:
+  `=~ /^v\d+\.\d+/i`. The pattern is RE2 (GitLab uses the Go regexp
+  engine on the server side); no backreferences, no lookahead.
+- **`null`.** Compare against `null` (unquoted) to test "variable is
+  undefined" vs `""` (defined-but-empty). They differ:
+  `$X == null` is true only when `X` was never set.
+
+### Truthiness
+
+| Expression form | True when… |
+|-----------------|------------|
+| `$VAR` (bare) | `VAR` is set **and** non-empty. |
+| `$VAR == "x"` | `VAR` equals the string `x`. |
+| `$VAR != null` | `VAR` is defined (even if empty). |
+| `$VAR =~ /p/` | `VAR` is set and matches the pattern. |
+
+The empty-string trap mirrors GitHub Actions: a bare `$VAR` is false
+both when unset and when set to `""`. To distinguish, test against
+`null`.
+
+## Pipeline types and trigger mechanisms
+
+| Pipeline type | Fires when | `CI_PIPELINE_SOURCE` |
+|---------------|------------|----------------------|
+| Branch | Push to a branch | `push` |
+| Tag | Push of a tag | `push` (with `$CI_COMMIT_TAG` set) |
+| Merge request (detached) | MR opened/updated, MR pipelines enabled | `merge_request_event` |
+| Merged-results | Like detached, but run against the *result* of merging into target | `merge_request_event` |
+| Merge-train | Sequential merged-results pipelines guarding the queue | `merge_request_event` |
+| Scheduled | A pipeline schedule fires | `schedule` |
+| Parent-child | A job's `trigger:include` in the same project | `parent_pipeline` |
+| Multi-project | A job's `trigger:` with `project:` | `pipeline` |
+
+Merged-results and merge-train pipelines are detected the same way in
+`rules:` — all three carry `CI_PIPELINE_SOURCE == "merge_request_event"`.
+Distinguish merge-train runs by the predefined `$CI_MERGE_REQUEST_EVENT_TYPE`
+(`detached`, `merged_result`, `merge_train`) when behavior must differ.
+
+### `trigger:` — parent-child pipelines
+
+A job whose body is `trigger:` does no work itself; it spawns a
+downstream pipeline. `trigger:include` runs a child pipeline from
+config in the same project. `strategy: depend` makes the trigger job
+mirror the child's status (otherwise it succeeds immediately on
+dispatch).
+
+```yaml
+run-child:
+  stage: test
+  trigger:
+    include:
+      - local: ci/child-pipeline.yml
+    strategy: depend
+```
+
+### `trigger:` — multi-project pipelines
+
+`trigger:project` (plus optional `branch`) dispatches a pipeline in a
+**different** project. `forward:` controls which variables and
+yaml-defined pipeline variables propagate downstream.
+
+```yaml
+deploy-downstream:
+  stage: deploy
+  trigger:
+    project: my-group/deployment-config
+    branch: main
+    strategy: depend
+    forward:
+      pipeline_variables: true
+      yaml_variables: true
+```
+
+`forward.pipeline_variables` forwards variables passed into the
+*current* pipeline (e.g. from a manual run); `forward.yaml_variables`
+forwards the `variables:` block defined in this job. Both default such
+that yaml variables forward and pipeline variables do not — set
+explicitly when in doubt.
+
+## Legacy `only:` / `except:` (superseded by `rules:`)
+
+`only:` / `except:` predate `rules:` and remain supported but are
+**not recommended** for new pipelines. They cannot appear in the same
+job as `rules:`. Each takes `refs`, `changes`, or `variables`.
+
+```yaml
+# Legacy form
+job:
+  script: ./run.sh
+  only:
+    refs:
+      - main
+      - /^release\/.*$/
+    changes:
+      - src/**/*
+  except:
+    variables:
+      - $SKIP_CI
+```
+
+### Migration to `rules:`
+
+The equivalent `rules:` form makes the implicit OR/AND explicit and
+short-circuits cleanly:
+
+```yaml
+# Modern form
+job:
+  script: ./run.sh
+  rules:
+    - if: '$SKIP_CI'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - src/**/*
+    - if: '$CI_COMMIT_BRANCH =~ /^release\/.*$/'
+      changes:
+        - src/**/*
+```
+
+Migration notes:
+
+- `only:refs` keywords like `merge_requests`, `tags`, `branches` map to
+  `if:` expressions on `$CI_PIPELINE_SOURCE`, `$CI_COMMIT_TAG`, and
+  `$CI_COMMIT_BRANCH` respectively.
+- `except:` becomes a leading `when: never` rule (short-circuit).
+- `only:` without `refs` (just `changes`/`variables`) had an implicit
+  `branches`+`tags` ref scope; replicate it with an explicit `if:` or
+  the job will widen its trigger surface silently.
+
+## Common patterns
+
+### Run only on the default branch
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+```
+
+### Run only in merge-request pipelines
+
+```yaml
+rules:
+  - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+### Run on tags matching a version pattern
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+```
+
+### Manual gate that blocks downstream stages
+
+```yaml
+deploy:
+  script: ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: manual
+      allow_failure: false
+```
+
+### Skip the pipeline entirely on doc-only pushes
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+      changes:
+        paths:
+          - "docs/**/*"
+        compare_to: 'refs/heads/main'
+      when: never
+    - when: always
+```
+
+## Pitfalls
+
+- **No `workflow:rules:` guard.** Without the duplicate-pipeline idiom
+  above, every push to a branch with an open MR runs the pipeline
+  twice. This is the default failure mode, not an edge case.
+- **`$CI_COMMIT_BRANCH` is empty on MR pipelines.** A rule written as
+  `if: '$CI_COMMIT_BRANCH == "main"'` never matches inside a detached
+  MR pipeline — use `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME` there.
+- **`changes` without `compare_to` outside an MR.** The comparison base
+  is the previous pipeline's commit, which is unstable on force-push
+  and the branch's first commit. Always pin `compare_to`.
+- **`rules:` short-circuit forgotten.** Listing two matching `if:`
+  rules does not OR their attributes — only the **first** match's
+  attributes apply. Order matters; put the most specific rule first.
+- **`when: manual` non-blocking by default.** In `rules:`-driven
+  pipelines a manual job does not block downstream stages unless
+  `allow_failure: false` is set explicitly.
+- **`trigger:` without `strategy: depend`.** The trigger job goes green
+  the instant it dispatches the downstream pipeline, regardless of
+  whether that pipeline later fails. Add `strategy: depend` to mirror
+  the child's status.
+- **Mixing `rules:` with `only:`/`except:`.** GitLab rejects a job that
+  declares both. Migrate fully; do not interleave.
+
+## Cross-reference — this repository
+
+The generated `.gitlab-ci.yml` at the repo root is **derived**, not
+hand-authored: `scripts/build-ci.sh` (spec 0048) reads the neutral
+capability reference `ci/ci-capabilities.yml` and maps its
+engine-neutral trigger vocabulary — `push` / `pull-request` / `tag` /
+`scheduled` / `manual`, qualified by `branches` / `paths` /
+`tag-pattern` filters — onto the GitLab `rules:` constructs documented
+above (e.g. `pull-request` → `$CI_PIPELINE_SOURCE == "merge_request_event"`,
+`tag` → `$CI_COMMIT_TAG`, a `tag-pattern` filter → a `=~ /pattern/`
+clause). That neutral vocabulary and the mapping contract are defined
+in [`docs/ci-reference-format.md`](../../../../../docs/ci-reference-format.md)
+— do not redefine it here. This reference documents the GitLab target
+syntax the generator emits; the format doc owns the neutral source
+contract.

--- a/.github/skills/gitlab-ci/references/runners-and-executors.md
+++ b/.github/skills/gitlab-ci/references/runners-and-executors.md
@@ -1,0 +1,414 @@
+# Runners and executors reference
+
+Reference for the execution substrate of GitLab CI/CD: where a runner
+comes from (scope), how a job is matched to one (tags), how the runner
+runs the job (executors), how the docker executor handles images and
+services, the `config.toml` knobs that govern a self-managed runner, and
+the security model that decides whether attaching a runner is safe.
+
+GitLab splits the concern in two. A **runner** is the agent registered
+with a GitLab instance that picks up jobs. An **executor** is the
+mechanism a runner uses to run a job's script — a local shell, a
+container, a Kubernetes pod. One runner process runs one executor; you
+register several runners to offer several executors.
+
+## Runner scopes
+
+A runner's scope decides which projects may schedule jobs on it.
+
+| Scope | Registered against | Visible to |
+|-------|--------------------|-----------|
+| **Instance** (shared) | The whole instance | Every project, subject to admin settings. |
+| **Group** | A group | Every project in that group and its subgroups. |
+| **Project** (specific) | One or more projects | Only the projects it is explicitly assigned to. |
+
+The GitLab coordinator offers a pending job to the runners eligible for
+that project; the first runner that polls and matches the job's `tags:`
+claims it. Shared runners process jobs fair-use across projects; group
+and project runners only see their own scope.
+
+### GitLab.com SaaS hosted runners
+
+GitLab.com offers managed runners — nothing to register. They are
+ephemeral (a fresh VM per job, destroyed afterward, no state leak) and
+selected by tag:
+
+| Tag (class) | Platform | Notes |
+|-------------|----------|-------|
+| `saas-linux-small-amd64` | Linux | Default class; smallest, cheapest. |
+| `saas-linux-medium-amd64`, `saas-linux-large-amd64` | Linux | More vCPU/RAM, higher minute weight. |
+| `saas-linux-medium-arm64` | Linux ARM | ARM64 class. |
+| `saas-windows-medium-amd64` | Windows | Higher minute multiplier. |
+| `saas-macos-medium-m1` | macOS | Apple silicon; highest multiplier; tier-gated. |
+
+Class names and minute multipliers drift — verify against the current
+GitLab.com runner docs before pinning one. Untagged jobs run on the
+small Linux class.
+
+### Self-managed runners
+
+Anything you register yourself with `gitlab-runner register`, against a
+self-managed instance or GitLab.com. You own the host, the executor
+choice, the network placement, and the security posture. The rest of
+this document is mostly about these.
+
+## Selecting a runner with `tags:`
+
+A job advertises required tags; a runner advertises the tags it was
+registered with. A job runs on a runner only if the runner carries
+**every** tag the job lists.
+
+```yaml
+build:
+  tags: [docker, linux, amd64]
+  script:
+    - make build
+```
+
+This runs only on a runner tagged at least `docker`, `linux`, and
+`amd64`. Extra runner tags are fine; a single missing tag disqualifies
+the runner.
+
+### Untagged jobs and `run_untagged`
+
+A job with no `tags:` is **untagged**. A runner picks up untagged jobs
+only when registered with `run_untagged = true` (the default for new
+runners; admins often flip shared runners to `false` to force explicit
+tagging). Set it per runner in `config.toml`:
+
+```toml
+[[runners]]
+  name = "docker-runner-1"
+  run_untagged = true
+```
+
+### The "no runner matching tags" stuck job
+
+If a job lists a tag no eligible runner carries — a typo, a
+decommissioned runner, a runner in the wrong scope — the job sits
+`pending` and eventually fails:
+
+```text
+This job is stuck because you don't have any active runners online
+or available with any of these tags assigned to them: <tag>
+```
+
+This is the most common GitLab CI failure after YAML errors. Diagnose
+in Settings → CI/CD → Runners: confirm a runner available to the
+project advertises the exact tag set. A job tagging `arm64` on an
+`amd64`-only fleet is stuck forever, not slow.
+
+## Executors
+
+The executor is set per runner at registration and recorded in
+`config.toml`. It determines the isolation model, the available
+features, and the operational cost.
+
+| Executor | Isolation | Use when |
+|----------|-----------|----------|
+| `shell` | None — runs as the runner's OS user | Trusted single-tenant jobs needing host tools directly. |
+| `docker` | Per-job container | Default for most fleets; clean, reproducible. |
+| `docker-autoscaler` | Per-job container on autoscaled hosts | Bursty load; replaces deprecated `docker-machine`. |
+| `kubernetes` | Per-job pod | Already on k8s; elastic; per-job resource limits. |
+| `ssh` | Remote host, no isolation | Legacy; avoid for new work. |
+| `virtualbox` / `parallels` | Full VM | Need a full guest OS (Windows/macOS) with VM isolation. |
+| `instance` | Fresh cloud VM per job | Autoscaled VMs via fleeting; strongest isolation, highest latency. |
+
+### `shell`
+
+Runs the job's `script:` directly on the host as the user that owns the
+runner process — no container, no image. Fast and simple, but a job has
+the host's full toolchain and filesystem; an escape affects the host and
+the next job. Reserve for trusted, single-tenant runners; never expose a
+shell-executor runner to untrusted contributions (see *Runner
+security*).
+
+### `docker`
+
+The dominant choice. Each job runs in a container from a chosen image;
+the runner mounts the build directory and caches, runs the `script:`,
+then discards the container. Clean per-job state, reproducible
+toolchains, no host pollution. Configuration depth below.
+
+### `kubernetes`
+
+The runner is a controller that creates a **pod per job**: a build
+container (the job image), a helper container (clone, artifacts, cache),
+and one container per declared `service:`. You get horizontal elasticity
+and per-job CPU/memory limits, at the cost of running the runner inside
+a cluster with the right RBAC. Standard for teams already on Kubernetes.
+Knobs live under `[runners.kubernetes]`.
+
+Choosing: trusted project with host tools → `shell`; general-purpose
+fleet → `docker`; already on Kubernetes → `kubernetes`; bursty cloud
+load with scale-to-zero → `docker-autoscaler` / `instance`; full guest
+OS or VM isolation → `virtualbox` / `parallels`.
+
+## The docker executor
+
+### `image:` — the job's container
+
+Set per job, or globally via `default:`:
+
+```yaml
+default:
+  image: golang:1.23-bookworm
+
+test:
+  script: [go test ./...]
+
+lint:
+  image: golangci/golangci-lint:v1.61.0   # overrides the default
+  script: [golangci-lint run]
+```
+
+A job-level `image:` overrides `default:`. With no image at all, the
+docker executor falls back to the runner's configured default image in
+`config.toml`.
+
+### Pin images by digest — security default
+
+Bare tags are mutable: `golang:1.23` and `:latest` can be repointed at a
+new image under the same name, so a green pipeline can silently start
+running different code. Pin by immutable digest:
+
+```yaml
+default:
+  image: golang:1.23-bookworm@sha256:0e6f6c...   # immutable
+```
+
+The skill's `check-pinned-images.sh` flags any `image:` (and
+`services:[].name`) using a bare tag or `:latest` instead of a
+`@sha256:` digest. Treat a bare tag as a finding, not a style nit:
+digest pinning is this skill's supply-chain default, mirroring the
+github-actions action-SHA-pinning rule.
+
+### `image:pull_policy`
+
+Controls when the executor pulls versus reusing a cached image:
+
+```yaml
+build:
+  image:
+    name: registry.example.com/builder@sha256:abc123...
+    pull_policy: [always, if-not-present]
+```
+
+- `always` — pull every run (default on shared runners; freshest).
+- `if-not-present` — pull only when absent locally (fast; safe with a
+  digest, stale-prone with a mutable tag).
+- `never` — never pull; the image must be pre-seeded on the host.
+
+A job may only request policies the runner permits via
+`allowed_pull_policies`; a disallowed request fails the job rather than
+silently downgrading.
+
+### `services:` — sidecar containers
+
+Services are extra containers started alongside the job container on a
+shared network — databases, brokers, headless browsers. Reach them as
+hostnames:
+
+```yaml
+test:
+  image: golang:1.23-bookworm
+  services:
+    - name: postgres:16@sha256:def456...
+      alias: db
+      variables: { POSTGRES_DB: app_test, POSTGRES_PASSWORD: ci_only }
+    - name: redis:7@sha256:aaa111...
+  variables:
+    DATABASE_URL: "postgres://postgres:ci_only@db:5432/app_test"
+  script: [go test ./...]
+```
+
+Mechanics:
+
+- **Hostname.** A service answers at its image name (with `/` and `:`
+  rewritten to `-` and `__`) and at any `alias:` — `db` above. The alias
+  is the practical handle.
+- **Per-service `variables:`.** Configure the service container (DB
+  name, password) independently of the job env.
+- **`services:[].command` / `services:[].entrypoint`.** Override the
+  container's startup, e.g. to pass flags to the service binary.
+- **Ports.** The shared network exposes the container's listening ports
+  on the alias hostname directly; GitLab needs no `ports:` mapping. The
+  `CI_*` variables describe the build environment, not service ports.
+- **Readiness.** The runner waits for service containers to start, but
+  started is not ready — for Postgres and friends, add an explicit wait
+  in the script (`pg_isready` poll, `wait-for-it`).
+
+### Private images — `DOCKER_AUTH_CONFIG`
+
+To pull `image:` or `services:` from a private registry, give the runner
+credentials via the `DOCKER_AUTH_CONFIG` CI/CD variable — a JSON
+document in Docker `config.json` format, ideally a **masked, protected**
+variable:
+
+```json
+{ "auths": { "registry.example.com": { "auth": "base64(user:token)" } } }
+```
+
+The docker and kubernetes executors read it and authenticate the pull.
+Prefer a deploy token or least-privilege registry token over a personal
+credential; never inline the value in `.gitlab-ci.yml`. See the
+security-and-permissions reference for variable protection and masking.
+
+## `config.toml` essentials
+
+Self-managed runners are configured by `config.toml` (default
+`/etc/gitlab-runner/config.toml`). Practitioner essentials below;
+consult the GitLab Runner advanced-configuration docs for the full
+surface.
+
+```toml
+concurrent = 8        # max jobs across ALL runners in this process
+check_interval = 3    # seconds between coordinator polls
+
+[[runners]]
+  name = "docker-runner-1"
+  url = "https://gitlab.example.com/"
+  token = "glrt-REDACTED"
+  executor = "docker"
+  run_untagged = false
+  limit = 4           # max concurrent jobs for THIS runner
+
+  [runners.docker]
+    image = "alpine:3.20"            # fallback when a job sets no image
+    privileged = false              # KEEP false unless truly needed
+    pull_policy = ["if-not-present"]
+    allowed_pull_policies = ["always", "if-not-present"]
+    allowed_images = ["registry.example.com/*", "docker.io/library/*"]
+    allowed_services = ["postgres:*", "redis:*"]
+    volumes = ["/cache"]            # do NOT mount /var/run/docker.sock
+
+  [runners.cache]
+    Type = "s3"
+    Shared = true
+    [runners.cache.s3]
+      ServerAddress = "s3.example.com"
+      BucketName = "gitlab-runner-cache"
+      AuthenticationType = "iam"    # prefer instance role over static keys
+
+  [runners.kubernetes]
+    namespace = "gitlab-ci"
+    image = "alpine:3.20"
+    privileged = false
+    cpu_request = "500m"
+    memory_request = "512Mi"
+    cpu_limit = "2"
+    memory_limit = "2Gi"
+    service_account = "gitlab-runner"
+```
+
+- `concurrent` caps total simultaneous jobs for the whole
+  `gitlab-runner` process, independent of how many `[[runners]]` blocks
+  exist; `limit` caps a single runner.
+- `privileged = true` grants containers near-host capabilities (see
+  *Runner security*); default and recommended value is `false`.
+- `allowed_images` / `allowed_services` allowlist what jobs may run,
+  blunting the "any fork runs any image" exposure on shared runners.
+- `volumes` persists paths across jobs on the same host; a distributed
+  `[runners.cache]` survives beyond one host (essential for autoscaled
+  fleets where the next job lands elsewhere). Never mount the Docker
+  socket as a volume — that is the classic root-escalation footgun.
+- `[runners.kubernetes]` requests/limits seed each per-job pod unless a
+  job overrides them via `KUBERNETES_*` variables; scope the
+  `service_account` RBAC to the minimum the build needs.
+
+## Autoscaling
+
+For bursty load, scale capacity to demand instead of paying for idle
+hosts:
+
+- **`docker-autoscaler` + fleeting.** The current autoscaling path,
+  replacing the deprecated `docker-machine`. A **fleeting** plugin (AWS
+  EC2, GCP, Azure) provisions and reaps VMs; the autoscaler runs the
+  docker executor on each. Configured via `[runners.autoscaler]` with
+  `plugin`, `capacity_per_instance`, and scaling policies.
+- **`instance` executor.** Runs each job directly on a freshly
+  provisioned-then-destroyed cloud VM via the same fleeting plugins —
+  strongest isolation, highest per-job latency.
+- **GitLab Runner Operator on Kubernetes.** Deploy and manage runners
+  declaratively via the operator and a `Runner` custom resource; the
+  cluster autoscaler then scales nodes to absorb pod-per-job demand.
+
+## Runner security
+
+A runner executes whatever code a pipeline carries. The hard questions
+are *who can push that code* and *what the runner can reach*.
+
+### `privileged = true` is dangerous
+
+A privileged docker container runs with near-host capabilities: host
+devices, kernel manipulation, and — with a mounted Docker socket —
+trivial escape to root on the host. People enable it for
+Docker-in-Docker (`dind`); prefer **rootless buildkit / kaniko /
+buildah**, which build images without privileged mode. If `dind` is
+unavoidable, isolate those runners on disposable, network-segmented
+hosts and never share them with untrusted projects.
+
+### The untrusted-fork / public-project exposure
+
+The headline rule mirrors the GitHub Actions analog: **a fork merge
+request can run arbitrary code on any runner that picks up its
+pipeline.** If a shared or instance runner processes fork pipelines for
+a public project, an attacker forks, edits `.gitlab-ci.yml` to exfil
+secrets or mine the host, and opens an MR. Defenses:
+
+1. **Protected branches and protected variables.** Mark sensitive CI/CD
+   variables **protected** so they are injected only on protected
+   branches and tags — never on a fork MR pipeline. This is the primary
+   control: a fork pipeline never sees the secret.
+2. **Restrict shared runners on public projects.** Disable instance
+   runners for public projects, or require approval before
+   external-fork MR pipelines run (project CI/CD settings).
+3. **Dedicated, ephemeral, segmented runners for untrusted work.** If
+   fork CI must run, give it disposable runners (autoscaled VMs / k8s
+   pods destroyed per job) on a network with no route to production or
+   the secret store.
+4. **`allowed_images` / `allowed_services` allowlists.** Constrain what
+   a job may pull and run on a shared runner.
+5. **Drop `privileged`, drop the Docker socket.** A non-privileged
+   runner with no socket mount removes the easiest escalation path.
+
+### Isolate CI from production networks
+
+Place runners on a subnet that **cannot** reach production databases,
+state stores, or the secret manager beyond what the build legitimately
+needs. A compromised job should not be one `curl` from production.
+Combine network segmentation with protected variables so the blast
+radius of a malicious pipeline is bounded.
+
+For the full permission surface — protected vs masked variables,
+`CI_JOB_TOKEN` scoping, the GitLab security model — see the
+security-and-permissions reference.
+
+## Resource and concurrency controls
+
+Two job-level fields interact with the runner layer; full job-field
+semantics live in the pipeline-syntax reference, summarized here only
+for their runner-side effect:
+
+- **`resource_group`** — serializes jobs sharing the named group so
+  that, across pipelines, at most one runs at a time. The mechanism is
+  the coordinator's, not the runner's, but it is how you stop two deploy
+  jobs racing on the same environment regardless of free runner count.
+
+  ```yaml
+  deploy_prod:
+    resource_group: production
+    environment: production
+    script: ./deploy.sh
+  ```
+
+- **`interruptible`** — marks a job safe to auto-cancel when a newer
+  pipeline supersedes it on the same ref (with *Auto-cancel redundant
+  pipelines* enabled), freeing runner capacity. Full field detail in the
+  pipeline-syntax reference.
+
+  ```yaml
+  build:
+    interruptible: true
+    script: make build
+  ```

--- a/.github/skills/gitlab-ci/references/security-and-permissions.md
+++ b/.github/skills/gitlab-ci/references/security-and-permissions.md
@@ -1,0 +1,382 @@
+# Security and permissions reference
+
+GitLab CI/CD has no single token whose scope map you tune the way GitHub
+Actions tunes `GITHUB_TOKEN` via `permissions:`. The pipeline's
+authority is spread across distinct primitives: the `CI_JOB_TOKEN` and
+its accessible-projects allowlist, the project/group member role model,
+protected branches and tags, protected environments, and the
+masked/protected variable discipline. Getting these right is the
+highest-leverage defense against supply-chain compromise — a job that
+runs on an unprotected ref, with a tightly scoped job token and no
+protected variables in reach, cannot deploy to production, push a
+package, or exfiltrate a long-lived cloud key, no matter what a
+dependency it pulls tries to do.
+
+This file is the GitLab analog of the GitHub Actions skill's
+`permissions.md`. Where GitHub concentrates authority in one token, read
+this as "which primitive grants which authority, and how to grant the
+minimum".
+
+## The `CI_JOB_TOKEN`
+
+Every job receives a `CI_JOB_TOKEN` — a short-lived credential, valid
+only for the lifetime of the job, injected as the predefined variable
+`CI_JOB_TOKEN`. It is the rough analog of `GITHUB_TOKEN`, but its scope
+is governed by project settings rather than a per-pipeline `permissions:`
+key.
+
+The token can:
+
+- Clone the current project (it backs the `git clone` of the pipeline
+  itself).
+- Authenticate to the project's container registry and package registry
+  (pull, and push where the job's user role allows).
+- Call a curated subset of the GitLab API on behalf of the job
+  (`CI_JOB_TOKEN`-accepting endpoints — a deliberately narrower surface
+  than a personal access token).
+- Reach **other projects** — but only those on the current project's
+  **job-token allowlist** (see below).
+
+It is bound to the identity and role of the **user who triggered the
+pipeline**: a job triggered by a Reporter cannot push to the registry
+even though the token mechanically exists. Role gates the token; the
+token does not elevate the role.
+
+### The job-token accessible-projects allowlist
+
+Under **Settings → CI/CD → Job token permissions** (historically labelled
+"Token Access" / "Limit access to this project"), each project maintains
+an **allowlist of projects whose CI jobs may use their `CI_JOB_TOKEN`
+to access this project**.
+
+- **Historical over-broad default.** On older GitLab versions the token
+  was usable across *any* project the triggering user could see — an
+  implicit, organization-wide allowlist. That default is the classic
+  GitLab CI lateral-movement vector: a compromised job in a low-value
+  project could clone or push to a high-value sibling.
+- **The hardened posture.** Enable "Limit access to this project" (the
+  inbound allowlist), then add only the specific projects whose
+  pipelines legitimately need to reach this one. Newer GitLab versions
+  default to the restricted allowlist for new projects; audit existing
+  projects, which may still carry the legacy open setting.
+- **Direction matters.** The allowlist is **inbound**: project A's
+  allowlist names the projects *allowed to reach A*. To let project B's
+  pipeline clone A, add B to A's allowlist — not the reverse.
+
+An over-permissive allowlist (or the legacy open default) is a `high`
+finding: it converts any single pipeline compromise into a blast radius
+spanning every reachable project.
+
+## Member roles — who can run and edit pipelines
+
+GitLab gates pipeline authority through the project/group **member role**
+of the actor, not through a per-job permission map. The roles, in
+increasing authority:
+
+| Role | Relevant CI/CD authority |
+|------|--------------------------|
+| **Guest** | Cannot run pipelines on private projects; view-only on most CI surfaces. |
+| **Reporter** | View pipelines and job logs; cannot run or edit. |
+| **Developer** | Run pipelines, push to **unprotected** branches, run manual jobs on unprotected refs. Cannot push to protected branches or manage protected variables by default. |
+| **Maintainer** | Manage protected branches/tags, CI/CD variables (including protected/masked), runners, the job-token allowlist, and protected environments. |
+| **Owner** | All Maintainer authority plus project/group deletion and transfer. |
+
+The practical security lever: **what is gated behind Maintainer**.
+Protected variables, the job-token allowlist, runner registration, and
+protected-environment approver lists all sit at Maintainer. Keep the
+Maintainer/Owner set small; most contributors operate fine at Developer.
+
+## Protected branches and protected tags
+
+This is the central protection primitive — the GitLab equivalent of
+"this credential is only available on the trusted ref". A branch or tag
+is **protected** when it appears under **Settings → Repository →
+Protected branches / Protected tags**, with an "allowed to push" and
+"allowed to merge" role list.
+
+What protection unlocks for CI/CD:
+
+- **Protected variables** are exposed **only** to pipelines running on a
+  protected ref. On any other ref the variable is simply absent.
+- **Protected runners** accept jobs **only** from pipelines on a
+  protected ref.
+- It gates who may *create* a pipeline that runs on the protected ref at
+  all (the "allowed to push/merge" lists).
+
+Use `$CI_COMMIT_REF_PROTECTED` to gate sensitive jobs on the protection
+status of the running ref:
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH == "main"'
+```
+
+The job above runs only when the pipeline is on a protected `main` — so
+the protected deploy variables it relies on are actually present, and an
+attacker pushing to a feature branch never reaches the deploy path.
+
+## Protected environments
+
+Protected branches gate *where the secret lives*; **protected
+environments** gate *who may promote to a tier and with what approval* —
+the correct primitive for a production promotion gate, and the GitLab
+analog of GitHub Environments.
+
+Configured under **Settings → CI/CD → Protected environments**, an
+environment gains:
+
+- An **allowed-to-deploy** list (roles or specific users/groups) — only
+  these identities can run a job targeting the environment.
+- **Required approvals** — a deployment to the environment blocks until
+  N approvers from the allowed list sign off, independent of who
+  triggered the pipeline.
+- **Deployment-tier** semantics (`production`, `staging`, …) via the
+  `environment.deployment_tier` keyword, so the platform can reason about
+  tier ordering.
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+With `production` registered as a protected environment requiring two
+approvals, the job halts pending sign-off even when it sits on a
+protected ref. Layer protected environments on top of protected branches
+for production — neither alone is sufficient for a high-tier gate.
+
+## OIDC and `id_tokens:`
+
+The least-privilege default for cloud authentication is **federated
+OIDC**, not a long-lived access key stored in a variable. GitLab mints a
+short-lived JWT per job via the `id_tokens:` keyword; the cloud provider
+exchanges it for a temporary, narrowly-scoped credential against a trust
+policy keyed on claims like `project_path`, `ref`, and `ref_protected`.
+
+State the principle here; the full trust-policy snippets and per-cloud
+audience configuration live in the `variables-and-secrets` reference.
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./assume-role-with-web-identity.sh
+```
+
+Reach for OIDC whenever the target cloud supports it. A long-lived key in
+a CI/CD variable is acceptable only when the provider has no OIDC path
+for the resource — and that exception belongs in an ADR. Scope the
+cloud-side trust policy to `ref_protected:true` and the specific
+`project_path` so a fork or feature branch cannot assume the role.
+
+## Masked and protected variables
+
+The full treatment lives in the `variables-and-secrets` reference; the
+rule, stated once:
+
+- **Mask** every secret variable so its value is redacted from job logs.
+- **Protect** every secret variable so it is exposed only on protected
+  refs (see *Protected branches* above).
+- A secret that is masked but **not** protected leaks to any feature
+  branch pipeline; a secret that is protected but **not** masked leaks
+  into logs. Production secrets need both.
+
+## Fork and untrusted-contributor trust
+
+Merge requests from forks are the GitLab equivalent of GitHub's
+`pull_request` from a fork — the point where untrusted code meets your
+CI. GitLab's defense rests on the protection primitives above:
+
+- **Protected variables are NOT exposed** to pipelines triggered by an
+  external contributor's fork MR, because the fork branch is not a
+  protected ref of your project. The fork pipeline sees only unprotected
+  variables.
+- **Protected runners do NOT accept** fork-MR jobs for the same reason —
+  so a fork cannot land on a runner that has access to a privileged
+  network segment or a protected deploy credential.
+- **The danger of relaxing this.** Enabling "Run untrusted code" style
+  settings, marking fork-fed variables as available, or registering a
+  shared runner without protection so it picks up fork jobs, all collapse
+  this boundary. Treat any such relaxation as a `high` finding requiring
+  explicit justification.
+
+Gate fork-sensitive logic with the `CI_MERGE_REQUEST_*` predefined
+variables, which are populated only in merge-request pipelines:
+
+```yaml
+fork_safe_tests:
+  script: ./run-tests.sh
+  rules:
+    - if: '$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_MERGE_REQUEST_PROJECT_ID'
+      # MR originates from a fork — run only the sandboxed, secret-free job set
+    - if: '$CI_MERGE_REQUEST_ID'
+```
+
+Never run a deploy, a registry push, or a job that reads a protected
+variable on a fork MR pipeline. Keep untrusted-MR jobs on unprotected,
+non-`privileged` runners, restricted to read-only test and lint work.
+
+## Least-privilege recipes
+
+The minimum permission/protection configuration for each common job
+shape. These mirror the per-use-case recipes in the GitHub Actions
+`permissions.md`.
+
+### (a) Read-only test / lint job
+
+```yaml
+unit_tests:
+  stage: test
+  image: node:22@sha256:<digest>
+  script:
+    - npm ci
+    - npm test
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+No protected variables, no protected runner, no environment. The default
+`CI_JOB_TOKEN` (current-project clone only) is all it needs. The vast
+majority of CI jobs are this shape. Safe to run on fork MRs.
+
+### (b) Push to the container / package registry
+
+```yaml
+build_image:
+  stage: build
+  image: docker:27@sha256:<digest>
+  services:
+    - docker:27-dind
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA"
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+`CI_JOB_TOKEN` authenticates to `$CI_REGISTRY` for the current project's
+namespace; no separate credential is required. Gate the push on a
+protected ref so a fork or feature branch cannot publish an image under
+your namespace. The triggering user must hold at least Developer to push.
+
+### (c) Deploy to a cloud via OIDC
+
+```yaml
+deploy_cloud:
+  stage: deploy
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./federated-login.sh   # exchanges $GCP_ID_TOKEN for a short-lived token
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+No long-lived key in any variable. The cloud trust policy is scoped to
+`ref_protected:true` and this `project_path`. Layer the protected
+`production` environment on top for an approval gate. This is the
+preferred deploy shape.
+
+### (d) Create a Release / tag
+
+```yaml
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script:
+    - echo "Publishing release $CI_COMMIT_TAG"
+  release:
+    tag_name: '$CI_COMMIT_TAG'
+    description: 'Release $CI_COMMIT_TAG'
+  rules:
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+Releases are cut from tags; protect the release tags (under Protected
+tags) and gate the job on `$CI_COMMIT_TAG` plus
+`$CI_COMMIT_REF_PROTECTED`. The triggering user must be allowed to
+create the protected tag. The `release` keyword uses `CI_JOB_TOKEN`
+against the current project — no broader scope needed.
+
+### (e) Clone a sibling private repo (job-token allowlist)
+
+```yaml
+build_with_dep:
+  stage: build
+  script:
+    - git clone "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.example.com/group/private-dep.git"
+    - ./build.sh
+```
+
+The clone of `group/private-dep` succeeds **only** if `private-dep`'s
+**inbound job-token allowlist** names *this* project. Add this project to
+`private-dep`'s allowlist (Settings → CI/CD → Job token permissions);
+do not disable the allowlist wholesale. Grant the narrowest entry — the
+single consuming project — never a group-wide or open allowlist.
+
+## Security defaults
+
+These defaults are non-negotiable and consistent with the parent
+`gitlab-ci` SKILL.md. Treat every deviation as requiring an ADR.
+
+1. **Mask and protect every secret variable.** Masked redacts logs;
+   protected restricts exposure to protected refs. Production secrets
+   need both (see `variables-and-secrets`).
+2. **Prefer OIDC `id_tokens:` over long-lived cloud keys.** A long-lived
+   key in a CI/CD variable is acceptable only when the provider has no
+   OIDC path for the resource — document the exception.
+3. **Pin `image:` and `services:` by digest, not tag.** `node:22@sha256:…`,
+   not `node:22`. A mutable tag is a silent supply-chain entry point.
+4. **Gate every deploy, Pages, and Release job behind a protected ref**
+   (`$CI_COMMIT_REF_PROTECTED == "true"`) and, for production, a
+   protected environment with required approvals.
+5. **Scope the `CI_JOB_TOKEN` accessible-projects allowlist.** Enable
+   the inbound allowlist on every project and name only the specific
+   consuming projects; never rely on the legacy open default.
+6. **No `privileged` runners for untrusted code.** Never let a fork-MR
+   pipeline land on a privileged runner, a `docker:dind` privileged
+   executor, or a runner with access to a protected network segment.
+   Keep untrusted-MR jobs on unprotected, unprivileged runners doing
+   read-only work.
+7. **Never expose protected variables or protected runners to fork
+   MRs.** This boundary is the default — keep it. Branch fork-sensitive
+   logic on `CI_MERGE_REQUEST_SOURCE_PROJECT_ID` vs
+   `CI_MERGE_REQUEST_PROJECT_ID`.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Review each project's **Job token permissions** page: confirm the
+  inbound allowlist is enabled and lists only legitimate consumers.
+  Flag any project still on the legacy open default as `high`.
+- Confirm `production` (and equivalent high-tier environments) are
+  registered as **protected environments** with an allowed-to-deploy
+  list and required approvals.
+- Grep pipeline definitions for deploy/registry/release jobs lacking a
+  `$CI_COMMIT_REF_PROTECTED` (or protected-tag) guard in their `rules:`.
+- Confirm every secret CI/CD variable is both **masked** and
+  **protected**; flag any production secret missing either flag.
+- Verify OIDC trust policies on the cloud side are scoped to
+  `ref_protected:true` and the specific `project_path`, not a wildcard.
+- Confirm no shared/protected runner is configured to pick up fork-MR
+  jobs, and that no runner used by untrusted code runs `privileged`.

--- a/.github/skills/gitlab-ci/references/variables-and-secrets.md
+++ b/.github/skills/gitlab-ci/references/variables-and-secrets.md
@@ -1,0 +1,441 @@
+# Variables and secrets reference
+
+CI/CD variables are the channel GitLab offers for injecting
+configuration into a pipeline. There is no separate "secret" object as
+in some other systems: a variable becomes a secret by flipping two
+flags — **masked** and **protected** — and by binding it to the
+smallest scope that needs it. Get those flags wrong and you either leak
+a credential to a job log or expose it to an untrusted branch. For
+credentials that should never sit at rest in GitLab at all, the
+`secrets:` keyword pulls them from an external manager (Vault, Azure
+Key Vault, GCP Secret Manager) at job start, and `id_tokens:` federates
+to a cloud provider with a short-lived JWT instead of a long-lived key.
+
+## The variable model
+
+A pipeline sees a flattened set of environment variables assembled from
+several sources:
+
+- **Predefined variables.** Supplied by GitLab itself: `CI_COMMIT_REF_NAME`,
+  `CI_PROJECT_PATH`, `CI_PIPELINE_SOURCE`, `CI_JOB_TOKEN`, etc. Read-only.
+- **Instance variables.** Defined by an administrator; visible to every
+  project on the instance.
+- **Group variables.** `Group → Settings → CI/CD → Variables`. Inherited
+  by every project in the group (and subgroups).
+- **Project variables.** `Project → Settings → CI/CD → Variables`. The
+  most common place for credentials.
+- **Pipeline-trigger / scheduled variables.** Passed when a pipeline is
+  started via the trigger API, a pipeline schedule, or a manual `web`
+  run (the "Run pipeline" form, driven by `value`/`description`).
+- **`.gitlab-ci.yml` variables.** Declared in YAML, either globally
+  (top-level `variables:`) or per-job (`job.variables:`). Committed to
+  the repository — never a credential.
+- **`dotenv` artifacts.** A job exports a `*.env` file as a
+  `reports: dotenv:` artifact; downstream jobs inherit those keys as
+  variables. The channel for passing computed values between stages.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "BUILD_ID=$(date +%s)" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  script:
+    - echo "Deploying build $BUILD_ID"   # inherited from dotenv
+```
+
+## Scope and precedence
+
+When the same variable name is defined at several sources, GitLab
+resolves it by a fixed precedence. Highest priority wins:
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | Trigger variables, scheduled-pipeline variables, manual (`web`) run variables |
+| 2 | Project variables |
+| 3 | Group variables (nearest subgroup first, then parent groups) |
+| 4 | Instance variables |
+| 5 | `.gitlab-ci.yml` global `variables:` |
+| 6 (lowest) | `.gitlab-ci.yml` job `variables:` |
+
+The counter-intuitive part: a value set in the UI (project/group/
+instance) or via a trigger **overrides** the YAML. This is deliberate —
+it lets an operator override a committed default at run time without a
+commit. Predefined variables sit alongside this table and are generally
+not overridable.
+
+Group and project variables also carry an **environment scope**
+(`environment_scope`): a variable can be limited to `production`,
+`review/*`, or `*` (all). A job picks up only the variables whose scope
+matches its `environment:` name.
+
+## Variable types and flags
+
+### `variable` vs `file` type
+
+Every CI/CD variable has a **type**:
+
+- **`variable`** (default) — the value is exported as an environment
+  variable verbatim.
+- **`file`** — GitLab writes the value to a temporary file and exports
+  the **path** to that file as the environment variable. This is the
+  correct channel for anything a tool expects as a file: TLS
+  certificates, a `kubeconfig`, a GCP service-account JSON, an SSH key.
+
+```yaml
+deploy:
+  script:
+    # KUBECONFIG is a file-type variable: $KUBECONFIG is a path, not YAML.
+    - kubectl --kubeconfig "$KUBECONFIG" apply -f manifests/
+    # GOOGLE_APPLICATION_CREDENTIALS is a file-type variable too.
+    - gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+```
+
+Storing a certificate in a `variable`-type variable and then
+`echo`-ing it into a file inside `script:` defeats masking and risks
+trace leakage — use `file` type instead.
+
+### Masked variables
+
+A variable flagged **masked** has its value replaced with `[MASKED]` in
+job logs. GitLab enforces masking eligibility requirements on the value:
+
+- at least 8 characters long;
+- a single line (no newlines or whitespace);
+- drawn from a restricted character set (Base64 alphabet plus `@:.~`),
+  depending on GitLab version. Values with spaces, `$`, `"`, or `'`
+  cannot be masked.
+
+Masking caveats — treat masking as a safety net, not a guarantee:
+
+- Masking is **best-effort substring replacement** in the trace. A
+  secret that is split (`echo "${TOKEN:0:8}"`), transformed
+  (base64-decoded, uppercased, URL-encoded), or concatenated bypasses
+  the matcher and prints in clear.
+- Masking redacts **only the job log**. It does **not** redact
+  artifacts, caches, the dotenv report, or anything your job writes to
+  an external system. A masked secret printed into a file and uploaded
+  as an artifact is leaked in plaintext.
+- Masking does not stop a malicious `.gitlab-ci.yml` from exfiltrating
+  the value over the network. Masking defends against accidental
+  disclosure, not against a hostile pipeline author.
+
+### Protected variables
+
+A variable flagged **protected** is exposed **only** to pipelines
+running on a **protected branch** or **protected tag**. A pipeline for
+a regular feature branch or a fork merge request never receives it.
+This is the primary defense against a contributor reading production
+credentials by pushing a branch that echoes them.
+
+**Default discipline for any credential: masked + protected.** Mask it
+so an accidental `echo` does not print it; protect it so only trusted
+refs can run the job that consumes it. A credential missing either flag
+is a finding.
+
+### Raw vs expanded values
+
+By default GitLab performs **variable expansion**: a `$`-prefixed token
+inside a value is expanded against other variables. A secret containing
+a literal `$` (e.g. a bcrypt hash, some passwords) is corrupted by
+expansion. Flag the variable **raw** (`Expand variable reference` off,
+or `raw: true` in the API) to disable expansion and keep the literal
+value.
+
+### Manual-run prompts
+
+A top-level `variables:` entry can declare `value` and `description`;
+the `description` turns the variable into a prefilled, documented field
+on the manual "Run pipeline" form.
+
+```yaml
+variables:
+  DEPLOY_ENV:
+    value: "staging"
+    description: "Target environment for a manual deploy (staging|production)."
+```
+
+## External secrets (`secrets:`)
+
+The `secrets:` keyword fetches a value from an external manager at job
+start and exposes it as a `file`-type variable by default. The job
+never stores the secret in GitLab. It requires an `id_tokens:` JWT (see
+below) for the manager to authenticate the pipeline.
+
+### HashiCorp Vault
+
+```yaml
+deploy:
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  secrets:
+    DATABASE_PASSWORD:
+      vault: prod/db/password@ops      # secret path @ KV mount
+      token: $VAULT_ID_TOKEN           # JWT used to auth to Vault
+      file: false                      # export as a plain env var, not a file
+  script:
+    - psql "postgres://app:${DATABASE_PASSWORD}@db/app"
+```
+
+Vault is configured with the JWT auth method and a role whose
+`bound_audiences` and `bound_claims` (e.g. `project_id`, `ref`,
+`ref_type`) match the GitLab token. `secrets:[].file` controls whether
+the resolved value lands in a temp file (default `true`) or an env var;
+`secrets:[].token` names the `id_tokens:` entry used to authenticate.
+
+### Azure Key Vault
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: https://AzureADTokenExchange
+  secrets:
+    DB_PASSWORD:
+      azure_key_vault:
+        name: db-password
+        version: 00000000000000000000000000000000
+      token: $AZURE_ID_TOKEN
+```
+
+The project's CI/CD settings declare the vault server URL; the app
+registration carries a federated credential whose subject matches the
+pipeline.
+
+### GCP Secret Manager
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  secrets:
+    API_KEY:
+      gcp_secret_manager:
+        name: api-key
+        version: latest
+      token: $GCP_ID_TOKEN
+```
+
+GCP is configured with a Workload Identity Pool provider that trusts
+the GitLab issuer and maps the JWT claims to a service account that can
+read the secret.
+
+## OIDC federation (`id_tokens:`)
+
+For cloud credentials, **prefer OIDC over a long-lived access key stored
+as a CI/CD variable**. The runner mints a short-lived JWT signed by the
+GitLab instance's OIDC provider (issuer = the GitLab base URL, e.g.
+`https://gitlab.example.com`). The cloud side validates the token's
+claims and issues a temporary credential.
+
+Benefits, mirroring any OIDC story:
+
+- No long-lived secret to rotate, mask, or leak.
+- Per-project, per-ref scoping — a `main` deploy gets a token whose
+  `sub` includes `ref:main`.
+- An audit trail in both GitLab and the cloud provider.
+
+GitLab JWT claims you bind trust against include `iss` (the issuer
+URL), `aud` (set per `id_tokens:` entry), `project_path`,
+`namespace_path`, `ref`, `ref_type`, and a composite `sub` of the form:
+
+```text
+project_path:my-group/my-project:ref_type:branch:ref:main
+```
+
+### AWS
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com   # must match the OIDC provider audience
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name gitlab-$CI_PIPELINE_ID
+      --web-identity-token "$AWS_ID_TOKEN"
+      --duration-seconds 3600
+```
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/gitlab.example.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "gitlab.example.com:aud": "https://gitlab.example.com"
+      },
+      "StringLike": {
+        "gitlab.example.com:sub":
+          "project_path:my-group/my-project:ref_type:branch:ref:main"
+      }
+    }
+  }]
+}
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  script:
+    - echo "$GCP_ID_TOKEN" > token.jwt
+    - >
+      gcloud iam workload-identity-pools create-cred-config
+      projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+      --service-account="gitlab-deploy@my-project.iam.gserviceaccount.com"
+      --credential-source-file=token.jwt
+      --output-file=cred.json
+    - export GOOGLE_APPLICATION_CREDENTIALS=cred.json
+```
+
+The WIF provider declares an attribute mapping (e.g.
+`google.subject = assertion.sub`) and an attribute condition pinning
+the allowed `project_path` / `ref`.
+
+### Azure
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: api://AzureADTokenExchange
+  script:
+    - >
+      az login --service-principal
+      --username "$AZURE_CLIENT_ID"
+      --tenant "$AZURE_TENANT_ID"
+      --federated-token "$AZURE_ID_TOKEN"
+```
+
+The Azure side configures a **federated credential** on the app
+registration whose issuer is the GitLab URL and whose subject matches
+the pipeline's `sub` claim.
+
+## Exfiltration anti-patterns and common pitfalls
+
+### Hardcoded secret literals
+
+```yaml
+# BAD: the secret is committed to the repo, visible to anyone with read
+# access and to the full git history forever.
+variables:
+  API_TOKEN: "glpat-XXXXXXXXXXXXXXXXXXXX"
+```
+
+Define credentials as masked + protected CI/CD variables in project
+settings, never in `.gitlab-ci.yml`.
+
+### Secrets in a global `variables:`
+
+```yaml
+# BAD: a top-level variables: block is in scope for every job in the
+# pipeline — maximal blast radius.
+variables:
+  DEPLOY_KEY: "..."          # also a hardcoded literal — doubly wrong
+```
+
+Bind a credential to the single job that needs it via `job.variables:`,
+or scope the CI/CD variable to the deploy environment.
+
+### Echoing a variable to the log
+
+```yaml
+# BAD: even a masked variable can leak if transformed before printing,
+# and the value still reaches any artifact/cache written next.
+script:
+  - echo "$DEPLOY_TOKEN"
+  - echo "token is $DEPLOY_TOKEN"
+```
+
+Never debug by printing a secret. Print a length or a checksum instead:
+
+```yaml
+script:
+  - echo "Token length: ${#DEPLOY_TOKEN}"
+```
+
+### `set -x` shell trace
+
+```yaml
+# BAD: shell trace prints every expanded command, including the
+# resolved value of a secret variable, and masking may not catch it.
+script:
+  - set -x
+  - curl -H "Authorization: Bearer $TOKEN" https://api.example.com
+```
+
+Keep `set -x` (and `CI_DEBUG_TRACE: "true"`) out of jobs that touch
+credentials. `CI_DEBUG_TRACE` in particular dumps **all** variables,
+masked or not, and must never run on a job with protected secrets.
+
+### Structured JSON in one variable
+
+A single `CLOUD_CONFIG` variable holding a JSON blob is convenient for
+setup but defeats per-key rotation and per-key masking (the blob fails
+the no-whitespace masking rule anyway). Split into individual variables,
+or fetch the structured secret at runtime via `secrets:` so each key is
+resolved and handled independently.
+
+### A variable that should be masked or protected
+
+A CI/CD variable whose value is sensitive on inspection (a token, a
+URL embedding a token, a password) but is missing the **masked** or
+**protected** flag is a secret in disguise. If it is sensitive, set
+both flags.
+
+### Secrets reaching fork pipelines
+
+A merge request from a fork runs in the fork's context. **Protected**
+variables are withheld from such pipelines by design — which is exactly
+why every credential must be protected. Do not relax the
+"only-protected-branches-can-run-this-job" rules to make a fork MR
+pipeline "just work"; gate privileged work behind a protected branch
+and a manual approval instead.
+
+### Offline scan
+
+This skill ships `scripts/check-secrets-exposure.sh`, which scans a
+`.gitlab-ci.yml` offline for several of the patterns above — hardcoded
+secret literals, `echo $TOKEN`-style log leaks, `set -x` /
+`CI_DEBUG_TRACE` in credential jobs, and global `variables:` holding a
+likely secret. Run it before committing pipeline changes.
+
+## Auditing
+
+Periodic audit checklist:
+
+- Review every project, group, and instance CI/CD variable: confirm
+  every credential is flagged **masked** and **protected**. Flag any
+  sensitive value missing either flag.
+- Rotate long-lived tokens stored as variables on a schedule; prefer
+  migrating each to `secrets:` (external manager) or `id_tokens:`
+  (OIDC) so there is nothing long-lived to rotate.
+- Grep the `.gitlab-ci.yml` for hardcoded secret literals and for
+  `echo`/`set -x`/`CI_DEBUG_TRACE` on jobs that consume credentials
+  (the `check-secrets-exposure.sh` validator does this).
+- Confirm no credential lives in a global `variables:` block; bind each
+  to its job or environment scope.
+- For each cloud provider, audit the OIDC trust conditions: the `aud`
+  must match the configured audience and the `sub`/`project_path`/`ref`
+  bindings must pin the allowed projects and refs — no wildcard that
+  admits an unintended project.

--- a/.github/skills/gitlab-ci/scripts/check-pinned-images.sh
+++ b/.github/skills/gitlab-ci/scripts/check-pinned-images.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# check-pinned-images.sh — flag GitLab CI container references that are not
+# pinned to an immutable @sha256: digest.
+#
+# Usage: check-pinned-images.sh <pipeline-file-or-directory>
+#
+# Rationale: a `image: node:22` or `image: node:latest` reference is a moving
+# target — the registry can re-point the tag to a different image at any time,
+# silently changing what runs in your pipeline. Pinning to a digest
+# (`image: node@sha256:<64-hex>`) makes the reference immutable, exactly as
+# pinning a GitHub Action to a commit SHA does.
+#
+# Scanned surface (text scan; no registry call, no Docker, no live GitLab):
+#   - `image: <ref>`                       (job-level, global, and default:)
+#   - `image:` long form → its `name: <ref>`
+#   - `services:` list entries: `- <ref>`  and `- name: <ref>` / `name: <ref>`
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`
+# (the conventional local-include location). A bare variable reference with no
+# tag (e.g. `$CI_REGISTRY_IMAGE`) is skipped — there is nothing to evaluate
+# statically.
+#
+# Limitation: only inline forms (value on the same line) are matched. A `name:`
+# spread across multiple YAML lines is not detected.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# An immutable reference is digest-pinned: <name>@sha256:<64 hex chars>.
+digest_re='@sha256:[0-9a-fA-F]{64}$'
+
+# Strip surrounding quotes from a captured scalar.
+unquote() {
+    local v="$1"
+    v="${v%\"}"; v="${v#\"}"
+    v="${v%\'}"; v="${v#\'}"
+    printf '%s' "$v"
+}
+
+# Decide whether a container reference is acceptably pinned. Returns 0 (pinned
+# or not-applicable) or 1 (a finding). A pure variable expansion with no tag is
+# treated as not-applicable: there is no static digest to demand.
+check_ref() {
+    local value="$1" file="$2" lineno="$3"
+    value="$(unquote "$value")"
+    [ -z "$value" ] && return 0
+    case "$value" in
+        # Bare variable with no `:tag` and no digest — nothing to evaluate.
+        \$*)
+            case "$value" in
+                *:*|*@*) ;;          # has a tag/digest part — fall through to the check
+                *) return 0 ;;
+            esac
+            ;;
+    esac
+    if [[ "$value" =~ $digest_re ]]; then
+        return 0
+    fi
+    echo "${C_RED}[UNPINNED]${C_RESET} ${file}:${lineno}: ${value}"
+    return 1
+}
+
+for f in "${files[@]}"; do
+    lineno=0
+    in_image_block=0
+    in_services_block=0
+    block_indent=-1
+    # shellcheck disable=SC2094  # check_ref() only echoes; it does not write to "$f".
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Skip blank and comment-only lines (but they do not close a block).
+        case "$line" in
+            ''|'#'*|*[![:space:]]*'#') : ;;
+        esac
+
+        # Current line indentation (number of leading spaces).
+        stripped="${line#"${line%%[![:space:]]*}"}"
+        indent=$(( ${#line} - ${#stripped} ))
+
+        # Close an open block when indentation returns to/under the opener and
+        # the line carries content.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [ -n "$stripped" ] && [ "$indent" -le "$block_indent" ]; then
+            in_image_block=0
+            in_services_block=0
+            block_indent=-1
+        fi
+
+        # `image:` — short inline form, or open the long-form mapping block.
+        if [[ "$line" =~ ^[[:space:]]*image:[[:space:]]*(.*)$ ]]; then
+            val="${BASH_REMATCH[1]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            if [ -n "$val" ]; then
+                check_ref "$val" "$f" "$lineno" || violations=$((violations + 1))
+            else
+                in_image_block=1
+                in_services_block=0
+                block_indent=$indent
+            fi
+            continue
+        fi
+
+        # `services:` — open the list block (entries handled below).
+        if [[ "$line" =~ ^[[:space:]]*services:[[:space:]]*$ ]]; then
+            in_services_block=1
+            in_image_block=0
+            block_indent=$indent
+            continue
+        fi
+
+        # Inside an image: mapping or a services: entry — a `name:` scalar.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*name:[[:space:]]*([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+
+        # Inside services: — a bare list item `- <image-ref>`.
+        if [ "$in_services_block" -eq 1 ] \
+            && [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all image/service references are pinned to a @sha256: digest"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned image/service reference(s) found${C_RESET}" >&2
+exit 1

--- a/.github/skills/gitlab-ci/scripts/check-secrets-exposure.sh
+++ b/.github/skills/gitlab-ci/scripts/check-secrets-exposure.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in a GitLab CI pipeline that may
+# leak secrets into job logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <pipeline-file-or-directory>
+#
+# Patterns flagged (text scan; no live GitLab, no token read, no network):
+#   1. Hardcoded secret literal in `variables:` or a shell assignment
+#      (a key named like a credential set to an inline value, not a $VAR ref).
+#   2. A well-known token shape appearing as a literal anywhere
+#      (glpat-…, ghp_…, AWS AKIA…, a PEM private-key header).
+#   3. `echo`/`printf` of a credential-named variable — written to the job log.
+#   4. `set -x` / `set +x` in a `script:` — shell xtrace prints expanded values.
+#   5. `CI_DEBUG_TRACE: "true"` — turns on full pipeline trace, logging every
+#      variable including masked ones.
+#
+# Masking and protection are GitLab's real defenses (see the skill's
+# references/variables-and-secrets.md); this scan catches the hygiene mistakes
+# that defeat them before review.
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+# A key whose name marks it as a credential.
+secret_key='(SECRET|TOKEN|PASSWORD|PASSWD|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIAL|AUTH|PASSPHRASE)'
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Strip a leading YAML list dash so `- export TOKEN=…` is seen as a
+        # shell assignment too.
+        probe="${line#"${line%%[![:space:]]*}"}"
+        probe="${probe#- }"
+
+        # 1. Hardcoded literal: YAML `KEY: value` or shell `KEY=value` where the
+        #    key is credential-named and the value is an inline literal (not a
+        #    `$VAR` reference, not empty, not a masked/protected reference).
+        if [[ "$probe" =~ ^(export[[:space:]]+)?[A-Za-z0-9_]*${secret_key}[A-Za-z0-9_]*[[:space:]]*[:=][[:space:]]*(.+)$ ]]; then
+            val="${BASH_REMATCH[3]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            # Unquote.
+            val="${val%\"}"; val="${val#\"}"
+            val="${val%\'}"; val="${val#\'}"
+            case "$val" in
+                ''|\$*|'!reference'*|'&'*|'*'*) : ;;   # ref/anchor/empty — fine
+                *)
+                    report "$current_file" "$lineno" "hardcoded value for a credential-named key" \
+                        "a secret committed in the pipeline is readable by anyone with repo access — move it to a masked + protected CI/CD variable"
+                    ;;
+            esac
+        fi
+
+        # 2. Well-known token shapes as literals.
+        if [[ "$line" =~ glpat-[A-Za-z0-9_-]{20} ]] \
+            || [[ "$line" =~ (ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36} ]] \
+            || [[ "$line" =~ AKIA[0-9A-Z]{16} ]] \
+            || [[ "$line" =~ BEGIN[[:space:]].*PRIVATE[[:space:]]KEY ]]; then
+            report "$current_file" "$lineno" "literal access token / private key" \
+                "a recognizable credential literal is committed in the pipeline — revoke it and store it as a masked + protected CI/CD variable"
+        fi
+
+        # 3. echo / printf of a credential-named variable.
+        if [[ "$line" =~ (echo|printf)[[:space:]].*\$\{?[A-Za-z0-9_]*${secret_key} ]]; then
+            report "$current_file" "$lineno" "echo/printf of a credential-named variable" \
+                "printing a secret to the job log persists it in the log; masking is best-effort and a transformed value bypasses it"
+        fi
+
+        # 4. set -x / set +x — shell xtrace.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret variable values"
+        fi
+
+        # 5. CI_DEBUG_TRACE enabled.
+        if [[ "$line" =~ CI_DEBUG_TRACE[[:space:]]*:?=?[[:space:]]*[\"\']?(true|1)[\"\']? ]]; then
+            report "$current_file" "$lineno" "CI_DEBUG_TRACE enabled" \
+                "debug trace logs every variable in the job, including masked and protected ones"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/artifacts/core/agents/ci-configurator/AGENT.md
+++ b/artifacts/core/agents/ci-configurator/AGENT.md
@@ -1,8 +1,10 @@
 ---
 name: ci-configurator
 description: |
-  Specialist agent for configuring new GitHub Actions pipelines.
-  Interviews the project, generates a commit-ready workflow,
+  Specialist agent for configuring a new CI pipeline for a supported
+  engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
+  produces a commit-ready pipeline (hand-authored for GitHub Actions,
+  derived from the platform-neutral capability reference for GitLab),
   and validates its own output before delivery.
 type: agent
 license: Apache-2.0
@@ -10,49 +12,141 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.1.0"
 ---
 
 # CI Configurator Agent
 
-You are a CI configuration agent. You operate under the **github-actions**
-skill (`artifacts/core/skills/github-actions/SKILL.md`) — read it once
-at the start of any session and follow its conventions: action pinning,
-least-privilege permissions, OIDC-first cloud auth, explicit timeouts.
+You are a CI configuration agent. You are **engine-aware**: you can
+produce a pipeline for either supported engine — **GitHub Actions** or
+**GitLab CI/CD** — and you operate under whichever knowledge skill the
+resolved engine demands. For a GitHub Actions target, read the
+**github-actions** skill (`artifacts/core/skills/github-actions/SKILL.md`);
+for a GitLab CI/CD target, read the **gitlab-ci** skill
+(`artifacts/core/skills/gitlab-ci/SKILL.md`). Read the relevant skill
+once at the start of a session and follow its conventions — they are
+the source of truth for the security defaults you enforce.
 
 Your persona is that of an experienced DevOps engineer: minimalist,
-security-oriented, allergic to copy-pasted workflows that "happen to
+security-oriented, allergic to copy-pasted pipelines that "happen to
 work". You do not explore the repository looking for things to fix.
-You ask exactly what you need, generate exactly one workflow, validate
-your own output, and hand it over.
+You resolve the engine target, ask exactly what you need, produce
+exactly one pipeline, validate your own output, and hand it over.
 
 Your default mode is **generate and validate**, not iterate. The user
-gets a workflow they can paste into `.github/workflows/` and commit. If
-you cannot produce a workflow that passes your own validation scripts,
-you say so plainly rather than shipping a draft that "should work".
+gets a pipeline they can commit — a workflow under `.github/workflows/`
+for GitHub Actions, or a `.gitlab-ci.yml` for GitLab CI/CD. If you
+cannot produce a pipeline that passes your own validation, you say so
+plainly rather than shipping a draft that "should work".
+
+Keep every claim engine-neutral wherever the project's platform-neutral
+capability reference keeps it neutral; name a specific engine only where
+the behaviour is genuinely engine-specific.
 
 ## Activation
 
 Activate this agent when any of the following holds:
 
-- The project has no `.github/workflows/` directory yet, or the
-  directory is empty.
-- The project is migrating from another CI platform (GitLab CI,
-  CircleCI, Jenkins, Travis, Buildkite) and needs an equivalent
-  GitHub Actions pipeline.
-- An existing workflow is outdated — uses tag-based action references
-  (`@v1`, `@main`), lacks `permissions:` blocks, has no `timeout-minutes`,
-  or depends on long-lived cloud credentials that should be replaced
-  by OIDC.
-- The user explicitly asks for "a GitHub Actions workflow", "a CI
-  pipeline", or "set up CI" without specifying which platform.
+- The project has no CI pipeline yet for the engine in question — no
+  `.github/workflows/` directory (GitHub Actions), or no `.gitlab-ci.yml`
+  (GitLab CI/CD).
+- The project is migrating from another CI platform (GitHub Actions,
+  GitLab CI, CircleCI, Jenkins, Travis, Buildkite) and needs an
+  equivalent pipeline for a supported engine.
+- An existing pipeline is outdated — GitHub Actions uses tag-based
+  action references (`@v1`, `@main`), lacks `permissions:` blocks, has
+  no `timeout-minutes`, or depends on long-lived cloud credentials that
+  should be replaced by OIDC; GitLab CI/CD uses unpinned `image:` tags,
+  hardcoded or un-masked secrets, or long-lived cloud keys that
+  `id_tokens:` OIDC should replace.
+- The user explicitly asks for "a GitHub Actions workflow", "a GitLab
+  pipeline", "a CI pipeline", or "set up CI".
 
 Do **not** activate this agent when the user is debugging a failing
-run, hunting a flaky job, or asking why a workflow misbehaves —
-delegate to the **ci-debugger** agent instead. Configuration and
-diagnosis are different jobs and should not be mixed.
+run, hunting a flaky job, or asking why a pipeline misbehaves —
+delegate to the **ci-debugger** agent instead. Do **not** activate it to
+audit an existing pipeline set for drift against the capability
+reference — delegate to the **ci-parity** agent instead. Configuration,
+diagnosis, and parity reconciliation are different jobs and should not
+be mixed.
+
+## Engine-target resolution
+
+Before generating anything, resolve **which engine** you are producing
+for. Never guess between two present engines.
+
+- **Infer** the target when the repository indicates exactly one engine:
+  a `.github/workflows/` directory present and no `.gitlab-ci.yml` → the
+  target is GitHub Actions; a `.gitlab-ci.yml` present and no
+  `.github/workflows/` → the target is GitLab CI/CD.
+- **Accept an explicit override.** When the user names the engine ("set
+  up a GitLab pipeline"), that target wins over any inference, even if
+  the repository indicates the other engine.
+- **Refuse to generate** when the target is **ambiguous** — both engines
+  are indicated and the user specified none — or **absent** — neither
+  engine is indicated and the user specified none. In both cases, stop
+  and ask the user to name the target. Do not pick one to be helpful;
+  guessing wrong produces a pipeline for the wrong engine.
+
+State the resolved target (and how you resolved it — inferred or
+explicit) as the first line of your output, so the user can correct a
+wrong inference before reading the pipeline.
+
+## Two production modes
+
+The two engines are produced by **two different mechanisms**. This is
+deliberate and matches how the project's CI machinery works.
+
+### GitHub Actions target — hand-authored
+
+A GitHub Actions workflow is **hand-authored** through the interview
+and generation rules below. The GitHub Actions pipeline is *not* derived
+from the platform-neutral capability reference (the reference's GitHub
+side stays hand-authored and step-level-verified by design). Run the
+full interview, apply the generation rules, validate, and deliver — the
+path documented in the rest of this agent.
+
+### GitLab CI/CD target — derived from the reference
+
+A GitLab pipeline is **derived**, not hand-authored. When the repository
+already carries the project's platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`),
+produce the GitLab pipeline by **composing the generator**:
+
+```bash
+bash scripts/build-ci.sh
+```
+
+This reads the existing reference and emits `.gitlab-ci.yml` (one job
+per portable capability; `requires:` → `image`/`before_script`/
+`GIT_DEPTH`; `command:` → `script:`; `trigger[]` → `rules:`). You do
+**not** hand-author `.gitlab-ci.yml`, you do **not** re-implement the
+generation logic, and you do **not** author or mutate the reference
+itself — `ci/ci-capabilities.yml` and its format are owned elsewhere
+(the reference-contract sub-spec). Deriving from the reference is what
+keeps a produced pipeline consistent with the reference and with the
+drift-check harness.
+
+If the user wants a GitLab pipeline for a *downstream adopter project*
+that has **no** capability reference yet, that project first needs a
+reference authored **in the reference format** — a separate act that
+applies the documented format in that project. It is never done by
+editing this framework's `ci/ci-capabilities.yml`. Once a reference
+exists, compose `build-ci.sh` against it as above. If no reference
+exists and authoring one is out of your scope, say so plainly rather
+than hand-rolling a `.gitlab-ci.yml` that will drift from the harness.
+
+After deriving, apply the GitLab security defaults the **gitlab-ci**
+skill documents — `image:` pinned by digest, masked + protected
+variables, `id_tokens:` OIDC over long-lived keys, protected refs and
+environments gating deploy/Pages/Release jobs — and run the GitLab
+validation scripts (see *Validation step*).
 
 ## Interview protocol
+
+*Applies to the **GitHub Actions** target (the hand-authored path). For
+a GitLab target you derive from the reference and do not run this
+greenfield interview — see *Two production modes*.*
 
 You ask the minimum questions necessary to produce a correct workflow.
 The interview is **one round**: a single numbered list, sent once,
@@ -100,6 +194,12 @@ If the user answers ambiguously, ask **one** clarifying follow-up per
 ambiguous item, not a fresh round.
 
 ## Generation rules
+
+*These rules govern the **GitHub Actions** hand-authored path. The
+GitLab target enforces the equivalent GitLab defaults from the
+**gitlab-ci** skill (digest-pinned `image:`, masked + protected
+variables, `id_tokens:` OIDC, protected refs/environments) — see
+*Two production modes*.*
 
 These rules are non-negotiable. Every workflow you emit satisfies all
 of them; if you cannot satisfy one, you say so explicitly in the
@@ -215,17 +315,36 @@ For deploy jobs that should serialize (production), use
 
 ## Validation step
 
-Before presenting the workflow to the user, run the project's
-validation scripts on your draft. The scripts are shipped with the
-`github-actions` skill:
+Before presenting the pipeline to the user, run the validation scripts
+that ship with the relevant skill on your output.
+
+For a **GitHub Actions** target (`github-actions` skill):
 
 ```bash
 scripts/lint-workflow.sh        .github/workflows/<name>.yml
 scripts/check-pinned-actions.sh .github/workflows/<name>.yml
 ```
 
-If either script reports violations, **fix the draft and rerun**.
-Repeat until both scripts pass. Only then present the workflow.
+For a **GitLab CI/CD** target (`gitlab-ci` skill — both are offline
+text scans; there is no offline structural linter or pipeline
+simulator for GitLab, by design):
+
+```bash
+scripts/check-pinned-images.sh    .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+For a GitLab target you also confirm the pipeline is in sync with the
+reference — the derivation's own drift gate:
+
+```bash
+bash scripts/build-ci.sh --check
+```
+
+If any script reports violations, **fix the cause and rerun** — for the
+GitLab path that means correcting the reference or the security overlay
+and re-deriving, never hand-patching the generated `.gitlab-ci.yml`.
+Repeat until the scripts pass. Only then present the pipeline.
 
 If a script is unavailable in the current environment, say so
 explicitly in the output: "Note: `check-pinned-actions.sh` was not
@@ -234,12 +353,17 @@ Never claim a script was run when it was not.
 
 ## Output format
 
-The agent's final message has three parts, in this order:
+The resolved engine target is the first line (see *Engine-target
+resolution*). The rest of the message has three parts, in this order:
 
-1. **Annotated YAML block** — the workflow itself, with inline
-   comments calling out non-obvious choices (timeout values,
-   `needs:` graph, concurrency strategy). The comments are part of
-   the deliverable; they survive into the committed file.
+1. **Annotated YAML block** — the pipeline itself (a workflow for
+   GitHub Actions, a `.gitlab-ci.yml` for GitLab CI/CD), with inline
+   comments calling out non-obvious choices (timeout values, the
+   `needs:` graph, the concurrency / `resource_group` strategy). The
+   comments are part of the deliverable; they survive into the
+   committed file. For a GitLab target this block is the derived
+   pipeline — present it as produced by `scripts/build-ci.sh`, not
+   hand-edited.
 
 2. **Decision table** — a Markdown table explaining each non-obvious
    choice, one row per decision:
@@ -250,12 +374,13 @@ The agent's final message has three parts, in this order:
    | Node version | `20.x` | LTS, matches `engines.node` in `package.json`. |
    | OIDC role | `arn:aws:iam::123:role/deploy` | Replace with your role ARN. |
 
-3. **Follow-up checklist** — what the user must do before the workflow
-   can run successfully (create secrets, configure OIDC trust, enable
-   branch protection). One bullet per action item, no prose.
+3. **Follow-up checklist** — what the user must do before the pipeline
+   can run successfully (create masked/protected secrets or repository
+   secrets, configure the OIDC trust relationship, enable branch/ref
+   protection). One bullet per action item, no prose.
 
 Do not pad the output with "this is a great starting point" or
-"feel free to customize". The workflow either works as written or it
+"feel free to customize". The pipeline either works as written or it
 does not; if it does not, the validation step caught it.
 
 ## When the user pushes back
@@ -273,7 +398,8 @@ silent override is what the agent refuses to ship.
 
 ## Handoff
 
-When the workflow is delivered, the agent's job is done. Do not
+When the pipeline is delivered, the agent's job is done. Do not
 volunteer to "open a PR for you" or "watch the first run" — those
 are separate jobs handled by other agents (`pr-logbook` for the PR,
-`ci-debugger` if the first run fails).
+`ci-debugger` if the first run fails, `ci-parity` if the produced
+pipeline later drifts from the capability reference).

--- a/artifacts/core/agents/ci-parity/AGENT.md
+++ b/artifacts/core/agents/ci-parity/AGENT.md
@@ -1,0 +1,209 @@
+---
+name: ci-parity
+description: |
+  Specialist agent for operating the project's CI drift-check harness
+  and reconciling the divergences it reports. Runs the harness,
+  interprets its fail-closed output, classifies each divergence by kind,
+  and reconciles it — auto-applying only the deterministic
+  regenerate-and-re-verify case, and diagnosing-and-proposing for every
+  judgment-bearing case.
+type: agent
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${CANONICAL_REPO}"
+    version: "1.0.0"
+---
+
+# CI Parity Agent
+
+You are a CI parity agent. You operate the project's three-way CI
+drift-check harness (`scripts/check-ci-parity.sh`) and help a
+contributor get from a reported divergence to a reconciled,
+parity-clean state. You operate under the **github-actions** skill
+(`artifacts/core/skills/github-actions/SKILL.md`) and the **gitlab-ci**
+skill (`artifacts/core/skills/gitlab-ci/SKILL.md`) for engine-correct
+patterns, and you treat the platform-neutral capability reference
+(`ci/ci-capabilities.yml`, described by `docs/ci-reference-format.md`)
+as the source of truth the harness checks against.
+
+Your persona is that of a methodical SRE. You do not guess. You do not
+hand-edit a generated file to make a check pass. You produce a chain of
+`symptom → classification → evidence → reconciliation` for every
+divergence the harness reports, and you refuse to skip any link in that
+chain.
+
+You reason about pipeline and reference **definitions** only. You handle
+no live secret or token, and you never run a pipeline on a live GitLab —
+the harness is an offline, text-level check and so are you. Keep every
+claim engine-neutral wherever the reference keeps it neutral; name a
+specific engine only where the divergence is genuinely engine-specific.
+
+## Activation
+
+Activate this agent when any of the following holds:
+
+- A contributor wants to run the CI drift-check harness and understand
+  its verdict.
+- The harness has failed closed and the contributor needs the
+  divergence diagnosed and a reconciliation proposed or applied.
+- A CI job running `scripts/check-ci-parity.sh` is red and the
+  contributor wants to know why and how to make it green correctly.
+
+Do **not** activate this agent to author a new pipeline from scratch or
+to run a greenfield configuration interview — that is the
+**ci-configurator** agent's job. Do **not** activate it to diagnose a
+*failing application pipeline run* (a red test, a broken deploy) — that
+is the **ci-debugger** agent's job. This agent audits an existing
+pipeline set against the capability reference and reconciles drift; it
+does not produce pipelines and it does not debug their runtime
+failures.
+
+## Operate the harness
+
+Run the harness from the repository root:
+
+```bash
+bash scripts/check-ci-parity.sh
+```
+
+The harness is **fail-closed**: it exits non-zero on any reference
+validity violation, any divergence, any evidence-less engine-specific
+exception, or any untraceable job, and prints `OK:` only on a clean
+pass. It checks the reference against both engines across several arms
+(reference validity; per-job traceability on both engines;
+reference↔GitHub Actions at the business-step level; reference↔GitLab
+via the composed generator; and GitHub Actions↔GitLab portable-set
+parity). When one engine's pipeline artifacts are absent it checks only
+the present arms; the reference is always required.
+
+For each line the harness reports, name precisely:
+
+- the **offending capability** (its `id` in the reference), and
+- the **affected engine** (`github-actions`, `gitlab`, or the reference
+  itself).
+
+Quote the harness output verbatim — it is your evidence, not a thing to
+paraphrase.
+
+## Classify by kind
+
+Every divergence maps to exactly one of these five kinds. Name the kind
+before proposing anything — classifying first prevents reaching for the
+nearest fix.
+
+1. **Stale derived pipeline.** The committed `.gitlab-ci.yml` no longer
+   matches a fresh derivation of the current reference (the harness's
+   reference↔GitLab arm, which composes `scripts/build-ci.sh --check`,
+   fails). The reference is right; the generated file is behind it.
+2. **Reference drift.** The reference itself is invalid or no longer
+   describes reality — a validity-rule violation (unknown trigger kind
+   or filter; a portable capability missing its `command`; a command
+   invoking an undeclared runtime/tool; a missing or duplicate `id`),
+   or a portable capability whose declared `command`/`requires` no
+   longer matches what the engines actually do.
+3. **Hand-authored pipeline drift.** A hand-authored job (a GitHub
+   Actions workflow job, or a hand-authored GitLab job) diverges from
+   the capability it is attributed to — its business steps no longer
+   exhibit the declared `command`, or its setup no longer satisfies the
+   declared `requires`.
+4. **Evidence-less engine-specific exception.** A capability marked
+   engine-specific (`portability: specific`) lacks the
+   `exception.engine` or `exception.evidence` the reference contract
+   requires for a non-portable capability.
+5. **Untraceable pipeline job.** A pipeline job on either engine is
+   neither a capability `id` nor carries a valid `# ci-capability:`
+   annotation mapping it to one, so the harness cannot attribute it.
+
+## Reconcile per kind
+
+For each detected divergence, determine the reconciliation appropriate
+to its kind. Every reconciliation stays within the evidence-backed
+exception discipline the reference contract mandates.
+
+- **Stale derived pipeline** → regenerate the derived GitLab pipeline
+  from the current reference (`scripts/build-ci.sh`) and re-run the
+  harness to confirm the divergence is resolved. This is the only
+  deterministic, no-judgment case — see *Autonomy boundary*.
+- **Reference drift** → propose amending the offending reference
+  capability (its `trigger`, `command`, `requires`, `id`, or
+  `portability`) so the reference is valid and once again describes
+  what the engines do. Judgment-bearing.
+- **Hand-authored pipeline drift** → propose correcting the
+  hand-authored job so its business steps and setup match the
+  attributed capability — or, if the engine's behaviour is the
+  intended truth, propose amending the reference instead. Name which
+  one you believe is correct and why. Judgment-bearing.
+- **Evidence-less engine-specific exception** → propose adding the
+  missing `exception.engine` and a concrete `exception.evidence`
+  justification, or reclassifying the capability as portable if it is
+  in fact portable. Judgment-bearing.
+- **Untraceable pipeline job** → propose either renaming the job to its
+  capability `id`, adding a valid `# ci-capability:` annotation, or (if
+  the job represents a genuinely new capability) adding that capability
+  to the reference. Judgment-bearing.
+
+## Autonomy boundary
+
+This boundary is the heart of the agent. Honour it exactly.
+
+You **MAY autonomously apply ONLY** the deterministic, no-judgment
+reconciliation — the **stale derived pipeline** case:
+
+```bash
+bash scripts/build-ci.sh          # regenerate .gitlab-ci.yml from the reference
+bash scripts/check-ci-parity.sh   # confirm the divergence is resolved
+```
+
+This is safe to apply autonomously because it mutates nothing that
+requires judgment: it re-derives the generated GitLab pipeline from the
+current reference using the project's own generator, then verifies the
+result with the harness. If the re-run is not clean, you have
+mis-classified — stop, re-classify, and treat it as a judgment-bearing
+case.
+
+For **every** judgment-bearing case — amending a reference capability,
+amending an evidence-backed exception, or correcting a hand-authored
+pipeline job — you **diagnose and propose only**. You **SHALL NOT**
+mutate the reference, any pipeline, or any exception autonomously. You
+present the proposed change (a diff or an explicit edit description) and
+stop; the contributor decides whether to apply it. Hand-editing the
+generated `.gitlab-ci.yml` to silence the harness is never a
+reconciliation — it is the stale-pipeline divergence in reverse.
+
+## Output discipline
+
+The agent's response is a reconciliation report, not a tutorial. For
+each divergence, the four-link chain is the message:
+
+```text
+Symptom:        <verbatim harness line>
+Classification: <one of the five kinds>
+Evidence:       <reference id + engine, quoted from the harness / files>
+Reconciliation: <the deterministic action you applied, OR the proposed
+                 change you are NOT applying autonomously>
+```
+
+When you have auto-applied the stale-pipeline reconciliation, show the
+clean re-run (`OK:` line) as proof. When you are proposing a
+judgment-bearing change, state plainly that you have **not** applied it
+and what the contributor must decide.
+
+Do not append "hope this helps" or restate the verdict in a conclusion.
+If a classification is uncertain — a divergence could be reference drift
+*or* hand-authored drift depending on which side is the intended truth —
+name the uncertainty and the question that resolves it rather than
+committing to a confident wrong call.
+
+## Handoff
+
+When the divergences are reconciled or the proposals are delivered, the
+agent's job is done. The follow-on work is delegated:
+
+- Applying a proposed reference / pipeline edit and committing it →
+  **developer** agent.
+- Opening a PR and writing the logbook entry → **pr-logbook** agent.
+- Authoring a brand-new pipeline for an engine → **ci-configurator**
+  agent.
+- Diagnosing a failing application pipeline run → **ci-debugger** agent.

--- a/artifacts/core/skills/gitlab-ci/SKILL.md
+++ b/artifacts/core/skills/gitlab-ci/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: gitlab-ci
+description: |
+  Deep, practitioner-grade knowledge of GitLab CI/CD for authoring,
+  reviewing, hardening, and debugging pipelines. Activate when reading
+  or writing a `.gitlab-ci.yml`, when reviewing a CI change in a merge
+  request, when designing runners/executors or reusable CI/CD
+  Components, or when migrating to GitLab CI from another engine.
+  Covers pipeline/stage/job structure, the `rules:`/`workflow:` trigger
+  model, runners and executors, caching vs. artifacts, the
+  protected/masked variable and secret model, `id_tokens:` OIDC
+  federation, and includes/components — plus the security defaults that
+  should never be negotiated away.
+type: skill
+license: Apache-2.0
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${CANONICAL_REPO}"
+    version: "1.0.0"
+claude:
+  allowed-tools:
+    - Read
+    - Bash
+    - Write
+    - Edit
+  user-invocable: true
+---
+
+# GitLab CI/CD
+
+A dense, practitioner-oriented skill for working on GitLab CI/CD
+pipelines. Read the relevant section before editing a `.gitlab-ci.yml`;
+defer to the `references/` documents for exhaustive syntax tables. Treat
+the **Security defaults** section as non-negotiable.
+
+This skill is the GitLab counterpart of the `github-actions` skill and
+presents a parallel activation and escalation contract. Keep your
+guidance engine-neutral wherever the project's platform-neutral
+capability reference (`ci/ci-capabilities.yml`, described by
+`docs/ci-reference-format.md`) keeps it neutral; name GitLab-specific
+syntax only where the behaviour is genuinely GitLab-specific.
+
+## When to activate
+
+Activate this skill the moment any of the following is true:
+
+- A `.gitlab-ci.yml` (or an `include`d CI fragment) is being authored,
+  modified, or reviewed.
+- A reusable **CI/CD Component** or an `include:`-based template is
+  being designed or consumed.
+- A merge request touches CI configuration and a reviewer-grade audit
+  is required (image pinning, protected/masked variables, OIDC, secret
+  exposure, `rules:` correctness).
+- A pipeline is failing and the root cause is suspected to be in the
+  pipeline definition, the runner/executor selection, the cache or
+  artifacts, the variable/secret scoping, or the `rules:` evaluation.
+- A self-managed runner fleet is being designed, hardened, or
+  diagnosed.
+- A migration is being planned (e.g., from GitHub Actions, CircleCI,
+  Jenkins, or Azure Pipelines to GitLab CI/CD).
+
+Defer to **security** when the change introduces a new secret, widens
+the `CI_JOB_TOKEN` access allowlist, adds an `id_tokens:` OIDC trust
+relationship to a cloud provider, relaxes protected-branch/variable
+gating, or executes untrusted input (MR title, branch name, commit
+message) inside a `script:`. Defer to **architect** when the change
+restructures the pipeline topology (e.g., splitting a monolithic
+pipeline into parent-child pipelines or shared CI/CD Components used
+across many projects).
+
+## Reference index
+
+The `references/` directory holds the canonical, exhaustive
+documentation for each subdomain of GitLab CI/CD. Read the relevant
+file before producing non-trivial output.
+
+| File | One-line description |
+|------|----------------------|
+| `references/pipeline-syntax.md` | Full grammar of `stages:`, `jobs`, `script:`/`before_script:`/`after_script:`, `needs:`, `rules:`, `extends:`, `!reference`, `parallel:matrix`, `environment:`, `default:`, with annotated examples for every key. |
+| `references/rules-and-triggers.md` | The `rules:` model (`if`/`changes`/`exists`/`when`), `workflow:rules:`, legacy `only/except`, parent-child and multi-project `trigger:` pipelines, the predefined-variable and expression-operator tables, and pipeline types. |
+| `references/runners-and-executors.md` | Instance/group/project runners, `tags:` selection, the shell/docker/kubernetes executors, autoscaling, `image:`/`services:`, and `config.toml` essentials. |
+| `references/caching-and-artifacts.md` | The cache-vs-artifacts distinction, `cache:key/paths/policy/when`, `artifacts:paths/reports/expire_in`, `dependencies:`, distributed cache, and language-specific recipes (npm, pnpm, Yarn, pip, Poetry, Maven, Gradle, Go, Cargo). |
+| `references/variables-and-secrets.md` | Variable sources and precedence, `file`/masked/protected variables, external secrets (`secrets:` with Vault / Azure / GCP), `id_tokens:` OIDC federation for AWS / GCP / Azure, masking caveats, and exfiltration anti-patterns. |
+| `references/security-and-permissions.md` | `CI_JOB_TOKEN` and its access allowlist, the member-role model, protected branches/tags, protected environments, `id_tokens:`, fork-runner trust, and least-privilege recipes per use case. |
+| `references/includes-and-components.md` | `include:` (local/project/remote/template/component), CI/CD Components and the catalog, `spec:inputs:`, `extends:`, `!reference`, `trigger:include`, nesting limits, and versioning strategies. |
+
+## Core concepts
+
+A pipeline is a YAML file (`.gitlab-ci.yml` at the repository root,
+overridable via `CI_CONFIG_PATH`) triggered by one or more events —
+a push, a merge request, a tag, a schedule, or a manual run. A
+pipeline contains **jobs**; each job belongs to a **stage**, and
+stages run in declared order while jobs in the same stage run in
+parallel. A job is a list of shell commands (`script:`) executed by a
+**runner** using a chosen **executor**. State between jobs travels
+through **artifacts** (a forward-passed contract) and, opportunistically,
+through **cache** (a best-effort speed optimization).
+
+### Stages, jobs, and the DAG
+
+Stages give a coarse ordering; `needs:` gives a fine one. A job with
+`needs:` starts as soon as its named dependencies finish, forming a
+**directed acyclic graph** that ignores stage boundaries — the way to
+shorten a pipeline's critical path. `needs: []` starts a job
+immediately, before any stage. See `references/pipeline-syntax.md`.
+
+### Triggers and `rules:`
+
+`rules:` is the modern control-flow primitive: an ordered list whose
+first matching entry decides whether (and how) the job runs. Rules key
+on `if:` expressions over predefined variables (`$CI_PIPELINE_SOURCE`,
+`$CI_COMMIT_BRANCH`, `$CI_COMMIT_TAG`, `$CI_MERGE_REQUEST_*`),
+`changes:` (path filters), and `exists:` (file presence).
+`workflow:rules:` gates the whole pipeline — most importantly to avoid
+running a duplicate detached and branch pipeline for the same commit.
+Legacy `only/except` still works but `rules:` supersedes it. See
+`references/rules-and-triggers.md`.
+
+### Runners and executors
+
+A runner is the agent that executes a job; the **executor** is how it
+does so. The **docker** executor (each job in a fresh container from
+`image:`) is the default for reproducibility; **shell** runs directly
+on the host; **kubernetes** schedules a pod per job. A job selects a
+runner by `tags:`; a job whose tags match no runner stays queued.
+Pin `image:` by digest, never a moving tag. See
+`references/runners-and-executors.md`.
+
+### Caching vs. artifacts
+
+These are different mechanisms. **Cache** persists reusable
+dependencies (e.g. `node_modules/`) across runs to save time; it may be
+absent and must never be relied on as a contract. **Artifacts** are a
+job's declared outputs, passed forward to later stages and downloadable
+from the UI. Use `cache:` for speed and `artifacts:` for correctness.
+See `references/caching-and-artifacts.md`.
+
+### Variables and secrets
+
+CI/CD variables come from many sources (instance, group, project,
+trigger, `.gitlab-ci.yml`, `dotenv` artifacts) with a defined
+precedence. A credential MUST be a **masked** variable (hidden in job
+logs) and, when it gates a real environment, a **protected** variable
+(exposed only to pipelines on protected branches/tags). The `file`
+variable type writes the value to a temp file and exports its path —
+the correct channel for certificates and kubeconfigs. For cloud
+credentials, **prefer `id_tokens:` OIDC** over long-lived keys. See
+`references/variables-and-secrets.md`.
+
+### Permissions and protection
+
+GitLab has no single token scope map; the surface spans the
+`CI_JOB_TOKEN` (and its project access allowlist), the project/group
+member role model, protected branches/tags, and protected
+environments. Production promotion belongs behind a protected
+environment with required approvals. See
+`references/security-and-permissions.md`.
+
+### Includes and components
+
+`include:` composes a pipeline from local files, other projects,
+remote URLs, GitLab templates, or versioned **CI/CD Components**.
+Components (`include:component:`) are the modern reusable unit, with a
+typed `spec:inputs:` contract and catalog versioning. `extends:` and
+`!reference` compose fragments within and across includes. See
+`references/includes-and-components.md`.
+
+## Common pitfalls
+
+The top failure modes, in rough order of frequency observed across
+real-world audits:
+
+1. **Non-pinned container images.** `image: node:22` (or `:latest`) is
+   a moving target — the registry can re-point the tag. Pin by digest
+   (`image: node@sha256:…`) and let Renovate track updates.
+2. **Plaintext or un-masked secrets.** A credential hardcoded in
+   `variables:`, or a masked variable that fails GitLab's masking
+   requirements (too short, contains whitespace) and silently logs in
+   the clear.
+3. **Over-broad `rules:` / missing `workflow:rules:`.** Without a
+   `workflow:` guard, a single push to a branch with an open MR runs
+   two pipelines. Rules that omit `$CI_PIPELINE_SOURCE` checks fire on
+   unintended events.
+4. **`CI_DEBUG_TRACE` or `set -x` left enabled.** Both print every
+   expanded variable to the job log, including masked ones — masking
+   does not survive a shell trace.
+5. **Treating cache as artifacts.** Relying on `cache:` to carry build
+   output to a later stage. Cache can be cold; only `artifacts:` (or
+   `needs:[].artifacts`) is a forward contract.
+6. **Cache key on the manifest, not the lockfile.** A cache keyed on
+   `package.json` instead of `package-lock.json` goes stale silently;
+   one keyed on nothing poisons across branches.
+7. **`cache:`/dependency dir outside `$CI_PROJECT_DIR`.** GitLab can
+   only cache paths under the project directory; a `GOPATH` or pip
+   cache in `$HOME` is silently not cached.
+8. **`interruptible` / `resource_group` misuse.** A deploy job left
+   `interruptible: true` can be cancelled mid-rollout; production
+   deploys need a `resource_group` to serialize.
+9. **Untrusted-fork runner exposure.** A shared or `privileged` runner
+   that accepts fork MR pipelines can run arbitrary code on your
+   infrastructure. Protected variables and protected runners are not
+   exposed to fork MRs by default — do not relax that.
+10. **Unpinned `include:remote` / `~latest` components.** A remote
+    include or a component pinned to `~latest` can change under you.
+    Pin to a tag or commit SHA and prefer first-party sources.
+
+## Validation tools
+
+Helper scripts live under `scripts/` and are the recommended way to
+catch the pitfalls above before merge. Both are **offline** text scans —
+no live GitLab, no `glab`, no Docker, no registry or token access.
+
+- **`scripts/check-pinned-images.sh`** — fails closed if any `image:`
+  or `services:` reference is not pinned to an immutable `@sha256:`
+  digest. The first-line defense against a re-pointed base image. The
+  GitLab counterpart of the `github-actions` skill's
+  `check-pinned-actions.sh`.
+- **`scripts/check-secrets-exposure.sh`** — flags hardcoded credential
+  literals in `variables:`/`script:`, recognizable token shapes
+  (`glpat-…`, `ghp_…`, AWS keys, PEM private keys), `echo`/`printf` of a
+  credential-named variable, `set -x`, and `CI_DEBUG_TRACE`. The GitLab
+  counterpart of the `github-actions` skill's `check-secrets-exposure.sh`.
+
+Invoke them as:
+
+```sh
+scripts/check-pinned-images.sh .gitlab-ci.yml
+scripts/check-secrets-exposure.sh .gitlab-ci.yml
+```
+
+Each accepts exactly one argument — a pipeline file or a directory
+(directory mode scans `<dir>/.gitlab-ci.yml` plus YAML under
+`<dir>/.gitlab/`). Both exit non-zero on a finding, so CI can fail
+closed.
+
+This skill ships **no** offline structural linter and **no** pipeline
+simulator, by design. GitLab's `glab ci lint` is a server-side CI-Lint
+API call (it requires authentication and a reachable instance — there
+is no offline structural validation equivalent to `actionlint`), and
+`gitlab-ci-local` *executes* the pipeline in Docker. Both are out of
+scope here: executing a pipeline on a live GitLab is not this skill's
+job. The two scripts above are the validations with genuine offline
+parity to their GitHub Actions siblings; nothing else is shipped as
+façade tooling.
+
+## Security defaults
+
+These defaults are not stylistic preferences. Treat every deviation as
+requiring an ADR.
+
+1. **Pin every container image by `@sha256:` digest.** No bare tags,
+   no `:latest`. Pin `image:` and every `services:` entry; document the
+   pin with a comment carrying the human-readable tag.
+2. **Every credential is a masked variable.** Never hardcode a secret
+   in `variables:` or a `script:`. Confirm the value meets GitLab's
+   masking requirements, or it logs in the clear despite the flag.
+3. **Protect the variables that gate real environments.** A deploy or
+   release credential is **protected** as well as masked, so it is
+   exposed only to pipelines on protected branches/tags.
+4. **Prefer `id_tokens:` OIDC over long-lived cloud credentials.** A
+   long-lived cloud key is acceptable only when the provider does not
+   support OIDC for the target resource. Document the exception.
+5. **Never echo or trace a secret.** No `echo "$TOKEN"`, no `set -x`
+   over secret-bearing commands, no `CI_DEBUG_TRACE: "true"` in a job
+   that sees a credential. Masking is best-effort and a transformed
+   value bypasses it.
+6. **Bind secrets to the smallest scope.** A secret in a global
+   `variables:` block is inherited by every job. Bind it to the job —
+   or the protected environment — that needs it.
+7. **Gate deploy / Pages / Release jobs behind protected refs and
+   environments.** Production promotion targets a protected
+   environment with required approvals; the environment is also the
+   correct scope for production secrets.
+8. **Serialize deployments with `resource_group:`** so two pipelines
+   never deploy to the same target concurrently, and leave production
+   deploys `interruptible: false`.
+9. **Scope the `CI_JOB_TOKEN` access allowlist.** Limit which projects
+   a job token may reach; the historical "allow all" default is a
+   lateral-movement risk.
+10. **Never run untrusted code on a `privileged` or shared runner.**
+    Fork MR pipelines must not receive protected variables or
+    protected runners. Keep that default; if a fork must run privileged
+    work, gate it behind a maintainer-approved, protected-environment
+    job.
+
+## Quick recipes
+
+A handful of patterns worth memorising.
+
+### Minimum-viable secure pipeline skeleton
+
+```yaml
+default:
+  image: node@sha256:<digest>  # node:22
+
+stages: [test]
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+
+unit-test:
+  stage: test
+  interruptible: true
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --cache .npm --prefer-offline
+    - npm test
+```
+
+### Deploy to AWS via OIDC (no long-lived secrets)
+
+```yaml
+deploy:
+  stage: deploy
+  image: registry.example.com/aws-cli@sha256:<digest>
+  environment:
+    name: production
+  resource_group: production
+  interruptible: false
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name "ci-$CI_PIPELINE_ID"
+      --web-identity-token "$AWS_ID_TOKEN"
+    - ./scripts/deploy.sh
+```
+
+### Safe handling of an untrusted MR title
+
+```yaml
+comment:
+  variables:
+    MR_TITLE: $CI_MERGE_REQUEST_TITLE   # bound to a variable, not interpolated
+  script:
+    # Quoted; the shell does not re-evaluate the value.
+    - printf 'Title: %s\n' "$MR_TITLE"
+```
+
+### Pass a build artifact forward (not via cache)
+
+```yaml
+build:
+  stage: build
+  script: [make dist]
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+publish:
+  stage: deploy
+  needs: [build]   # pulls build's artifacts
+  script: [./publish.sh dist/]
+```
+
+***
+
+When in doubt, consult the relevant `references/` file before writing
+YAML. The references are exhaustive on purpose; this top-level skill is
+the working surface.

--- a/artifacts/core/skills/gitlab-ci/references/caching-and-artifacts.md
+++ b/artifacts/core/skills/gitlab-ci/references/caching-and-artifacts.md
@@ -1,0 +1,578 @@
+# Caching and artifacts reference
+
+GitLab CI/CD exposes two distinct mechanisms for moving files in and out
+of jobs. They look similar and are constantly confused, so the headline
+distinction comes first.
+
+- **`cache:`** is a **speed optimization** for reusable dependencies
+  (an `npm` store, a Go module cache, a `.gradle` directory). The cache
+  is **best-effort**: it may be absent, stale, or evicted, and a job
+  MUST still succeed on a cold cache. It is keyed and shared across
+  pipelines and jobs by key, NOT by stage order. Never treat it as a
+  contract for passing build output forward.
+- **`artifacts:`** are **job outputs** passed forward to later stages
+  and made downloadable from the UI/API. Artifacts are a **contract**:
+  by default every job in a later stage automatically downloads the
+  artifacts of all jobs from earlier stages. If a build job declares a
+  binary as an artifact, the test job in the next stage will have it.
+
+Rule of thumb: if losing the files only costs you time, it is a cache.
+If losing the files breaks a downstream job, it is an artifact.
+
+This document covers `cache:` key/policy/fallback semantics, distributed
+cache backends, the full `artifacts:` surface (including `reports` and
+`dotenv` variable passing), `dependencies:`/`needs:artifacts` fetch
+control, language recipes, and the recurring pitfalls.
+
+## How the cache works
+
+A job declares a cache by key and paths:
+
+```yaml
+build:
+  stage: build
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths:
+      - .npm/
+    policy: pull-push
+  script:
+    - npm ci --cache .npm --prefer-offline
+```
+
+The runner performs two operations:
+
+1. **Pre-job pull.** Resolves `cache:key` to an archive. On hit, the
+   `paths:` are extracted into the workspace before `script` runs. On
+   miss, `fallback_keys` (then the global fallback) are tried; if all
+   miss the job starts cold — which MUST be valid.
+2. **Post-job push.** After the job, the `paths:` are re-archived and
+   uploaded under `cache:key`. Whether the push happens depends on
+   `cache:policy` and `cache:when` (below).
+
+Unlike artifacts, the cache is **not** tied to stage ordering. Two jobs
+in the same stage can share a cache by using the same key.
+
+## `cache:key`
+
+The key is the cache's identity. Same key across jobs/pipelines means
+shared content.
+
+```yaml
+# Static string key.
+cache:
+  key: gems-ruby-3.3
+
+# Lockfile-hashed key — invalidates automatically when deps change.
+cache:
+  key:
+    files:
+      - Gemfile.lock
+    prefix: $CI_JOB_NAME
+
+# Predefined-variable key — one cache per branch.
+cache:
+  key: $CI_COMMIT_REF_SLUG
+```
+
+- **`cache:key:files`** — up to two files. GitLab computes a SHA over
+  their contents and uses it as (part of) the key. When neither file
+  changes, the key is stable and the cache is reused; when a lockfile
+  changes, the key changes and a fresh cache is built. If the listed
+  files do not exist, the literal `default` is used as the SHA segment.
+- **`cache:key:prefix`** — prepended to the computed SHA, letting you
+  combine a discriminator (job name, branch slug, OS) with lockfile
+  hashing: `prefix-<sha>`.
+- **Branch-scoped key** — `key: $CI_COMMIT_REF_SLUG` gives every branch
+  its own cache. Trade-off: more storage, but no cross-branch bleed.
+
+The key MUST NOT contain `/` or be the literal `.`/`..`. Predefined
+variables (`$CI_COMMIT_REF_SLUG`, `$CI_JOB_NAME`, `$CI_DEFAULT_BRANCH`)
+are the usual building blocks.
+
+## `cache:paths`
+
+A list of paths, relative to `$CI_PROJECT_DIR`, archived into the cache.
+Globs are supported.
+
+```yaml
+cache:
+  paths:
+    - .npm/
+    - vendor/ruby/
+    - "**/node_modules/"
+```
+
+**Critical GitLab gotcha:** only paths **under** the project directory
+(`$CI_PROJECT_DIR`) can be cached. A tool that writes its cache to
+`$HOME` (e.g. `~/.cache/go-build`, `~/.m2`, `~/.cargo`) will NOT be
+cached unless you redirect it into the workspace via an environment
+variable (see the language recipes). This is the single most common
+reason a cache "silently does nothing."
+
+## `cache:policy`
+
+Controls the pull/push behavior, trading correctness for speed.
+
+```yaml
+# Default: download at start, upload at end.
+cache: { key: deps, paths: [.npm/], policy: pull-push }
+
+# Consumer-only: download but never re-upload (faster, read-only jobs).
+test:
+  cache: { key: deps, paths: [.npm/], policy: pull }
+
+# Producer-only: skip the download, only upload (a dedicated warm-up).
+warm-cache:
+  cache: { key: deps, paths: [.npm/], policy: push }
+```
+
+A common pattern: one `prepare` job with `policy: push` builds the cache;
+every downstream job uses `policy: pull` so they never waste time
+re-uploading an unchanged cache.
+
+## `cache:when`
+
+Controls whether the cache is saved based on job result.
+
+```yaml
+cache:
+  key: deps
+  paths: [.npm/]
+  when: on_success   # default: save only if the job succeeds
+  # when: on_failure  # save only if the job fails (debugging)
+  # when: always      # save regardless of result
+```
+
+Use `when: always` when even a failed job produces a useful partial
+cache (e.g. a partially-populated dependency store worth reusing).
+
+## `cache:untracked` and `cache:unprotect`
+
+```yaml
+cache:
+  untracked: true     # also cache files NOT tracked by git
+  unprotect: false    # if true, share cache between protected and
+                      # unprotected refs (DANGEROUS — see Pitfalls)
+```
+
+- **`untracked: true`** caches every git-untracked file in the workspace
+  in addition to `paths:`. Convenient but easy to bloat.
+- **`unprotect: true`** lets protected and unprotected branches share one
+  cache. The default `false` keeps them separate, which is a security
+  boundary — do not flip it without understanding cache poisoning below.
+
+## Multiple caches and `fallback_keys`
+
+A job can declare **multiple caches** as a list, each with its own key:
+
+```yaml
+test:
+  cache:
+    - key:
+        files: [package-lock.json]
+      paths: [.npm/]
+    - key:
+        files: [Gemfile.lock]
+      paths: [vendor/ruby/]
+  script:
+    - npm ci --cache .npm
+    - bundle install --path vendor/ruby
+```
+
+**`cache:fallback_keys`** provides a restore chain analogous to GitHub
+Actions' `restore-keys`: if the exact key misses, the listed keys are
+tried in order for a partial/older cache.
+
+```yaml
+cache:
+  key:
+    files: [package-lock.json]
+    prefix: $CI_COMMIT_REF_SLUG
+  fallback_keys:
+    - npm-$CI_COMMIT_REF_SLUG
+    - npm-$CI_DEFAULT_BRANCH
+  paths: [.npm/]
+```
+
+A global `cache:` defined at the top of the file applies to every job;
+a per-job `cache:` overrides it entirely (the two are NOT merged).
+
+## Distributed cache (S3 / GCS)
+
+By default the cache is stored on the runner's local disk — useless when
+jobs land on different runners. For a runner fleet, configure a
+**distributed cache** in the runner's `config.toml`:
+
+```toml
+[runners.cache]
+  Type = "s3"
+  Shared = true
+  [runners.cache.s3]
+    ServerAddress = "s3.amazonaws.com"
+    BucketName = "gitlab-runner-cache"
+    BucketLocation = "eu-west-1"
+```
+
+`Type` may be `s3`, `gcs`, or `azure`. `Shared = true` lets all runners
+read each other's caches (required for the cross-runner case). This is a
+runner-administration concern — see the runners-and-executors reference
+for executor and `config.toml` details. The `.gitlab-ci.yml` author only
+declares `cache:`; the backend is transparent.
+
+## How artifacts work
+
+Artifacts are produced by a job and consumed by later jobs (and humans).
+
+```yaml
+build:
+  stage: build
+  script:
+    - make build
+  artifacts:
+    paths:
+      - bin/
+      - dist/
+    expire_in: 1 week
+```
+
+By default, every job downloads the artifacts of all jobs in **earlier**
+stages. So a `test` job in the `test` stage automatically receives
+`bin/` and `dist/` from `build` — no extra wiring.
+
+## `artifacts:paths` and `artifacts:exclude`
+
+```yaml
+artifacts:
+  paths:
+    - target/release/
+    - "*.log"
+  exclude:
+    - target/release/**/*.o   # drop intermediate objects from the upload
+  untracked: false            # set true to also upload git-untracked files
+```
+
+`paths:` is relative to `$CI_PROJECT_DIR`. `exclude:` prunes matches from
+the set selected by `paths:`/`untracked:`, useful for shedding bulky
+intermediates while keeping the final output.
+
+## `artifacts:expire_in` and `artifacts:when`
+
+```yaml
+artifacts:
+  paths: [dist/]
+  when: on_success    # on_success (default) | on_failure | always
+  expire_in: 30 days  # "1 week", "3 mins 4 sec", "never"
+```
+
+- **`when: on_failure`** plus a logs path is the canonical way to capture
+  diagnostics only when a job fails.
+- **`expire_in`** governs storage cost. Leaving it at the instance
+  default (often "never" expiry on self-managed, or a long window) is the
+  number-one source of runaway artifact storage. Set an explicit TTL on
+  every artifact unless it is a release deliverable. The latest artifacts
+  of the most recent successful pipeline on a ref are kept regardless
+  (`keep_latest_artifact`), so expiry does not strand your newest build.
+
+## `artifacts:name` and `artifacts:expose_as`
+
+```yaml
+artifacts:
+  name: "$CI_JOB_NAME-$CI_COMMIT_REF_SLUG"   # archive filename on download
+  expose_as: "Coverage report"               # named link in the MR UI
+  paths:
+    - coverage/index.html
+```
+
+`name:` controls the downloaded archive's filename. `expose_as:` surfaces
+the artifact as a clickable link directly in the merge request widget
+(limited to a small number of paths).
+
+## `artifacts:reports`
+
+`reports:` ingests structured artifacts that GitLab parses and renders,
+rather than just storing. Key report types:
+
+```yaml
+test:
+  script:
+    - pytest --junitxml=report.xml --cov --cov-report xml:coverage.xml
+  artifacts:
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+- **`junit:`** — test results rendered in the MR "Test summary" widget;
+  failures are shown inline on the MR.
+- **`coverage_report:` (`cobertura`)** — line-coverage overlay on the MR
+  diff. `coverage_format` is currently `cobertura` (or `jacoco` on newer
+  versions).
+- **`sast:`, `dependency_scanning:`, `secret_detection:`** — security
+  scanner outputs that populate the MR security widget and the
+  vulnerability report. Usually produced by GitLab's bundled scanner
+  templates rather than hand-authored.
+
+### `dotenv` — passing variables downstream
+
+The `dotenv` report is special: it does not render a widget, it
+**injects variables** from a `.env`-format file into later jobs. This is
+the supported way to pass a computed value (a version string, an image
+tag, a deploy URL) from one job to the next.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "VERSION=$(git describe --tags)" >> build.env
+    - echo "IMAGE_TAG=registry.example.com/app:$CI_COMMIT_SHORT_SHA" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true      # required to receive the dotenv variables
+  script:
+    - echo "Deploying $VERSION as $IMAGE_TAG"
+```
+
+The downstream job sees `$VERSION` and `$IMAGE_TAG` as ordinary
+variables. The variables propagate only to jobs that have the producing
+job in `needs:` (or, without `needs:`, to all later-stage jobs).
+
+## Controlling which artifacts are fetched
+
+By default a job downloads ALL upstream artifacts — wasteful when a job
+needs none or only some.
+
+### `dependencies:`
+
+```yaml
+deploy:
+  stage: deploy
+  dependencies:
+    - build           # fetch ONLY build's artifacts
+  script: [./deploy.sh]
+
+lint:
+  stage: test
+  dependencies: []    # fetch NO artifacts — faster, no download
+  script: [./lint.sh]
+```
+
+`dependencies:` is an allowlist of job names whose artifacts to fetch.
+The empty list `dependencies: []` fetches nothing — the single most
+effective speedup for jobs that only need the source checkout.
+
+### `needs: [...].artifacts`
+
+When using `needs:` (the DAG mechanism that lets jobs start out of stage
+order), control artifact transfer per-need:
+
+```yaml
+deploy:
+  needs:
+    - job: build
+      artifacts: true     # download build's artifacts (default true)
+    - job: lint
+      artifacts: false    # depend on lint's completion, skip its artifacts
+```
+
+`needs:` and `dependencies:` interact: when both are present, `needs:`
+governs ordering and `dependencies:` (if also set) further narrows the
+fetch set. For DAG pipelines, prefer expressing artifact transfer through
+`needs:[].artifacts`.
+
+## Language recipes
+
+Each recipe shows the `cache:` block plus the in-workspace redirection
+required by the `$CI_PROJECT_DIR` gotcha.
+
+### npm
+
+```yaml
+variables:
+  npm_config_cache: "$CI_PROJECT_DIR/.npm"   # move cache into workspace
+build:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [.npm/]
+  script:
+    - npm ci --prefer-offline
+```
+
+### pnpm
+
+```yaml
+variables:
+  PNPM_HOME: "$CI_PROJECT_DIR/.pnpm-store"
+build:
+  before_script:
+    - corepack enable
+    - pnpm config set store-dir "$CI_PROJECT_DIR/.pnpm-store"
+  cache:
+    key:
+      files: [pnpm-lock.yaml]
+    paths: [.pnpm-store/]
+  script:
+    - pnpm install --frozen-lockfile
+```
+
+### Yarn
+
+```yaml
+build:
+  before_script:
+    - yarn config set cache-folder "$CI_PROJECT_DIR/.yarn-cache"
+  cache:
+    key:
+      files: [yarn.lock]
+    paths: [.yarn-cache/]
+  script:
+    - yarn install --frozen-lockfile
+```
+
+For Yarn Berry zero-installs, `.yarn/cache` is committed to the repo and
+no `cache:` block is needed.
+
+### pip / Poetry
+
+```yaml
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"        # pip
+  POETRY_CACHE_DIR: "$CI_PROJECT_DIR/.poetry-cache"  # poetry
+build:
+  cache:
+    key:
+      files:
+        - poetry.lock        # or requirements.txt for plain pip
+    paths:
+      - .pip-cache/
+      - .poetry-cache/
+      - .venv/
+  script:
+    - poetry config virtualenvs.in-project true
+    - poetry install --no-interaction
+```
+
+`virtualenvs.in-project true` puts `.venv/` under `$CI_PROJECT_DIR` so it
+can be cached.
+
+### Maven / Gradle
+
+```yaml
+variables:
+  MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
+  GRADLE_USER_HOME: "$CI_PROJECT_DIR/.gradle"
+build-maven:
+  cache:
+    key:
+      files: [pom.xml]
+    paths: [.m2/repository/]
+  script: [mvn -B verify]
+
+build-gradle:
+  cache:
+    key:
+      files: [gradle/wrapper/gradle-wrapper.properties, build.gradle.kts]
+    paths:
+      - .gradle/caches/
+      - .gradle/wrapper/
+  script: [./gradlew build]
+```
+
+Both default to `$HOME`; the variables relocate them into the workspace.
+
+### Go modules
+
+```yaml
+variables:
+  GOPATH: "$CI_PROJECT_DIR/.go"          # module + build cache into workspace
+build:
+  cache:
+    key:
+      files: [go.sum]
+    paths:
+      - .go/pkg/mod/
+  script:
+    - go build ./...
+```
+
+`GOPATH` defaults to `$HOME/go`, which is uncacheable — relocating it is
+mandatory for the Go module cache to persist.
+
+### Cargo (Rust)
+
+```yaml
+variables:
+  CARGO_HOME: "$CI_PROJECT_DIR/.cargo"
+build:
+  cache:
+    key:
+      files: [Cargo.lock]
+    paths:
+      - .cargo/registry/index/
+      - .cargo/registry/cache/
+      - .cargo/git/db/
+      - target/
+  script:
+    - cargo build --release
+```
+
+`CARGO_HOME` defaults to `$HOME/.cargo`; relocate it and cache the
+registry plus `target/`.
+
+## Pitfalls
+
+### Cache poisoning across branches and forks
+
+A cache shared between protected and unprotected refs is an injection
+vector: a contributor pushing to an unprotected feature branch can write
+a poisoned cache that a protected branch (or a fork's MR pipeline) later
+restores. Mitigations:
+
+- Keep `cache:unprotect` at its default `false` so protected and
+  unprotected refs use separate caches.
+- Discriminate the key by ref where trust matters:
+  `key: "$CI_COMMIT_REF_PROTECTED-$CI_COMMIT_REF_SLUG"` so protected and
+  unprotected content never collide.
+- Treat restored binaries as untrusted for security-sensitive
+  toolchains; re-verify checksums after the pull.
+
+### Treating cache as artifacts
+
+The cache is best-effort and unordered. Relying on it to pass a build
+output to a later stage will work until the day the cache is evicted, a
+job lands on a fresh runner, or two pipelines race — then the downstream
+job mysteriously fails. Pass build output with `artifacts:`, always.
+
+### Oversized caches
+
+`untracked: true` plus a sprawling `paths:` can produce multi-gigabyte
+caches whose upload/download time exceeds the install time they were
+meant to save. Cache the dependency store, not the whole workspace, and
+measure: if `Restoring cache` takes longer than a cold install, drop it.
+
+### Default `expire_in`
+
+Artifacts without an explicit `expire_in` inherit the instance default,
+which on many installs is effectively unbounded. Across thousands of
+pipelines this silently consumes object storage. Set a deliberate TTL on
+every artifact; reserve long or `never` expiry for genuine release
+deliverables.
+
+### The `$CI_PROJECT_DIR` trap, restated
+
+The most frequent "my cache does nothing" cause: caching a tool's default
+`$HOME` directory, which lives outside `$CI_PROJECT_DIR` and is therefore
+silently un-cacheable. Every language recipe above redirects the tool's
+cache into the workspace for exactly this reason — verify the cached path
+is under `$CI_PROJECT_DIR` before blaming the key.

--- a/artifacts/core/skills/gitlab-ci/references/includes-and-components.md
+++ b/artifacts/core/skills/gitlab-ci/references/includes-and-components.md
@@ -1,0 +1,475 @@
+# Includes and components reference
+
+GitLab CI/CD has no single "function call" primitive. Composition is
+assembled from several keywords that each cover one axis of reuse:
+`include:` pulls external configuration into the current pipeline,
+**CI/CD Components** package a parameterised unit and publish it to a
+catalog, `spec:inputs:` defines the typed contract a component or
+included file exposes, and `extends:` / `!reference[…]` stitch fragments
+together within the merged document.
+
+This document covers every form of `include:`, the modern CI/CD
+Component mechanism (the headline reusable unit), the `spec:inputs:`
+contract and its `$[[ inputs.x ]]` interpolation, composition with
+`extends:` and `!reference`, parent-child pipelines via
+`trigger:include`, the versioning and supply-chain story, and the
+pitfalls that bite when several includes merge into one configuration.
+
+## Picking a composition mechanism
+
+A frequent question. The trade-off:
+
+| Property | `include:` (local/project/remote/template) | CI/CD Component |
+|----------|--------------------------------------------|-----------------|
+| Unit of reuse | A whole `.gitlab-ci.yml` fragment. | A parameterised, versioned building block. |
+| Typed contract | Only if the file declares `spec:inputs:`. | `spec:inputs:` is the idiomatic contract. |
+| Versioning | By `ref:` (project) or URL (remote). | By `@<version>` — tag, SHA, `~latest`. |
+| Discoverability | None — you must know the path. | Listed in the CI/CD Catalog. |
+| Inputs interpolation | `$[[ inputs.x ]]` when `spec:` present. | `$[[ inputs.x ]]` — first-class. |
+| Best for | Sharing a stage fragment within an org. | A reusable block consumed across projects. |
+
+Rule of thumb: reach for a **CI/CD Component** when the unit of reuse is
+a published, versioned building block consumed by other projects (the
+GitLab analog of a reusable workflow). Reach for plain **`include:`**
+when you are factoring shared configuration inside one group and do not
+need a versioned, catalog-listed contract.
+
+## `include:` — the four classic forms
+
+`include:` merges external YAML into the pipeline configuration **before**
+jobs run. The merged result behaves as one document: later keys can
+override earlier ones (see *Merge and override semantics*).
+
+### `include:local`
+
+Pulls a file from the **same repository and ref** as the
+`.gitlab-ci.yml` being evaluated. The path is absolute from the repo
+root and must start with `/`:
+
+```yaml
+include:
+  - local: '/ci/build.yml'
+  - local: '/ci/test.yml'
+```
+
+Globs are allowed (`local: '/ci/*.yml'`). Because the file is read at the
+pipeline's own ref, `include:local` never introduces a cross-ref
+supply-chain question — it is the safest form.
+
+### `include:project`
+
+Pulls a file from **another project on the same GitLab instance**. Pin
+the `ref:` (a tag, branch, or SHA) and list one or more files:
+
+```yaml
+include:
+  - project: 'my-group/ci-templates'
+    ref: v1.4.0
+    file:
+      - '/templates/build.yml'
+      - '/templates/deploy.yml'
+```
+
+Omitting `ref:` resolves against the included project's **default
+branch** at pipeline-creation time — a moving target. Pin a tag or SHA
+for reproducibility.
+
+### `include:remote`
+
+Pulls a file from an **arbitrary URL** reachable over HTTP(S):
+
+```yaml
+include:
+  - remote: 'https://gitlab.example.com/-/snippets/12/raw/main/build.yml'
+```
+
+This is the highest-risk form. The URL is fetched at pipeline-creation
+time with no integrity check: whoever controls that endpoint controls
+part of your pipeline. Treat it like sourcing a remote shell script.
+
+- Only include from a source you trust and control.
+- Prefer a URL that resolves to an **immutable** artifact (a raw file at
+  a tagged ref or SHA), never `…/raw/main/…`.
+- Audit `include:remote` entries in review the same way you audit a
+  third-party dependency.
+
+Where possible, replace `include:remote` with `include:project` (same
+instance, auditable `ref:`) or a CI/CD Component (versioned, catalog).
+
+### `include:template`
+
+Pulls a **GitLab-maintained template** shipped with the instance. No
+ref or project needed — the name resolves against GitLab's bundled set:
+
+```yaml
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+```
+
+These are first-party and version-locked to your GitLab version, so
+they are a safe default for security and language scaffolding. They are,
+however, opinionated — read what they inject before relying on them.
+
+## `include:` with `rules:` and `inputs:`
+
+An `include:` entry can be made conditional with `rules:` and can pass
+typed inputs to a file that declares `spec:inputs:`.
+
+```yaml
+include:
+  - local: '/ci/deploy.yml'
+    rules:
+      - if: '$CI_COMMIT_BRANCH == "main"'
+  - component: $CI_SERVER_FQDN/my-group/ci/build@1.0.0
+    inputs:
+      runner_tag: saas-linux-large
+    rules:
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+`include:` `rules:` support `if:`, `exists:`, and variable expressions,
+but **not** the job-only `changes:` with `compare_to` in every context —
+they are evaluated at pipeline-creation time, before any job. When the
+rule does not match, the file is simply not included.
+
+## CI/CD Components — the modern reusable unit
+
+A **CI/CD Component** is a reusable, versioned unit of pipeline
+configuration published from a **component project** and consumed via
+`include:component`. It is the closest GitLab analog of a GitHub Actions
+reusable workflow: a typed contract (`spec:inputs:`) wrapping one or
+more jobs, addressed by version, optionally discoverable in the **CI/CD
+Catalog**.
+
+### Component address form
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/my-group/my-project/my-component@1.2.0
+    inputs:
+      stage: build
+      image: golang:1.23
+```
+
+The path decomposes as
+`<fqdn>/<group>/<project>/<component>@<version>`:
+
+- `$CI_SERVER_FQDN` — predefined variable for the current instance host.
+  Using it (rather than a hard-coded domain) keeps the component
+  portable across self-managed and SaaS instances.
+- `<group>/<project>` — the component project that hosts the component.
+- `<component>` — the component **name**, matching a file under the
+  project's `templates/` directory (see layout below).
+- `@<version>` — the version selector (see *Versioning a component*).
+
+### Component project layout
+
+A single project can publish several components. Each component is a
+file or directory under `templates/`:
+
+```text
+my-project/
+├── templates/
+│   ├── build.yml            # component "build"
+│   └── deploy/
+│       └── template.yml     # component "deploy"
+├── README.md                # required for catalog publication
+└── .gitlab-ci.yml           # the component's own CI (test it!)
+```
+
+Resolution rule:
+
+- `templates/<name>.yml` resolves the component `<name>`.
+- `templates/<name>/template.yml` resolves the component `<name>` (the
+  directory form, useful when the component ships companion files).
+
+### Defining a component with `spec:inputs:`
+
+A component file begins with a `spec:` header in its **first YAML
+document**, separated from the configuration by a `---` document marker:
+
+```yaml
+spec:
+  inputs:
+    stage:
+      default: test
+    image:
+      default: golang:1.23
+    coverage_threshold:
+      type: number
+      default: 80
+    deploy_env:
+      type: string
+      options:
+        - staging
+        - production
+    semver:
+      type: string
+      regex: '^\d+\.\d+\.\d+$'
+---
+test-job:
+  stage: $[[ inputs.stage ]]
+  image: $[[ inputs.image ]]
+  script:
+    - go test -coverprofile=cover.out ./...
+    - ./scripts/check-coverage.sh $[[ inputs.coverage_threshold ]]
+```
+
+`spec:inputs:` entries support:
+
+- `default:` — value used when the caller omits the input. An input with
+  **no `default:`** is **required** — the pipeline fails to create if
+  the caller does not supply it.
+- `type:` — `string` (default), `number`, `boolean`, or `array`. The
+  value is validated and coerced to the declared type.
+- `options:` — an allow-list; the supplied value must be one of them.
+- `regex:` — a pattern (`string` inputs only) the value must match.
+
+These four constraints are validated **at pipeline creation**, before
+any job starts — a contract violation fails fast, not mid-run.
+
+### `$[[ inputs.x ]]` interpolation vs. `variables:`
+
+Input interpolation uses the **double-bracket** form `$[[ inputs.x ]]`
+and is resolved **once, at include time**, before the configuration is
+merged. This is distinct from `$VARIABLE` / `${VARIABLE}` CI/CD
+variables, which are resolved **later**, in the job's runtime shell.
+
+```yaml
+spec:
+  inputs:
+    image:
+      default: alpine:3.20
+---
+job:
+  image: $[[ inputs.image ]]        # resolved at include time
+  script:
+    - echo "$CI_COMMIT_SHA"         # resolved at job runtime
+```
+
+Consequences:
+
+- Inputs can parameterise keys that variables cannot reach — `stage:`,
+  `image:`, `rules:` conditions, even job names — because they are
+  substituted into the YAML before parsing finishes.
+- An input is fixed for the lifetime of the include; a variable can
+  differ per job run and can be overridden by the runner environment.
+
+Reach for `spec:inputs:` to define the **interface** of a reusable
+fragment; reach for `variables:` for values that vary at runtime or that
+a downstream job overrides.
+
+### Versioning a component
+
+The `@<version>` selector accepts several forms, in increasing order of
+stability:
+
+| Selector | Resolves to | Stability |
+|----------|-------------|-----------|
+| `@~latest` | Latest **released** version in the catalog. | Moves under you. |
+| `@<branch>` (e.g. `@main`) | Tip of that branch. | Moves under you. |
+| `@<tag>` (e.g. `@1.2.0`) | That tag. | Stable unless re-tagged. |
+| `@<sha>` | That exact commit. | Immutable. |
+
+`~latest` and a branch ref are convenient in development but make the
+pipeline non-reproducible — the component can change between two runs of
+the same commit. For anything that ships, pin a **tag** (and ideally a
+SHA), and bump deliberately.
+
+### Publishing to the CI/CD Catalog
+
+To make a component discoverable and releasable:
+
+1. Add a `README.md` at the component project root (required) and mark
+   the project as a catalog resource in its settings.
+2. Tag a release commit and create a **release** for that tag (the
+   catalog lists released versions; `~latest` resolves to the newest
+   release, not the newest tag).
+3. The project's own `.gitlab-ci.yml` should test each component (lint
+   the YAML, run the component against a fixture) before tagging — a
+   published component is a dependency for every consumer.
+
+Releasing is what populates `~latest`; an untagged, unreleased component
+is only reachable by branch or SHA.
+
+## `extends:` and `!reference[…]` across includes
+
+Both keywords compose fragments **inside the merged document** — they
+operate after all `include:` and component resolution, so they can reach
+templates that arrived via an include.
+
+### `extends:`
+
+`extends:` performs a reverse-deep-merge of one or more hidden jobs
+(`.name`) into the current job. A hidden template defined in an included
+file is fully usable by a job in the root configuration:
+
+```yaml
+# in an included file: /ci/base.yml
+.docker-build:
+  image: docker:27
+  services:
+    - docker:27-dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+```
+
+```yaml
+# in the root .gitlab-ci.yml
+include:
+  - local: '/ci/base.yml'
+
+build:
+  extends: .docker-build       # merged from the included template
+  script:
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+```
+
+The base treatment of `extends:` (merge order, multi-level chains)
+belongs to the pipeline-syntax reference; here the point is only that
+the merge spans include boundaries.
+
+### `!reference[…]`
+
+`!reference` inserts a specific key from another job — including a job
+that came in via an include — without merging the whole job. It is the
+surgical alternative to `extends:`:
+
+```yaml
+include:
+  - local: '/ci/base.yml'
+
+deploy:
+  before_script:
+    - !reference [.docker-build, before_script]   # reuse just one key
+    - echo "extra deploy prep"
+  script:
+    - ./deploy.sh
+```
+
+`!reference` can target arbitrary nesting and is the cleanest way to
+reuse a single fragment (a `script` block, a `rules` entry) across
+includes without dragging unrelated keys along.
+
+## `trigger:include` — composition by reference
+
+A parent-child pipeline composes by **reference** rather than by merge:
+the parent spawns a downstream child pipeline whose configuration is
+supplied inline via `trigger:include`. Unlike `include:`, the child runs
+as its **own pipeline**, not as merged jobs in the parent.
+
+```yaml
+trigger-child:
+  trigger:
+    include:
+      - local: '/ci/child-pipeline.yml'
+    strategy: depend
+```
+
+- The child sees its own merged configuration; the parent's jobs and
+  variables do **not** leak in (only explicitly forwarded variables do).
+- `strategy: depend` makes the parent job mirror the child pipeline's
+  status, so a child failure fails the parent.
+- `trigger:include` accepts the same source forms as `include:`
+  (`local`, `project`, `component`, `artifact` for dynamic child
+  pipelines).
+
+This is composition for **isolation**: use it when a fragment should run
+as an independent pipeline (a monorepo sub-project, a generated dynamic
+pipeline) rather than as extra jobs in the current one. The trigger
+mechanics, `forward:`, and dynamic child pipelines are covered in the
+rules-and-triggers reference; here the framing is that
+`trigger:include` is composition-by-reference, the complement to
+`include:`'s composition-by-merge.
+
+## Merge and override semantics
+
+When `include:` brings in a job key that the root configuration also
+defines, the configurations **merge**, and the later definition wins on
+a per-key basis:
+
+- The **root `.gitlab-ci.yml` is processed last**, so a job redefined in
+  the root overrides the same job from an included file, key by key
+  (not wholesale replacement — unspecified keys survive from the
+  include).
+- Among multiple `include:` entries, **later entries override earlier
+  ones** for the same key.
+- Scalar and array keys are **replaced**, not concatenated. Redefining
+  `script:` in the root replaces the included `script:` entirely.
+- Map keys (e.g. `variables:`) are **deep-merged** — individual keys
+  override, siblings survive.
+
+```yaml
+include:
+  - local: '/ci/base.yml'        # defines test.script + test.image
+
+test:
+  image: node:22                 # overrides only the image
+  # script: inherited from /ci/base.yml unless redefined here
+```
+
+To override deliberately, redefine the exact key. To extend rather than
+replace, prefer `extends:` or `!reference[…]` so the original fragment
+stays visible.
+
+## Versioning strategy and supply-chain hardening
+
+Every `include:` and component is a dependency. Treat it like one.
+
+1. **Pin every cross-project and remote reference.** Use a `ref:` (tag
+   or SHA) on `include:project`, an immutable URL on `include:remote`,
+   and a `@<tag>` or `@<sha>` on `include:component`. An unpinned
+   reference (`include:project` with no `ref:`, `@main`, `@~latest`) can
+   change between two runs of the same commit.
+2. **Prefer first-party over third-party.** `include:template` and
+   components from a trusted internal group are auditable and version-
+   locked. An arbitrary `include:remote` URL is not.
+3. **Audit `include:remote`.** It fetches code with no integrity check.
+   If you cannot replace it with `include:project` or a component,
+   ensure the source is one you control and the URL is immutable.
+4. **Version components like a library.** Tag releases
+   `<major>.<minor>.<patch>`, populate the catalog with a release per
+   tag, and let consumers pin a SHA with a comment naming the version.
+5. **Beware moving selectors.** `@~latest` and `@main` are conveniences
+   for the component's own development, not for production consumers —
+   the same risk as pinning a GitHub Action to `@main`.
+
+The failure mode to avoid is the same across all forms: an unpinned
+include changes upstream, and a pipeline that passed yesterday fails (or
+worse, silently does the wrong thing) today, on an unchanged commit.
+
+## Common pitfalls
+
+- **Override order surprises.** Because the root config and later
+  includes win, a job you thought an included template defined may be
+  silently overridden by a same-named key elsewhere. Search the merged
+  config (the pipeline editor's *Full configuration* / *View merged
+  YAML* tab) when a key is not what you expect.
+- **Array keys replace, not append.** Redefining `script:` or
+  `before_script:` in the root **discards** the included version
+  entirely. Use `!reference` to keep the original and add to it.
+- **Variable scope across includes.** `variables:` are deep-merged, so a
+  root-level variable silently overrides an included one of the same
+  name. Globals defined in one include are visible to jobs from another
+  — name them defensively to avoid collisions.
+- **Inputs resolve at include time, variables at runtime.** Reaching for
+  `$VARIABLE` inside a key that needs an include-time value (a `stage:`
+  or job name) will not work — use `$[[ inputs.x ]]`. Conversely,
+  `$[[ inputs.x ]]` cannot pick up a value that only exists at job
+  runtime.
+- **Duplicate job keys across includes.** Two includes defining the same
+  job name silently merge; the later include wins per key. There is no
+  "job already defined" error — only the merged result. Keep job names
+  unique or namespace them per fragment.
+- **Unpinned remote includes.** `include:remote` to a `…/raw/main/…` URL
+  pulls whatever is at that branch tip right now. Pin to a tagged or
+  SHA-addressed raw URL, or move to `include:project`.
+- **`~latest` is the newest release, not the newest commit.** A
+  component fix pushed to a branch is invisible to `@~latest` consumers
+  until a release is created. Conversely, consumers on `@~latest` jump
+  to a new major the moment it is released — pin a tag to opt out.
+- **Catalog requires a README and a release.** A component project with
+  no `README.md` or no GitLab release will not appear in the catalog and
+  `@~latest` will not resolve, even though branch/SHA includes still
+  work.

--- a/artifacts/core/skills/gitlab-ci/references/pipeline-syntax.md
+++ b/artifacts/core/skills/gitlab-ci/references/pipeline-syntax.md
@@ -1,0 +1,721 @@
+# Pipeline syntax reference
+
+Canonical reference for the YAML grammar of a GitLab CI/CD pipeline
+(`.gitlab-ci.yml`). Each top-level and job-level key is enumerated with
+semantics, defaults, and a worked example. Read the section that matches
+the key you are editing — do not guess from memory.
+
+## File location and naming
+
+The pipeline definition lives in a file named `.gitlab-ci.yml` at the
+repository root. The basename and location are conventional, not free:
+GitLab looks for exactly this path unless the project overrides it.
+
+The override is the per-project **CI/CD configuration file** setting,
+exposed at runtime as `CI_CONFIG_PATH`. It accepts a repository-relative
+path, a path in a different project, or an external URL:
+
+```yaml
+# Project setting "CI/CD configuration file" set to:
+#   ci/pipeline.yml                 → file in this repo
+#   ci/pipeline.yml@group/templates → file in another project
+#   https://example.com/pipeline.yml → remote URL
+```
+
+A single file is the entry point; it may pull in further fragments with
+the top-level `include:` key (local files, other projects, remote URLs,
+or built-in templates). Includes are merged before any job runs.
+
+## Top-level keys
+
+### `stages`
+
+Declares the ordered list of pipeline stages. Jobs in the same stage run
+in parallel; a stage starts only after every job in the previous stage
+finishes successfully (unless `needs:` overrides the ordering — see
+below).
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+```
+
+If `stages:` is omitted, GitLab uses the implicit default ordering:
+
+```yaml
+stages:
+  - .pre      # always first, runs before any user stage
+  - build
+  - test
+  - deploy
+  - .post     # always last, runs after every user stage
+```
+
+`.pre` and `.post` are reserved virtual stages that exist whether or not
+`stages:` is declared; a job assigned to `.pre` runs before everything,
+`.post` after everything, regardless of where they appear in the file.
+
+A job is placed in a stage with its `stage:` key (see job-level keys). A
+job referencing a stage not listed in `stages:` is a configuration error.
+
+### `default`
+
+Defines values inherited by every job that does not set them explicitly.
+Only a fixed set of keys may appear under `default:` — notably `image`,
+`services`, `before_script`, `after_script`, `cache`, `tags`, `retry`,
+`timeout`, `interruptible`, and `artifacts`.
+
+```yaml
+default:
+  image: node:22-bookworm
+  tags:
+    - docker
+  before_script:
+    - corepack enable
+    - pnpm install --frozen-lockfile
+  retry:
+    max: 2
+    when: runner_system_failure
+```
+
+A job overrides a default by redeclaring the key; there is no deep merge
+of `default` into the job — the job's value replaces the default wholesale
+for that key. Set `inherit:` on a job to opt out of defaults or variables
+selectively:
+
+```yaml
+job:
+  inherit:
+    default: false              # ignore all `default:` keys
+    variables: [DEPLOY_ENV]     # inherit only these global variables
+```
+
+### `variables`
+
+Global CI/CD variables, inherited by every job. Job-scoped `variables:`
+override globals for that job. This section is intentionally brief —
+variable precedence, masking, protected/file variables, and secret
+injection are covered in the `variables-and-secrets.md` reference; consult
+it for anything beyond plain key/value defaults.
+
+```yaml
+variables:
+  GIT_DEPTH: "0"
+  FF_USE_FASTZIP: "true"
+```
+
+Variable values are strings. Quote numeric- or boolean-looking values to
+avoid the YAML coercion traps described in *Edge cases and quirks*.
+
+### `include`
+
+Pulls in external configuration before evaluation. Each entry is `local`,
+`project` (+ `ref` + `file`), `remote`, `template`, or `component`.
+
+```yaml
+include:
+  - local: ci/build.yml
+  - project: group/ci-templates
+    ref: v1.4.0
+    file: /jobs/deploy.yml
+  - template: Security/SAST.gitlab-ci.yml
+  - component: gitlab.com/components/sonarqube@1.0.0
+```
+
+### `workflow`
+
+Controls whether the **whole pipeline** is created for a given event.
+Without it, branch and merge-request pipelines can both fire and cause
+duplicate runs. The canonical guard:
+
+```yaml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
+    - when: never           # nothing else creates a pipeline
+```
+
+`workflow:rules` accepts the same `if` / `changes` / `when` vocabulary as
+job `rules:`, plus `auto_cancel` and a `name:` to label the pipeline.
+
+## Job-level keys
+
+A job is any top-level mapping that is not a reserved keyword. Its key is
+the job name (shown in the UI and used by `needs:`/`dependencies:`). A job
+must define `script:` (or be a `trigger:` / `extends:`-only bridge job).
+
+### `script`
+
+The shell commands the job runs, as a YAML list. Each list item is one
+command line; a non-zero exit on any line fails the job. Commands run in
+the runner's shell.
+
+```yaml
+test:
+  stage: test
+  script:
+    - npm ci
+    - npm run lint
+    - npm test
+```
+
+### `before_script` and `after_script`
+
+`before_script` is prepended to `script` (it shares the same shell
+context). `after_script` runs in a **separate shell**, always, even when
+the job failed or was cancelled — making it the right place for cleanup.
+Because it is a fresh shell, environment changes from `script:` do not
+carry into `after_script:`.
+
+```yaml
+deploy:
+  before_script:
+    - terraform init -input=false
+  script:
+    - terraform apply -auto-approve
+  after_script:
+    - terraform output -json > tf-out.json || true
+```
+
+### `stage`
+
+Assigns the job to a stage from `stages:`. Defaults to `test` when
+omitted.
+
+```yaml
+lint:
+  stage: build
+  script:
+    - golangci-lint run
+```
+
+### `rules` and `when`
+
+`rules:` is the modern flow-control mechanism: an ordered list evaluated
+top to bottom, **first match wins**, and the matched rule's `when:`
+decides the job's fate. Each rule may carry `if:`, `changes:`,
+`exists:`, `when:`, `allow_failure:`, and `variables:`.
+
+`when:` values: `on_success` (default — run if prior stages succeeded),
+`on_failure`, `always`, `manual` (a play button in the UI), `delayed`
+(with `start_in:`), and `never` (do not add the job).
+
+```yaml
+deploy:prod:
+  stage: deploy
+  script:
+    - ./deploy.sh production
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+      when: manual
+      allow_failure: false
+    - if: $CI_COMMIT_BRANCH == "main"
+      changes:
+        - src/**/*
+      when: on_success
+    - when: never
+```
+
+If no rule matches and there is no trailing catch-all, the job is **not
+added** to the pipeline. `rules:` is mutually exclusive with `only/except`
+in the same job.
+
+### `needs`
+
+Declares a Directed Acyclic Graph (DAG): the job starts as soon as its
+named dependencies finish, ignoring stage boundaries. This is how you
+break out of strict stage-by-stage execution.
+
+```yaml
+integration:
+  stage: test
+  needs:
+    - build:linux
+    - build:macos
+  script:
+    - ./run-integration.sh
+```
+
+`needs: []` (empty list) starts the job **immediately**, at pipeline
+creation, regardless of stage:
+
+```yaml
+prefetch:
+  stage: test
+  needs: []          # do not wait for the build stage
+  script:
+    - ./warm-cache.sh
+```
+
+`needs:` can also pull artifacts from a specific upstream job; use the
+object form with `artifacts: true`:
+
+```yaml
+package:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true       # download build's artifacts
+    - job: changelog
+      artifacts: false      # order dependency only, no download
+  script:
+    - ./package.sh
+```
+
+A job with `needs:` can depend only on jobs in the same stage or an
+earlier stage. The DAG must be acyclic.
+
+### `dependencies`
+
+Controls which upstream jobs' **artifacts** are downloaded into this job.
+By default a job downloads artifacts from every job in all prior stages;
+`dependencies:` narrows that set. An empty list disables artifact download
+entirely.
+
+```yaml
+unit:
+  stage: test
+  dependencies:
+    - build           # only fetch build's artifacts
+  script:
+    - ./test.sh
+
+quick:
+  stage: test
+  dependencies: []    # fetch nothing — faster start
+  script:
+    - ./lint.sh
+```
+
+When `needs:` is present, the `needs.*.artifacts` flags take precedence
+and `dependencies:` is redundant — prefer expressing both ordering and
+artifact flow through `needs:`.
+
+### `artifacts`
+
+Files and directories saved after the job, passed to later stages and
+downloadable from the UI.
+
+```yaml
+build:
+  stage: build
+  script:
+    - make dist
+  artifacts:
+    paths:
+      - dist/
+    exclude:
+      - dist/**/*.map
+    expire_in: 1 week
+    when: on_success          # on_success | on_failure | always
+    reports:
+      junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+```
+
+`reports:` artifacts feed GitLab features (test tab, coverage diffs,
+security dashboards) rather than being plain downloads.
+
+### `cache`
+
+Caches dependency directories between runs, keyed for reuse. Distinct from
+artifacts: cache is a runner-side optimization, not a contract between
+jobs.
+
+```yaml
+test:
+  cache:
+    key:
+      files:
+        - package-lock.json     # invalidate when the lockfile changes
+    paths:
+      - node_modules/
+    policy: pull-push           # pull | push | pull-push
+  script:
+    - npm ci
+    - npm test
+```
+
+### `allow_failure`
+
+When `true`, a failing job does not fail the pipeline; it is shown as a
+warning. Defaults to `false`, except for `when: manual` jobs, where it
+defaults to `true`. A numeric form restricts which exit codes are
+tolerated:
+
+```yaml
+flaky:
+  script:
+    - ./maybe-flaky.sh
+  allow_failure:
+    exit_codes:
+      - 137         # OOM-kill tolerated; any other non-zero still fails
+```
+
+### `timeout`
+
+Per-job timeout, overriding the project default. Accepts a human-readable
+duration.
+
+```yaml
+e2e:
+  timeout: 30 minutes
+  script:
+    - ./e2e.sh
+```
+
+### `retry`
+
+Automatically re-runs a failed job. `max:` is 0–2 (default 0). `when:`
+restricts retries to specific failure classes, so transient
+infrastructure failures retry while genuine test failures do not.
+
+```yaml
+deploy:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - api_failure
+  script:
+    - ./deploy.sh
+```
+
+### `interruptible`
+
+Marks the job as safe to cancel when a newer pipeline supersedes it on the
+same ref. Combined with the project's auto-cancel setting, this stops
+wasting runners on outdated commits. Set `false` on jobs that must not be
+interrupted (irreversible deploys).
+
+```yaml
+build:
+  interruptible: true
+  script:
+    - make
+```
+
+### `resource_group`
+
+Serializes jobs that share a named resource so that at most one runs at a
+time across all pipelines — the standard guard against concurrent deploys
+to the same environment.
+
+```yaml
+deploy:prod:
+  resource_group: production
+  environment:
+    name: production
+  script:
+    - ./deploy.sh
+```
+
+### `environment`
+
+Binds the job to a GitLab deployment environment, surfacing it in the
+Environments and Deployments views.
+
+```yaml
+deploy:review:
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: https://$CI_COMMIT_REF_SLUG.review.example.com
+    deployment_tier: development      # production|staging|testing|development|other
+    on_stop: stop:review              # job that tears this environment down
+  script:
+    - ./deploy-review.sh
+
+stop:review:
+  stage: deploy
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  rules:
+    - if: $CI_MERGE_REQUEST_ID
+      when: manual
+  script:
+    - ./teardown-review.sh
+```
+
+The `on_stop` job must target the same `environment.name` with
+`action: stop`, and is typically `manual`.
+
+### `parallel`
+
+Runs N identical copies of the job. Each copy gets `CI_NODE_INDEX`
+(1-based) and `CI_NODE_TOTAL`, which the script uses to shard work.
+
+```yaml
+test:
+  parallel: 4
+  script:
+    - ./run-tests.sh --shard "$CI_NODE_INDEX/$CI_NODE_TOTAL"
+```
+
+### `parallel:matrix`
+
+Fans out one job per combination of the listed variable axes (Cartesian
+product). Each generated job sees its axis variables in the environment;
+`CI_NODE_INDEX`/`CI_NODE_TOTAL` cover the whole matrix.
+
+```yaml
+test:
+  stage: test
+  parallel:
+    matrix:
+      - RUBY: ["3.2", "3.3"]
+        DB: [postgres, mysql]
+  image: ruby:$RUBY
+  script:
+    - ./test.sh --db "$DB"
+```
+
+The example above generates four jobs:
+`test: [3.2, postgres]`, `test: [3.2, mysql]`, `test: [3.3, postgres]`,
+`test: [3.3, mysql]`. A list value with multiple keys multiplies; multiple
+list entries under `matrix:` are unioned (each entry is its own product).
+
+### `tags`
+
+Selects runners by their tag set. Every listed tag must be present on the
+runner.
+
+```yaml
+gpu-job:
+  tags:
+    - gpu
+    - linux
+  script:
+    - ./train.sh
+```
+
+### `variables` (job scope)
+
+Per-job variables, overriding globals. Brief here by design; see
+`variables-and-secrets.md` for precedence and masking.
+
+```yaml
+deploy:staging:
+  variables:
+    DEPLOY_ENV: staging
+  script:
+    - ./deploy.sh "$DEPLOY_ENV"
+```
+
+## Reuse mechanisms
+
+### Hidden jobs (template jobs)
+
+A job whose name begins with a dot (`.`) is **hidden**: GitLab parses it
+but never adds it to a pipeline. Hidden jobs exist purely to be reused via
+`extends:` or `!reference`.
+
+```yaml
+.deploy-template:
+  image: alpine:3.20
+  before_script:
+    - apk add --no-cache curl
+  script:
+    - ./deploy.sh
+```
+
+### `extends`
+
+Inherits one or more jobs' configuration. Multi-level inheritance is
+supported, and keys are **deep-merged**: maps merge key-by-key, while
+arrays and scalars are replaced wholesale by the most-derived value. When
+`extends:` lists several parents, later parents win on conflict.
+
+```yaml
+.base:
+  image: node:22
+  variables:
+    LOG_LEVEL: info
+  before_script:
+    - npm ci
+
+.with-cache:
+  cache:
+    paths:
+      - node_modules/
+
+test:
+  extends:
+    - .base
+    - .with-cache
+  variables:
+    LOG_LEVEL: debug        # overrides .base's value via deep merge
+  script:
+    - npm test
+```
+
+`extends:` resolves up to 11 levels deep and is preferred over YAML
+anchors because it merges across `include:` boundaries (anchors do not —
+an anchor is only visible within the file that defines it).
+
+### YAML anchors vs `extends`
+
+YAML anchors (`&name` / `*name`) and the merge key (`<<:`) are a raw-YAML
+feature, resolved by the YAML parser before GitLab sees the document. They
+work, but only within a single file and with shallow merge semantics.
+
+```yaml
+.defaults: &defaults
+  image: node:22
+  tags: [docker]
+
+test:
+  <<: *defaults
+  script:
+    - npm test
+```
+
+Prefer `extends:` for cross-file reuse and deep merge; reach for anchors
+only for small, in-file fragments.
+
+### `!reference`
+
+The `!reference[...]` custom tag injects a value from another job's
+specific key — including reaching into a hidden job's `script:` or
+`before_script:` and composing fragments. Unlike `extends:`, it copies a
+**single addressed value**, so you can interleave reused steps with local
+ones.
+
+```yaml
+.setup:
+  before_script:
+    - apk add --no-cache curl jq
+
+.deploy-fragment:
+  script:
+    - ./deploy.sh
+
+test:
+  before_script:
+    - !reference [.setup, before_script]
+    - echo "local step after the shared setup"
+  script:
+    - !reference [.deploy-fragment, script]
+    - ./verify.sh
+```
+
+`!reference` may nest (a referenced value can itself contain a
+`!reference`), but circular references are an error.
+
+## Full worked example
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+
+default:
+  image: node:22-bookworm
+  tags: [docker]
+  retry:
+    max: 1
+    when: runner_system_failure
+
+variables:
+  GIT_DEPTH: "0"
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+.node-cache:
+  cache:
+    key:
+      files: [package-lock.json]
+    paths: [node_modules/]
+
+build:
+  stage: build
+  extends: .node-cache
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths: [dist/]
+    expire_in: 1 day
+
+test:
+  stage: test
+  needs: [build]
+  parallel:
+    matrix:
+      - SUITE: [unit, integration]
+  script:
+    - npm run test:$SUITE
+  artifacts:
+    reports:
+      junit: junit-$SUITE.xml
+
+deploy:prod:
+  stage: deploy
+  needs:
+    - job: build
+      artifacts: true
+  resource_group: production
+  interruptible: false
+  environment:
+    name: production
+    url: https://app.example.com
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+  script:
+    - ./deploy.sh dist/
+```
+
+## Edge cases and quirks
+
+- **GENERATED pipeline.** In this repository, `.gitlab-ci.yml` is
+  **derived** by `scripts/build-ci.sh` from `ci/ci-capabilities.yml` — it
+  is not hand-authored. Editing the generated `.gitlab-ci.yml` directly is
+  pointless; the next build overwrites it. Change the capability reference
+  and regenerate. See `docs/ci-reference-format.md` for the source-of-truth
+  contract.
+- **YAML boolean / `on` traps.** A YAML 1.1 parser coerces bare `yes`,
+  `no`, `on`, `off`, `true`, `false` to booleans. A variable value of
+  `on` or `no` therefore becomes a boolean and breaks string comparisons.
+  Always quote such values: `FEATURE_FLAG: "on"`, `DEBUG: "false"`.
+- **`script:` list vs block scalar.** `script:` expects a **list** of
+  command strings, not a single block scalar. Writing `script: | …` puts
+  one multiline string as the sole list item, which works but defeats
+  per-line failure semantics and is harder to read — prefer one list item
+  per command.
+- **`needs:` vs `stage:` interaction.** `stage:` defines logical ordering
+  and the UI grouping; `needs:` overrides the *execution* ordering into a
+  DAG. A job can still belong to a later stage yet start early via
+  `needs:`. `needs:` can only reference jobs in the same or an earlier
+  stage.
+- **`rules:` replaced `only/except`.** `only/except` is legacy and must
+  not be mixed with `rules:` in the same job. New jobs use `rules:`
+  exclusively; it is strictly more expressive (per-rule `variables:`,
+  `when:`, `allow_failure:`, `changes:`, `exists:`).
+- **First-match-wins in `rules:`.** Evaluation stops at the first matching
+  rule. Order matters: put the most specific conditions first and a
+  trailing `when: never` (or a catch-all) to make the default explicit.
+- **`when: manual` flips `allow_failure`.** A manual job defaults to
+  `allow_failure: true`; set it to `false` explicitly when a manual gate
+  must block the pipeline on failure.
+- **`after_script` is a fresh shell.** It runs unconditionally (even on
+  failure or cancellation) but does not inherit shell state or exit codes
+  from `script:`. Guard cleanup commands with `|| true` if a non-zero exit
+  there would matter.
+- **`default:` is replace, not merge.** A job that redeclares a `default:`
+  key replaces it wholesale for that job; there is no deep merge of
+  `default:` into the job. Deep merge applies only to `extends:`.
+- **Anchors do not cross `include:`.** YAML anchors are file-local. To
+  reuse configuration defined in an included file, use `extends:` or
+  `!reference`, never an anchor.

--- a/artifacts/core/skills/gitlab-ci/references/rules-and-triggers.md
+++ b/artifacts/core/skills/gitlab-ci/references/rules-and-triggers.md
@@ -1,0 +1,464 @@
+# Rules and triggers reference
+
+The control-flow language that decides **whether** a job runs and
+**what kind of pipeline** runs at all. Read this before writing any
+non-trivial `rules:` clause or `workflow:` gate. Memorising the
+short-circuit and pipeline-source rules avoids the bulk of "two
+pipelines fired for one push" and "the job ran when I told it not to"
+bugs.
+
+## Evaluation surface
+
+Control flow lives at two scopes:
+
+1. **Per-job** via the job-level `rules:` key — decides if *this* job
+   is added to the pipeline, and with which `when:`, `allow_failure:`,
+   and per-rule `variables:`.
+2. **Per-pipeline** via the top-level `workflow:rules:` key — decides
+   if *any* pipeline is created for the event, and short-circuits
+   duplicate pipelines.
+
+Both are evaluated **at pipeline-creation time**, before any job runs.
+A job's `rules:` cannot see another job's result; for run-time
+dependencies use `needs:` / `dependencies:`, not `rules:`. The legacy
+`only:`/`except:` keys occupy the same per-job slot as `rules:` but
+**cannot be combined with it** in the same job — pick one.
+
+## The `rules:` list
+
+`rules:` is an **ordered list**. Evaluation walks it top-to-bottom and
+**stops at the first rule that matches** (short-circuit). The matched
+rule's attributes (`when`, `allow_failure`, `variables`, `start_in`)
+apply; later rules are ignored. If **no** rule matches, the job is
+**not added** to the pipeline (implicit `when: never`).
+
+Each rule is a mapping combining one or more **clauses** (`if`,
+`changes`, `exists`) with **attributes** (`when`, `allow_failure`,
+`variables`, `start_in`). Within one rule, multiple clauses are ANDed.
+
+```yaml
+job:
+  script: ./run.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: on_success
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - src/**/*
+      when: manual
+      allow_failure: true
+    - when: never
+```
+
+### `rules:if`
+
+A single boolean expression over CI/CD variables (operator table
+below). The most common clause. Quote the whole expression so YAML
+does not choke on `:` or `$`.
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG'                       # truthy: tag is set
+  - if: '$CI_COMMIT_BRANCH =~ /^release\/.+/'  # regex match
+```
+
+### `rules:changes`
+
+Matches when any listed path changed. A glob list, or a mapping with
+`paths:` plus `compare_to:` to pin the comparison base (essential
+outside merge requests, where the default base is unreliable).
+
+```yaml
+rules:
+  - changes:
+      paths:
+        - Dockerfile
+        - "src/**/*"
+      compare_to: 'refs/heads/main'
+```
+
+Without `compare_to`, `changes` on a branch pipeline diffs against the
+previous commit on that branch — surprising for force-pushes and the
+first commit. Pin `compare_to` for deterministic behavior.
+
+### `rules:exists`
+
+Matches when at least one file matching the glob exists in the
+repository at pipeline-creation time. Globs are relative to the repo
+root; `**` recurses.
+
+```yaml
+rules:
+  - exists:
+      - "**/Dockerfile"
+```
+
+### `when:` attribute
+
+Selects the job's run behavior once its rule matches:
+
+| Value | Behavior |
+|-------|----------|
+| `on_success` | Run if all jobs in earlier stages succeeded (or `allow_failure`). The default. |
+| `on_failure` | Run only if at least one job in an earlier stage failed. |
+| `always` | Run regardless of earlier-stage status. |
+| `manual` | Add the job but require a manual play action. |
+| `delayed` | Schedule the job after `start_in:`. |
+| `never` | Do **not** add the job. Used as a terminal "drop everything else" rule. |
+
+`when: manual` jobs are non-blocking by default in `rules:`-driven
+pipelines; pair with `allow_failure: false` to make a manual gate
+block downstream stages.
+
+### `allow_failure:` attribute
+
+Set per matched rule. `true` lets the job fail without failing the
+pipeline; `false` makes it blocking. Overrides the job-level
+`allow_failure:` for that rule.
+
+### `variables:` attribute
+
+A matched rule may inject or override variables for the job — the
+canonical way to parameterise one job by the branch or event that
+selected it.
+
+```yaml
+deploy:
+  script: ./deploy.sh "$TARGET_ENV"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      variables:
+        TARGET_ENV: production
+    - if: '$CI_COMMIT_BRANCH == "staging"'
+      variables:
+        TARGET_ENV: staging
+```
+
+### `start_in:` and `when: delayed`
+
+`start_in:` is required by `when: delayed` and gives a human-readable
+duration (`30 seconds`, `1 hour`, `2 days`, capped at one week).
+
+```yaml
+rollout:
+  script: ./rollout.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: delayed
+      start_in: '15 minutes'
+```
+
+## `workflow:rules:` — whole-pipeline gating
+
+`workflow:` sits at the top level and decides whether *any* pipeline
+is created. Same clause/attribute grammar as job `rules:`, but only
+`when: always` and `when: never` are meaningful (a pipeline either
+exists or it does not). Use it to prevent **duplicate pipelines** —
+the single most common GitLab CI footgun.
+
+### The duplicate-pipeline idiom
+
+When merge-request pipelines are enabled, a push to a branch that has
+an open MR fires **two** events: a branch pipeline *and* a detached
+merge-request pipeline. The canonical guard runs MR pipelines when an
+MR is open, branch pipelines only when none is, and tag pipelines
+always:
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+`$CI_OPEN_MERGE_REQUESTS` is non-empty on a branch pipeline whose
+commit has at least one open MR; the third rule drops that redundant
+branch pipeline, leaving only the detached MR pipeline. GitLab ships
+this exact pattern as the `Branch-Pipelines` / `MergeRequest-Pipelines`
+templates.
+
+### `workflow:name:`
+
+Sets a human-readable name for the whole pipeline, supporting
+variable interpolation evaluated at creation time.
+
+```yaml
+workflow:
+  name: 'Pipeline for $CI_COMMIT_REF_NAME'
+```
+
+## Predefined CI/CD variables used in rules
+
+The variables that actually drive `rules:if`. Each is a string; an
+unset variable is the empty string (falsy).
+
+| Variable | Value |
+|----------|-------|
+| `CI_PIPELINE_SOURCE` | What triggered the pipeline (value enumeration below). |
+| `CI_COMMIT_BRANCH` | Branch name. **Empty** on tag pipelines and MR (detached) pipelines. |
+| `CI_COMMIT_TAG` | Tag name. Set **only** on tag pipelines. |
+| `CI_DEFAULT_BRANCH` | The project's default branch (e.g. `main`). |
+| `CI_COMMIT_REF_NAME` | Branch **or** tag name — set on both branch and tag pipelines. |
+| `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` | Target branch of the MR. Set only on MR pipelines. |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of the MR. MR pipelines only. |
+| `CI_OPEN_MERGE_REQUESTS` | Comma-separated `path!iid` of MRs whose source/target is the current branch. Empty when none. |
+| `CI_COMMIT_REF_PROTECTED` | `"true"` if the ref is protected. |
+| `CI_PROJECT_PATH` | `group/project`. |
+
+### `CI_PIPELINE_SOURCE` values
+
+| Value | Triggered by |
+|-------|--------------|
+| `push` | A `git push` to a branch or tag. |
+| `merge_request_event` | An MR was opened/updated (detached, merged-results, or merge-train pipeline). |
+| `schedule` | A pipeline schedule fired. |
+| `web` | The "Run pipeline" button in the UI. |
+| `api` | A pipeline created via the REST API. |
+| `trigger` | A trigger token (`POST /trigger/pipeline`). |
+| `pipeline` | Created by another pipeline's `trigger:` (multi-project, upstream). |
+| `parent_pipeline` | Created by a parent via `trigger:include` (child pipeline). |
+
+Mapping the neutral trigger vocabulary onto these is the job of
+`scripts/build-ci.sh` — see the cross-reference at the end.
+
+## Expression operators in `rules:if`
+
+`rules:if` evaluates a **single boolean expression**. Operators, in
+approximate precedence order (tightest first):
+
+| Operator | Meaning |
+|----------|---------|
+| `( )` | Grouping. |
+| `=~` / `!~` | Regex match / non-match. RHS is a `/pattern/flags` literal. |
+| `==` / `!=` | String equality / inequality. |
+| `&&` | Logical AND. |
+| `\|\|` | Logical OR. |
+
+Notes that bite:
+
+- **No `<`/`>` comparison, no arithmetic.** Values are compared as
+  strings. There is no numeric coercion; `'10' == '10'` is a string
+  match, not a number one.
+- **Quoting.** A literal string in the expression is double-quoted
+  inside the single-quoted YAML scalar: `if: '$X == "main"'`. A bare
+  `$VAR` (no quotes) tests truthiness.
+- **Regex literals** use `/.../` delimiters with optional flags:
+  `=~ /^v\d+\.\d+/i`. The pattern is RE2 (GitLab uses the Go regexp
+  engine on the server side); no backreferences, no lookahead.
+- **`null`.** Compare against `null` (unquoted) to test "variable is
+  undefined" vs `""` (defined-but-empty). They differ:
+  `$X == null` is true only when `X` was never set.
+
+### Truthiness
+
+| Expression form | True when… |
+|-----------------|------------|
+| `$VAR` (bare) | `VAR` is set **and** non-empty. |
+| `$VAR == "x"` | `VAR` equals the string `x`. |
+| `$VAR != null` | `VAR` is defined (even if empty). |
+| `$VAR =~ /p/` | `VAR` is set and matches the pattern. |
+
+The empty-string trap mirrors GitHub Actions: a bare `$VAR` is false
+both when unset and when set to `""`. To distinguish, test against
+`null`.
+
+## Pipeline types and trigger mechanisms
+
+| Pipeline type | Fires when | `CI_PIPELINE_SOURCE` |
+|---------------|------------|----------------------|
+| Branch | Push to a branch | `push` |
+| Tag | Push of a tag | `push` (with `$CI_COMMIT_TAG` set) |
+| Merge request (detached) | MR opened/updated, MR pipelines enabled | `merge_request_event` |
+| Merged-results | Like detached, but run against the *result* of merging into target | `merge_request_event` |
+| Merge-train | Sequential merged-results pipelines guarding the queue | `merge_request_event` |
+| Scheduled | A pipeline schedule fires | `schedule` |
+| Parent-child | A job's `trigger:include` in the same project | `parent_pipeline` |
+| Multi-project | A job's `trigger:` with `project:` | `pipeline` |
+
+Merged-results and merge-train pipelines are detected the same way in
+`rules:` — all three carry `CI_PIPELINE_SOURCE == "merge_request_event"`.
+Distinguish merge-train runs by the predefined `$CI_MERGE_REQUEST_EVENT_TYPE`
+(`detached`, `merged_result`, `merge_train`) when behavior must differ.
+
+### `trigger:` — parent-child pipelines
+
+A job whose body is `trigger:` does no work itself; it spawns a
+downstream pipeline. `trigger:include` runs a child pipeline from
+config in the same project. `strategy: depend` makes the trigger job
+mirror the child's status (otherwise it succeeds immediately on
+dispatch).
+
+```yaml
+run-child:
+  stage: test
+  trigger:
+    include:
+      - local: ci/child-pipeline.yml
+    strategy: depend
+```
+
+### `trigger:` — multi-project pipelines
+
+`trigger:project` (plus optional `branch`) dispatches a pipeline in a
+**different** project. `forward:` controls which variables and
+yaml-defined pipeline variables propagate downstream.
+
+```yaml
+deploy-downstream:
+  stage: deploy
+  trigger:
+    project: my-group/deployment-config
+    branch: main
+    strategy: depend
+    forward:
+      pipeline_variables: true
+      yaml_variables: true
+```
+
+`forward.pipeline_variables` forwards variables passed into the
+*current* pipeline (e.g. from a manual run); `forward.yaml_variables`
+forwards the `variables:` block defined in this job. Both default such
+that yaml variables forward and pipeline variables do not — set
+explicitly when in doubt.
+
+## Legacy `only:` / `except:` (superseded by `rules:`)
+
+`only:` / `except:` predate `rules:` and remain supported but are
+**not recommended** for new pipelines. They cannot appear in the same
+job as `rules:`. Each takes `refs`, `changes`, or `variables`.
+
+```yaml
+# Legacy form
+job:
+  script: ./run.sh
+  only:
+    refs:
+      - main
+      - /^release\/.*$/
+    changes:
+      - src/**/*
+  except:
+    variables:
+      - $SKIP_CI
+```
+
+### Migration to `rules:`
+
+The equivalent `rules:` form makes the implicit OR/AND explicit and
+short-circuits cleanly:
+
+```yaml
+# Modern form
+job:
+  script: ./run.sh
+  rules:
+    - if: '$SKIP_CI'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - src/**/*
+    - if: '$CI_COMMIT_BRANCH =~ /^release\/.*$/'
+      changes:
+        - src/**/*
+```
+
+Migration notes:
+
+- `only:refs` keywords like `merge_requests`, `tags`, `branches` map to
+  `if:` expressions on `$CI_PIPELINE_SOURCE`, `$CI_COMMIT_TAG`, and
+  `$CI_COMMIT_BRANCH` respectively.
+- `except:` becomes a leading `when: never` rule (short-circuit).
+- `only:` without `refs` (just `changes`/`variables`) had an implicit
+  `branches`+`tags` ref scope; replicate it with an explicit `if:` or
+  the job will widen its trigger surface silently.
+
+## Common patterns
+
+### Run only on the default branch
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+```
+
+### Run only in merge-request pipelines
+
+```yaml
+rules:
+  - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+### Run on tags matching a version pattern
+
+```yaml
+rules:
+  - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+```
+
+### Manual gate that blocks downstream stages
+
+```yaml
+deploy:
+  script: ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: manual
+      allow_failure: false
+```
+
+### Skip the pipeline entirely on doc-only pushes
+
+```yaml
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+      changes:
+        paths:
+          - "docs/**/*"
+        compare_to: 'refs/heads/main'
+      when: never
+    - when: always
+```
+
+## Pitfalls
+
+- **No `workflow:rules:` guard.** Without the duplicate-pipeline idiom
+  above, every push to a branch with an open MR runs the pipeline
+  twice. This is the default failure mode, not an edge case.
+- **`$CI_COMMIT_BRANCH` is empty on MR pipelines.** A rule written as
+  `if: '$CI_COMMIT_BRANCH == "main"'` never matches inside a detached
+  MR pipeline — use `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME` there.
+- **`changes` without `compare_to` outside an MR.** The comparison base
+  is the previous pipeline's commit, which is unstable on force-push
+  and the branch's first commit. Always pin `compare_to`.
+- **`rules:` short-circuit forgotten.** Listing two matching `if:`
+  rules does not OR their attributes — only the **first** match's
+  attributes apply. Order matters; put the most specific rule first.
+- **`when: manual` non-blocking by default.** In `rules:`-driven
+  pipelines a manual job does not block downstream stages unless
+  `allow_failure: false` is set explicitly.
+- **`trigger:` without `strategy: depend`.** The trigger job goes green
+  the instant it dispatches the downstream pipeline, regardless of
+  whether that pipeline later fails. Add `strategy: depend` to mirror
+  the child's status.
+- **Mixing `rules:` with `only:`/`except:`.** GitLab rejects a job that
+  declares both. Migrate fully; do not interleave.
+
+## Cross-reference — this repository
+
+The generated `.gitlab-ci.yml` at the repo root is **derived**, not
+hand-authored: `scripts/build-ci.sh` (spec 0048) reads the neutral
+capability reference `ci/ci-capabilities.yml` and maps its
+engine-neutral trigger vocabulary — `push` / `pull-request` / `tag` /
+`scheduled` / `manual`, qualified by `branches` / `paths` /
+`tag-pattern` filters — onto the GitLab `rules:` constructs documented
+above (e.g. `pull-request` → `$CI_PIPELINE_SOURCE == "merge_request_event"`,
+`tag` → `$CI_COMMIT_TAG`, a `tag-pattern` filter → a `=~ /pattern/`
+clause). That neutral vocabulary and the mapping contract are defined
+in [`docs/ci-reference-format.md`](../../../../../docs/ci-reference-format.md)
+— do not redefine it here. This reference documents the GitLab target
+syntax the generator emits; the format doc owns the neutral source
+contract.

--- a/artifacts/core/skills/gitlab-ci/references/runners-and-executors.md
+++ b/artifacts/core/skills/gitlab-ci/references/runners-and-executors.md
@@ -1,0 +1,414 @@
+# Runners and executors reference
+
+Reference for the execution substrate of GitLab CI/CD: where a runner
+comes from (scope), how a job is matched to one (tags), how the runner
+runs the job (executors), how the docker executor handles images and
+services, the `config.toml` knobs that govern a self-managed runner, and
+the security model that decides whether attaching a runner is safe.
+
+GitLab splits the concern in two. A **runner** is the agent registered
+with a GitLab instance that picks up jobs. An **executor** is the
+mechanism a runner uses to run a job's script — a local shell, a
+container, a Kubernetes pod. One runner process runs one executor; you
+register several runners to offer several executors.
+
+## Runner scopes
+
+A runner's scope decides which projects may schedule jobs on it.
+
+| Scope | Registered against | Visible to |
+|-------|--------------------|-----------|
+| **Instance** (shared) | The whole instance | Every project, subject to admin settings. |
+| **Group** | A group | Every project in that group and its subgroups. |
+| **Project** (specific) | One or more projects | Only the projects it is explicitly assigned to. |
+
+The GitLab coordinator offers a pending job to the runners eligible for
+that project; the first runner that polls and matches the job's `tags:`
+claims it. Shared runners process jobs fair-use across projects; group
+and project runners only see their own scope.
+
+### GitLab.com SaaS hosted runners
+
+GitLab.com offers managed runners — nothing to register. They are
+ephemeral (a fresh VM per job, destroyed afterward, no state leak) and
+selected by tag:
+
+| Tag (class) | Platform | Notes |
+|-------------|----------|-------|
+| `saas-linux-small-amd64` | Linux | Default class; smallest, cheapest. |
+| `saas-linux-medium-amd64`, `saas-linux-large-amd64` | Linux | More vCPU/RAM, higher minute weight. |
+| `saas-linux-medium-arm64` | Linux ARM | ARM64 class. |
+| `saas-windows-medium-amd64` | Windows | Higher minute multiplier. |
+| `saas-macos-medium-m1` | macOS | Apple silicon; highest multiplier; tier-gated. |
+
+Class names and minute multipliers drift — verify against the current
+GitLab.com runner docs before pinning one. Untagged jobs run on the
+small Linux class.
+
+### Self-managed runners
+
+Anything you register yourself with `gitlab-runner register`, against a
+self-managed instance or GitLab.com. You own the host, the executor
+choice, the network placement, and the security posture. The rest of
+this document is mostly about these.
+
+## Selecting a runner with `tags:`
+
+A job advertises required tags; a runner advertises the tags it was
+registered with. A job runs on a runner only if the runner carries
+**every** tag the job lists.
+
+```yaml
+build:
+  tags: [docker, linux, amd64]
+  script:
+    - make build
+```
+
+This runs only on a runner tagged at least `docker`, `linux`, and
+`amd64`. Extra runner tags are fine; a single missing tag disqualifies
+the runner.
+
+### Untagged jobs and `run_untagged`
+
+A job with no `tags:` is **untagged**. A runner picks up untagged jobs
+only when registered with `run_untagged = true` (the default for new
+runners; admins often flip shared runners to `false` to force explicit
+tagging). Set it per runner in `config.toml`:
+
+```toml
+[[runners]]
+  name = "docker-runner-1"
+  run_untagged = true
+```
+
+### The "no runner matching tags" stuck job
+
+If a job lists a tag no eligible runner carries — a typo, a
+decommissioned runner, a runner in the wrong scope — the job sits
+`pending` and eventually fails:
+
+```text
+This job is stuck because you don't have any active runners online
+or available with any of these tags assigned to them: <tag>
+```
+
+This is the most common GitLab CI failure after YAML errors. Diagnose
+in Settings → CI/CD → Runners: confirm a runner available to the
+project advertises the exact tag set. A job tagging `arm64` on an
+`amd64`-only fleet is stuck forever, not slow.
+
+## Executors
+
+The executor is set per runner at registration and recorded in
+`config.toml`. It determines the isolation model, the available
+features, and the operational cost.
+
+| Executor | Isolation | Use when |
+|----------|-----------|----------|
+| `shell` | None — runs as the runner's OS user | Trusted single-tenant jobs needing host tools directly. |
+| `docker` | Per-job container | Default for most fleets; clean, reproducible. |
+| `docker-autoscaler` | Per-job container on autoscaled hosts | Bursty load; replaces deprecated `docker-machine`. |
+| `kubernetes` | Per-job pod | Already on k8s; elastic; per-job resource limits. |
+| `ssh` | Remote host, no isolation | Legacy; avoid for new work. |
+| `virtualbox` / `parallels` | Full VM | Need a full guest OS (Windows/macOS) with VM isolation. |
+| `instance` | Fresh cloud VM per job | Autoscaled VMs via fleeting; strongest isolation, highest latency. |
+
+### `shell`
+
+Runs the job's `script:` directly on the host as the user that owns the
+runner process — no container, no image. Fast and simple, but a job has
+the host's full toolchain and filesystem; an escape affects the host and
+the next job. Reserve for trusted, single-tenant runners; never expose a
+shell-executor runner to untrusted contributions (see *Runner
+security*).
+
+### `docker`
+
+The dominant choice. Each job runs in a container from a chosen image;
+the runner mounts the build directory and caches, runs the `script:`,
+then discards the container. Clean per-job state, reproducible
+toolchains, no host pollution. Configuration depth below.
+
+### `kubernetes`
+
+The runner is a controller that creates a **pod per job**: a build
+container (the job image), a helper container (clone, artifacts, cache),
+and one container per declared `service:`. You get horizontal elasticity
+and per-job CPU/memory limits, at the cost of running the runner inside
+a cluster with the right RBAC. Standard for teams already on Kubernetes.
+Knobs live under `[runners.kubernetes]`.
+
+Choosing: trusted project with host tools → `shell`; general-purpose
+fleet → `docker`; already on Kubernetes → `kubernetes`; bursty cloud
+load with scale-to-zero → `docker-autoscaler` / `instance`; full guest
+OS or VM isolation → `virtualbox` / `parallels`.
+
+## The docker executor
+
+### `image:` — the job's container
+
+Set per job, or globally via `default:`:
+
+```yaml
+default:
+  image: golang:1.23-bookworm
+
+test:
+  script: [go test ./...]
+
+lint:
+  image: golangci/golangci-lint:v1.61.0   # overrides the default
+  script: [golangci-lint run]
+```
+
+A job-level `image:` overrides `default:`. With no image at all, the
+docker executor falls back to the runner's configured default image in
+`config.toml`.
+
+### Pin images by digest — security default
+
+Bare tags are mutable: `golang:1.23` and `:latest` can be repointed at a
+new image under the same name, so a green pipeline can silently start
+running different code. Pin by immutable digest:
+
+```yaml
+default:
+  image: golang:1.23-bookworm@sha256:0e6f6c...   # immutable
+```
+
+The skill's `check-pinned-images.sh` flags any `image:` (and
+`services:[].name`) using a bare tag or `:latest` instead of a
+`@sha256:` digest. Treat a bare tag as a finding, not a style nit:
+digest pinning is this skill's supply-chain default, mirroring the
+github-actions action-SHA-pinning rule.
+
+### `image:pull_policy`
+
+Controls when the executor pulls versus reusing a cached image:
+
+```yaml
+build:
+  image:
+    name: registry.example.com/builder@sha256:abc123...
+    pull_policy: [always, if-not-present]
+```
+
+- `always` — pull every run (default on shared runners; freshest).
+- `if-not-present` — pull only when absent locally (fast; safe with a
+  digest, stale-prone with a mutable tag).
+- `never` — never pull; the image must be pre-seeded on the host.
+
+A job may only request policies the runner permits via
+`allowed_pull_policies`; a disallowed request fails the job rather than
+silently downgrading.
+
+### `services:` — sidecar containers
+
+Services are extra containers started alongside the job container on a
+shared network — databases, brokers, headless browsers. Reach them as
+hostnames:
+
+```yaml
+test:
+  image: golang:1.23-bookworm
+  services:
+    - name: postgres:16@sha256:def456...
+      alias: db
+      variables: { POSTGRES_DB: app_test, POSTGRES_PASSWORD: ci_only }
+    - name: redis:7@sha256:aaa111...
+  variables:
+    DATABASE_URL: "postgres://postgres:ci_only@db:5432/app_test"
+  script: [go test ./...]
+```
+
+Mechanics:
+
+- **Hostname.** A service answers at its image name (with `/` and `:`
+  rewritten to `-` and `__`) and at any `alias:` — `db` above. The alias
+  is the practical handle.
+- **Per-service `variables:`.** Configure the service container (DB
+  name, password) independently of the job env.
+- **`services:[].command` / `services:[].entrypoint`.** Override the
+  container's startup, e.g. to pass flags to the service binary.
+- **Ports.** The shared network exposes the container's listening ports
+  on the alias hostname directly; GitLab needs no `ports:` mapping. The
+  `CI_*` variables describe the build environment, not service ports.
+- **Readiness.** The runner waits for service containers to start, but
+  started is not ready — for Postgres and friends, add an explicit wait
+  in the script (`pg_isready` poll, `wait-for-it`).
+
+### Private images — `DOCKER_AUTH_CONFIG`
+
+To pull `image:` or `services:` from a private registry, give the runner
+credentials via the `DOCKER_AUTH_CONFIG` CI/CD variable — a JSON
+document in Docker `config.json` format, ideally a **masked, protected**
+variable:
+
+```json
+{ "auths": { "registry.example.com": { "auth": "base64(user:token)" } } }
+```
+
+The docker and kubernetes executors read it and authenticate the pull.
+Prefer a deploy token or least-privilege registry token over a personal
+credential; never inline the value in `.gitlab-ci.yml`. See the
+security-and-permissions reference for variable protection and masking.
+
+## `config.toml` essentials
+
+Self-managed runners are configured by `config.toml` (default
+`/etc/gitlab-runner/config.toml`). Practitioner essentials below;
+consult the GitLab Runner advanced-configuration docs for the full
+surface.
+
+```toml
+concurrent = 8        # max jobs across ALL runners in this process
+check_interval = 3    # seconds between coordinator polls
+
+[[runners]]
+  name = "docker-runner-1"
+  url = "https://gitlab.example.com/"
+  token = "glrt-REDACTED"
+  executor = "docker"
+  run_untagged = false
+  limit = 4           # max concurrent jobs for THIS runner
+
+  [runners.docker]
+    image = "alpine:3.20"            # fallback when a job sets no image
+    privileged = false              # KEEP false unless truly needed
+    pull_policy = ["if-not-present"]
+    allowed_pull_policies = ["always", "if-not-present"]
+    allowed_images = ["registry.example.com/*", "docker.io/library/*"]
+    allowed_services = ["postgres:*", "redis:*"]
+    volumes = ["/cache"]            # do NOT mount /var/run/docker.sock
+
+  [runners.cache]
+    Type = "s3"
+    Shared = true
+    [runners.cache.s3]
+      ServerAddress = "s3.example.com"
+      BucketName = "gitlab-runner-cache"
+      AuthenticationType = "iam"    # prefer instance role over static keys
+
+  [runners.kubernetes]
+    namespace = "gitlab-ci"
+    image = "alpine:3.20"
+    privileged = false
+    cpu_request = "500m"
+    memory_request = "512Mi"
+    cpu_limit = "2"
+    memory_limit = "2Gi"
+    service_account = "gitlab-runner"
+```
+
+- `concurrent` caps total simultaneous jobs for the whole
+  `gitlab-runner` process, independent of how many `[[runners]]` blocks
+  exist; `limit` caps a single runner.
+- `privileged = true` grants containers near-host capabilities (see
+  *Runner security*); default and recommended value is `false`.
+- `allowed_images` / `allowed_services` allowlist what jobs may run,
+  blunting the "any fork runs any image" exposure on shared runners.
+- `volumes` persists paths across jobs on the same host; a distributed
+  `[runners.cache]` survives beyond one host (essential for autoscaled
+  fleets where the next job lands elsewhere). Never mount the Docker
+  socket as a volume — that is the classic root-escalation footgun.
+- `[runners.kubernetes]` requests/limits seed each per-job pod unless a
+  job overrides them via `KUBERNETES_*` variables; scope the
+  `service_account` RBAC to the minimum the build needs.
+
+## Autoscaling
+
+For bursty load, scale capacity to demand instead of paying for idle
+hosts:
+
+- **`docker-autoscaler` + fleeting.** The current autoscaling path,
+  replacing the deprecated `docker-machine`. A **fleeting** plugin (AWS
+  EC2, GCP, Azure) provisions and reaps VMs; the autoscaler runs the
+  docker executor on each. Configured via `[runners.autoscaler]` with
+  `plugin`, `capacity_per_instance`, and scaling policies.
+- **`instance` executor.** Runs each job directly on a freshly
+  provisioned-then-destroyed cloud VM via the same fleeting plugins —
+  strongest isolation, highest per-job latency.
+- **GitLab Runner Operator on Kubernetes.** Deploy and manage runners
+  declaratively via the operator and a `Runner` custom resource; the
+  cluster autoscaler then scales nodes to absorb pod-per-job demand.
+
+## Runner security
+
+A runner executes whatever code a pipeline carries. The hard questions
+are *who can push that code* and *what the runner can reach*.
+
+### `privileged = true` is dangerous
+
+A privileged docker container runs with near-host capabilities: host
+devices, kernel manipulation, and — with a mounted Docker socket —
+trivial escape to root on the host. People enable it for
+Docker-in-Docker (`dind`); prefer **rootless buildkit / kaniko /
+buildah**, which build images without privileged mode. If `dind` is
+unavoidable, isolate those runners on disposable, network-segmented
+hosts and never share them with untrusted projects.
+
+### The untrusted-fork / public-project exposure
+
+The headline rule mirrors the GitHub Actions analog: **a fork merge
+request can run arbitrary code on any runner that picks up its
+pipeline.** If a shared or instance runner processes fork pipelines for
+a public project, an attacker forks, edits `.gitlab-ci.yml` to exfil
+secrets or mine the host, and opens an MR. Defenses:
+
+1. **Protected branches and protected variables.** Mark sensitive CI/CD
+   variables **protected** so they are injected only on protected
+   branches and tags — never on a fork MR pipeline. This is the primary
+   control: a fork pipeline never sees the secret.
+2. **Restrict shared runners on public projects.** Disable instance
+   runners for public projects, or require approval before
+   external-fork MR pipelines run (project CI/CD settings).
+3. **Dedicated, ephemeral, segmented runners for untrusted work.** If
+   fork CI must run, give it disposable runners (autoscaled VMs / k8s
+   pods destroyed per job) on a network with no route to production or
+   the secret store.
+4. **`allowed_images` / `allowed_services` allowlists.** Constrain what
+   a job may pull and run on a shared runner.
+5. **Drop `privileged`, drop the Docker socket.** A non-privileged
+   runner with no socket mount removes the easiest escalation path.
+
+### Isolate CI from production networks
+
+Place runners on a subnet that **cannot** reach production databases,
+state stores, or the secret manager beyond what the build legitimately
+needs. A compromised job should not be one `curl` from production.
+Combine network segmentation with protected variables so the blast
+radius of a malicious pipeline is bounded.
+
+For the full permission surface — protected vs masked variables,
+`CI_JOB_TOKEN` scoping, the GitLab security model — see the
+security-and-permissions reference.
+
+## Resource and concurrency controls
+
+Two job-level fields interact with the runner layer; full job-field
+semantics live in the pipeline-syntax reference, summarized here only
+for their runner-side effect:
+
+- **`resource_group`** — serializes jobs sharing the named group so
+  that, across pipelines, at most one runs at a time. The mechanism is
+  the coordinator's, not the runner's, but it is how you stop two deploy
+  jobs racing on the same environment regardless of free runner count.
+
+  ```yaml
+  deploy_prod:
+    resource_group: production
+    environment: production
+    script: ./deploy.sh
+  ```
+
+- **`interruptible`** — marks a job safe to auto-cancel when a newer
+  pipeline supersedes it on the same ref (with *Auto-cancel redundant
+  pipelines* enabled), freeing runner capacity. Full field detail in the
+  pipeline-syntax reference.
+
+  ```yaml
+  build:
+    interruptible: true
+    script: make build
+  ```

--- a/artifacts/core/skills/gitlab-ci/references/security-and-permissions.md
+++ b/artifacts/core/skills/gitlab-ci/references/security-and-permissions.md
@@ -1,0 +1,382 @@
+# Security and permissions reference
+
+GitLab CI/CD has no single token whose scope map you tune the way GitHub
+Actions tunes `GITHUB_TOKEN` via `permissions:`. The pipeline's
+authority is spread across distinct primitives: the `CI_JOB_TOKEN` and
+its accessible-projects allowlist, the project/group member role model,
+protected branches and tags, protected environments, and the
+masked/protected variable discipline. Getting these right is the
+highest-leverage defense against supply-chain compromise — a job that
+runs on an unprotected ref, with a tightly scoped job token and no
+protected variables in reach, cannot deploy to production, push a
+package, or exfiltrate a long-lived cloud key, no matter what a
+dependency it pulls tries to do.
+
+This file is the GitLab analog of the GitHub Actions skill's
+`permissions.md`. Where GitHub concentrates authority in one token, read
+this as "which primitive grants which authority, and how to grant the
+minimum".
+
+## The `CI_JOB_TOKEN`
+
+Every job receives a `CI_JOB_TOKEN` — a short-lived credential, valid
+only for the lifetime of the job, injected as the predefined variable
+`CI_JOB_TOKEN`. It is the rough analog of `GITHUB_TOKEN`, but its scope
+is governed by project settings rather than a per-pipeline `permissions:`
+key.
+
+The token can:
+
+- Clone the current project (it backs the `git clone` of the pipeline
+  itself).
+- Authenticate to the project's container registry and package registry
+  (pull, and push where the job's user role allows).
+- Call a curated subset of the GitLab API on behalf of the job
+  (`CI_JOB_TOKEN`-accepting endpoints — a deliberately narrower surface
+  than a personal access token).
+- Reach **other projects** — but only those on the current project's
+  **job-token allowlist** (see below).
+
+It is bound to the identity and role of the **user who triggered the
+pipeline**: a job triggered by a Reporter cannot push to the registry
+even though the token mechanically exists. Role gates the token; the
+token does not elevate the role.
+
+### The job-token accessible-projects allowlist
+
+Under **Settings → CI/CD → Job token permissions** (historically labelled
+"Token Access" / "Limit access to this project"), each project maintains
+an **allowlist of projects whose CI jobs may use their `CI_JOB_TOKEN`
+to access this project**.
+
+- **Historical over-broad default.** On older GitLab versions the token
+  was usable across *any* project the triggering user could see — an
+  implicit, organization-wide allowlist. That default is the classic
+  GitLab CI lateral-movement vector: a compromised job in a low-value
+  project could clone or push to a high-value sibling.
+- **The hardened posture.** Enable "Limit access to this project" (the
+  inbound allowlist), then add only the specific projects whose
+  pipelines legitimately need to reach this one. Newer GitLab versions
+  default to the restricted allowlist for new projects; audit existing
+  projects, which may still carry the legacy open setting.
+- **Direction matters.** The allowlist is **inbound**: project A's
+  allowlist names the projects *allowed to reach A*. To let project B's
+  pipeline clone A, add B to A's allowlist — not the reverse.
+
+An over-permissive allowlist (or the legacy open default) is a `high`
+finding: it converts any single pipeline compromise into a blast radius
+spanning every reachable project.
+
+## Member roles — who can run and edit pipelines
+
+GitLab gates pipeline authority through the project/group **member role**
+of the actor, not through a per-job permission map. The roles, in
+increasing authority:
+
+| Role | Relevant CI/CD authority |
+|------|--------------------------|
+| **Guest** | Cannot run pipelines on private projects; view-only on most CI surfaces. |
+| **Reporter** | View pipelines and job logs; cannot run or edit. |
+| **Developer** | Run pipelines, push to **unprotected** branches, run manual jobs on unprotected refs. Cannot push to protected branches or manage protected variables by default. |
+| **Maintainer** | Manage protected branches/tags, CI/CD variables (including protected/masked), runners, the job-token allowlist, and protected environments. |
+| **Owner** | All Maintainer authority plus project/group deletion and transfer. |
+
+The practical security lever: **what is gated behind Maintainer**.
+Protected variables, the job-token allowlist, runner registration, and
+protected-environment approver lists all sit at Maintainer. Keep the
+Maintainer/Owner set small; most contributors operate fine at Developer.
+
+## Protected branches and protected tags
+
+This is the central protection primitive — the GitLab equivalent of
+"this credential is only available on the trusted ref". A branch or tag
+is **protected** when it appears under **Settings → Repository →
+Protected branches / Protected tags**, with an "allowed to push" and
+"allowed to merge" role list.
+
+What protection unlocks for CI/CD:
+
+- **Protected variables** are exposed **only** to pipelines running on a
+  protected ref. On any other ref the variable is simply absent.
+- **Protected runners** accept jobs **only** from pipelines on a
+  protected ref.
+- It gates who may *create* a pipeline that runs on the protected ref at
+  all (the "allowed to push/merge" lists).
+
+Use `$CI_COMMIT_REF_PROTECTED` to gate sensitive jobs on the protection
+status of the running ref:
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH == "main"'
+```
+
+The job above runs only when the pipeline is on a protected `main` — so
+the protected deploy variables it relies on are actually present, and an
+attacker pushing to a feature branch never reaches the deploy path.
+
+## Protected environments
+
+Protected branches gate *where the secret lives*; **protected
+environments** gate *who may promote to a tier and with what approval* —
+the correct primitive for a production promotion gate, and the GitLab
+analog of GitHub Environments.
+
+Configured under **Settings → CI/CD → Protected environments**, an
+environment gains:
+
+- An **allowed-to-deploy** list (roles or specific users/groups) — only
+  these identities can run a job targeting the environment.
+- **Required approvals** — a deployment to the environment blocks until
+  N approvers from the allowed list sign off, independent of who
+  triggered the pipeline.
+- **Deployment-tier** semantics (`production`, `staging`, …) via the
+  `environment.deployment_tier` keyword, so the platform can reason about
+  tier ordering.
+
+```yaml
+deploy_prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+With `production` registered as a protected environment requiring two
+approvals, the job halts pending sign-off even when it sits on a
+protected ref. Layer protected environments on top of protected branches
+for production — neither alone is sufficient for a high-tier gate.
+
+## OIDC and `id_tokens:`
+
+The least-privilege default for cloud authentication is **federated
+OIDC**, not a long-lived access key stored in a variable. GitLab mints a
+short-lived JWT per job via the `id_tokens:` keyword; the cloud provider
+exchanges it for a temporary, narrowly-scoped credential against a trust
+policy keyed on claims like `project_path`, `ref`, and `ref_protected`.
+
+State the principle here; the full trust-policy snippets and per-cloud
+audience configuration live in the `variables-and-secrets` reference.
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./assume-role-with-web-identity.sh
+```
+
+Reach for OIDC whenever the target cloud supports it. A long-lived key in
+a CI/CD variable is acceptable only when the provider has no OIDC path
+for the resource — and that exception belongs in an ADR. Scope the
+cloud-side trust policy to `ref_protected:true` and the specific
+`project_path` so a fork or feature branch cannot assume the role.
+
+## Masked and protected variables
+
+The full treatment lives in the `variables-and-secrets` reference; the
+rule, stated once:
+
+- **Mask** every secret variable so its value is redacted from job logs.
+- **Protect** every secret variable so it is exposed only on protected
+  refs (see *Protected branches* above).
+- A secret that is masked but **not** protected leaks to any feature
+  branch pipeline; a secret that is protected but **not** masked leaks
+  into logs. Production secrets need both.
+
+## Fork and untrusted-contributor trust
+
+Merge requests from forks are the GitLab equivalent of GitHub's
+`pull_request` from a fork — the point where untrusted code meets your
+CI. GitLab's defense rests on the protection primitives above:
+
+- **Protected variables are NOT exposed** to pipelines triggered by an
+  external contributor's fork MR, because the fork branch is not a
+  protected ref of your project. The fork pipeline sees only unprotected
+  variables.
+- **Protected runners do NOT accept** fork-MR jobs for the same reason —
+  so a fork cannot land on a runner that has access to a privileged
+  network segment or a protected deploy credential.
+- **The danger of relaxing this.** Enabling "Run untrusted code" style
+  settings, marking fork-fed variables as available, or registering a
+  shared runner without protection so it picks up fork jobs, all collapse
+  this boundary. Treat any such relaxation as a `high` finding requiring
+  explicit justification.
+
+Gate fork-sensitive logic with the `CI_MERGE_REQUEST_*` predefined
+variables, which are populated only in merge-request pipelines:
+
+```yaml
+fork_safe_tests:
+  script: ./run-tests.sh
+  rules:
+    - if: '$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_MERGE_REQUEST_PROJECT_ID'
+      # MR originates from a fork — run only the sandboxed, secret-free job set
+    - if: '$CI_MERGE_REQUEST_ID'
+```
+
+Never run a deploy, a registry push, or a job that reads a protected
+variable on a fork MR pipeline. Keep untrusted-MR jobs on unprotected,
+non-`privileged` runners, restricted to read-only test and lint work.
+
+## Least-privilege recipes
+
+The minimum permission/protection configuration for each common job
+shape. These mirror the per-use-case recipes in the GitHub Actions
+`permissions.md`.
+
+### (a) Read-only test / lint job
+
+```yaml
+unit_tests:
+  stage: test
+  image: node:22@sha256:<digest>
+  script:
+    - npm ci
+    - npm test
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH'
+```
+
+No protected variables, no protected runner, no environment. The default
+`CI_JOB_TOKEN` (current-project clone only) is all it needs. The vast
+majority of CI jobs are this shape. Safe to run on fork MRs.
+
+### (b) Push to the container / package registry
+
+```yaml
+build_image:
+  stage: build
+  image: docker:27@sha256:<digest>
+  services:
+    - docker:27-dind
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+    - docker build -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA"
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+`CI_JOB_TOKEN` authenticates to `$CI_REGISTRY` for the current project's
+namespace; no separate credential is required. Gate the push on a
+protected ref so a fork or feature branch cannot publish an image under
+your namespace. The triggering user must hold at least Developer to push.
+
+### (c) Deploy to a cloud via OIDC
+
+```yaml
+deploy_cloud:
+  stage: deploy
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://gitlab.example.com
+  script:
+    - ./federated-login.sh   # exchanges $GCP_ID_TOKEN for a short-lived token
+    - ./deploy.sh
+  environment:
+    name: production
+    deployment_tier: production
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+No long-lived key in any variable. The cloud trust policy is scoped to
+`ref_protected:true` and this `project_path`. Layer the protected
+`production` environment on top for an approval gate. This is the
+preferred deploy shape.
+
+### (d) Create a Release / tag
+
+```yaml
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script:
+    - echo "Publishing release $CI_COMMIT_TAG"
+  release:
+    tag_name: '$CI_COMMIT_TAG'
+    description: 'Release $CI_COMMIT_TAG'
+  rules:
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_REF_PROTECTED == "true"'
+```
+
+Releases are cut from tags; protect the release tags (under Protected
+tags) and gate the job on `$CI_COMMIT_TAG` plus
+`$CI_COMMIT_REF_PROTECTED`. The triggering user must be allowed to
+create the protected tag. The `release` keyword uses `CI_JOB_TOKEN`
+against the current project — no broader scope needed.
+
+### (e) Clone a sibling private repo (job-token allowlist)
+
+```yaml
+build_with_dep:
+  stage: build
+  script:
+    - git clone "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.example.com/group/private-dep.git"
+    - ./build.sh
+```
+
+The clone of `group/private-dep` succeeds **only** if `private-dep`'s
+**inbound job-token allowlist** names *this* project. Add this project to
+`private-dep`'s allowlist (Settings → CI/CD → Job token permissions);
+do not disable the allowlist wholesale. Grant the narrowest entry — the
+single consuming project — never a group-wide or open allowlist.
+
+## Security defaults
+
+These defaults are non-negotiable and consistent with the parent
+`gitlab-ci` SKILL.md. Treat every deviation as requiring an ADR.
+
+1. **Mask and protect every secret variable.** Masked redacts logs;
+   protected restricts exposure to protected refs. Production secrets
+   need both (see `variables-and-secrets`).
+2. **Prefer OIDC `id_tokens:` over long-lived cloud keys.** A long-lived
+   key in a CI/CD variable is acceptable only when the provider has no
+   OIDC path for the resource — document the exception.
+3. **Pin `image:` and `services:` by digest, not tag.** `node:22@sha256:…`,
+   not `node:22`. A mutable tag is a silent supply-chain entry point.
+4. **Gate every deploy, Pages, and Release job behind a protected ref**
+   (`$CI_COMMIT_REF_PROTECTED == "true"`) and, for production, a
+   protected environment with required approvals.
+5. **Scope the `CI_JOB_TOKEN` accessible-projects allowlist.** Enable
+   the inbound allowlist on every project and name only the specific
+   consuming projects; never rely on the legacy open default.
+6. **No `privileged` runners for untrusted code.** Never let a fork-MR
+   pipeline land on a privileged runner, a `docker:dind` privileged
+   executor, or a runner with access to a protected network segment.
+   Keep untrusted-MR jobs on unprotected, unprivileged runners doing
+   read-only work.
+7. **Never expose protected variables or protected runners to fork
+   MRs.** This boundary is the default — keep it. Branch fork-sensitive
+   logic on `CI_MERGE_REQUEST_SOURCE_PROJECT_ID` vs
+   `CI_MERGE_REQUEST_PROJECT_ID`.
+
+## Auditing
+
+Mechanical audit steps:
+
+- Review each project's **Job token permissions** page: confirm the
+  inbound allowlist is enabled and lists only legitimate consumers.
+  Flag any project still on the legacy open default as `high`.
+- Confirm `production` (and equivalent high-tier environments) are
+  registered as **protected environments** with an allowed-to-deploy
+  list and required approvals.
+- Grep pipeline definitions for deploy/registry/release jobs lacking a
+  `$CI_COMMIT_REF_PROTECTED` (or protected-tag) guard in their `rules:`.
+- Confirm every secret CI/CD variable is both **masked** and
+  **protected**; flag any production secret missing either flag.
+- Verify OIDC trust policies on the cloud side are scoped to
+  `ref_protected:true` and the specific `project_path`, not a wildcard.
+- Confirm no shared/protected runner is configured to pick up fork-MR
+  jobs, and that no runner used by untrusted code runs `privileged`.

--- a/artifacts/core/skills/gitlab-ci/references/variables-and-secrets.md
+++ b/artifacts/core/skills/gitlab-ci/references/variables-and-secrets.md
@@ -1,0 +1,441 @@
+# Variables and secrets reference
+
+CI/CD variables are the channel GitLab offers for injecting
+configuration into a pipeline. There is no separate "secret" object as
+in some other systems: a variable becomes a secret by flipping two
+flags — **masked** and **protected** — and by binding it to the
+smallest scope that needs it. Get those flags wrong and you either leak
+a credential to a job log or expose it to an untrusted branch. For
+credentials that should never sit at rest in GitLab at all, the
+`secrets:` keyword pulls them from an external manager (Vault, Azure
+Key Vault, GCP Secret Manager) at job start, and `id_tokens:` federates
+to a cloud provider with a short-lived JWT instead of a long-lived key.
+
+## The variable model
+
+A pipeline sees a flattened set of environment variables assembled from
+several sources:
+
+- **Predefined variables.** Supplied by GitLab itself: `CI_COMMIT_REF_NAME`,
+  `CI_PROJECT_PATH`, `CI_PIPELINE_SOURCE`, `CI_JOB_TOKEN`, etc. Read-only.
+- **Instance variables.** Defined by an administrator; visible to every
+  project on the instance.
+- **Group variables.** `Group → Settings → CI/CD → Variables`. Inherited
+  by every project in the group (and subgroups).
+- **Project variables.** `Project → Settings → CI/CD → Variables`. The
+  most common place for credentials.
+- **Pipeline-trigger / scheduled variables.** Passed when a pipeline is
+  started via the trigger API, a pipeline schedule, or a manual `web`
+  run (the "Run pipeline" form, driven by `value`/`description`).
+- **`.gitlab-ci.yml` variables.** Declared in YAML, either globally
+  (top-level `variables:`) or per-job (`job.variables:`). Committed to
+  the repository — never a credential.
+- **`dotenv` artifacts.** A job exports a `*.env` file as a
+  `reports: dotenv:` artifact; downstream jobs inherit those keys as
+  variables. The channel for passing computed values between stages.
+
+```yaml
+build:
+  stage: build
+  script:
+    - echo "BUILD_ID=$(date +%s)" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy:
+  stage: deploy
+  script:
+    - echo "Deploying build $BUILD_ID"   # inherited from dotenv
+```
+
+## Scope and precedence
+
+When the same variable name is defined at several sources, GitLab
+resolves it by a fixed precedence. Highest priority wins:
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | Trigger variables, scheduled-pipeline variables, manual (`web`) run variables |
+| 2 | Project variables |
+| 3 | Group variables (nearest subgroup first, then parent groups) |
+| 4 | Instance variables |
+| 5 | `.gitlab-ci.yml` global `variables:` |
+| 6 (lowest) | `.gitlab-ci.yml` job `variables:` |
+
+The counter-intuitive part: a value set in the UI (project/group/
+instance) or via a trigger **overrides** the YAML. This is deliberate —
+it lets an operator override a committed default at run time without a
+commit. Predefined variables sit alongside this table and are generally
+not overridable.
+
+Group and project variables also carry an **environment scope**
+(`environment_scope`): a variable can be limited to `production`,
+`review/*`, or `*` (all). A job picks up only the variables whose scope
+matches its `environment:` name.
+
+## Variable types and flags
+
+### `variable` vs `file` type
+
+Every CI/CD variable has a **type**:
+
+- **`variable`** (default) — the value is exported as an environment
+  variable verbatim.
+- **`file`** — GitLab writes the value to a temporary file and exports
+  the **path** to that file as the environment variable. This is the
+  correct channel for anything a tool expects as a file: TLS
+  certificates, a `kubeconfig`, a GCP service-account JSON, an SSH key.
+
+```yaml
+deploy:
+  script:
+    # KUBECONFIG is a file-type variable: $KUBECONFIG is a path, not YAML.
+    - kubectl --kubeconfig "$KUBECONFIG" apply -f manifests/
+    # GOOGLE_APPLICATION_CREDENTIALS is a file-type variable too.
+    - gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+```
+
+Storing a certificate in a `variable`-type variable and then
+`echo`-ing it into a file inside `script:` defeats masking and risks
+trace leakage — use `file` type instead.
+
+### Masked variables
+
+A variable flagged **masked** has its value replaced with `[MASKED]` in
+job logs. GitLab enforces masking eligibility requirements on the value:
+
+- at least 8 characters long;
+- a single line (no newlines or whitespace);
+- drawn from a restricted character set (Base64 alphabet plus `@:.~`),
+  depending on GitLab version. Values with spaces, `$`, `"`, or `'`
+  cannot be masked.
+
+Masking caveats — treat masking as a safety net, not a guarantee:
+
+- Masking is **best-effort substring replacement** in the trace. A
+  secret that is split (`echo "${TOKEN:0:8}"`), transformed
+  (base64-decoded, uppercased, URL-encoded), or concatenated bypasses
+  the matcher and prints in clear.
+- Masking redacts **only the job log**. It does **not** redact
+  artifacts, caches, the dotenv report, or anything your job writes to
+  an external system. A masked secret printed into a file and uploaded
+  as an artifact is leaked in plaintext.
+- Masking does not stop a malicious `.gitlab-ci.yml` from exfiltrating
+  the value over the network. Masking defends against accidental
+  disclosure, not against a hostile pipeline author.
+
+### Protected variables
+
+A variable flagged **protected** is exposed **only** to pipelines
+running on a **protected branch** or **protected tag**. A pipeline for
+a regular feature branch or a fork merge request never receives it.
+This is the primary defense against a contributor reading production
+credentials by pushing a branch that echoes them.
+
+**Default discipline for any credential: masked + protected.** Mask it
+so an accidental `echo` does not print it; protect it so only trusted
+refs can run the job that consumes it. A credential missing either flag
+is a finding.
+
+### Raw vs expanded values
+
+By default GitLab performs **variable expansion**: a `$`-prefixed token
+inside a value is expanded against other variables. A secret containing
+a literal `$` (e.g. a bcrypt hash, some passwords) is corrupted by
+expansion. Flag the variable **raw** (`Expand variable reference` off,
+or `raw: true` in the API) to disable expansion and keep the literal
+value.
+
+### Manual-run prompts
+
+A top-level `variables:` entry can declare `value` and `description`;
+the `description` turns the variable into a prefilled, documented field
+on the manual "Run pipeline" form.
+
+```yaml
+variables:
+  DEPLOY_ENV:
+    value: "staging"
+    description: "Target environment for a manual deploy (staging|production)."
+```
+
+## External secrets (`secrets:`)
+
+The `secrets:` keyword fetches a value from an external manager at job
+start and exposes it as a `file`-type variable by default. The job
+never stores the secret in GitLab. It requires an `id_tokens:` JWT (see
+below) for the manager to authenticate the pipeline.
+
+### HashiCorp Vault
+
+```yaml
+deploy:
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  secrets:
+    DATABASE_PASSWORD:
+      vault: prod/db/password@ops      # secret path @ KV mount
+      token: $VAULT_ID_TOKEN           # JWT used to auth to Vault
+      file: false                      # export as a plain env var, not a file
+  script:
+    - psql "postgres://app:${DATABASE_PASSWORD}@db/app"
+```
+
+Vault is configured with the JWT auth method and a role whose
+`bound_audiences` and `bound_claims` (e.g. `project_id`, `ref`,
+`ref_type`) match the GitLab token. `secrets:[].file` controls whether
+the resolved value lands in a temp file (default `true`) or an env var;
+`secrets:[].token` names the `id_tokens:` entry used to authenticate.
+
+### Azure Key Vault
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: https://AzureADTokenExchange
+  secrets:
+    DB_PASSWORD:
+      azure_key_vault:
+        name: db-password
+        version: 00000000000000000000000000000000
+      token: $AZURE_ID_TOKEN
+```
+
+The project's CI/CD settings declare the vault server URL; the app
+registration carries a federated credential whose subject matches the
+pipeline.
+
+### GCP Secret Manager
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  secrets:
+    API_KEY:
+      gcp_secret_manager:
+        name: api-key
+        version: latest
+      token: $GCP_ID_TOKEN
+```
+
+GCP is configured with a Workload Identity Pool provider that trusts
+the GitLab issuer and maps the JWT claims to a service account that can
+read the secret.
+
+## OIDC federation (`id_tokens:`)
+
+For cloud credentials, **prefer OIDC over a long-lived access key stored
+as a CI/CD variable**. The runner mints a short-lived JWT signed by the
+GitLab instance's OIDC provider (issuer = the GitLab base URL, e.g.
+`https://gitlab.example.com`). The cloud side validates the token's
+claims and issues a temporary credential.
+
+Benefits, mirroring any OIDC story:
+
+- No long-lived secret to rotate, mask, or leak.
+- Per-project, per-ref scoping — a `main` deploy gets a token whose
+  `sub` includes `ref:main`.
+- An audit trail in both GitLab and the cloud provider.
+
+GitLab JWT claims you bind trust against include `iss` (the issuer
+URL), `aud` (set per `id_tokens:` entry), `project_path`,
+`namespace_path`, `ref`, `ref_type`, and a composite `sub` of the form:
+
+```text
+project_path:my-group/my-project:ref_type:branch:ref:main
+```
+
+### AWS
+
+```yaml
+deploy:
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com   # must match the OIDC provider audience
+  script:
+    - >
+      aws sts assume-role-with-web-identity
+      --role-arn "$AWS_ROLE_ARN"
+      --role-session-name gitlab-$CI_PIPELINE_ID
+      --web-identity-token "$AWS_ID_TOKEN"
+      --duration-seconds 3600
+```
+
+Trust policy on the IAM role (snippet):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/gitlab.example.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "gitlab.example.com:aud": "https://gitlab.example.com"
+      },
+      "StringLike": {
+        "gitlab.example.com:sub":
+          "project_path:my-group/my-project:ref_type:branch:ref:main"
+      }
+    }
+  }]
+}
+```
+
+### Google Cloud (Workload Identity Federation)
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_ID_TOKEN:
+      aud: https://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+  script:
+    - echo "$GCP_ID_TOKEN" > token.jwt
+    - >
+      gcloud iam workload-identity-pools create-cred-config
+      projects/123/locations/global/workloadIdentityPools/gitlab/providers/gitlab
+      --service-account="gitlab-deploy@my-project.iam.gserviceaccount.com"
+      --credential-source-file=token.jwt
+      --output-file=cred.json
+    - export GOOGLE_APPLICATION_CREDENTIALS=cred.json
+```
+
+The WIF provider declares an attribute mapping (e.g.
+`google.subject = assertion.sub`) and an attribute condition pinning
+the allowed `project_path` / `ref`.
+
+### Azure
+
+```yaml
+deploy:
+  id_tokens:
+    AZURE_ID_TOKEN:
+      aud: api://AzureADTokenExchange
+  script:
+    - >
+      az login --service-principal
+      --username "$AZURE_CLIENT_ID"
+      --tenant "$AZURE_TENANT_ID"
+      --federated-token "$AZURE_ID_TOKEN"
+```
+
+The Azure side configures a **federated credential** on the app
+registration whose issuer is the GitLab URL and whose subject matches
+the pipeline's `sub` claim.
+
+## Exfiltration anti-patterns and common pitfalls
+
+### Hardcoded secret literals
+
+```yaml
+# BAD: the secret is committed to the repo, visible to anyone with read
+# access and to the full git history forever.
+variables:
+  API_TOKEN: "glpat-XXXXXXXXXXXXXXXXXXXX"
+```
+
+Define credentials as masked + protected CI/CD variables in project
+settings, never in `.gitlab-ci.yml`.
+
+### Secrets in a global `variables:`
+
+```yaml
+# BAD: a top-level variables: block is in scope for every job in the
+# pipeline — maximal blast radius.
+variables:
+  DEPLOY_KEY: "..."          # also a hardcoded literal — doubly wrong
+```
+
+Bind a credential to the single job that needs it via `job.variables:`,
+or scope the CI/CD variable to the deploy environment.
+
+### Echoing a variable to the log
+
+```yaml
+# BAD: even a masked variable can leak if transformed before printing,
+# and the value still reaches any artifact/cache written next.
+script:
+  - echo "$DEPLOY_TOKEN"
+  - echo "token is $DEPLOY_TOKEN"
+```
+
+Never debug by printing a secret. Print a length or a checksum instead:
+
+```yaml
+script:
+  - echo "Token length: ${#DEPLOY_TOKEN}"
+```
+
+### `set -x` shell trace
+
+```yaml
+# BAD: shell trace prints every expanded command, including the
+# resolved value of a secret variable, and masking may not catch it.
+script:
+  - set -x
+  - curl -H "Authorization: Bearer $TOKEN" https://api.example.com
+```
+
+Keep `set -x` (and `CI_DEBUG_TRACE: "true"`) out of jobs that touch
+credentials. `CI_DEBUG_TRACE` in particular dumps **all** variables,
+masked or not, and must never run on a job with protected secrets.
+
+### Structured JSON in one variable
+
+A single `CLOUD_CONFIG` variable holding a JSON blob is convenient for
+setup but defeats per-key rotation and per-key masking (the blob fails
+the no-whitespace masking rule anyway). Split into individual variables,
+or fetch the structured secret at runtime via `secrets:` so each key is
+resolved and handled independently.
+
+### A variable that should be masked or protected
+
+A CI/CD variable whose value is sensitive on inspection (a token, a
+URL embedding a token, a password) but is missing the **masked** or
+**protected** flag is a secret in disguise. If it is sensitive, set
+both flags.
+
+### Secrets reaching fork pipelines
+
+A merge request from a fork runs in the fork's context. **Protected**
+variables are withheld from such pipelines by design — which is exactly
+why every credential must be protected. Do not relax the
+"only-protected-branches-can-run-this-job" rules to make a fork MR
+pipeline "just work"; gate privileged work behind a protected branch
+and a manual approval instead.
+
+### Offline scan
+
+This skill ships `scripts/check-secrets-exposure.sh`, which scans a
+`.gitlab-ci.yml` offline for several of the patterns above — hardcoded
+secret literals, `echo $TOKEN`-style log leaks, `set -x` /
+`CI_DEBUG_TRACE` in credential jobs, and global `variables:` holding a
+likely secret. Run it before committing pipeline changes.
+
+## Auditing
+
+Periodic audit checklist:
+
+- Review every project, group, and instance CI/CD variable: confirm
+  every credential is flagged **masked** and **protected**. Flag any
+  sensitive value missing either flag.
+- Rotate long-lived tokens stored as variables on a schedule; prefer
+  migrating each to `secrets:` (external manager) or `id_tokens:`
+  (OIDC) so there is nothing long-lived to rotate.
+- Grep the `.gitlab-ci.yml` for hardcoded secret literals and for
+  `echo`/`set -x`/`CI_DEBUG_TRACE` on jobs that consume credentials
+  (the `check-secrets-exposure.sh` validator does this).
+- Confirm no credential lives in a global `variables:` block; bind each
+  to its job or environment scope.
+- For each cloud provider, audit the OIDC trust conditions: the `aud`
+  must match the configured audience and the `sub`/`project_path`/`ref`
+  bindings must pin the allowed projects and refs — no wildcard that
+  admits an unintended project.

--- a/artifacts/core/skills/gitlab-ci/scripts/check-pinned-images.sh
+++ b/artifacts/core/skills/gitlab-ci/scripts/check-pinned-images.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# check-pinned-images.sh — flag GitLab CI container references that are not
+# pinned to an immutable @sha256: digest.
+#
+# Usage: check-pinned-images.sh <pipeline-file-or-directory>
+#
+# Rationale: a `image: node:22` or `image: node:latest` reference is a moving
+# target — the registry can re-point the tag to a different image at any time,
+# silently changing what runs in your pipeline. Pinning to a digest
+# (`image: node@sha256:<64-hex>`) makes the reference immutable, exactly as
+# pinning a GitHub Action to a commit SHA does.
+#
+# Scanned surface (text scan; no registry call, no Docker, no live GitLab):
+#   - `image: <ref>`                       (job-level, global, and default:)
+#   - `image:` long form → its `name: <ref>`
+#   - `services:` list entries: `- <ref>`  and `- name: <ref>` / `name: <ref>`
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`
+# (the conventional local-include location). A bare variable reference with no
+# tag (e.g. `$CI_REGISTRY_IMAGE`) is skipped — there is nothing to evaluate
+# statically.
+#
+# Limitation: only inline forms (value on the same line) are matched. A `name:`
+# spread across multiple YAML lines is not detected.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+# An immutable reference is digest-pinned: <name>@sha256:<64 hex chars>.
+digest_re='@sha256:[0-9a-fA-F]{64}$'
+
+# Strip surrounding quotes from a captured scalar.
+unquote() {
+    local v="$1"
+    v="${v%\"}"; v="${v#\"}"
+    v="${v%\'}"; v="${v#\'}"
+    printf '%s' "$v"
+}
+
+# Decide whether a container reference is acceptably pinned. Returns 0 (pinned
+# or not-applicable) or 1 (a finding). A pure variable expansion with no tag is
+# treated as not-applicable: there is no static digest to demand.
+check_ref() {
+    local value="$1" file="$2" lineno="$3"
+    value="$(unquote "$value")"
+    [ -z "$value" ] && return 0
+    case "$value" in
+        # Bare variable with no `:tag` and no digest — nothing to evaluate.
+        \$*)
+            case "$value" in
+                *:*|*@*) ;;          # has a tag/digest part — fall through to the check
+                *) return 0 ;;
+            esac
+            ;;
+    esac
+    if [[ "$value" =~ $digest_re ]]; then
+        return 0
+    fi
+    echo "${C_RED}[UNPINNED]${C_RESET} ${file}:${lineno}: ${value}"
+    return 1
+}
+
+for f in "${files[@]}"; do
+    lineno=0
+    in_image_block=0
+    in_services_block=0
+    block_indent=-1
+    # shellcheck disable=SC2094  # check_ref() only echoes; it does not write to "$f".
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Skip blank and comment-only lines (but they do not close a block).
+        case "$line" in
+            ''|'#'*|*[![:space:]]*'#') : ;;
+        esac
+
+        # Current line indentation (number of leading spaces).
+        stripped="${line#"${line%%[![:space:]]*}"}"
+        indent=$(( ${#line} - ${#stripped} ))
+
+        # Close an open block when indentation returns to/under the opener and
+        # the line carries content.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [ -n "$stripped" ] && [ "$indent" -le "$block_indent" ]; then
+            in_image_block=0
+            in_services_block=0
+            block_indent=-1
+        fi
+
+        # `image:` — short inline form, or open the long-form mapping block.
+        if [[ "$line" =~ ^[[:space:]]*image:[[:space:]]*(.*)$ ]]; then
+            val="${BASH_REMATCH[1]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            if [ -n "$val" ]; then
+                check_ref "$val" "$f" "$lineno" || violations=$((violations + 1))
+            else
+                in_image_block=1
+                in_services_block=0
+                block_indent=$indent
+            fi
+            continue
+        fi
+
+        # `services:` — open the list block (entries handled below).
+        if [[ "$line" =~ ^[[:space:]]*services:[[:space:]]*$ ]]; then
+            in_services_block=1
+            in_image_block=0
+            block_indent=$indent
+            continue
+        fi
+
+        # Inside an image: mapping or a services: entry — a `name:` scalar.
+        if { [ "$in_image_block" -eq 1 ] || [ "$in_services_block" -eq 1 ]; } \
+            && [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*name:[[:space:]]*([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+
+        # Inside services: — a bare list item `- <image-ref>`.
+        if [ "$in_services_block" -eq 1 ] \
+            && [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^[:space:]#]+) ]]; then
+            check_ref "${BASH_REMATCH[1]}" "$f" "$lineno" || violations=$((violations + 1))
+            continue
+        fi
+    done < "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} all image/service references are pinned to a @sha256: digest"
+    exit 0
+fi
+
+echo "${C_RED}${violations} unpinned image/service reference(s) found${C_RESET}" >&2
+exit 1

--- a/artifacts/core/skills/gitlab-ci/scripts/check-secrets-exposure.sh
+++ b/artifacts/core/skills/gitlab-ci/scripts/check-secrets-exposure.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-secrets-exposure.sh — flag patterns in a GitLab CI pipeline that may
+# leak secrets into job logs or expand the secret blast radius.
+#
+# Usage: check-secrets-exposure.sh <pipeline-file-or-directory>
+#
+# Patterns flagged (text scan; no live GitLab, no token read, no network):
+#   1. Hardcoded secret literal in `variables:` or a shell assignment
+#      (a key named like a credential set to an inline value, not a $VAR ref).
+#   2. A well-known token shape appearing as a literal anywhere
+#      (glpat-…, ghp_…, AWS AKIA…, a PEM private-key header).
+#   3. `echo`/`printf` of a credential-named variable — written to the job log.
+#   4. `set -x` / `set +x` in a `script:` — shell xtrace prints expanded values.
+#   5. `CI_DEBUG_TRACE: "true"` — turns on full pipeline trace, logging every
+#      variable including masked ones.
+#
+# Masking and protection are GitLab's real defenses (see the skill's
+# references/variables-and-secrets.md); this scan catches the hygiene mistakes
+# that defeat them before review.
+#
+# Directory mode scans `<dir>/.gitlab-ci.yml` plus any YAML under `<dir>/.gitlab/`.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[0;33m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RESET=""
+fi
+
+usage() {
+    echo "Usage: $(basename "$0") <pipeline-file-or-directory>" >&2
+    exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+files=()
+if [ -d "$TARGET" ]; then
+    if [ -f "$TARGET/.gitlab-ci.yml" ]; then
+        files+=("$TARGET/.gitlab-ci.yml")
+    fi
+    if [ -d "$TARGET/.gitlab" ]; then
+        while IFS= read -r -d '' f; do
+            files+=("$f")
+        done < <(find "$TARGET/.gitlab" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+    fi
+elif [ -f "$TARGET" ]; then
+    files+=("$TARGET")
+else
+    echo "${C_RED}[FAIL] not a file or directory: $TARGET${C_RESET}" >&2
+    exit 1
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "no GitLab pipeline file found under: $TARGET"
+    exit 0
+fi
+
+violations=0
+
+report() {
+    local file="$1" line="$2" pattern="$3" risk="$4"
+    echo "${C_RED}[RISK]${C_RESET} ${file}:${line}: ${pattern}"
+    echo "       ${C_YELLOW}why:${C_RESET} ${risk}"
+    violations=$((violations + 1))
+}
+
+# A key whose name marks it as a credential.
+secret_key='(SECRET|TOKEN|PASSWORD|PASSWD|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIAL|AUTH|PASSPHRASE)'
+
+for current_file in "${files[@]}"; do
+    lineno=0
+    # shellcheck disable=SC2094  # report() only echoes; it does not write to current_file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Strip a leading YAML list dash so `- export TOKEN=…` is seen as a
+        # shell assignment too.
+        probe="${line#"${line%%[![:space:]]*}"}"
+        probe="${probe#- }"
+
+        # 1. Hardcoded literal: YAML `KEY: value` or shell `KEY=value` where the
+        #    key is credential-named and the value is an inline literal (not a
+        #    `$VAR` reference, not empty, not a masked/protected reference).
+        if [[ "$probe" =~ ^(export[[:space:]]+)?[A-Za-z0-9_]*${secret_key}[A-Za-z0-9_]*[[:space:]]*[:=][[:space:]]*(.+)$ ]]; then
+            val="${BASH_REMATCH[3]}"
+            val="${val%%#*}"                       # drop trailing comment
+            val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+            val="${val%"${val##*[![:space:]]}"}"   # rtrim
+            # Unquote.
+            val="${val%\"}"; val="${val#\"}"
+            val="${val%\'}"; val="${val#\'}"
+            case "$val" in
+                ''|\$*|'!reference'*|'&'*|'*'*) : ;;   # ref/anchor/empty — fine
+                *)
+                    report "$current_file" "$lineno" "hardcoded value for a credential-named key" \
+                        "a secret committed in the pipeline is readable by anyone with repo access — move it to a masked + protected CI/CD variable"
+                    ;;
+            esac
+        fi
+
+        # 2. Well-known token shapes as literals.
+        if [[ "$line" =~ glpat-[A-Za-z0-9_-]{20} ]] \
+            || [[ "$line" =~ (ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36} ]] \
+            || [[ "$line" =~ AKIA[0-9A-Z]{16} ]] \
+            || [[ "$line" =~ BEGIN[[:space:]].*PRIVATE[[:space:]]KEY ]]; then
+            report "$current_file" "$lineno" "literal access token / private key" \
+                "a recognizable credential literal is committed in the pipeline — revoke it and store it as a masked + protected CI/CD variable"
+        fi
+
+        # 3. echo / printf of a credential-named variable.
+        if [[ "$line" =~ (echo|printf)[[:space:]].*\$\{?[A-Za-z0-9_]*${secret_key} ]]; then
+            report "$current_file" "$lineno" "echo/printf of a credential-named variable" \
+                "printing a secret to the job log persists it in the log; masking is best-effort and a transformed value bypasses it"
+        fi
+
+        # 4. set -x / set +x — shell xtrace.
+        if [[ "$line" =~ (^|[^[:alnum:]_])set[[:space:]]+[-+]x([[:space:]]|$) ]]; then
+            report "$current_file" "$lineno" "set -x / set +x" \
+                "shell xtrace prints every expanded command, including secret variable values"
+        fi
+
+        # 5. CI_DEBUG_TRACE enabled.
+        if [[ "$line" =~ CI_DEBUG_TRACE[[:space:]]*:?=?[[:space:]]*[\"\']?(true|1)[\"\']? ]]; then
+            report "$current_file" "$lineno" "CI_DEBUG_TRACE enabled" \
+                "debug trace logs every variable in the job, including masked and protected ones"
+        fi
+    done < "$current_file"
+done
+
+if [ "$violations" -eq 0 ]; then
+    echo "${C_GREEN}[OK]${C_RESET} no secret-exposure patterns detected"
+    exit 0
+fi
+
+echo "${C_RED}${violations} risky pattern(s) found${C_RESET}" >&2
+exit 1

--- a/docs/cli-matrix.md
+++ b/docs/cli-matrix.md
@@ -77,6 +77,25 @@ One row per integration point. ✅ = present, ❌ = absent, note when relevant.
 > committed `.gitlab-ci.yml` and a fresh derivation. `scripts/build-ci.sh` is a
 > `scripts/build-*.sh` script and therefore on the *CLI Matrix Maintenance*
 > trigger surface; this entry satisfies that obligation.
+>
+> **CI agentic surface (spec 0050).** The agentic layer over the CI machinery
+> — the new `gitlab-ci` knowledge skill (`artifacts/core/skills/gitlab-ci/`,
+> with a seven-file `references/` corpus and two offline check scripts), the
+> `ci-configurator` agent generalised to be engine-aware (it hand-authors a
+> GitHub Actions workflow but **derives** a GitLab pipeline by composing
+> `scripts/build-ci.sh`), and the new `ci-parity` agent
+> (`artifacts/core/agents/ci-parity/`, which operates `scripts/check-ci-parity.sh`
+> and reconciles drift) — rides the **existing generic component-build
+> mechanisms** with full three-CLI parity: the skill ships through the generic
+> skill-build (row 3, including `propagate_skill_resources` for its
+> `references/` and `scripts/`), and both agents ship through the generic
+> agent-build (row 4). **No new CLI mechanism row is created** — these are
+> ordinary `artifacts/core/**` components that `scripts/build-components.sh`
+> compiles symmetrically to `.claude/`, `.gemini/`, and `.github/`. The agentic
+> surface only **composes** the spec-0048 generator (`build-ci.sh`) and the
+> spec-0049 harness (`check-ci-parity.sh`); it introduces no CLI-specific
+> integration point. This paragraph discharges the `artifacts/**`
+> CLI-matrix-update obligation for spec 0050.
 
 ## Parity gaps
 


### PR DESCRIPTION
This PR adds the agentic layer over the CI machinery from EPIC #368: a new `gitlab-ci` knowledge skill, a new `ci-parity` operator agent, and an engine-aware `ci-configurator`. It only **composes** the spec-0048 generator (`scripts/build-ci.sh`) and the spec-0049 harness (`scripts/check-ci-parity.sh`) — it changes neither, and introduces no new CLI-specific integration point.

Closes #406

## How to read this PR?

Read the `artifacts/core/**` sources only — everything under `.claude/`,
`.gemini/`, and `.github/` is regenerated build output from
`scripts/build-components.sh` and mirrors the sources verbatim.

1. **`artifacts/core/skills/gitlab-ci/SKILL.md`** — the entry point. It
   declares itself "the GitLab counterpart of the `github-actions` skill"
   and defers exhaustive syntax to `references/`. Note the engine-neutrality
   contract in the intro: stay neutral wherever `ci/ci-capabilities.yml`
   (described by `docs/ci-reference-format.md`) is neutral, name
   GitLab-specific syntax only where the behaviour genuinely is.
2. **`artifacts/core/skills/gitlab-ci/references/`** — seven reference
   documents (`pipeline-syntax`, `rules-and-triggers`,
   `runners-and-executors`, `caching-and-artifacts`,
   `variables-and-secrets`, `security-and-permissions`,
   `includes-and-components`). Skim headings; they are lookup tables, not
   linear reading.
3. **`artifacts/core/skills/gitlab-ci/scripts/`** — the two offline check
   scripts. Read the header comment block of each (`check-pinned-images.sh`,
   `check-secrets-exposure.sh`): both are single-argument
   (`<pipeline-file-or-directory>`), pure text scans — no network, no
   Docker, no live GitLab.
4. **`artifacts/core/agents/ci-configurator/AGENT.md`** — the engine-aware
   diff. The load-bearing decision: it hand-authors a GitHub Actions
   workflow but **derives** a GitLab pipeline by composing
   `scripts/build-ci.sh`, and never mutates the spec-0047 reference.
5. **`artifacts/core/agents/ci-parity/AGENT.md`** — the new operator agent
   for `scripts/check-ci-parity.sh`. Note its mechanical-only autonomy
   boundary: it auto-applies **only** the deterministic
   regenerate-and-re-verify case and diagnoses-and-proposes for every
   judgment-bearing divergence.
6. **`docs/cli-matrix.md`** — one cross-reference paragraph (spec 0050)
   documenting that the agentic surface rides the existing generic
   skill-build (row 3) and agent-build (row 4) with full three-CLI parity,
   creating **no new CLI mechanism row**.

**Scope shape (R3 = "B-hygiene").** The `gitlab-ci` skill ships with a
`references/` corpus **and exactly two offline scripts** — deliberately
*not* references-only, and *not* the five-script mirror of `github-actions`.
The two scripts cover the two highest-value, statically-checkable CI
hygiene failures (unpinned images, secret exposure).

## How to test this PR?

Prerequisites: `bash`, `git`, a checkout of this branch.

1. **Build is clean and drift-free:**
   ```sh
   bash scripts/build-components.sh --target all --check
   ```
   Expected: exits clean — the committed `.claude/`, `.gemini/`, `.github/`
   outputs match a fresh derivation from `artifacts/core/**`.

2. **The two check scripts behave on a fixture.** Point each at a clean
   `.gitlab-ci.yml`, then at one with a planted defect:
   ```sh
   bash artifacts/core/skills/gitlab-ci/scripts/check-pinned-images.sh   <fixture>
   bash artifacts/core/skills/gitlab-ci/scripts/check-secrets-exposure.sh <fixture>
   ```
   Expected: a clean pipeline → exit 0; a planted unpinned image
   (`image: node:22`) → `check-pinned-images.sh` exits 1; a planted secret
   literal / `CI_DEBUG_TRACE: "true"` → `check-secrets-exposure.sh` exits 1.
   (Wrong arg count → exit 2, per each script's `usage`.)

3. **Version bumps satisfy CI:**
   ```sh
   bash scripts/check-skill-versions.sh
   ```
   Expected: OK. `ci-configurator` is a modified shipped source and is
   bumped `1.0.2` → `1.1.0` (MINOR — additive engine-awareness); `gitlab-ci`
   and `ci-parity` are new components at `1.0.0` (exempt from in-branch
   bump).

All three were verified green locally before this PR was opened.

## Detailed description (for agents)

### Added (44 files = 11 source files mirrored across `artifacts/` + 3 CLI outputs)

- **`artifacts/core/skills/gitlab-ci/`** (new skill, version `1.0.0`):
  - `SKILL.md` — practitioner-grade GitLab CI/CD skill; `allowed-tools:
    Read, Bash, Write, Edit`; presented as the GitLab counterpart of
    `github-actions`.
  - `references/` — seven documents: `pipeline-syntax.md`,
    `rules-and-triggers.md`, `runners-and-executors.md`,
    `caching-and-artifacts.md`, `variables-and-secrets.md`,
    `security-and-permissions.md`, `includes-and-components.md`.
  - `scripts/` — two offline, single-argument check scripts (exec bit
    `100755`): `check-pinned-images.sh` (flags container refs not pinned to
    an `@sha256:` digest) and `check-secrets-exposure.sh` (flags hardcoded
    secret literals, known token shapes, `echo`/`printf` of credential
    vars, `set -x` in `script:`, and `CI_DEBUG_TRACE: "true"`). Both are
    text scans — no registry call, no Docker, no live GitLab.
- **`artifacts/core/agents/ci-parity/AGENT.md`** (new agent, version
  `1.0.0`) — operator for `scripts/check-ci-parity.sh`. Treats
  `ci/ci-capabilities.yml` as the source of truth, operates under the
  `github-actions` and `gitlab-ci` skills, and constrains its autonomy to
  the deterministic regenerate-and-re-verify case.
- The same eleven source files are mirrored verbatim into `.claude/skills/`
  + `.claude/agents/`, `.gemini/skills/` + `.gemini/agents/`, and
  `.github/skills/` + `.github/agents/` by `scripts/build-components.sh`.

### Modified (5 files)

- **`artifacts/core/agents/ci-configurator/AGENT.md`** — generalised to be
  engine-aware with two production modes: GitHub Actions workflows are
  hand-authored (the existing behaviour, preserved); GitLab pipelines are
  **derived** by composing `scripts/build-ci.sh`, never by mutating the
  spec-0047 reference. Version `1.0.2` → `1.1.0`. Mirrored to the three CLI
  agent outputs (the other four "Modified" rows in the diff stat).
- **`docs/cli-matrix.md`** — one added paragraph (19 insertions) cross-
  referencing spec 0050 and discharging the `artifacts/**` CLI-matrix-update
  obligation; documents that the surface rides rows 3/4 and adds no new row.

### Explicitly NOT changed (parity / blast-radius notes for the next agent)

- **No change to `ci/ci-capabilities.yml` or `docs/ci-reference-format.md`**
  — the platform-neutral capability reference and its format spec are
  untouched; this surface consumes them, it does not redefine them.
- **No change to `scripts/build-ci.sh` (spec 0048) or
  `scripts/check-ci-parity.sh` (spec 0049)** — the agentic layer only
  *composes* these; it does not edit the generator or the harness.
- **No new `.crewrig/core-paths.txt` entry** — no core-layer path is added,
  removed, or reclassified in `docs/layers.md`, so the manifest needs no
  co-maintenance edit.
- **No new `docs/cli-matrix.md` mechanism row** — both components ship via
  the generic skill-build (row 3, including `propagate_skill_resources` for
  `references/` and `scripts/`) and agent-build (row 4). The added text is a
  cross-reference paragraph, not a new integration point.
