### PR TITLE
📝 Transition spec 0069 to approved

### DIFF
--- a/specs/0069-mempalace-wakeup-parity.md
+++ b/specs/0069-mempalace-wakeup-parity.md
@@ -1,7 +1,7 @@
 ---
 id: "0069"
 slug: mempalace-wakeup-parity
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 415


### PR DESCRIPTION
Records the `draft → approved` lifecycle transition for spec 0069, due since spec-PR #511 merged on `main` with the user-authorized INTERMEDIATE gate. Metadata-only edit, exempt from the normative-content freeze per `docs/spec-format.md` → *Delta-spec convention*.

## How to read this PR?

One file, one line: `specs/0069-mempalace-wakeup-parity.md` frontmatter `status: draft` → `status: approved`. Precedent: #499 (spec 0067), #504 (spec 0068).

## How to test this PR?

```sh
node scripts/lib/spec-linter.js specs/0069-mempalace-wakeup-parity.md
```

Verify the diff touches only the `status` frontmatter field.

## Detailed description (for agents)

Lifecycle bookkeeping per `docs/spec-format.md` → *Lifecycle states*: the `approved` trigger is "Spec PR merged on `main`" (authority: spec reviewer per the interaction mode). Spec-PR #511 merged 2026-07-15 with explicit user authorization; this PR records the transition that should accompany it. No normative content changes. The pending delta-spec 0069.delta-01 (R4 correction, spec-class PLAN-review finding on #415) rides its own branch and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)