### PR TITLE
📝 Add spec 0069 delta-01 — restate R4 without the config/TOOLS.md build-output premise

### DIFF
--- a/specs/0069-mempalace-wakeup-parity.delta-01.md
+++ b/specs/0069-mempalace-wakeup-parity.delta-01.md
@@ -1,0 +1,47 @@
+---
+id: "0069"
+slug: mempalace-wakeup-parity
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 415
+version: 2.0.0
+---
+
+# Record the MemPalace layered-wake-up parity gap and bound the session sweep
+
+## ADDED
+
+_None._
+
+## MODIFIED
+
+Requirement 4 is replaced. The original R4 rested on a false premise:
+`config/TOOLS.md` is not a build output of
+`artifacts/core/rules/60-tools.md`. Its own header comment declares that
+it "carries organization-specific additions only" and
+`scripts/setup-claude-interactive.sh` deploys the two files
+independently (`artifacts/core/rules/60-tools.md` at priority 60,
+`config/TOOLS.md` as the priority-65 organization overlay); moreover
+`scripts/build-components.sh` never processes rules files and contains no
+reference to `TOOLS.md`. Implementing the original R4 verbatim is
+therefore either vacuous — no such build step exists — or harmful, since
+duplicating framework rule content into the organization overlay breaks
+the core/overlay separation.
+
+- Original R4:
+
+  > The corrected rule content SHALL be reflected in its build output
+  > `config/TOOLS.md` within the same change.
+
+- Replacement R4:
+
+  > The change SHALL run the component build
+  > (`bash scripts/build-components.sh`) and confirm zero drift in
+  > committed build outputs; framework rule content SHALL NOT be
+  > duplicated into the priority-65 organization overlay
+  > `config/TOOLS.md`.
+
+## REMOVED
+
+_None._


### PR DESCRIPTION
Carries the spec-class finding from the cold PLAN review on #415 into a delta-spec, per the retroactive-routing contract: original R4 of spec 0069 rested on a false premise and is replaced before any DEV effort is spent. One file, own branch, merges before the implementation branch is cut.

## How to read this PR?

Single file: `specs/0069-mempalace-wakeup-parity.delta-01.md`. Read `## MODIFIED` — it quotes the original R4 verbatim, states the verified false premise (`config/TOOLS.md` is the priority-65 org overlay, not a build output of `60-tools.md`; `build-components.sh` never processes rules files), and shows the replacement R4 (run the build, confirm zero drift, never duplicate framework content into the overlay). `## ADDED` and `## REMOVED` are intentionally empty per the delta convention.

## How to test this PR?

```sh
node scripts/lib/spec-linter.js specs/0069-mempalace-wakeup-parity.delta-01.md
```

Verify: frontmatter carries the parent id `0069` and slug; `version: 2.0.0` (MAJOR — normative replacement of an existing requirement, precedent: spec 0026 delta-01); the three H2 delta sections are present in order; the file is the only change in the diff.

## Detailed description (for agents)

Delta-spec per `docs/spec-format.md` → *Delta-spec convention*, produced by the spec-class routing of the PLAN-review finding at https://github.com/crewrig/crewrig/issues/415#issuecomment-4982525178. MODIFIED: R4 replaced — the change SHALL run `bash scripts/build-components.sh` and confirm zero drift in committed build outputs; framework rule content SHALL NOT be duplicated into the priority-65 organization overlay `config/TOOLS.md`. ADDED: none. REMOVED: none. Evidence for the false premise: `config/TOOLS.md` header ("organization-specific additions only"), `scripts/setup-claude-interactive.sh` deploying the two files at priorities 60/65 independently, and the absence of any rules-file processing in `scripts/build-components.sh`. Per the independence rule this spec-PR closes no issue; after merge, PLAN v2 is re-authored on #415 and DEV follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)