### PR TITLE
📝 Transition spec 0064 to its implemented lifecycle state

### DIFF
--- a/specs/0064-sync-upstream-deletion.md
+++ b/specs/0064-sync-upstream-deletion.md
@@ -1,7 +1,7 @@
 ---
 id: "0064"
 slug: sync-upstream-deletion
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 474


### PR DESCRIPTION
Metadata-only lifecycle transition: `specs/0064-sync-upstream-deletion.md` moves from `approved` to `implemented` following the merge of implementation PR #476.

## How to read this PR?

Single file changed: `specs/0064-sync-upstream-deletion.md`, one-line diff (`status: approved` → `status: implemented`).

## How to test this PR?

No code change. Verify the diff is metadata-only.

## Detailed description (for agents)

`specs/0064-sync-upstream-deletion.md`: `status` field updated from `approved` to `implemented`. Normative content (`## Intent`, `## Requirements`, `## Scenarios`, `## Out of scope`, `## Open questions`) and all identifying fields (`id`, `slug`, `version`) are unchanged, per `docs/spec-format.md` → *Lifecycle states → Recording a status transition*.