### PR TITLE
📝 Transition spec 0063 to its implemented lifecycle state

### DIFF
--- a/specs/0063-antigravity-extension-formalism.md
+++ b/specs/0063-antigravity-extension-formalism.md
@@ -1,7 +1,7 @@
 ---
 id: "0063"
 slug: antigravity-extension-formalism
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 470


### PR DESCRIPTION
Transitions spec 0063 (Antigravity extension formalism) from `approved` to `implemented` following the merge of PR #472.