### PR TITLE
📝 Fix spec 0054 delta-01: community-tier path and R6 library tier routing

### DIFF
--- a/specs/0054-antigravity-setup-script.delta-01.md
+++ b/specs/0054-antigravity-setup-script.delta-01.md
@@ -1,0 +1,59 @@
+---
+id: "0054"
+slug: antigravity-setup-script
+status: draft
+complexity: trivial
+interaction-mode: INTERMEDIATE
+related-issue: 424
+version: 1.1.0
+---
+
+# Antigravity CLI setup script
+
+## ADDED
+
+(none)
+
+## MODIFIED
+
+**Community-tier scenario path — original (spec 0054, line 84):**
+
+> Given a built `dist/community/.gemini/` staging tree is present
+
+**Replacement:**
+
+> Given a built `dist/community/.agents/` staging tree is present
+
+Rationale: spec 0053 R2 establishes that the Antigravity build pipeline
+emits non-core tier outputs to `<output-root>/.agents/` (i.e.
+`dist/<tier>/.agents/`), not to `dist/<tier>/.gemini/`. The original
+scenario text predates spec 0053 and referenced the Gemini staging path
+by mistake. The implementation plan correctly follows `dist/community/.agents/`
+already; the spec text is brought into alignment here.
+
+---
+
+**R6 tier-routing policy — original (spec 0054, line 37):**
+
+> 6. The script SHALL follow the tier-routed install pattern: the core tier
+>    SHALL be deployed automatically; library, community, and org tiers SHALL
+>    each require explicit opt-in from the user.
+
+**Replacement:**
+
+> 6. The script SHALL follow the tier-routed install pattern: the core tier
+>    SHALL be deployed automatically; the library tier SHALL also be deployed
+>    automatically (matching the behavior of `scripts/setup-gemini-interactive.sh`,
+>    which auto-installs the library tier); the community and org tiers SHALL
+>    each require explicit opt-in from the user.
+
+Rationale: the Gemini setup script (`scripts/setup-gemini-interactive.sh`)
+auto-installs the library tier without prompting. The Antigravity setup
+script is specified to follow that same pattern for consistency across CLIs.
+The original R6 text incorrectly grouped the library tier with the opt-in
+tiers; the plan's implementation mirrors the Gemini precedent and is correct.
+This delta aligns the WHAT (spec) with the plan and the implemented behavior.
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Delta-spec 0054-01 addresses two `class: spec` non-blocking findings from the cold REVIEW pass on the spec 0054 approval PR. Both corrections align the spec text with the already-correct plan and the Gemini-precedent behavior.

## How to read this PR?

Read the single new file `specs/0054-antigravity-setup-script.delta-01.md`. It contains three sections (`## ADDED`, `## MODIFIED`, `## REMOVED`) per the delta-spec convention in `docs/spec-format.md`. Only `## MODIFIED` is non-empty; the other two are present as required placeholders.

## How to test this PR?

1. Confirm the file parses as valid YAML frontmatter (all required fields present, `version` bumped to `1.1.0`).
2. Confirm the three delta section headings are present at H2 level in the correct order.
3. Confirm the community-tier scenario now cites `dist/community/.agents/` (not `.gemini/`).
4. Confirm R6 now states that the library tier is deployed automatically.

## Detailed description (for agents)

Two modifications are recorded in `## MODIFIED`:

1. **Community-tier scenario path:** The original scenario (spec 0054 line 84) referenced `dist/community/.gemini/` as the staging tree. Spec 0053 R2 establishes `dist/<tier>/.agents/` as the canonical Antigravity staging path. The scenario is updated to `dist/community/.agents/`.

2. **R6 library-tier routing:** The original R6 grouped the library tier with community and org as opt-in. The Gemini setup script (`scripts/setup-gemini-interactive.sh`) auto-installs the library tier; the Antigravity script follows that same pattern per the plan. R6 is updated to reflect: library tier auto-installs, community and org require explicit opt-in.

`version` bumps from `1.0.0` to `1.1.0` (MINOR — normative requirement modified).

Related to #424