### PR TITLE
📝 Transition spec 0052 to its approved lifecycle state (#429)

### DIFF
--- a/specs/0052-antigravity-workspace-layout.md
+++ b/specs/0052-antigravity-workspace-layout.md
@@ -1,7 +1,7 @@
 ---
 id: "0052"
 slug: antigravity-workspace-layout
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 422


### PR DESCRIPTION
Metadata-only edit: transitions `specs/0052-antigravity-workspace-layout.md` from `status: draft` to `status: approved` following the merge of spec-PR #429. No normative content changed.