### PR TITLE
🐛 Fix sync-from-upstream strict-path guard and restore (spec 0059)

### DIFF
--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -173,6 +173,29 @@ path_in_org_history() {
 }
 
 # ---------------------------------------------------------------------------
+# strict_blob_is_dirty <path>
+# Return 0 (dirty) iff <path> is locally modified relative to upstream.
+# Three cases:
+#   - File present locally: dirty iff blob is absent from FETCH_HEAD history.
+#   - File absent locally, present in HEAD: locally deleted → dirty.
+#   - File absent locally, absent from HEAD: new upstream file → not dirty.
+# ---------------------------------------------------------------------------
+strict_blob_is_dirty() {
+  local path="$1" current
+  if [ -e "$REPO_DIR/$path" ]; then
+    current="$(git hash-object "$REPO_DIR/$path" 2>/dev/null)"
+    upstream_has_blob "$path" "$current" && return 1
+    return 0
+  else
+    if git cat-file -e "HEAD:$path" 2>/dev/null; then
+      return 0  # was in HEAD, now absent: locally deleted
+    else
+      return 1  # new upstream file, never committed here
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # reconcile_member <path>
 # Run the spec-0020 two-tier "modified?" decision for one adopt-on-edit member
 # file that exists in BOTH the upstream tree and the working tree, restoring it
@@ -279,9 +302,10 @@ git fetch "$CANONICAL_REPO"
 IS_SHALLOW="$(git rev-parse --is-shallow-repository 2>/dev/null || echo false)"
 
 # ---------------------------------------------------------------------------
-# Dirty-core detection: strict paths only. A local modification relative to
-# FETCH_HEAD (excluding any nested org subtree) aborts the sync. adopt-on-edit
-# and excluded paths never abort.
+# Dirty-core detection: strict paths only. Upstream-history membership
+# distinguishes "stale upstream version" from genuine local modification.
+# Directory entries are enumerated member-by-member so new-in-upstream files
+# are not treated as false positives (spec 0059 R1–R2).
 # ---------------------------------------------------------------------------
 DIRTY=()
 for i in "${!PATHS[@]}"; do
@@ -292,9 +316,26 @@ for i in "${!PATHS[@]}"; do
   # dirty against a non-existent upstream object. Skip it silently here — the
   # single warning belongs to the apply loop below.
   resolves_at_fetch_head "$path" || continue
-  mapfile -d '' spec < <(pathspec_for "$path")
-  if ! git diff --quiet FETCH_HEAD -- "${spec[@]}" 2>/dev/null; then
-    DIRTY+=("$path")
+
+  if [ "$(git cat-file -t "FETCH_HEAD:$path" 2>/dev/null)" = "tree" ]; then
+    # Directory entry: check each upstream member individually.
+    dir_dirty=0
+    while IFS= read -r member; do
+      [ -n "$member" ] || continue
+      skip=0
+      while IFS= read -r excl; do
+        case "$member" in "$excl"/*|"$excl") skip=1; break ;; esac
+      done < <(excluded_children_of "$path")
+      [ "$skip" -eq 1 ] && continue
+      if strict_blob_is_dirty "$member"; then
+        dir_dirty=1
+        break
+      fi
+    done < <(git ls-tree -r --name-only FETCH_HEAD -- "$path/" 2>/dev/null)
+    [ "$dir_dirty" -eq 1 ] && DIRTY+=("$path")
+  else
+    # Blob entry: upstream-history membership check.
+    strict_blob_is_dirty "$path" && DIRTY+=("$path")
   fi
 done
 
@@ -325,8 +366,23 @@ for i in "${!PATHS[@]}"; do
         echo "Warning: skipping manifest entry absent from upstream: $path" >&2
         continue
       fi
-      mapfile -d '' spec < <(pathspec_for "$path")
-      git restore --source=FETCH_HEAD --worktree -- "${spec[@]}"
+      if [ "$(git cat-file -t "FETCH_HEAD:$path" 2>/dev/null)" = "tree" ]; then
+        # Directory entry: enumerate upstream members and restore each individually
+        # so new-in-upstream files absent from the local index are instantiated
+        # (spec 0059 R3–R4).
+        while IFS= read -r member; do
+          [ -n "$member" ] || continue
+          skip=0
+          while IFS= read -r excl; do
+            case "$member" in "$excl"/*|"$excl") skip=1; break ;; esac
+          done < <(excluded_children_of "$path")
+          [ "$skip" -eq 1 ] && continue
+          git restore --source=FETCH_HEAD --worktree -- "$member"
+        done < <(git ls-tree -r --name-only FETCH_HEAD -- "$path/" 2>/dev/null)
+      else
+        mapfile -d '' spec < <(pathspec_for "$path")
+        git restore --source=FETCH_HEAD --worktree -- "${spec[@]}"
+      fi
       ;;
     adopt-on-edit)
       # Phantom guard at the top of the arm covers both sub-branches: the

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -865,6 +865,70 @@ run_case_stderr() {
 }
 
 # ---------------------------------------------------------------------------
+# Case p — Bug 1 regression: strict blob at an older upstream version exits 0.
+# The fork is at upstream commit-1 content; upstream advances to commit-2.
+# No local modifications → guard must NOT abort.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content"
+  commit_files "$upstream" "advance" \
+    "core-file.txt" "upstream v2 content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "core-file.txt" "upstream v1 content"
+
+  run_case "case-p strict blob behind upstream exits 0 (Bug 1 regression)" "$adopter" 0
+
+  synced="$(cat "$adopter/core-file.txt" 2>/dev/null)"
+  if [ "$synced" = "upstream v2 content" ]; then
+    echo "PASS  case-p: strict blob behind upstream updated to v2"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-p: expected 'upstream v2 content', got '$synced'"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case q — Bug 2 regression: strict directory entry; upstream adds a new file
+# absent from the local index → sync must exit 0 and create the file.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "specs/0001.md" "spec one content"
+  commit_files "$upstream" "add new spec" \
+    "specs/0099-new.md" "new upstream spec"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'specs\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "specs/0001.md" "spec one content"
+
+  run_case "case-q strict dir new upstream file created (Bug 2 regression)" "$adopter" 0
+
+  if [ -f "$adopter/specs/0099-new.md" ]; then
+    echo "PASS  case-q: strict dir new upstream file instantiated"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-q: strict dir new upstream file not found after sync"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))


### PR DESCRIPTION
Fixes two bugs in `scripts/sync-from-upstream.sh` that prevent a clean fork behind upstream from syncing when strict directory entries are present (issue #365 / spec 0059).

## How to read this PR?

Start with `scripts/sync-from-upstream.sh`: the new `strict_blob_is_dirty` helper (after `path_in_org_history`), then the dirty-guard block (Bug 1), then the strict restore arm of the apply loop (Bug 2). Then read `scripts/tests/test-sync-from-upstream.sh` cases p and q at the end.

## How to test this PR?

```bash
bash scripts/tests/test-sync-from-upstream.sh
# Expected: 44 PASS, 0 FAIL
```

Reproduce the original Bug 1: create a fork at upstream commit-1, advance upstream to commit-2, run sync → should exit 0 and update the file (previously aborted with false "local modifications" error).

Reproduce the original Bug 2: create a strict directory entry, add a new file in upstream, run sync → new file must appear in the working tree (previously silently skipped).

## Detailed description (for agents)

**`scripts/sync-from-upstream.sh`** — 64 insertions, 8 deletions:
- Added `strict_blob_is_dirty <path>` helper: for present files uses `git hash-object` + `upstream_has_blob`; for absent files distinguishes locally-deleted (was in HEAD → dirty) from new-in-upstream (not in HEAD → not dirty).
- Replaced dirty-guard block: branches on `git cat-file -t FETCH_HEAD:$path` (blob vs. tree). Blob entries call `strict_blob_is_dirty`; tree entries enumerate members via `git ls-tree -r --name-only FETCH_HEAD -- $path/`, filter excluded children via `excluded_children_of`, and call `strict_blob_is_dirty` per member.
- Replaced strict restore arm: same blob vs. tree branch. Tree entries restore each upstream member individually so index-absent files are instantiated; blob entries keep the existing `pathspec_for` + `git restore` path.

**`scripts/tests/test-sync-from-upstream.sh`** — 64 insertions:
- Case p: Bug 1 regression — strict blob at older upstream version exits 0 and updates to new version.
- Case q: Bug 2 regression — strict directory with new upstream file; file is created in working tree after sync.

Closes #365