### PR TITLE
📝 Transition specs 0056 and 0057 to their implemented lifecycle state

### DIFF
--- a/specs/0056-antigravity-hooks.md
+++ b/specs/0056-antigravity-hooks.md
@@ -1,7 +1,7 @@
 ---
 id: "0056"
 slug: antigravity-hooks
-status: approved
+status: implemented
 complexity: trivial
 interaction-mode: INTERMEDIATE
 related-issue: 426

--- a/specs/0057-antigravity-plugin-build.md
+++ b/specs/0057-antigravity-plugin-build.md
@@ -1,7 +1,7 @@
 ---
 id: "0057"
 slug: antigravity-plugin-build
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 427


### PR DESCRIPTION
Advances lifecycle status of specs 0056 and 0057 from `approved` to `implemented`, matching their merged implementation PRs.

## How to read this PR?

Two one-line frontmatter edits: `status: approved` → `status: implemented` in both spec files. Implementation evidence in the detailed description.

## How to test this PR?

```bash
grep "^status:" specs/0056-antigravity-hooks.md specs/0057-antigravity-plugin-build.md
# Expected: status: implemented for both
```

## Detailed description (for agents)

- `specs/0056-antigravity-hooks.md` — `status: approved` → `status: implemented`. Implementation delivered by PR #448 (`hooks/antigravity-transcript-hooks.json`).
- `specs/0057-antigravity-plugin-build.md` — `status: approved` → `status: implemented`. Implementation delivered by PR #449 (`scripts/build-antigravity-plugin.sh`, `scripts/install-antigravity-plugin.sh`, `Taskfile.yml` entries).

No other files are changed.