### PR TITLE
📝 Add spec 0069 — MemPalace layered wake-up parity gap and bounded sweep

### DIFF
--- a/specs/0069-mempalace-wakeup-parity.md
+++ b/specs/0069-mempalace-wakeup-parity.md
@@ -1,0 +1,87 @@
+---
+id: "0069"
+slug: mempalace-wakeup-parity
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 415
+version: 1.0.0
+---
+
+# Record the MemPalace layered-wake-up parity gap and bound the session sweep
+
+## Intent
+
+An agent starting a session primes its cross-session memory within a
+bounded, predictable, and documented cost, and any memory capability the
+vendor offers but the agent cannot actually reach is surfaced as a known
+limitation rather than silently assumed available.
+
+## Requirements
+
+1. The session-start sweep documented in
+   `artifacts/core/rules/60-tools.md` SHALL carry an explicit, bounded
+   token budget for its wake-up cost, covering every step of the sweep —
+   including the optional system-context store mirror introduced by
+   spec 0068, when MemPalace is reachable.
+
+2. `docs/cli-matrix.md` SHALL record the parity status of MemPalace's
+   layered wake-up capability between the agent-facing MCP tool surface
+   and the CLI/library surface, with evidence pinned to the installed
+   MemPalace version.
+
+3. A MemPalace capability that the vendor documents but that is absent
+   from the agent-facing MCP tool surface SHALL be recorded as a known
+   gap in `docs/cli-matrix.md`, and SHALL NOT be presented to agents as
+   an available action.
+
+4. The corrected rule content SHALL be reflected in its build output
+   `config/TOOLS.md` within the same change.
+
+5. No MemPalace capability reachable only outside the agent-facing MCP
+   tool surface SHALL be introduced as an ad-hoc agent action.
+
+## Scenarios
+
+**Scenario:** Agent primes a session within the stated budget.
+
+Given a session opens on a project with a MemPalace wing  
+And the agent reads the Memory Activation Protocol in `60-tools.md`  
+When the agent runs the session-start sweep  
+Then the sweep names a bounded token budget for the wake-up  
+And that budget accounts for the optional store-mirror step  
+And the agent primes its cross-session context within that budget
+
+**Scenario:** Agent encounters the documented wake-up gap.
+
+Given the layered wake-up is absent from the agent-facing MCP tool
+surface on the installed MemPalace version  
+And the agent considers loading a layered wake-up at session start  
+When the agent consults `docs/cli-matrix.md`  
+Then it finds the capability recorded as a known MCP-vs-CLI parity gap  
+And it does not attempt an ad-hoc CLI or library call to reach it
+
+## Out of scope
+
+- A source-controlled Python carve-out that invokes
+  `MemoryStack.wake_up()` at every session start.
+- Adopting the importance-ranked L1 "essential story" auto-summary into
+  the deterministic sweep.
+- The MemPalace tool-surface drift corrections (diary `wing` parameter,
+  tool-reference table — hosted since spec 0068 in the system-context
+  store at `artifacts/core/system-context/mcp-tools-reference.md` —
+  and AAAK) — tracked separately in issue #416.
+- Filing the upstream MemPalace feature request to expose the wake-up
+  through MCP — a consent-gated outward-facing follow-up, not part of
+  this change.
+- Any modification to the transcript hook or the transcripts wing.
+
+## Open questions
+
+- None. The parity verdict is settled by the issue #415 spike (the
+  installed MemPalace exposes the wake-up only through the CLI/library,
+  not MCP) and was re-verified on 2026-07-15 against the live MCP tool
+  surface. The concrete numeric token budget is a PLAN-stage
+  calibration measured against the installed version and the
+  post-spec-0068 sweep shape (six steps plus the optional store
+  mirror), not an open spec-level question.


### PR DESCRIPTION
Re-vehicles the spec formerly carried by PR #417, whose id 0051 collided with the implemented Antigravity spec. Qualifies #415: documents the MemPalace layered wake-up (L0–L3) as an MCP↔CLI parity gap on the pinned version, and mandates a bounded token budget for the session-start sweep — recalibrated for the post-spec-0068 sweep shape.

## How to read this PR?

Single file: `specs/0069-mempalace-wakeup-parity.md`. Read `## Intent` first (the outcome), then `## Requirements` (5 normative SHALL lines — note R1 now explicitly covers the optional system-context store mirror introduced by spec 0068), then `## Out of scope`, which records what was deliberately rejected (the per-session Python carve-out and the L1 semantic auto-summary) and what is split to issue #416 (tool-surface drift — whose target moved to `artifacts/core/system-context/mcp-tools-reference.md` with spec 0068). `## Open questions` is intentionally closed: the #415 spike settled the parity verdict, re-verified 2026-07-15 against the live MCP tool surface.

Diff vs the closed PR #417: frontmatter id `0051`→`0069`; R1 extended to cover the spec-0068 store-mirror step; scenario 1 gains a matching Then-line; the #416 out-of-scope bullet re-points the tool-reference table to its post-0068 home; the open-questions note pins the budget calibration to the post-0068 sweep shape.

## How to test this PR?

```sh
node scripts/lib/spec-linter.js specs/0069-mempalace-wakeup-parity.md
```

Verify: frontmatter parses (id 0069, slug matches filename, status draft, complexity small, interaction-mode INTERMEDIATE, related-issue 415, version 1.0.0); the five mandatory body headings are present in order; the file is the only change in the diff (one-file rule); no other spec on `main` claims id 0069.

## Detailed description (for agents)

Adds one spec under `/specs/`, conforming to `docs/spec-format.md`.

- **Intent** — bounded, documented session priming; unreachable vendor capabilities surfaced as known gaps, not silently assumed.
- **Requirements** — (1) sweep carries a bounded token budget covering every step including the optional spec-0068 store mirror; (2) `docs/cli-matrix.md` records the wake-up parity status with version-pinned evidence; (3) capabilities absent from the MCP surface are recorded as known gaps and not presented as available actions; (4) build output `config/TOOLS.md` reflects rule changes in the same change; (5) no CLI/library-only capability is introduced as an ad-hoc agent action.
- **Scenarios** — one happy path (prime within budget, mirror step counted), one gap path (agent finds the documented parity gap and does not attempt an ad-hoc CLI call).
- **Out of scope** — Python carve-out; L1 auto-summary adoption; tool-surface drift (#416, target re-pointed post-0068); upstream feature request (consent-gated); transcript hook.

Evidence for the parity verdict: source-level probe of installed MemPalace 3.3.5 (`mempalace.layers` exposes `MemoryStack.wake_up()`; `mempalace.mcp_server` exposes no `wake`/`layer`/`stack` tool) — full detail in #415 — re-verified 2026-07-15 against the live MCP tool surface (30 tools, none wake-related).

Per AGENTS.md *Spec-PR workflow → Independence rule*, this spec-PR closes no issue on merge; the implementation PR will close #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)