### PR TITLE
📝 Transition spec 0070 to implemented

### DIFF
--- a/specs/0070-mempalace-tool-surface-drift.md
+++ b/specs/0070-mempalace-tool-surface-drift.md
@@ -1,7 +1,7 @@
 ---
 id: "0070"
 slug: mempalace-tool-surface-drift
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 416


### PR DESCRIPTION
Metadata-only status transition for specs/0070-mempalace-tool-surface-drift.md, following DEV-stage PR #518 (merged c555826) and its REVIEW-stage APPROVE verdict.

## How to read this PR?

Single-line frontmatter change: `status: approved` → `status: implemented`. Same pattern as PR #517 (draft→approved) and the equivalent transition on the sibling ticket (spec 0069, PR #515).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0070-mempalace-tool-surface-drift.md frontmatter `status` field bumped from `approved` to `implemented`, closing out the SPECS→PLAN→DEV→REVIEW lifecycle for issue #416 (closed, completed). DEV PR #518 merged the corrected wording into `artifacts/core/rules/60-tools.md` and `artifacts/core/system-context/mcp-tools-reference.md`; REVIEW posted APPROVE with zero blocking findings. No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.