### PR TITLE
📝 Transition specs 0053 and 0054 to their implemented lifecycle state

### DIFF
--- a/specs/0053-antigravity-build-pipeline.md
+++ b/specs/0053-antigravity-build-pipeline.md
@@ -1,7 +1,7 @@
 ---
 id: "0053"
 slug: antigravity-build-pipeline
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 423

--- a/specs/0054-antigravity-setup-script.md
+++ b/specs/0054-antigravity-setup-script.md
@@ -1,7 +1,7 @@
 ---
 id: "0054"
 slug: antigravity-setup-script
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 424


### PR DESCRIPTION
Both implementation PRs (#441 for spec 0053 and #443 for spec 0054) have merged, so these specs are transitioned to `status: implemented`.

## How to read this PR?

Two single-line frontmatter changes in `specs/0053-antigravity-build-pipeline.md` and `specs/0054-antigravity-setup-script.md` — `status: approved` → `status: implemented`.

## How to test this PR?

Verify both spec files carry `status: implemented` in their frontmatter.

## Detailed description (for agents)

- `specs/0053-antigravity-build-pipeline.md`: `status` field changed from `approved` to `implemented`.
- `specs/0054-antigravity-setup-script.md`: `status` field changed from `approved` to `implemented`.

Related to #423, #424