### PR TITLE
🐛 Fix build-antigravity-plugin.sh source paths (spec 0062)

### DIFF
--- a/scripts/build-antigravity-plugin.sh
+++ b/scripts/build-antigravity-plugin.sh
@@ -4,9 +4,17 @@
 # Usage:
 #   bash scripts/build-antigravity-plugin.sh [output-dir]
 #
-# Reads compiled components from dist/ and generates a self-contained Antigravity
-# CLI plugin directory containing plugin.json, skills/, agents/, commands/, and
-# an optional hooks.json copied from hooks/antigravity-transcript-hooks.json.
+# Reads compiled components from the Antigravity build output paths and generates
+# a self-contained Antigravity CLI plugin directory containing plugin.json,
+# skills/, agents/, and an optional hooks.json.
+#
+# Source paths (spec 0062):
+#   Core tier  : <repo>/.agents/skills/  and  <repo>/.agents/agents/
+#   Non-core   : dist/<tier>/.agents/skills/  and  dist/<tier>/.agents/agents/
+#                for each tier directory under dist/ that contains a .agents/ subtree
+#
+# Commands are emitted as skills in the Antigravity build; no separate commands/
+# directory is produced or included.
 #
 # The dist/ directory must be present (run scripts/build-components.sh first).
 
@@ -25,8 +33,9 @@ rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
 echo "Building Antigravity CLI plugin: crewrig"
-echo "  Source: $REPO_DIR/dist"
-echo "  Output: $OUTPUT_DIR"
+echo "  Core source : $REPO_DIR/.agents/"
+echo "  Dist source : $REPO_DIR/dist/<tier>/.agents/"
+echo "  Output      : $OUTPUT_DIR"
 
 # --- Generate plugin.json ---
 # Populate name (required), plus optional version and description from release
@@ -58,23 +67,41 @@ else
 fi
 echo "  Generated: plugin.json"
 
-# --- Copy skills/ ---
-if [ -d "$REPO_DIR/dist/skills" ]; then
-  cp -r "$REPO_DIR/dist/skills" "$OUTPUT_DIR/skills"
-  echo "  Copied: skills/"
-fi
+# --- Merge skills/ and agents/ from all tiers (spec 0062) ---
+# build-components.sh --target antigravity writes:
+#   core tier  → <repo>/.agents/<component>/<name>/
+#   non-core   → dist/<tier>/.agents/<component>/<name>/
+# Commands are emitted as skills; no separate commands/ tree exists.
+merge_component() {
+  local component="$1"
+  local found=0
 
-# --- Copy agents/ ---
-if [ -d "$REPO_DIR/dist/agents" ]; then
-  cp -r "$REPO_DIR/dist/agents" "$OUTPUT_DIR/agents"
-  echo "  Copied: agents/"
-fi
+  # Core tier
+  local core_src="$REPO_DIR/.agents/$component"
+  if [ -d "$core_src" ]; then
+    mkdir -p "$OUTPUT_DIR/$component"
+    cp -r "$core_src/." "$OUTPUT_DIR/$component/"
+    found=1
+  fi
 
-# --- Copy commands/ ---
-if [ -d "$REPO_DIR/dist/commands" ]; then
-  cp -r "$REPO_DIR/dist/commands" "$OUTPUT_DIR/commands"
-  echo "  Copied: commands/"
-fi
+  # Non-core tiers (library, community, org, …)
+  if [ -d "$REPO_DIR/dist" ]; then
+    for tier_dir in "$REPO_DIR/dist"/*/; do
+      [ -d "$tier_dir" ] || continue
+      local tier_src="${tier_dir}.agents/$component"
+      if [ -d "$tier_src" ]; then
+        mkdir -p "$OUTPUT_DIR/$component"
+        cp -r "$tier_src/." "$OUTPUT_DIR/$component/"
+        found=1
+      fi
+    done
+  fi
+
+  [ "$found" -eq 1 ] && echo "  Merged: $component/"
+}
+
+merge_component "skills"
+merge_component "agents"
 
 # --- Copy hooks (conditional) ---
 HOOKS_SRC="$REPO_DIR/hooks/antigravity-transcript-hooks.json"


### PR DESCRIPTION
Fixes the silent path mismatch in `scripts/build-antigravity-plugin.sh` (issue #466): the script was reading `dist/skills`, `dist/agents`, and `dist/commands` — paths that `build-components.sh` never creates — causing the plugin to install without skills or agents.

## How to read this PR?

Single file change: `scripts/build-antigravity-plugin.sh`. The three broken copy blocks (lines 62–77) are replaced by a `merge_component` helper that reads from the correct Antigravity build output paths.

## How to test this PR?

```bash
bash scripts/build-components.sh --target antigravity
bash scripts/install-antigravity-plugin.sh
agy plugin list
```

Expected: `crewrig` entry with `components` containing `skills`, `agents`, and `hooks`.

## Detailed description (for agents)

**Changed:** `scripts/build-antigravity-plugin.sh`

- **Removed:** Three copy blocks reading `dist/skills`, `dist/agents`, `dist/commands` (none of these paths are written by `build-components.sh`).
- **Added:** `merge_component` shell function that reads from:
  - Core tier: `<repo>/.agents/<component>/` (populated by `build-components.sh --target antigravity` for `tier=core`)
  - Non-core tiers: `dist/<tier>/.agents/<component>/` for each tier directory under `dist/` containing a `.agents/` subtree
  - Merges into `$OUTPUT_DIR/<component>/`; later tiers overwrite on name collision (no collision expected).
- **Removed:** `dist/commands` copy block (commands are emitted as skills in the Antigravity build — spec 0062 R4).
- **Updated:** Script header comment to document the corrected source paths.
- **Updated:** Build echo line to show accurate source paths.

**CLI Matrix Maintenance:** Consulted `docs/cli-matrix.md` rows 13 and 14. Row 13 (`build-antigravity-plugin.sh`) and row 14 (`install-antigravity-plugin.sh`) describe these scripts by name and purpose; the internal path fix does not change the described behaviour or the CLI-matrix content. No update required.

Closes #466