### PR TITLE
📝 Transition spec 0062 to its implemented lifecycle state

### DIFF
--- a/specs/0062-fix-antigravity-plugin-paths.md
+++ b/specs/0062-fix-antigravity-plugin-paths.md
@@ -1,7 +1,7 @@
 ---
 id: "0062"
 slug: fix-antigravity-plugin-paths
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 466


### PR DESCRIPTION
Transitions `specs/0062-fix-antigravity-plugin-paths.md` from `approved` to `implemented` following the merge of PR #468.