### PR TITLE
📝 Add spec 0067 — reduce AGENTS.md below the most-restrictive CLI budget

### DIFF
--- a/specs/0067-agents-md-size-budget.md
+++ b/specs/0067-agents-md-size-budget.md
@@ -1,0 +1,86 @@
+---
+id: "0067"
+slug: agents-md-size-budget
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 495
+version: 1.0.0
+---
+
+# Reduce AGENTS.md below the most-restrictive CLI context budget
+
+## Intent
+
+`AGENTS.md` stays small enough that every supported CLI loads it in full —
+including the most space-constrained one — so no working rule is ever silently
+dropped when an agent loads its context. The single file continues to serve
+every CLI unchanged; only its size shrinks, and every rule it once carried
+remains reachable to any agent.
+
+## Requirements
+
+1. `AGENTS.md` SHALL NOT meet or exceed the budget of the most-restrictive
+   supported CLI, fixed at **22 000 bytes** — a safety margin held below the
+   tightest current truncation point (Antigravity, reported at 24 000 bytes) so
+   that surrounding load-time overhead cannot push the effective size past that
+   point.
+2. The project build SHALL fail when `AGENTS.md` meets or exceeds the budget,
+   and the failure message SHALL state the measured size and the budget.
+3. The budget SHALL be measured in bytes.
+4. The budget SHALL apply to `AGENTS.md` alone; reference material relocated to
+   subordinate documents SHALL NOT count against it.
+5. Every rule present in `AGENTS.md` before the reduction SHALL remain
+   reachable afterwards — stated inline, or preserved in a referenced document
+   linked from `AGENTS.md`. No rule SHALL be deleted or have its meaning altered
+   by the reduction.
+6. `AGENTS.md` SHALL remain a single file loaded identically by every supported
+   CLI; the reduction SHALL NOT introduce a per-CLI variant of the file.
+
+## Scenarios
+
+**Scenario:** AGENTS.md within budget passes the build
+
+Given `AGENTS.md` is 21 500 bytes
+When  the size check runs during the build
+Then  the check passes and reports the size against the 22 000-byte budget
+
+**Scenario:** AGENTS.md over budget fails the build
+
+Given `AGENTS.md` is 22 500 bytes
+When  the size check runs during the build
+Then  the build fails with a message stating the measured size (22 500) and the
+      budget (22 000)
+
+**Scenario:** a relocated rule stays reachable
+
+Given a rule that lived inline in `AGENTS.md` before the reduction
+And   that rule was moved into a subordinate referenced document to fit the budget
+When  an agent loads its context after the reduction
+Then  the rule is still reachable — either inline or through the reference in
+      `AGENTS.md` — with its meaning unchanged
+
+## Out of scope
+
+- The user-space layered context system and every MemPalace, runtime-retrieval,
+  or cross-CLI filesystem-read (sandbox) concern — owned solely by
+  issue #496. `AGENTS.md` has no relationship to those.
+- Per-CLI generated bundles and any build or generation step for `AGENTS.md`;
+  it remains a single static file.
+- `AGENTS.org.md` (adopter-owned): its own size is not changed here. Its
+  contribution to any concatenated load-time size is acknowledged only as the
+  rationale for the safety margin in requirement 1.
+- Which specific sections of `AGENTS.md` are relocated — a PLAN/DEV decision,
+  not a spec-level requirement.
+- Rewriting or re-scoping any rule; the reduction relocates content, never
+  changes what a rule obliges, permits, or forbids.
+
+## Open questions
+
+- [USER-PARKED] The 24 000-byte Antigravity truncation figure is not documented
+  in `docs/` or `specs/` on `main`, and it is unconfirmed whether Antigravity
+  truncates `AGENTS.md` directly or a concatenated context file (see
+  spec 0061). The 22 000-byte safety margin (requirement 1) was chosen
+  deliberately to absorb this uncertainty; confirming an authoritative source
+  for the limit and the exact file it protects is deferred to PLAN/DEV, with the
+  owner's recorded consent to proceed under the margin.


### PR DESCRIPTION
This spec-PR qualifies the WHAT for issue #495: keep the single static `AGENTS.md` small enough that every supported CLI loads it whole, below the most-restrictive budget. It ships exactly one file under `/specs/` per the two-PR spec workflow and does not touch any implementation.

## How to read this PR?

Read the one new file top to bottom — `specs/0067-agents-md-size-budget.md`:

1. **Frontmatter** — `id 0067`, `complexity: small`, `interaction-mode: INTERMEDIATE`, `related-issue: 495`.
2. **`## Intent`** — the WHAT, no HOW words.
3. **`## Requirements`** — six `SHALL`/`MUST` lines. The load-bearing ones: R1 (22 000-byte budget, a margin under Antigravity's reported 24 000), R4 (budget scoped to `AGENTS.md` alone, `docs/` exempt), R5 (bytes, not characters), R6 (single file, no per-CLI variant).
4. **`## Scenarios`** — happy path, over-budget failure, and a rule-preservation scenario.
5. **`## Out of scope`** — explicitly excludes MemPalace / retrieval / sandbox (owned by sibling #496) and any build-time per-CLI generation.
6. **`## Open questions`** — one `[USER-PARKED]` grounding note (the 24 000 figure is undocumented on `main`; the margin absorbs the uncertainty, source confirmation deferred to PLAN/DEV with owner consent).

Non-obvious decision: the CI gate already exists (`scripts/check-agents-size.sh`, threshold 35 840 bytes). This spec **tightens** that budget rather than introducing a new mechanism — that realization is left to DEV.

## How to test this PR?

```sh
markdownlint specs/0067-agents-md-size-budget.md
```

Expected: clean. Verify by inspection that the five mandatory body sections are present in order (`## Intent`, `## Requirements`, `## Scenarios`, `## Out of scope`, `## Open questions`) and that the frontmatter carries every required field from `docs/spec-format.md`.

## Detailed description (for agents)

- **Added:** `specs/0067-agents-md-size-budget.md` — a single `draft`-status spec conforming to `docs/spec-format.md`.
- **Origin:** IDEA session #490 (parent #489), winning artifact `[COMPOSITION v2 — locked]`, unanimity. This spec realizes the **AGENTS.md (project scope)** half of the scope partition, as clarified by the session owner's plan-time corrections (recorded in #490's closing comment): `AGENTS.md` is static, single-file, byte-budgeted, most-restrictive-CLI-driven, with zero MemPalace/retrieval/sandbox involvement.
- **Grounding performed:** measured `AGENTS.md` at 34 253 bytes; found the pre-existing `scripts/check-agents-size.sh` gate (35 840-byte threshold); confirmed the byte-vs-character distinction (33 513 chars); confirmed spec 0011 as the docs/-extraction precedent. The undocumented 24 000-byte Antigravity figure is parked as a `[USER-PARKED]` open question.
- **Independence:** no dependency on sibling #496. The implementation branch for #495 will be cut only after this spec-PR merges (spec-PR ordering rule).

Closes #495
