### PR TITLE
📝 Transition spec 0059 to its approved lifecycle state

### DIFF
--- a/specs/0059-sync-strict-path-fix.md
+++ b/specs/0059-sync-strict-path-fix.md
@@ -1,7 +1,7 @@
 ---
 id: "0059"
 slug: sync-strict-path-fix
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 365


### PR DESCRIPTION
Transitions spec 0059 (`sync-strict-path-fix`) from `draft` to `approved` following the merge of spec-PR #453 and autonomous PLAN validation (AUTO mode, issue #365).

## How to read this PR?

Single-field change: `status: draft` → `status: approved` in `specs/0059-sync-strict-path-fix.md`.

## How to test this PR?

Verify `specs/0059-sync-strict-path-fix.md` frontmatter field `status` equals `approved`.

## Detailed description (for agents)

**Modified:** `specs/0059-sync-strict-path-fix.md`
- `status: draft` → `status: approved`

Lifecycle context: spec-PR #453 merged on main (SPECS stage complete). AUTO mode PLAN validated autonomously. Implementation branch `fix/0059-sync-strict-path-fix` cut from main after spec-PR was merged.