### PR TITLE
🐛 Correct MemPalace diary tool-surface drift in docs

### DIFF
--- a/artifacts/core/rules/60-tools.md
+++ b/artifacts/core/rules/60-tools.md
@@ -210,11 +210,20 @@ filter, transcript noise overwhelms the BM25 hybrid scoring and buries
 actual handoff entries. The wing+room scoped query above is the only
 deterministic discovery path through the current MCP surface.
 
-**Why not `mempalace_diary_read` for cross-tool resume?** The MCP
-surface for `mempalace_diary_read` does not expose a `wing` parameter
-— it only accepts `agent_name`. Diaries are per-agent silos at the MCP
-level; they cannot serve as the cross-tool handoff surface. Use them
-for your own provenance recovery only.
+**Why not `mempalace_diary_read` for cross-tool resume?** Not because
+the tool lacks a `wing` parameter — it has one, and it works: an
+explicit `wing` on `mempalace_diary_write` determines the wing an
+entry is stored under, and an explicit `wing` on `mempalace_diary_read`
+restricts the read to that wing (confirmed live during issue #416; see
+`mcp-tools-reference.md` for the full corrected note, including the
+still-unresolved omitted-`wing` fallback). The diary lane stays out of
+the cross-tool handoff lane by the project's deliberate lane-mapping
+convention instead (see *Lane mapping* in
+`palace-structure-conventions.md`): the handoff lane is
+`mempalace_add_drawer`/`mempalace_update_drawer` on a project
+`wing`+`room`, while the diary lane is reserved for per-agent
+self-recovery. Use `mempalace_diary_read` for your own provenance
+recovery only.
 
 **Optional — System-context store mirror (MemPalace only).** An opportunistic
 enhancement layered on the six-step sweep above, not a required part of it: when

--- a/artifacts/core/system-context/mcp-tools-reference.md
+++ b/artifacts/core/system-context/mcp-tools-reference.md
@@ -1,6 +1,10 @@
 # MCP Tools Reference
 
-MemPalace exposes the following tool categories (v3.3.x). Tools used by
+MemPalace's MCP tool surface is pinned to the installed **v3.3.5**
+(supported range `>=3.3.3,<3.4` per
+`scripts/setup-claude-interactive.sh:177-178`). Every claim below was
+re-verified live against that installed version during issue #416 —
+not carried forward from an earlier, unverified pass. Tools used by
 the cross-tool handoff protocol are highlighted in **bold**.
 
 | Category | Tools |
@@ -8,17 +12,40 @@ the cross-tool handoff protocol are highlighted in **bold**.
 | **Palace read** | **`mempalace_status`**, `mempalace_list_wings`, `mempalace_list_rooms`, `mempalace_list_drawers`, `mempalace_get_drawer`, `mempalace_get_taxonomy`, **`mempalace_search`**, `mempalace_check_duplicate`, `mempalace_get_aaak_spec` |
 | **Palace write** | **`mempalace_add_drawer`**, **`mempalace_update_drawer`**, `mempalace_delete_drawer` |
 | **Knowledge Graph** | **`mempalace_kg_query`**, `mempalace_kg_add`, `mempalace_kg_invalidate`, `mempalace_kg_timeline`, `mempalace_kg_stats` |
-| **Navigation** | `mempalace_traverse`, `mempalace_find_tunnels`, `mempalace_graph_stats` |
+| **Navigation** | `mempalace_traverse`, `mempalace_find_tunnels`, `mempalace_graph_stats`, `mempalace_create_tunnel`, `mempalace_delete_tunnel`, `mempalace_follow_tunnels`, `mempalace_list_tunnels` |
 | **Agent Diary** | `mempalace_diary_write`, **`mempalace_diary_read`** |
+| **Maintenance** | `mempalace_sync`, `mempalace_reconnect`, `mempalace_hook_settings`, `mempalace_memories_filed_away` |
 
-Notable v3.3.x facts that shape the protocol above:
+Notable facts (installed v3.3.5) that shape the protocol above:
 
 - `mempalace_add_drawer` and `mempalace_update_drawer` accept arbitrary
   `wing` and `room` — the only MCP write paths that do. The handoff
   lane is built on these.
