### PR TITLE
🐛 Emit stderr warning when harness-curator malformed-friction rate exceeds threshold

### DIFF
--- a/artifacts/library/skills/harness-curator/SKILL.md
+++ b/artifacts/library/skills/harness-curator/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.5.4"
+    version: "1.6.0"
 claude:
   allowed-tools:
     - Read

--- a/artifacts/library/skills/harness-curator/scripts/curate.py
+++ b/artifacts/library/skills/harness-curator/scripts/curate.py
@@ -85,6 +85,9 @@ TARGET_OVERRIDE = os.environ.get("TARGET_REPO_OVERRIDE", "").strip()
 STDIN_FILE = os.environ.get("FROM_STDIN_FILE", "").strip()
 DEEP_MODE = os.environ.get("DEEP_MODE", "false").lower() == "true"
 DEEP_WINDOW = int(os.environ.get("DEEP_WINDOW", "500"))
+# Fraction of malformed drawers above which a stderr warning fires (spec 0060 R3/R4).
+# Clamped to [0.0, 1.0]; values outside that range are silently corrected.
+WARN_SKIPPED_RATIO = max(0.0, min(1.0, float(os.environ.get("WARN_SKIPPED_RATIO", "0.25"))))
 
 # Heuristic keyword patterns for --deep pre-filter (label → regex)
 _DEEP_HEURISTICS: Dict[str, str] = {
@@ -602,6 +605,27 @@ def compose_deep_review(
     return "\n".join(lines)
 
 
+# --- Malformed-rate warning -----------------------------------------------
+
+
+def _emit_malformed_warning(stats: Dict[str, int], threshold: float) -> None:
+    """Emit a stderr warning when the malformed-friction rate exceeds threshold.
+
+    Spec 0060 R1–R6: fires only in non-deep mode (caller's responsibility),
+    skips when total_drawers is zero, writes to stderr only."""
+    total = stats.get("total_drawers", 0)
+    if total == 0:
+        return
+    malformed = stats.get("skipped_malformed", 0)
+    if malformed / total > threshold:
+        pct = round(malformed / total * 100)
+        print(
+            f"Warning: {malformed} of {total} drawers ({pct}%) were rejected as "
+            "malformed. Check the skipped[] array for details.",
+            file=sys.stderr,
+        )
+
+
 # --- Main -----------------------------------------------------------------
 
 
@@ -677,6 +701,8 @@ def main() -> int:
             continue
         parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
+
+    _emit_malformed_warning(stats, WARN_SKIPPED_RATIO)
 
     clusters = cluster_frictions(parsed)
     stats["clusters_formed"] = len(clusters)

--- a/artifacts/library/skills/harness-curator/scripts/test.sh
+++ b/artifacts/library/skills/harness-curator/scripts/test.sh
@@ -901,5 +901,105 @@ PY
   echo "  PASS test_real second-run: stamped drawer absent from clusters"
 fi
 
+# --- Spec 0060: malformed-rate warning (R1–R7) ----------------------------
+# W1 — high malformed rate (40 %, above 25 % default): warning fires.
+# 10 drawers: 6 valid singletons (severity:high so each forms its own
+# cluster) + 4 malformed (no FRICTION: prefix → reason=malformed).
+WARN_W1_FIXTURE=$(mktemp -t crewrig-warn-w1.XXXXXX)
+trap 'rm -f "$WARN_W1_FIXTURE"' EXIT
+cat > "$WARN_W1_FIXTURE" <<'JSON'
+[
+  {"drawer_id":"wv-1","room":"tool","content":"FRICTION: w1-valid-1\n\nwriter_agent: t\nsubcategory: w1-valid-1\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv-2","room":"tool","content":"FRICTION: w1-valid-2\n\nwriter_agent: t\nsubcategory: w1-valid-2\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv-3","room":"tool","content":"FRICTION: w1-valid-3\n\nwriter_agent: t\nsubcategory: w1-valid-3\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv-4","room":"tool","content":"FRICTION: w1-valid-4\n\nwriter_agent: t\nsubcategory: w1-valid-4\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv-5","room":"tool","content":"FRICTION: w1-valid-5\n\nwriter_agent: t\nsubcategory: w1-valid-5\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv-6","room":"tool","content":"FRICTION: w1-valid-6\n\nwriter_agent: t\nsubcategory: w1-valid-6\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wm-1","room":"tool","content":"Not a friction"},
+  {"drawer_id":"wm-2","room":"tool","content":"Not a friction"},
+  {"drawer_id":"wm-3","room":"tool","content":"Not a friction"},
+  {"drawer_id":"wm-4","room":"tool","content":"Not a friction"}
+]
+JSON
+
+set +e
+WARN_W1_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W1_FIXTURE" 2>/tmp/warn-w1-stderr)
+WARN_W1_RC=$?
+set -e
+assert "warn-w1 exit code" "0" "$WARN_W1_RC"
+
+# R1/R2/R6: warning fires on stderr; stdout is clean JSON (R5).
+WARN_W1_STDERR=$(cat /tmp/warn-w1-stderr)
+echo "$WARN_W1_STDERR" | grep -q "Warning:" || {
+  echo "FAIL warn-w1: no warning on stderr (4/10 malformed = 40 % > 25 % threshold)" >&2
+  echo "--- stderr ---" >&2
+  echo "$WARN_W1_STDERR" >&2
+  exit 1
+}
+echo "  PASS warn-w1 warning fires on stderr (40 % > 25 % default)"
+
+# R3: warning text includes malformed count (4), total (10), percentage (40).
+echo "$WARN_W1_STDERR" | grep -q "4 of 10" || {
+  echo "FAIL warn-w1: stderr warning missing '4 of 10' count" >&2
+  echo "$WARN_W1_STDERR" >&2
+  exit 1
+}
+echo "  PASS warn-w1 warning contains count (4 of 10)"
+echo "$WARN_W1_STDERR" | grep -q "40%" || {
+  echo "FAIL warn-w1: stderr warning missing '40%' percentage" >&2
+  echo "$WARN_W1_STDERR" >&2
+  exit 1
+}
+echo "  PASS warn-w1 warning contains percentage (40%)"
+
+# R5: stdout must be valid JSON (warning did not leak into stdout).
+if ! echo "$WARN_W1_STDOUT" | python3 -c "import json,sys; json.load(sys.stdin)" \
+    >/dev/null 2>&1; then
+  echo "FAIL warn-w1: stdout is not valid JSON (warning may have leaked)" >&2
+  echo "$WARN_W1_STDOUT" >&2
+  exit 1
+fi
+echo "  PASS warn-w1 stdout is valid JSON (no stderr contamination)"
+
+# R1/R2 stats sanity: 10 drawers, 6 valid, 4 malformed.
+assert "warn-w1 stats.total_drawers"    "10" "$(echo "$WARN_W1_STDOUT" | jq -r '.stats.total_drawers')"
+assert "warn-w1 stats.valid_frictions"  "6"  "$(echo "$WARN_W1_STDOUT" | jq -r '.stats.valid_frictions')"
+assert "warn-w1 stats.skipped_malformed" "4" "$(echo "$WARN_W1_STDOUT" | jq -r '.stats.skipped_malformed')"
+
+# W2 — low malformed rate (20 %, below 25 % default): warning is silent.
+# 10 drawers: 8 valid + 2 malformed.
+WARN_W2_FIXTURE=$(mktemp -t crewrig-warn-w2.XXXXXX)
+trap 'rm -f "$WARN_W2_FIXTURE"' EXIT
+cat > "$WARN_W2_FIXTURE" <<'JSON'
+[
+  {"drawer_id":"wv2-1","room":"tool","content":"FRICTION: w2-valid-1\n\nwriter_agent: t\nsubcategory: w2-valid-1\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-2","room":"tool","content":"FRICTION: w2-valid-2\n\nwriter_agent: t\nsubcategory: w2-valid-2\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-3","room":"tool","content":"FRICTION: w2-valid-3\n\nwriter_agent: t\nsubcategory: w2-valid-3\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-4","room":"tool","content":"FRICTION: w2-valid-4\n\nwriter_agent: t\nsubcategory: w2-valid-4\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-5","room":"tool","content":"FRICTION: w2-valid-5\n\nwriter_agent: t\nsubcategory: w2-valid-5\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-6","room":"tool","content":"FRICTION: w2-valid-6\n\nwriter_agent: t\nsubcategory: w2-valid-6\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-7","room":"tool","content":"FRICTION: w2-valid-7\n\nwriter_agent: t\nsubcategory: w2-valid-7\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wv2-8","room":"tool","content":"FRICTION: w2-valid-8\n\nwriter_agent: t\nsubcategory: w2-valid-8\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
+  {"drawer_id":"wm2-1","room":"tool","content":"Not a friction"},
+  {"drawer_id":"wm2-2","room":"tool","content":"Not a friction"}
+]
+JSON
+
+set +e
+WARN_W2_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W2_FIXTURE" 2>/tmp/warn-w2-stderr)
+WARN_W2_RC=$?
+set -e
+assert "warn-w2 exit code" "0" "$WARN_W2_RC"
+
+# R1/R2: no warning on stderr (2/10 = 20 % < 25 % default).
+WARN_W2_STDERR=$(cat /tmp/warn-w2-stderr)
+if echo "$WARN_W2_STDERR" | grep -q "Warning:"; then
+  echo "FAIL warn-w2: unexpected warning on stderr (2/10 malformed = 20 % < 25 % threshold)" >&2
+  echo "--- stderr ---" >&2
+  echo "$WARN_W2_STDERR" >&2
+  exit 1
+fi
+echo "  PASS warn-w2 warning silent (20 % < 25 % default threshold)"
+
 echo ""
 echo "OK: harness-curate smoke test passed."

--- a/artifacts/library/skills/harness-curator/scripts/test.sh
+++ b/artifacts/library/skills/harness-curator/scripts/test.sh
@@ -902,11 +902,18 @@ PY
 fi
 
 # --- Spec 0060: malformed-rate warning (R1–R7) ----------------------------
+# Allocate all temp files up front; a single trap cleans them all on EXIT.
+WARN_W1_FIXTURE=$(mktemp -t crewrig-warn-w1.XXXXXX)
+WARN_W1_STDERR_FILE=$(mktemp -t crewrig-warn-w1-err.XXXXXX)
+WARN_W2_FIXTURE=$(mktemp -t crewrig-warn-w2.XXXXXX)
+WARN_W2_STDERR_FILE=$(mktemp -t crewrig-warn-w2-err.XXXXXX)
+WARN_W3_FIXTURE=$(mktemp -t crewrig-warn-w3.XXXXXX)
+WARN_W3_STDERR_FILE=$(mktemp -t crewrig-warn-w3-err.XXXXXX)
+trap 'rm -f "$WARN_W1_FIXTURE" "$WARN_W1_STDERR_FILE" "$WARN_W2_FIXTURE" "$WARN_W2_STDERR_FILE" "$WARN_W3_FIXTURE" "$WARN_W3_STDERR_FILE"' EXIT
+
 # W1 — high malformed rate (40 %, above 25 % default): warning fires.
 # 10 drawers: 6 valid singletons (severity:high so each forms its own
 # cluster) + 4 malformed (no FRICTION: prefix → reason=malformed).
-WARN_W1_FIXTURE=$(mktemp -t crewrig-warn-w1.XXXXXX)
-trap 'rm -f "$WARN_W1_FIXTURE"' EXIT
 cat > "$WARN_W1_FIXTURE" <<'JSON'
 [
   {"drawer_id":"wv-1","room":"tool","content":"FRICTION: w1-valid-1\n\nwriter_agent: t\nsubcategory: w1-valid-1\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
@@ -923,13 +930,13 @@ cat > "$WARN_W1_FIXTURE" <<'JSON'
 JSON
 
 set +e
-WARN_W1_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W1_FIXTURE" 2>/tmp/warn-w1-stderr)
+WARN_W1_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W1_FIXTURE" 2>"$WARN_W1_STDERR_FILE")
 WARN_W1_RC=$?
 set -e
 assert "warn-w1 exit code" "0" "$WARN_W1_RC"
 
 # R1/R2/R6: warning fires on stderr; stdout is clean JSON (R5).
-WARN_W1_STDERR=$(cat /tmp/warn-w1-stderr)
+WARN_W1_STDERR=$(cat "$WARN_W1_STDERR_FILE")
 echo "$WARN_W1_STDERR" | grep -q "Warning:" || {
   echo "FAIL warn-w1: no warning on stderr (4/10 malformed = 40 % > 25 % threshold)" >&2
   echo "--- stderr ---" >&2
@@ -968,8 +975,6 @@ assert "warn-w1 stats.skipped_malformed" "4" "$(echo "$WARN_W1_STDOUT" | jq -r '
 
 # W2 — low malformed rate (20 %, below 25 % default): warning is silent.
 # 10 drawers: 8 valid + 2 malformed.
-WARN_W2_FIXTURE=$(mktemp -t crewrig-warn-w2.XXXXXX)
-trap 'rm -f "$WARN_W2_FIXTURE"' EXIT
 cat > "$WARN_W2_FIXTURE" <<'JSON'
 [
   {"drawer_id":"wv2-1","room":"tool","content":"FRICTION: w2-valid-1\n\nwriter_agent: t\nsubcategory: w2-valid-1\ncanonical: https://github.com/crewrig/crewrig\nseverity: high\nevidence:\n  - x.md:1\n"},
@@ -986,13 +991,13 @@ cat > "$WARN_W2_FIXTURE" <<'JSON'
 JSON
 
 set +e
-WARN_W2_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W2_FIXTURE" 2>/tmp/warn-w2-stderr)
+WARN_W2_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W2_FIXTURE" 2>"$WARN_W2_STDERR_FILE")
 WARN_W2_RC=$?
 set -e
 assert "warn-w2 exit code" "0" "$WARN_W2_RC"
 
 # R1/R2: no warning on stderr (2/10 = 20 % < 25 % default).
-WARN_W2_STDERR=$(cat /tmp/warn-w2-stderr)
+WARN_W2_STDERR=$(cat "$WARN_W2_STDERR_FILE")
 if echo "$WARN_W2_STDERR" | grep -q "Warning:"; then
   echo "FAIL warn-w2: unexpected warning on stderr (2/10 malformed = 20 % < 25 % threshold)" >&2
   echo "--- stderr ---" >&2
@@ -1000,6 +1005,29 @@ if echo "$WARN_W2_STDERR" | grep -q "Warning:"; then
   exit 1
 fi
 echo "  PASS warn-w2 warning silent (20 % < 25 % default threshold)"
+
+# W3 — empty wing (total_drawers == 0): no warning (spec R7).
+echo '[]' > "$WARN_W3_FIXTURE"
+
+set +e
+WARN_W3_STDOUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$WARN_W3_FIXTURE" 2>"$WARN_W3_STDERR_FILE")
+WARN_W3_RC=$?
+set -e
+assert "warn-w3 exit code" "0" "$WARN_W3_RC"
+
+# R7: total_drawers == 0 → no warning regardless of threshold.
+WARN_W3_STDERR=$(cat "$WARN_W3_STDERR_FILE")
+if echo "$WARN_W3_STDERR" | grep -q "Warning:"; then
+  echo "FAIL warn-w3: unexpected warning on stderr (empty wing — total_drawers == 0)" >&2
+  echo "--- stderr ---" >&2
+  echo "$WARN_W3_STDERR" >&2
+  exit 1
+fi
+echo "  PASS warn-w3 warning silent when total_drawers == 0 (R7)"
+
+# Sanity: empty fixture must report 0 drawers in stats.
+assert "warn-w3 stats.total_drawers"     "0" "$(echo "$WARN_W3_STDOUT" | jq -r '.stats.total_drawers')"
+assert "warn-w3 stats.skipped_malformed" "0" "$(echo "$WARN_W3_STDOUT" | jq -r '.stats.skipped_malformed')"
 
 echo ""
 echo "OK: harness-curate smoke test passed."


### PR DESCRIPTION
Implements spec 0060: when the fraction of malformed drawers in a curator sweep exceeds the configurable threshold (`WARN_SKIPPED_RATIO`, default 25%), a human-readable warning is emitted on stderr so the signal is visible at runtime rather than buried in the JSON `stats.skipped_malformed` field.

## How to read this PR?

Start with `specs/0060-curator-malformed-rate-warning.md` (already on `main` via PR #457) for the WHAT, then read `artifacts/library/skills/harness-curator/scripts/curate.py` — three isolated hunks: the `WARN_SKIPPED_RATIO` constant (~line 90), the `_emit_malformed_warning` helper (~line 611), and its call-site in `main()` (~line 705). `SKILL.md` is a MINOR version bump only (1.5.4 → 1.6.0). `scripts/test.sh` adds cases W1 and W2.

## How to test this PR?

```bash
# From the repo root or .worktrees/376/:
bash artifacts/library/skills/harness-curator/scripts/test.sh
# Expect: all assertions pass including "warn-w1 warning fires on stderr" and "warn-w2 warning silent"

# Manual smoke: pipe a fixture with 4/10 malformed drawers
echo '[{"drawer_id":"m1","room":"tool","content":"Not a friction"},{"drawer_id":"v1","room":"tool","content":"FRICTION: t\n\nwriter_agent: a\nevidence:\n  - x.md:1\n"}]' \
  | WARN_SKIPPED_RATIO=0.0 bash artifacts/library/skills/harness-curator/scripts/curate.sh --from-stdin --dry-run
# Expect: "Warning: … were rejected as malformed" on stderr, valid JSON on stdout
```

## Detailed description (for agents)

- **`curate.py`**: Added `WARN_SKIPPED_RATIO` constant (env-var override, clamped [0.0, 1.0], default 0.25). Added `_emit_malformed_warning(stats, threshold)` that reads `total_drawers` and `skipped_malformed` from the stats dict and prints a human-readable warning to `sys.stderr` when the ratio exceeds the threshold and total is non-zero. Called once in `main()` after the parsing loop, before clustering — fires only in normal mode (not `--deep`, per spec R1). Spec R5 (stderr-only, stdout unmodified) is enforced by using `file=sys.stderr` exclusively.
- **`SKILL.md`**: Version bumped 1.5.4 → 1.6.0 (additive behavior — MINOR per project convention).
- **`test.sh`**: Two new regression cases using inline JSON fixtures piped via `--from-stdin --dry-run`, capturing stderr to a temp file and asserting presence / absence of `"Warning:"` alongside the stats assertions.

Closes #376