### PR TITLE
📝 Transition spec 0051 to its approved lifecycle state

### DIFF
--- a/specs/0051-antigravity-cli-support.md
+++ b/specs/0051-antigravity-cli-support.md
@@ -1,7 +1,7 @@
 ---
 id: "0051"
 slug: antigravity-cli-support
-status: draft
+status: approved
 complexity: large
 interaction-mode: INTERMEDIATE
 related-issue: 418


### PR DESCRIPTION
Metadata-only lifecycle transition for spec 0051: `status: draft` → `status: approved`, triggered by the merge of spec-PR #419 on main.

## How to read this PR?

Single field change in `specs/0051-antigravity-cli-support.md` frontmatter (`status: draft` → `status: approved`). No normative content is modified — this is a lifecycle-metadata edit per `docs/spec-format.md` → *Recording a status transition*.

## How to test this PR?

```sh
grep "^status:" specs/0051-antigravity-cli-support.md
# Expected: status: approved
```

## Detailed description (for agents)

**File modified:** `specs/0051-antigravity-cli-support.md`
- `status` field: `draft` → `approved`
- No other field or body section changed.

Authority: spec reviewer (spec-PR #419 merged). Trigger: merge of `spec/0051-antigravity-cli-support` into `main` at commit `e29cc0e`.