### PR TITLE
📝 Transition specs 0053–0057 to their approved lifecycle state

### DIFF
--- a/specs/0053-antigravity-build-pipeline.md
+++ b/specs/0053-antigravity-build-pipeline.md
@@ -1,7 +1,7 @@
 ---
 id: "0053"
 slug: antigravity-build-pipeline
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 423

--- a/specs/0054-antigravity-setup-script.md
+++ b/specs/0054-antigravity-setup-script.md
@@ -1,7 +1,7 @@
 ---
 id: "0054"
 slug: antigravity-setup-script
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 424

--- a/specs/0055-antigravity-history-import.md
+++ b/specs/0055-antigravity-history-import.md
@@ -1,7 +1,7 @@
 ---
 id: "0055"
 slug: antigravity-history-import
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 425

--- a/specs/0056-antigravity-hooks.md
+++ b/specs/0056-antigravity-hooks.md
@@ -1,7 +1,7 @@
 ---
 id: "0056"
 slug: antigravity-hooks
-status: draft
+status: approved
 complexity: trivial
 interaction-mode: INTERMEDIATE
 related-issue: 426

--- a/specs/0057-antigravity-plugin-build.md
+++ b/specs/0057-antigravity-plugin-build.md
@@ -1,7 +1,7 @@
 ---
 id: "0057"
 slug: antigravity-plugin-build
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 427


### PR DESCRIPTION
Metadata-only batch edit: transitions specs 0053, 0054, 0055, 0056, 0057 from `status: draft` to `status: approved` following the merge of spec-PRs #431–#435. No normative content changed.