### PR TITLE
📝 Transition spec 0061 to its implemented lifecycle state

### DIFF
--- a/specs/0061-antigravity-gemini-md-concat.md
+++ b/specs/0061-antigravity-gemini-md-concat.md
@@ -1,7 +1,7 @@
 ---
 id: "0061"
 slug: antigravity-gemini-md-concat
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 461


### PR DESCRIPTION
Transitions `specs/0061-antigravity-gemini-md-concat.md` from `approved` to `implemented` now that PR #463 has been merged.

## How to read this PR?

Single-field frontmatter change: `status: approved` → `status: implemented`.

## How to test this PR?

Verify the spec frontmatter reflects `status: implemented`.

## Detailed description (for agents)

- File: `specs/0061-antigravity-gemini-md-concat.md`
- Change: `status` field updated from `approved` to `implemented`
- Trigger: implementation PR #463 merged on 2026-06-20