### PR TITLE
🐛 Exclude org-owned specs/org/ from upstream spec-linter validation

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -244,7 +244,7 @@ sync.
 
 | Path | Description |
 |---|---|
-| `specs/org/` | Organization-owned specification overlay, nested in core `specs/`. Excluded from upstream sync. |
+| `specs/org/` | Organization-owned specification overlay, nested in core `specs/`. Excluded from upstream sync, and from the spec linter's upstream filename/frontmatter/heading validation (spec 0071). |
 | `docs/org/` | Organization-owned documentation overlay, nested in core `docs/`. Excluded from upstream sync. |
 | `AGENTS.org.md` | Organization-owned agent-rules extension, loaded alongside the upstream `AGENTS.md` (natively on Claude via `@` import; via the priority-66 setup deployment on Gemini and Copilot). Excluded from upstream sync. |
 

--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -39,6 +39,59 @@ function globSpecs(targetPath) {
     return result;
 }
 
+// loadCorePathsManifest() — reads .crewrig/core-paths.txt and returns its
+// entries as { path, policy } objects. Mirrors the parsing rules in
+// scripts/check-core-paths.sh:41-54: blank/`#` lines are skipped, the path is
+// the first whitespace-delimited field, the policy is the next token
+// (defaulting to `strict`). A missing manifest resolves to an empty list
+// rather than throwing, so a checkout without the file still lints normally.
+function loadCorePathsManifest() {
+    const repoDir = process.env.CREWRIG_REPO_DIR || path.join(__dirname, '..', '..');
+    const manifestPath = path.join(repoDir, '.crewrig', 'core-paths.txt');
+
+    let content;
+    try {
+        content = fs.readFileSync(manifestPath, 'utf8');
+    } catch (e) {
+        return [];
+    }
+
+    const entries = [];
+    for (const rawLine of content.split('\n')) {
+        const line = rawLine.replace(/\r$/, '');
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed.startsWith('#')) {
+            continue;
+        }
+        const match = trimmed.match(/^(\S+)(?:\s+(\S+))?/);
+        if (!match) {
+            continue;
+        }
+        entries.push({ path: match[1], policy: match[2] || 'strict' });
+    }
+    return entries;
+}
+
+// isExcludedSpecPath(relPath, entries) — true iff the manifest entry whose
+// path most closely (longest-prefix match) matches relPath classifies it
+// `excluded`. relPath must match exactly, or relPath must sit under the
+// entry's path bounded by `/` (so `specs/org2` does not match an entry for
+// `specs/org`). This is the R5 mechanism: the caller never hardcodes
+// `specs/org` — whatever the manifest classifies `excluded` under `specs/`
+// is skipped, today and for any future nested entry.
+function isExcludedSpecPath(relPath, entries) {
+    const normalized = relPath.split(path.sep).join('/');
+    let best = null;
+    for (const entry of entries) {
+        if (normalized === entry.path || normalized.startsWith(entry.path + '/')) {
+            if (!best || entry.path.length > best.path.length) {
+                best = entry;
+            }
+        }
+    }
+    return best !== null && best.policy === 'excluded';
+}
+
 function lintFile(filePath) {
     let hasErrors = false;
     const errors = [];
@@ -208,8 +261,11 @@ function run() {
     
     console.log(`Running semantic validation...`);
     let totalErrors = 0;
-    
+
+    const manifestEntries = loadCorePathsManifest();
+
     for (const file of uniqueFiles) {
+        if (isExcludedSpecPath(file, manifestEntries)) continue;
         const { hasErrors, errors } = lintFile(file);
         if (hasErrors) {
             console.error(`\n[FAIL] ${file}`);

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -59,11 +59,12 @@ run_case() {
   local name="$1"
   local files="$2"
   local expected_exit="$3"
+  local env_repo_dir="${4:-}"
 
   local actual_exit=0
   local output
   # We run from TMP_ROOT so markdownlint finds .markdownlintrc
-  output=$( ( cd "$TMP_ROOT" && node "$LINTER_JS" $files 2>&1 ) ) || actual_exit=$?
+  output=$( ( cd "$TMP_ROOT" && CREWRIG_REPO_DIR="$env_repo_dir" node "$LINTER_JS" $files 2>&1 ) ) || actual_exit=$?
 
   if [ "$actual_exit" -eq "$expected_exit" ]; then
     echo "PASS  $name (exit $actual_exit)"
@@ -74,6 +75,16 @@ run_case() {
     echo "$output"
     fail=$((fail + 1))
   fi
+}
+
+# write_core_paths_fixture <dir> <content>
+# Write a standalone .crewrig/core-paths.txt fixture at <dir>, for use with
+# CREWRIG_REPO_DIR overrides (mirrors write_manifest() in
+# scripts/tests/test-check-core-paths.sh:63-67).
+write_core_paths_fixture() {
+  local dir="$1" content="$2"
+  mkdir -p "$dir/.crewrig"
+  printf '%s' "$content" > "$dir/.crewrig/core-paths.txt"
 }
 
 # -------------------------------------------------------------------------
@@ -205,6 +216,111 @@ run_case "Case 15 — headings inside code blocks are ignored passes" "$spec15" 
 spec16="0016-mandatory-heading-in-code.md"
 render_spec "0016" "mandatory-heading-in-code" "draft" "standard" "" "$(printf "## Intent\n\n## Requirements\n\n## Scenarios\n\n## Out of scope\n\n\`\`\`markdown\n## Open questions\n\`\`\`")" > "$TMP_ROOT/$spec16"
 run_case "Case 16 — mandatory heading missing but present in code block fails" "$spec16" 1
+
+# -------------------------------------------------------------------------
+# Cases 17-19 exercise the specs/org exclusion (spec 0071) against the real,
+# committed .crewrig/core-paths.txt — no CREWRIG_REPO_DIR override. This
+# deliberately couples their outcome to `specs/org` remaining classified
+# `excluded` in that manifest; Case 20/21 below are what actually prove the
+# exclusion mechanism is manifest-driven rather than hardcoded to
+# `specs/org`.
+# -------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# Case 17 — Scenario 1: default CI invocation (no target args, matching the
+# `lint-specs` job) ignores a non-conforming specs/org/ file.
+# -------------------------------------------------------------------------
+mkdir -p "$TMP_ROOT/specs/org"
+cat <<'EOF' > "$TMP_ROOT/specs/org/ORG-0001-example.md"
+---
+id: "ORG-0001"
+slug: "example"
+status: "draft"
+complexity: "standard"
+version: 1.0.0
+related-issue: 123
+---
+
+# Title
+
+## Intent
+
+## Requirements
+EOF
+run_case "Case 17 — non-conforming specs/org file ignored on default CI invocation" "" 0
+
+# -------------------------------------------------------------------------
+# Case 18 — Scenario 2: a non-conforming spec outside specs/org/, on the
+# same invocation, is still caught (R4).
+# -------------------------------------------------------------------------
+render_spec "9999" "bad" > "$TMP_ROOT/specs/9999-bad!name.md"
+run_case "Case 18 — non-conforming upstream spec still fails alongside specs/org" "" 1
+
+# -------------------------------------------------------------------------
+# Case 19 — Scenario 3: explicit `specs/org` target still exempts the
+# non-conforming file (reuses Case 17's fixture).
+# -------------------------------------------------------------------------
+run_case "Case 19 — explicit specs/org target still exempts non-conforming file" "specs/org" 0
+
+# -------------------------------------------------------------------------
+# Case 20 — Scenario 4: manifest-driven exclusion generalizes to a path
+# never special-cased in spec-linter.js (specs/experimental), proving R5
+# (no hardcoded `specs/org` string match). Uses an isolated tree distinct
+# from $TMP_ROOT/specs: the shared tree above already carries Case 18's
+# deliberately non-conforming, non-excluded specs/9999-bad!name.md fixture,
+# which would fail this invocation for an unrelated reason if reused — this
+# isolation keeps the assertion pointed squarely at the manifest override.
+# -------------------------------------------------------------------------
+SCENARIO4_ROOT="$TMP_ROOT/scenario4"
+mkdir -p "$SCENARIO4_ROOT/specs/experimental"
+cp "$ROOT_DIR/.markdownlintrc" "$SCENARIO4_ROOT/"
+ln -s "$ROOT_DIR/node_modules" "$SCENARIO4_ROOT/node_modules"
+cat <<'EOF' > "$SCENARIO4_ROOT/specs/experimental/9999-bad.md"
+---
+id: "9999"
+slug: "bad"
+status: "draft"
+complexity: "standard"
+version: 1.0.0
+related-issue: 123
+---
+
+# Title
+
+## Intent
+EOF
+
+write_core_paths_fixture "$TMP_ROOT/fixture-manifest" $'specs/experimental\texcluded\n'
+
+case20_exit=0
+case20_output=$( ( cd "$SCENARIO4_ROOT" && CREWRIG_REPO_DIR="$TMP_ROOT/fixture-manifest" node "$LINTER_JS" 2>&1 ) ) || case20_exit=$?
+if [ "$case20_exit" -eq 0 ]; then
+  echo "PASS  Case 20 — manifest-driven exclusion of a novel path (exit 0)"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 20 — expected exit 0, got $case20_exit"
+  echo "Output:"
+  echo "$case20_output"
+  fail=$((fail + 1))
+fi
+
+# -------------------------------------------------------------------------
+# Case 21 — negative control for Scenario 4: same fixture, no manifest
+# override → falls back to the real repo's .crewrig/core-paths.txt, which
+# does not classify specs/experimental as excluded → exit 1. Proves Case 20
+# passes because of the override, not a blanket skip.
+# -------------------------------------------------------------------------
+case21_exit=0
+case21_output=$( ( cd "$SCENARIO4_ROOT" && node "$LINTER_JS" 2>&1 ) ) || case21_exit=$?
+if [ "$case21_exit" -eq 1 ]; then
+  echo "PASS  Case 21 — same fixture without override still fails (exit 1)"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 21 — expected exit 1, got $case21_exit"
+  echo "Output:"
+  echo "$case21_output"
+  fail=$((fail + 1))
+fi
 
 # -------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
The spec linter enforced the upstream `<NNNN>-<kebab-slug>.md` filename/frontmatter/heading contract on every file under `specs/`, including the org-owned `specs/org/` overlay, so an adopter using a distinct numbering convention there (e.g. `ORG-0001`) got hard `task spec:lint` failures on content upstream doesn't own. This PR makes the exclusion generic — driven by `.crewrig/core-paths.txt`'s `excluded` classification — instead of hardcoding `specs/org`.

Closes #421

## How to read this PR?

Three files change, in this order:

1. **`scripts/lib/spec-linter.js`** — the load-bearing file. Two new functions:
   - `loadCorePathsManifest()` reads `.crewrig/core-paths.txt` (or the path pointed to by `CREWRIG_REPO_DIR`, defaulting to the repo root) and returns `{ path, policy }` entries, mirroring the parsing rules in `scripts/check-core-paths.sh:41-54`. A missing manifest returns an empty list rather than throwing.
   - `isExcludedSpecPath(relPath, entries)` does a longest-prefix match against those entries (bounded by `/` so `specs/org2` doesn't false-match an entry for `specs/org`) and returns true only if the winning entry's policy is `excluded`.
   - Both are wired into `run()`'s semantic-validation loop as a single guard: `if (isExcludedSpecPath(file, manifestEntries)) continue;`, ahead of the existing `lintFile()` call.
2. **`scripts/tests/test-spec-linter.sh`** — five new regression cases (17-21) plus a `write_core_paths_fixture()` helper and a `CREWRIG_REPO_DIR`-override parameter added to `run_case()`.
3. **`docs/layers.md`** — one clause added to the `specs/org/` row in the core-paths table, noting the row is now also excluded from the spec linter's upstream semantic validation (spec 0071).

**Non-obvious decision worth flagging:** Cases 20-21 (the "prove the mechanism is generic, not hardcoded" scenario) build their fixture in an isolated `$TMP_ROOT/scenario4/` tree, not the shared `$TMP_ROOT/specs/` tree Cases 17-19 use. Reusing the shared tree would let Case 18's deliberately non-conforming, non-excluded fixture (`specs/9999-bad!name.md`) leak into Case 20's default-target invocation and fail it for an unrelated reason — the isolation keeps the assertion pointed at the manifest override specifically. See the comment block above Case 20 in the diff.

A one-line comment was also added above Case 17 (a post-PLAN-review fix folded into DEV per the user's instruction, rather than spun into a separate PLAN iteration): it notes Cases 17-19 depend on `specs/org` remaining classified `excluded` in the real, committed `.crewrig/core-paths.txt` (currently true — see that file's line 47), while Cases 20-21 are what actually prove the mechanism is manifest-driven rather than hardcoded to `specs/org`.

## How to test this PR?

1. `bash scripts/tests/test-spec-linter.sh` — expect `Results: 21 passed, 0 failed` (verified locally: all 21 cases, including new Cases 17-21, pass).
2. `task spec:lint` — expect `Linting passed!` against the real repo content (verified locally: ran clean against the current `specs/` tree).
3. Manual repro of the original bug (per issue #421): create a non-conforming `specs/org/ORG-0001-example.md` (wrong filename shape, `ORG-0001` id), run `task spec:lint` — it now passes for that file. Then add an equally non-conforming file outside `specs/org/` (e.g. `specs/9999-bad!name.md`) and re-run — `task spec:lint` still fails, proving the exclusion is scoped to the `excluded`-classified path, not a blanket skip.

## Detailed description (for agents)

- **The exclusion mechanism is generic, not hardcoded.** `isExcludedSpecPath()` never compares against the literal string `specs/org`; it classifies any path via `.crewrig/core-paths.txt`'s `excluded` policy through longest-prefix match. This was an explicit requirement (R5) resolved by the user at the SPECS-stage validation gate for spec 0071, not a DEV-stage judgment call. Cases 20-21 in `scripts/tests/test-spec-linter.sh` exist specifically to prove this: Case 20 excludes a path (`specs/experimental`) never referenced anywhere in `spec-linter.js`, using a manifest fixture injected via `CREWRIG_REPO_DIR`, and Case 21 is the negative control — same fixture, no override, falls back to the real repo manifest (which does not classify `specs/experimental` as excluded), and fails as expected.
- **`globSpecs()` and the `npx markdownlint` invocation are untouched.** Excluded files are still discovered by `globSpecs()` and still get passed to `markdownlint` (the `spawnSync('npx', ['markdownlint', ...uniqueFiles, ...])` call in `run()` is unchanged) — only the upstream filename/frontmatter/heading semantic contract enforced by `lintFile()` is skipped for them. Generic Markdown style linting still applies.
- **Test verification.** `bash scripts/tests/test-spec-linter.sh` → 21/21 passed (Cases 1-16 pre-existing, 17-21 new). `task spec:lint` still passes on the real repo content (99 files globbed per the `Running markdownlint-cli on 99 files...` log line).
- **No build output, version bump, or CLI-matrix update needed.** `scripts/lib/spec-linter.js` is a plain script outside `artifacts/`, not a skill/agent source (`artifacts/core/skills/*/SKILL.md` or `artifacts/core/agents/*/AGENT.md`), so no `provenance.version` bump applies. None of the three changed files (`scripts/lib/spec-linter.js`, `scripts/tests/test-spec-linter.sh`, `docs/layers.md`) match any path on the CLI-matrix trigger list in `AGENTS.md` → *CLI Matrix Maintenance* (`.claude/**`, `.gemini/**`, `artifacts/**`, `extensions/**`, `hooks/*-transcript-hooks.json`, `config/claude/**`, `config/gemini/**`, `scripts/build-components.sh`, `scripts/{build,install,setup,import,manage}-*.sh`, the `claude.yml`/`gemini.yml` workflows, `CLAUDE.md`, `GEMINI.md`, or CLI-prefixed Taskfile entries) — already verified during PLAN and re-confirmed here.
- **Realizes spec `specs/0071-org-specs-lint-exclusion.md`** (status: approved, merged to `main`), per the plan posted at https://github.com/crewrig/crewrig/issues/421#issuecomment-4994202651, cold-reviewed APPROVE at https://github.com/crewrig/crewrig/issues/421#issuecomment-4994276737.
