### PR TITLE
📝 Transition spec 0052 to its implemented lifecycle state

### DIFF
--- a/specs/0052-antigravity-workspace-layout.md
+++ b/specs/0052-antigravity-workspace-layout.md
@@ -1,7 +1,7 @@
 ---
 id: "0052"
 slug: antigravity-workspace-layout
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 422


### PR DESCRIPTION
Metadata-only status transition: `status: approved` → `status: implemented` for spec 0052.

## How to read this PR?

Single-field edit to `specs/0052-antigravity-workspace-layout.md` frontmatter. Triggered by the merge of implementation PR #439.

## How to test this PR?

`grep 'status: implemented' specs/0052-antigravity-workspace-layout.md`

## Detailed description (for agents)

- `specs/0052-antigravity-workspace-layout.md`: `status` field changed from `approved` to `implemented`.
- No other content changed (lifecycle metadata carve-out per `docs/spec-format.md`).