-- `mempalace_diary_write` and `mempalace_diary_read` only accept
-  `agent_name`, not `wing` (despite the v3.3.3 changelog note about an
-  internal `wing` parameter). Diaries are MCP-level per-agent silos.
+- `mempalace_diary_write` and `mempalace_diary_read` both accept an
+  explicit `wing` argument — this corrects the prior "only accepts
+  `agent_name`" claim, which was false on the live surface. Confirmed
+  live during issue #416 (three independent probes across PLAN and its
+  cold review): an explicit `wing` on `mempalace_diary_write`
+  determines the wing the entry is stored under, and an explicit
+  `wing` on `mempalace_diary_read` restricts the read to that wing — a
+  matching explicit `wing` finds the entry, a different explicit
+  `wing` finds nothing. `scripts/setup-claude-interactive.sh:174-178`
+  already documents that v3.3.3 introduced the `wing` parameter on
+  diary tools; this note aligns the reference with that fact instead
+  of contradicting it. What the tool falls back to when `wing` is
+  **omitted** remains unresolved: the parameter description states it
+  reads from `wing_{agent_name}`, but the same probes found an
+  omitted-`wing` read still surfaces the entry even when
+  `wing_{agent_name}` holds zero drawers. The real fallback mechanism
+  is not conclusively established — do not assume a specific one.
+  Diaries stay out of the cross-tool handoff lane regardless of this
+  open question; that separation rests on the project's deliberate
+  lane-mapping convention (see *Lane mapping* in
+  `palace-structure-conventions.md`), not on the now-corrected
+  capability claim.
+- `mempalace_get_aaak_spec` returns a genuine, implemented
+  compressed-memory-format specification — not an inert or placeholder
+  tool.
 - `mempalace_search` returns BM25-hybrid (60 % vector + 40 % keyword)
   results since v3.3.0. The keyword share is real but does not
   overcome volumetric imbalance from the `transcripts` wing — always


### PR DESCRIPTION
Corrects a false claim in `60-tools.md` and `mcp-tools-reference.md`: both docs asserted `mempalace_diary_read`/`mempalace_diary_write` only accept `agent_name`, but the installed MemPalace v3.3.5 MCP surface exposes a working `wing` argument on both. Realizes spec 0070 (approved, merged to main) per the PLAN posted on #416.

Closes #416

## How to read this PR?

Two files change, both doc-only:

