### PR TITLE
📝 Transition spec 0060 to its approved lifecycle state

### DIFF
--- a/specs/0060-curator-malformed-rate-warning.md
+++ b/specs/0060-curator-malformed-rate-warning.md
@@ -1,7 +1,7 @@
 ---
 id: "0060"
 slug: curator-malformed-rate-warning
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 376


### PR DESCRIPTION
Advances spec 0060 (`curator-malformed-rate-warning`) from `draft` to `approved` following the autonomous plan review for issue #376, which returned an APPROVE verdict.

## How to read this PR?

Single-line change: `status: draft` → `status: approved` in `specs/0060-curator-malformed-rate-warning.md`. The implementation PR (`fix/0060-curator-malformed-rate-warning`) is cut from the current `main` and will be opened separately.

## How to test this PR?

```bash
grep "^status: approved" specs/0060-curator-malformed-rate-warning.md
```

## Detailed description (for agents)

- **Modified**: `specs/0060-curator-malformed-rate-warning.md` — `status` field updated from `draft` to `approved`. All other fields unchanged.