### PR TITLE
📝 Transition spec 0068 to approved

### DIFF
--- a/specs/0068-user-space-context-retrieval.md
+++ b/specs/0068-user-space-context-retrieval.md
@@ -1,7 +1,7 @@
 ---
 id: "0068"
 slug: user-space-context-retrieval
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 496


### PR DESCRIPTION
Records the SPECS-stage approval of spec 0068 by transitioning its frontmatter `status` from `draft` to `approved`. Metadata-only edit per `docs/spec-format.md` → *Recording a status transition*.

## How to read this PR?

One-line diff on `specs/0068-user-space-context-retrieval.md`: `status: draft` → `status: approved`. No normative content touched.

## How to test this PR?

```sh
git diff main -- specs/0068-user-space-context-retrieval.md
```

Expected: exactly one changed line; `lint-specs` green.

## Detailed description (for agents)

- **Modified:** `specs/0068-user-space-context-retrieval.md` frontmatter — `status` only.
- **Why:** spec-PR #502 merged on `main`, triggering the `draft → approved` transition (authority: spec reviewer under INTERMEDIATE mode).
- **Guarantee:** append-only rule respected — no body line, no `id`/`slug`/`version` changed.

Context: spec issue #496, implementation issue #503, IDEA session #490.
