### PR TITLE
📝 Transition spec 0067 to implemented

### DIFF
--- a/specs/0067-agents-md-size-budget.md
+++ b/specs/0067-agents-md-size-budget.md
@@ -1,7 +1,7 @@
 ---
 id: "0067"
 slug: agents-md-size-budget
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 495


### PR DESCRIPTION
Records that spec 0067 is now realized by transitioning its frontmatter `status` from `approved` to `implemented`. Metadata-only edit, permitted by `docs/spec-format.md` → *Recording a status transition*.

## How to read this PR?

One-line diff on `specs/0067-agents-md-size-budget.md`: `status: approved` → `status: implemented`. No normative content touched.

## How to test this PR?

```sh
git diff main -- specs/0067-agents-md-size-budget.md
```

Expected: exactly one changed line (the `status` field); `lint-specs` green.

## Detailed description (for agents)

- **Modified:** `specs/0067-agents-md-size-budget.md` frontmatter — `status` only.
- **Why:** implementation PR #500 (Closes #498) merged on `main`, which per `docs/spec-format.md` → *Lifecycle states* triggers the `approved → implemented` transition (authority: the implementation team's pr-logbook).
- **Guarantee:** append-only rule respected — no body line, no `id`/`slug`/`version` changed.

Context: spec issue #495, implementation issue #498, IDEA session #490.