1. `artifacts/core/system-context/mcp-tools-reference.md` — the primary correction. The "Notable facts" bullet list is rewritten: the old claim ("only accept `agent_name`, not `wing`") is replaced with the corrected one (both diary tools accept an explicit `wing`; an explicit `wing` on write determines storage, an explicit `wing` on read restricts the read to that wing — confirmed live during #416 across three independent probes: spec-authoring, PLAN, and PLAN's cold review). It also states what remains **unresolved**: the omitted-`wing` fallback behavior on `mempalace_diary_read`. A new "Maintenance" tool-category row and four navigation tools (`mempalace_create_tunnel`, `mempalace_delete_tunnel`, `mempalace_follow_tunnels`, `mempalace_list_tunnels`) are added to the tool table, and a note on `mempalace_get_aaak_spec` (genuine, not a placeholder) is added.
2. `artifacts/core/rules/60-tools.md` — the "Why not `mempalace_diary_read` for cross-tool resume?" callout is rewritten so it no longer repeats the disproven claim. The corrected reasoning: the diary lane stays out of cross-tool handoff not because the tool lacks a `wing` parameter, but by the project's deliberate lane-mapping convention (handoff via `mempalace_add_drawer`/`mempalace_update_drawer` on a project wing+room; diaries reserved for per-agent self-recovery).

Read `mcp-tools-reference.md` first — it carries the full corrected note; `60-tools.md`'s callout is the shorter, cross-referencing version.

## How to test this PR?

This is a documentation-only correction; there is no code path to execute. Verify by inspection:

1. `git diff crewrig/main -- artifacts/core/rules/60-tools.md artifacts/core/system-context/mcp-tools-reference.md` — confirm both diffs match the descriptions above and no other file changed.
2. Confirm neither file still asserts "only accepts `agent_name`" for the diary tools: `grep -rn "only accept" artifacts/core/rules/60-tools.md artifacts/core/system-context/mcp-tools-reference.md` should return no hits against the diary claim.
3. Cross-check against `scripts/setup-claude-interactive.sh:174-178`, which documents that v3.3.3 introduced the `wing` parameter on diary tools — the corrected note aligns with this rather than contradicting it.

## Detailed description (for agents)

**Scope of the diff** (`git diff crewrig/main --stat`): 2 files changed, 47 insertions, 11 deletions — `artifacts/core/rules/60-tools.md` and `artifacts/core/system-context/mcp-tools-reference.md`. No other files touched.

**What was verified during DEV, and why it matters for REVIEW:**

- `artifacts/core/system-context/palace-structure-conventions.md:52-55` repeats the same disproven "only accepts `agent_name`" claim ("The MCP surface forces this split: only `mempalace_add_drawer` and `mempalace_update_drawer` accept arbitrary `wing` and `room` parameters. The diary tools (`mempalace_diary_write` / `mempalace_diary_read`) only expose `agent_name`, so diary entries always land in `wing_<agent-name>` and cannot serve as the cross-tool handoff surface.") but is **deliberately left uncorrected** in this PR. Spec 0070's *Out of scope* section explicitly excludes it: "Adopting wing-scoped diary writes and reads as a cross-tool handoff mechanism. The existing lane-mapping design ... is not revisited." This PR does not touch that file. Flagging this explicitly so REVIEW does not raise it as a missed edit.
- `docs/cli-matrix.md` was consulted per this repo's CLI Matrix Maintenance mechanical-trigger rule (both edited files sit under `artifacts/**`). `grep -n -i "mempalace|diary|wing" docs/cli-matrix.md` returns matches only on unrelated rows (MCP server config, MemPalace backend wiring, the layered wake-up MCP gap at rows 7g/122, project-dir env vars, e2e pillars) — none reference the diary `wing`-parameter claim this PR corrects. No cell needed updating.
- No build output was regenerated and no `provenance.version` bump was applied. Both edited files deploy via direct `install_file`/`install_dir` copy in the CLI setup scripts, not through `scripts/build-components.sh` (which processes only `skills/`, `agents/`, and `commands/` sources — see spec 0070 *Out of scope*, third bullet). Neither file appears on `docs/version-bump-convention.md`'s affected-paths list (`artifacts/core/skills/*/SKILL.md`, `artifacts/core/agents/*/AGENT.md`, and their `library`/`community`/`extensions` counterparts) — confirmed by reading that file directly.
- Spec 0070 left one item as an open question rather than resolved: the exact fallback mechanism when `mempalace_diary_read`'s `wing` argument is **omitted**. Three independent live probes (spec-authoring, PLAN, and PLAN's cold review) confirm that explicit-`wing` scoping works on both read and write, but none of the three establish what happens when `wing` is omitted from the read — the tool's parameter description claims a `wing_{agent_name}` fallback, but a probe found an omitted-`wing` read still surfacing an entry even when `wing_{agent_name}` held zero drawers. This PR documents that mechanism as **unresolved** in `mcp-tools-reference.md` rather than asserting a guessed behavior.

**Diff contents, file by file:**

- `artifacts/core/rules/60-tools.md`: +14/-5 per `git diff crewrig/main --numstat`. The "Why not `mempalace_diary_read` for cross-tool resume?" paragraph is replaced. New text cross-references `mcp-tools-reference.md` for the full corrected note and `palace-structure-conventions.md`'s *Lane mapping* for the separation rationale.
- `artifacts/core/system-context/mcp-tools-reference.md`: +33/-6 per the same numstat. The intro paragraph now pins the installed version to v3.3.5 (supported range `>=3.3.3,<3.4` per `scripts/setup-claude-interactive.sh:177-178`) and states the claims below were re-verified live during #416. The tool table gains a "Maintenance" row (`mempalace_sync`, `mempalace_reconnect`, `mempalace_hook_settings`, `mempalace_memories_filed_away`) and four tunnel-navigation tools. The "Notable facts" list replaces the disproven diary-tool bullet with the corrected one (including the unresolved omitted-`wing` fallback, described above) and adds a bullet confirming `mempalace_get_aaak_spec` returns a genuine spec, not a placeholder.
