### PR TITLE
📝 Transition spec 0072 to approved

### DIFF
--- a/specs/0072-fork-release-workflow-guard.md
+++ b/specs/0072-fork-release-workflow-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0072"
 slug: fork-release-workflow-guard
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 491


### PR DESCRIPTION
Metadata-only status transition for specs/0072-fork-release-workflow-guard.md, following the PLAN stage's cold-review APPROVE verdict on issue #491 (AUTO mode — PLAN v2, zero findings, independently reproduced).

## How to read this PR?

Single-line frontmatter change: `status: draft` → `status: approved`. Same pattern as PR #521 (spec 0071's equivalent transition).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0072-fork-release-workflow-guard.md frontmatter `status` field bumped from `draft` to `approved`, reflecting that the PLAN stage for issue #491 completed with a cold-review APPROVE verdict on the revised plan (https://github.com/crewrig/crewrig/issues/491#issuecomment-4995323549), after an initial REQUEST CHANGES iteration (https://github.com/crewrig/crewrig/issues/491#issuecomment-4995196478) was resolved and independently re-verified. No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.