### PR TITLE
📝 Transition spec 0067 to approved

### DIFF
--- a/specs/0067-agents-md-size-budget.md
+++ b/specs/0067-agents-md-size-budget.md
@@ -1,7 +1,7 @@
 ---
 id: "0067"
 slug: agents-md-size-budget
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 495


### PR DESCRIPTION
Records the SPECS-stage approval of spec 0067 by transitioning its frontmatter `status` from `draft` to `approved`. Metadata-only edit, permitted by `docs/spec-format.md` → *Recording a status transition*.

## How to read this PR?

One-line diff on `specs/0067-agents-md-size-budget.md`: `status: draft` → `status: approved`. No normative content (body sections, `id`, `slug`, `version`) is touched.

## How to test this PR?

```sh
git diff main -- specs/0067-agents-md-size-budget.md
```

Expected: exactly one changed line (the `status` field). `lint-specs` stays green.

## Detailed description (for agents)

- **Modified:** `specs/0067-agents-md-size-budget.md` frontmatter — `status` field only.
- **Why:** spec-PR #497 merged on `main`, which per `docs/spec-format.md` → *Lifecycle states* triggers the `draft → approved` transition (authority: spec reviewer under INTERMEDIATE mode). This edit is the accompanying artifact.
- **Guarantee:** append-only rule respected — no body line, no `id`, `slug`, or `version` changed.

Context: spec issue #495, implementation issue #498, IDEA session #490.
