### PR TITLE
📝 Transition spec 0070 to approved

### DIFF
--- a/specs/0070-mempalace-tool-surface-drift.md
+++ b/specs/0070-mempalace-tool-surface-drift.md
@@ -1,7 +1,7 @@
 ---
 id: "0070"
 slug: mempalace-tool-surface-drift
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 416


### PR DESCRIPTION
Metadata-only status transition for specs/0070-mempalace-tool-surface-drift.md, following the PLAN stage's cold-review APPROVE verdict on issue #416.

## How to read this PR?

Single-line frontmatter change: `status: draft` → `status: approved`. Same pattern as PR #512 (spec 0069's equivalent transition).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0070-mempalace-tool-surface-drift.md frontmatter `status` field bumped from `draft` to `approved`, reflecting that the PLAN stage for issue #416 completed with a cold-review APPROVE verdict (https://github.com/crewrig/crewrig/issues/416#issuecomment-4992271648). No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.