### PR TITLE
📝 Transition spec 0060 to its implemented lifecycle state

### DIFF
--- a/specs/0060-curator-malformed-rate-warning.md
+++ b/specs/0060-curator-malformed-rate-warning.md
@@ -1,7 +1,7 @@
 ---
 id: "0060"
 slug: curator-malformed-rate-warning
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 376


### PR DESCRIPTION
Advances spec 0060 (`curator-malformed-rate-warning`) from `approved` to `implemented` following the merge of PR #459.

## How to read this PR?

Single-field diff: `status: approved` → `status: implemented` in `specs/0060-curator-malformed-rate-warning.md`.

## How to test this PR?

```bash
grep 'status: implemented' specs/0060-curator-malformed-rate-warning.md
```

## Detailed description (for agents)

Lifecycle metadata update only. Implementation landed in PR #459. No code or documentation changes.