### PR TITLE
📝 Transition spec 0058 to its approved lifecycle state

### DIFF
--- a/specs/0058-antigravity-cli-matrix.md
+++ b/specs/0058-antigravity-cli-matrix.md
@@ -1,7 +1,7 @@
 ---
 id: "0058"
 slug: antigravity-cli-matrix
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 428


### PR DESCRIPTION
Metadata-only status transition: `status: draft` → `status: approved` for spec 0058.

## How to read this PR?

Single-field edit to `specs/0058-antigravity-cli-matrix.md` frontmatter. No normative content changed. Triggered by the merge of spec-PR #437.

## How to test this PR?

Verify `grep 'status: approved' specs/0058-antigravity-cli-matrix.md` returns the line.

## Detailed description (for agents)

- `specs/0058-antigravity-cli-matrix.md`: `status` field changed from `draft` to `approved`.
- All other frontmatter and body content unchanged (lifecycle metadata carve-out per `docs/spec-format.md` → *Recording a status transition*).
- Closes #428 lifecycle milestone: all 7 sub-specs of issue #418 (specs 0052–0058) are now `status: approved`.