### PR TITLE
📝 Align spec 0047 delta-01/02 lifecycle status with the implemented base

### DIFF
--- a/specs/0047-ci-capability-reference.delta-01.md
+++ b/specs/0047-ci-capability-reference.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0047"
 slug: ci-capability-reference
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 383

--- a/specs/0047-ci-capability-reference.delta-02.md
+++ b/specs/0047-ci-capability-reference.delta-02.md
@@ -1,7 +1,7 @@
 ---
 id: "0047"
 slug: ci-capability-reference
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 389


### PR DESCRIPTION
Metadata-only cleanup: the two `0047` delta files were left `status: draft` although their content was realized via sub-spec B (#386) and the base spec is `implemented`. Flips both deltas `draft` → `implemented`.

## How to read this PR?

Two one-line frontmatter edits: `status: draft` → `status: implemented` on `specs/0047-ci-capability-reference.delta-01.md` and `delta-02.md`. No body/normative change (status is exempt from the delta-spec content freeze per `docs/spec-format.md`).

## How to test this PR?

```sh
task spec:lint   # frontmatter + section schema + markdownlint → clean
```

## Detailed description (for agents)

Pre-existing inconsistency surfaced while closing EPIC #368: base `0047` = `implemented`, deltas = `draft`. The deltas' normative content (delta-01 `command:` R10, delta-02 `requires:` R12) was merged and absorbed by sub-spec B's implementation-PR #386, so `implemented` is the truthful lifecycle state. Both deltas keep `interaction-mode: INTERMEDIATE` (required from `approved` onward). No code, no contract, no other file touched.

Closes #410