### PR TITLE
📝 Transition spec 0066 to its implemented lifecycle state

### DIFF
--- a/specs/0066-idea-convergence-stage.md
+++ b/specs/0066-idea-convergence-stage.md
@@ -1,7 +1,7 @@
 ---
 id: "0066"
 slug: idea-convergence-stage
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 485


### PR DESCRIPTION
Transitions `specs/0066-idea-convergence-stage.md` from `status: draft` to `status: implemented`, following the merge of the implementation PR #487.

## How to read this PR?

Single frontmatter field change (`status: draft` → `status: implemented`) in `specs/0066-idea-convergence-stage.md`. This is a metadata-only edit permitted by `docs/spec-format.md` → *Lifecycle states → Recording a status transition*.

## How to test this PR?

```bash
head -10 specs/0066-idea-convergence-stage.md
# Expected: status: implemented
```

## Detailed description (for agents)

- `specs/0066-idea-convergence-stage.md`: `status` field changed from `draft` to `implemented`.
- No normative content edited — only the lifecycle-tracking metadata field.
- Authority: implementation team's `pr-logbook`, per `docs/spec-format.md` → *Lifecycle states* table (row `implemented`).
- Trigger: merge of implementation PR #487 (feat/0485-idea-convergence-stage).