### PR TITLE
📝 Transition spec 0068 to implemented

### DIFF
--- a/specs/0068-user-space-context-retrieval.md
+++ b/specs/0068-user-space-context-retrieval.md
@@ -1,7 +1,7 @@
 ---
 id: "0068"
 slug: user-space-context-retrieval
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 496


### PR DESCRIPTION
Records that spec 0068 is now realized by transitioning its frontmatter `status` from `approved` to `implemented`. Metadata-only edit per `docs/spec-format.md` → *Recording a status transition*.

## How to read this PR?

One-line diff on `specs/0068-user-space-context-retrieval.md`: `status: approved` → `status: implemented`. No normative content touched.

## How to test this PR?

```sh
git diff main -- specs/0068-user-space-context-retrieval.md
```

Expected: exactly one changed line; `lint-specs` green.

## Detailed description (for agents)

- **Modified:** `specs/0068-user-space-context-retrieval.md` frontmatter — `status` only.
- **Why:** implementation PR #505 (Closes #503) merged on `main`, triggering the `approved → implemented` transition (authority: the implementation team's pr-logbook).
- **Guarantee:** append-only rule respected — no body line, no `id`/`slug`/`version` changed.

Context: spec issue #496, implementation issue #503, IDEA session #490.
