### PR TITLE
📝 Transition spec 0071 to approved

### DIFF
--- a/specs/0071-org-specs-lint-exclusion.md
+++ b/specs/0071-org-specs-lint-exclusion.md
@@ -1,7 +1,7 @@
 ---
 id: "0071"
 slug: org-specs-lint-exclusion
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 421


### PR DESCRIPTION
Metadata-only status transition for specs/0071-org-specs-lint-exclusion.md, following the PLAN stage's cold-review APPROVE verdict on issue #421.

## How to read this PR?

Single-line frontmatter change: `status: draft` → `status: approved`. Same pattern as PR #517 (spec 0070's equivalent transition).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0071-org-specs-lint-exclusion.md frontmatter `status` field bumped from `draft` to `approved`, reflecting that the PLAN stage for issue #421 completed with a cold-review APPROVE verdict (https://github.com/crewrig/crewrig/issues/421#issuecomment-4994276737). No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.