### PR TITLE
✨ Add .agents/ workspace layout for Antigravity CLI

### DIFF
--- a/.agents/ANTIGRAVITY.md
+++ b/.agents/ANTIGRAVITY.md
@@ -1,0 +1,3 @@
+# Agent Rules
+
+@AGENTS.md

--- a/.agents/ANTIGRAVITY.md
+++ b/.agents/ANTIGRAVITY.md
@@ -1,3 +1,5 @@
 # Agent Rules
 
+<!-- OQ1: @-import resolution against a live agy instance not yet end-to-end verified; see spec 0052 open questions -->
+
 @AGENTS.md

--- a/.agents/settings.local.json.example
+++ b/.agents/settings.local.json.example
@@ -1,0 +1,17 @@
+{
+  // Antigravity CLI workspace settings — copy to settings.local.json to activate.
+  // Key names derived from agy 1.0.10 binary strings; verify against official
+  // documentation if a public reference becomes available.
+
+  // The Gemini model to use for this workspace (e.g. "gemini-2.5-pro").
+  // "model": "gemini-2.5-pro",
+
+  // Tool permission level: "auto" (default) | "requireApproval" | "disabled".
+  // "toolPermission": "auto",
+
+  // Whether to send anonymised usage telemetry to Google.
+  // "enableTelemetry": true,
+
+  // Number of history entries to retain across sessions (integer ≥ 0).
+  // "historySize": 100
+}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ copilot-instructions.local.md
 tests/e2e/local.toml
 tests/e2e/reports/*
 !tests/e2e/reports/.gitkeep
+
+# Antigravity CLI
+.agents/settings.local.json
+ANTIGRAVITY.local.md
+dist-antigravity-*/


### PR DESCRIPTION
Introduces the `.agents/` directory at the repository root so that the Antigravity CLI (agy) can locate project agent rules and local configuration overrides when a developer works inside crewrig. This closes the Antigravity workspace-layout requirement defined in spec 0052.

## How to read this PR?

Start with `.agents/ANTIGRAVITY.md` — it is the agy workspace entry point, mirroring `CLAUDE.md` in shape: a one-liner that re-exports `AGENTS.md` via the `@AGENTS.md` import syntax. Then read `.agents/settings.local.json.example`, which documents the four supported workspace settings keys (`model`, `toolPermission`, `enableTelemetry`, `historySize`) using JSON-with-comments inline documentation. Finally review the three appended lines in `.gitignore` (Antigravity CLI section): `settings.local.json`, `ANTIGRAVITY.local.md`, and `dist-antigravity-*/`. Two open questions from spec 0052 are disclosed as `<!-- AUTO-PARKED -->` HTML comments inside the affected files rather than blocking the PR — see *Detailed description* below.

## How to test this PR?

**Prerequisites:** agy 1.0.x or later installed (optional — the files are plain text and are readable without the binary).

1. Check out this branch locally.
2. Confirm the three files changed: `.agents/ANTIGRAVITY.md` (new), `.agents/settings.local.json.example` (new), `.gitignore` (3 lines added in the Antigravity CLI section).
3. Copy the example template and edit a key:
   ```sh
   cp .agents/settings.local.json.example .agents/settings.local.json
   ```
4. Confirm `git status` shows `.agents/settings.local.json` as untracked-and-ignored (`git check-ignore -v .agents/settings.local.json` should print the `.gitignore` rule).
5. If agy is installed: run `agy` in the repository root and confirm it picks up `AGENTS.md` via the `@AGENTS.md` import in `.agents/ANTIGRAVITY.md`.
6. Confirm `ANTIGRAVITY.local.md` and any `dist-antigravity-*/` directory are also ignored by `.gitignore`.

**Failure mode:** if agy does not resolve `@`-imports inside `.agents/` (open question OQ-2 in spec 0052), agy starts without workspace context — no crash, no corruption. The absence is a documented known gap.

## Detailed description (for agents)

**`.agents/ANTIGRAVITY.md` (new, 3 lines)**
Agy workspace entry point. Uses the identical `@AGENTS.md` import pattern as `CLAUDE.md` (root) to re-use the single source of truth for agent working rules. No unique content — deliberate: future sub-specs (B–G of epic #418) will add to `.agents/` without touching this file.
<!-- AUTO-PARKED OQ-2: whether agy resolves @-imports inside .agents/ files has not been end-to-end verified against a running agy instance. If unsupported, R2 of spec 0052 must be revised (embed full AGENTS.md content or alternative re-export mechanism). -->

**`.agents/settings.local.json.example` (new, 17 lines)**
Documents four workspace settings keys using JSON-with-comments (`//`) per spec R6. Keys and their accepted values are derived from binary string inspection of agy 1.0.10 (spec R3). All keys are commented out so the file is a safe copy-to-activate template. The file header carries a warning that key names should be verified against official agy documentation once available.
<!-- AUTO-PARKED OQ-1: key names (model, toolPermission, enableTelemetry, historySize) were derived from agy 1.0.10 binary strings; if official docs reveal a different canonical set or casing convention, this file and spec R3 need updating. -->

**`.gitignore` (+5 lines including blank line and section header)**
Appends an `# Antigravity CLI` section at the end of the existing file with three ignore patterns matching spec R4: `settings.local.json` (per-user workspace settings), `ANTIGRAVITY.local.md` (local content overrides), `dist-antigravity-*/` (local build outputs via glob).

No build-system outputs require regeneration: this diff touches no `artifacts/` sources, so `scripts/build-components.sh` is not triggered (AGENTS.md — *Built components* rule). No skill/agent version bump applies (no `artifacts/core/skills/*/SKILL.md` modified).

Closes #422