### PR TITLE
✨ Add Antigravity CLI plugin build and install scripts (spec 0057)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,6 +180,14 @@ tasks:
     desc: "Install a Claude Code plugin (task install-claude-plugin EXT=hello-world)"
     cmd: bash {{.REPO_DIR}}/scripts/install-claude-plugin.sh {{.EXT}}
 
+  build-antigravity-plugin:
+    desc: Build the Antigravity CLI plugin from dist/
+    cmd: bash {{.REPO_DIR}}/scripts/build-antigravity-plugin.sh
+
+  install-antigravity-plugin:
+    desc: Build and install the Antigravity CLI plugin (requires agy in PATH)
+    cmd: bash {{.REPO_DIR}}/scripts/install-antigravity-plugin.sh
+
   # --- GitHub Copilot CLI tasks ---
 
   setup-copilot-interactive:

--- a/scripts/build-antigravity-plugin.sh
+++ b/scripts/build-antigravity-plugin.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# build-antigravity-plugin.sh — Assemble crewrig compiled components into an Antigravity CLI plugin
+#
+# Usage:
+#   bash scripts/build-antigravity-plugin.sh [output-dir]
+#
+# Reads compiled components from dist/ and generates a self-contained Antigravity
+# CLI plugin directory containing plugin.json, skills/, agents/, commands/, and
+# an optional hooks.json copied from hooks/antigravity-transcript-hooks.json.
+#
+# The dist/ directory must be present (run scripts/build-components.sh first).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# --- Guard: dist/ must exist before any write ---
+if [ ! -d "$REPO_DIR/dist" ]; then
+  echo "Error: dist/ directory not found. Run 'bash scripts/build-components.sh' first." >&2
+  exit 1
+fi
+
+OUTPUT_DIR="${1:-$REPO_DIR/dist-antigravity-plugin/crewrig}"
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+echo "Building Antigravity CLI plugin: crewrig"
+echo "  Source: $REPO_DIR/dist"
+echo "  Output: $OUTPUT_DIR"
+
+# --- Generate plugin.json ---
+# Populate name (required), plus optional version and description from release
+# metadata when available.
+PLUGIN_NAME="crewrig"
+PLUGIN_VERSION=""
+PLUGIN_DESCRIPTION=""
+
+# Read version from package.json at the repo root if present.
+if [ -f "$REPO_DIR/package.json" ] && command -v jq >/dev/null 2>&1; then
+  PLUGIN_VERSION=$(jq -r '.version // ""' "$REPO_DIR/package.json" 2>/dev/null || true)
+  PLUGIN_DESCRIPTION=$(jq -r '.description // ""' "$REPO_DIR/package.json" 2>/dev/null || true)
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  jq -n \
+    --arg name "$PLUGIN_NAME" \
+    --arg version "$PLUGIN_VERSION" \
+    --arg description "$PLUGIN_DESCRIPTION" \
+    '{
+      name: $name
+    }
+    + (if $version != "" then { version: $version } else {} end)
+    + (if $description != "" then { description: $description } else {} end)
+    ' > "$OUTPUT_DIR/plugin.json"
+else
+  # Fallback: write minimal plugin.json without jq.
+  printf '{"name":"%s"}\n' "$PLUGIN_NAME" > "$OUTPUT_DIR/plugin.json"
+fi
+echo "  Generated: plugin.json"
+
+# --- Copy skills/ ---
+if [ -d "$REPO_DIR/dist/skills" ]; then
+  cp -r "$REPO_DIR/dist/skills" "$OUTPUT_DIR/skills"
+  echo "  Copied: skills/"
+fi
+
+# --- Copy agents/ ---
+if [ -d "$REPO_DIR/dist/agents" ]; then
+  cp -r "$REPO_DIR/dist/agents" "$OUTPUT_DIR/agents"
+  echo "  Copied: agents/"
+fi
+
+# --- Copy commands/ ---
+if [ -d "$REPO_DIR/dist/commands" ]; then
+  cp -r "$REPO_DIR/dist/commands" "$OUTPUT_DIR/commands"
+  echo "  Copied: commands/"
+fi
+
+# --- Copy hooks (conditional) ---
+HOOKS_SRC="$REPO_DIR/hooks/antigravity-transcript-hooks.json"
+if [ -f "$HOOKS_SRC" ]; then
+  cp "$HOOKS_SRC" "$OUTPUT_DIR/hooks.json"
+  echo "  Copied: hooks.json (from hooks/antigravity-transcript-hooks.json)"
+fi
+
+echo ""
+echo "Plugin built: $OUTPUT_DIR"
+echo "Validate with: agy plugin validate $OUTPUT_DIR"

