### PR TITLE
📝 Transition specs 0051 and 0058 to their implemented lifecycle state

### DIFF
--- a/specs/0051-antigravity-cli-support.md
+++ b/specs/0051-antigravity-cli-support.md
@@ -1,7 +1,7 @@
 ---
 id: "0051"
 slug: antigravity-cli-support
-status: approved
+status: implemented
 complexity: large
 interaction-mode: INTERMEDIATE
 related-issue: 418

--- a/specs/0058-antigravity-cli-matrix.md
+++ b/specs/0058-antigravity-cli-matrix.md
@@ -1,7 +1,7 @@
 ---
 id: "0058"
 slug: antigravity-cli-matrix
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 428


### PR DESCRIPTION
Advances lifecycle status of specs 0051 and 0058 from `approved` to `implemented`, completing the Antigravity CLI support epic.

## How to read this PR?

Two one-line frontmatter edits. All 7 sub-specs (A–G) are merged; this marks the parent spec 0051 and the final sub-spec 0058 as implemented.

## How to test this PR?

```bash
grep "^status:" specs/0051-antigravity-cli-support.md specs/0058-antigravity-cli-matrix.md
# Expected: status: implemented for both
```

## Detailed description (for agents)

- `specs/0058-antigravity-cli-matrix.md` — `status: approved` → `status: implemented`. Implementation delivered by PR #451 (`docs/cli-matrix.md` full Antigravity column, `AGENTS.md` pillar updates, `scripts/manage-antigravity-component.sh`).
- `specs/0051-antigravity-cli-support.md` — `status: approved` → `status: implemented`. Parent large spec fully realized across 7 sub-specs: PR #439 (A/0052), #441 (B/0053), #443 (C/0054), #446 (D/0055), #448 (E/0056), #449 (F/0057), #451 (G/0058).