### PR TITLE
📝 Transition spec 0065 to its implemented lifecycle state

### DIFF
--- a/specs/0065-copilot-plugin-build.md
+++ b/specs/0065-copilot-plugin-build.md
@@ -1,7 +1,7 @@
 ---
 id: "0065"
 slug: copilot-plugin-build
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 481


### PR DESCRIPTION
Transitions spec 0065 (`copilot-plugin-build`) from `status: draft` to `status: implemented` following the successful merge of PR #483.

## How to read this PR?

Single field change: `status: draft` → `status: implemented` in `specs/0065-copilot-plugin-build.md`. No normative content is modified — this is a lifecycle metadata update only, which is explicitly allowed by `docs/spec-format.md` (lifecycle metadata is exempt from the spec immutability freeze).

## How to test this PR?

```bash
grep 'status:' specs/0065-copilot-plugin-build.md
# Expected: status: implemented
```

## Detailed description (for agents)

Single file modified: `specs/0065-copilot-plugin-build.md`
- `status: draft` → `status: implemented`

Implementation PR #483 (`✨ Add Copilot CLI plugin build & install (spec 0065)`) merged on 2026-06-22. Issue #481 closed.