--- a/scripts/install-antigravity-plugin.sh
+++ b/scripts/install-antigravity-plugin.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# install-antigravity-plugin.sh — Build and install the crewrig Antigravity CLI plugin
+#
+# Usage:
+#   bash scripts/install-antigravity-plugin.sh
+#
+# Builds the Antigravity CLI plugin from dist/ and registers it with the `agy`
+# binary via `agy plugin install`, which copies the plugin contents into
+# ~/.gemini/config/plugins/crewrig/.
+#
+# Prerequisites: agy, and a prior run of scripts/build-components.sh
+
+set -euo pipefail
+
+# --- Guard: agy binary must be present BEFORE any filesystem write ---
+command -v agy >/dev/null 2>&1 || {
+  echo "Error: 'agy' CLI is required. Install Antigravity CLI first."; exit 1;
+}
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLUGIN_DIR="${REPO_DIR}/dist-antigravity-plugin/crewrig"
+
+# --- Build ---
+bash "$REPO_DIR/scripts/build-antigravity-plugin.sh" "$PLUGIN_DIR"
+
+# --- Install ---
+agy plugin install "$PLUGIN_DIR"
+
+echo ""
+echo "Plugin installed. Restart Antigravity CLI to pick up the plugin."


### PR DESCRIPTION
This PR adds the two scripts that package crewrig's compiled components into an Antigravity CLI plugin and register it with the `agy` binary (spec 0057). After running the build pipeline, a single `task install-antigravity-plugin` call builds and installs the plugin.

## How to read this PR?

Start with `scripts/build-antigravity-plugin.sh` (the assembly core), then `scripts/install-antigravity-plugin.sh` (the thin orchestrator that calls it), then the two new Taskfile.yml tasks. There are no changes to `scripts/build-extension-pivot.sh` — spec 0057 R9 explicitly excludes it.

The `docs/cli-matrix.md` rows for Antigravity CLI plugin build/install/validate (rows 13, 14, 16) are not updated here; they are deferred to spec 0058 (#428) under the agreed `[GAP — deferred to spec 0058 #428]` annotation.

## How to test this PR?

Prerequisites: `agy` binary in `$PATH`; `dist/` populated by `bash scripts/build-components.sh`.

1. Build only:
   ```sh
   bash scripts/build-antigravity-plugin.sh
   # Expected: dist-antigravity-plugin/crewrig/ created with plugin.json, skills/, agents/, commands/
   agy plugin validate dist-antigravity-plugin/crewrig
   # Expected: exit 0, no error output
   ```

2. Build + install in one command:
   ```sh
   task install-antigravity-plugin
   # Expected: plugin built, agy plugin install called, confirmation printed
   ```

3. Absent-`agy` guard:
   ```sh
   PATH=/usr/bin:/bin bash scripts/install-antigravity-plugin.sh
   # Expected: non-zero exit, "Error: 'agy' CLI is required." printed, no filesystem write
   ```

4. Absent-`dist/` guard:
   ```sh
   mv dist dist.bak && bash scripts/build-antigravity-plugin.sh; mv dist.bak dist
   # Expected: non-zero exit, error on stderr before any write
   ```

## Detailed description (for agents)

**`scripts/build-antigravity-plugin.sh`** (new, `100755`):
- Guard on `dist/` absence: prints to stderr and exits 1 before any filesystem write (R1, R3).
- Assembles output in `dist-antigravity-plugin/crewrig/` (or a caller-supplied directory).
- Writes `plugin.json` with `name: crewrig` (required); conditionally adds `version` and `description` read from `package.json` via `jq`; falls back to a bare `{"name":"crewrig"}` when `jq` is absent (R1, R2).
- Copies `dist/skills/`, `dist/agents/`, `dist/commands/` each conditionally (only when the source directory exists) (R3).
- Copies `hooks/antigravity-transcript-hooks.json` to `hooks.json` inside the plugin directory when the source file exists; silently skips when absent (R3).
- Does NOT touch `scripts/build-extension-pivot.sh` (R9).

**`scripts/install-antigravity-plugin.sh`** (new, `100755`):
- Checks for the `agy` binary as the very first statement, before any filesystem operation; exits non-zero with a human-readable message when absent (R7).
- Delegates the build step to `scripts/build-antigravity-plugin.sh` (R6).
- Calls `agy plugin install <plugin-dir>` to register the plugin under `~/.gemini/config/plugins/crewrig/` (R5).

**`Taskfile.yml`** (modified):
- Two tasks added at lines 183–189, immediately after the `install-claude-plugin` block: `build-antigravity-plugin` and `install-antigravity-plugin`, following the `<cli>-plugin` naming pattern (R8).

**`docs/cli-matrix.md`**: NOT modified in this PR. Antigravity rows 13, 14, and 16 carry `[GAP — deferred to spec 0058 #428]` and will be updated in that follow-up PR.

Closes #427