### PR TITLE
📝 Transition spec 0071 to implemented

### DIFF
--- a/specs/0071-org-specs-lint-exclusion.md
+++ b/specs/0071-org-specs-lint-exclusion.md
@@ -1,7 +1,7 @@
 ---
 id: "0071"
 slug: org-specs-lint-exclusion
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 421


### PR DESCRIPTION
Metadata-only status transition for specs/0071-org-specs-lint-exclusion.md, following DEV-stage PR #522 (merged 8bc9453) and its REVIEW-stage APPROVE verdict.

## How to read this PR?

Single-line frontmatter change: `status: approved` → `status: implemented`. Same pattern as PR #519 (the equivalent transition on the sibling ticket, #416/spec 0070).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0071-org-specs-lint-exclusion.md frontmatter `status` field bumped from `approved` to `implemented`, closing out the SPECS→PLAN→DEV→REVIEW lifecycle for issue #421 (closed, completed). DEV PR #522 merged the manifest-driven exclusion into `scripts/lib/spec-linter.js`, extended `scripts/tests/test-spec-linter.sh` (21/21 passing), and updated `docs/layers.md`; REVIEW posted APPROVE with one non-blocking finding. No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.