### PR TITLE
✨ Guard release workflows against non-canonical forks

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   package-and-release:
     runs-on: ubuntu-latest
+    if: github.repository == 'crewrig/crewrig'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-monorepo.yml
+++ b/.github/workflows/release-monorepo.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.repository == 'crewrig/crewrig'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -338,7 +338,7 @@ capabilities:
       engine: github-actions
       evidence: >
         Creates a GitHub Release via `softprops/action-gh-release`
-        (.github/workflows/release-extension.yml lines 69-74), a
+        (.github/workflows/release-extension.yml lines 70-75), a
         GitHub-Releases-specific surface. GitLab's release mechanism
         (`release:` keyword / release-cli) is a distinct, non-interchangeable
         contract, so the release capability has no faithful equivalent on the
@@ -359,7 +359,7 @@ capabilities:
         `${{ secrets.GITHUB_TOKEN }}` with `issues: write` /
         `pull-requests: write` permissions to create GitHub Releases and
         comment on GitHub issues/PRs
-        (.github/workflows/release-monorepo.yml lines 9-43). The release
+        (.github/workflows/release-monorepo.yml lines 9-44). The release
         tooling targets the GitHub Releases and GitHub issue APIs, which have
         no faithful equivalent on GitLab CI, so the capability is hand-authored
         per engine, not generated.

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -43,6 +43,16 @@ configuration home. The repository may be public or private.
    git push -u origin main
    ```
 
+   > **Note — release automation stays inert on your fork.** The release
+   > workflows (`.github/workflows/release-monorepo.yml` and
+   > `.github/workflows/release-extension.yml`) are reserved for the
+   > canonical `crewrig/crewrig` repository. On your fork, pushing to `main`
+   > or pushing a release-pattern tag is expected to leave these workflows
+   > inert — no release run, no red run on the Actions tab. If you see one
+   > fail instead, see
+   > [Release workflow fails with "Could not resolve to an issue or pull
+   > request"](#release-workflow-inert-on-fork) in Troubleshooting.
+
    If you used the GitHub Fork button, clone your fork and skip the push above:
 
    ```bash
@@ -428,3 +438,27 @@ offending paths.
    sync. The `.crewrig/core-paths.txt` manifest lists exactly which paths
    are considered core; files outside that list are overlay and are always
    left untouched by the sync.
+
+### Release workflow fails with "Could not resolve to an issue or pull request" {#release-workflow-inert-on-fork}
+
+**Cause:** The fork synced from an upstream commit predating this ticket's
+canonical-repository guard, so its `release-monorepo.yml` (or
+`release-extension.yml`) still lacks the `if: github.repository ==
+'crewrig/crewrig'` condition.
+
+**Effect:** "Analyze & Release (Monorepo)" (or "Release Extension") fails
+with the quoted symptom — a red run on the fork's Actions tab, caused by
+the release tooling resolving a pull-request or issue reference that
+belongs to the upstream `crewrig/crewrig` repository, not the fork.
+
+**Resolution:** Choose one of two paths:
+
+1. **Sync to pick up the fix** — run `bash scripts/sync-from-upstream.sh`
+   to pull in the canonical-repository guard, commit the result, and push.
+   The next push or tag push leaves the workflow inert on the fork instead
+   of failing.
+2. **Disable the workflow pre-emptively** — if release automation is never
+   wanted on this fork, disable `release-monorepo.yml` and/or
+   `release-extension.yml` from the fork's Actions tab, or remove or
+   override the workflow file, before the next triggering push or tag
+   push.


### PR DESCRIPTION
Adds a job-level `if: github.repository == 'crewrig/crewrig'` guard to both release workflows so a push or tag push on an adopter's fork leaves release automation inert (GitHub's native "skipped" job conclusion) instead of failing on an unresolved upstream issue/PR reference, and documents the expected inert behavior plus a self-serve troubleshooting path in the adoption guide. Implements spec 0072 per PLAN v2 (cold-reviewed APPROVE, zero findings).

Closes #491

## How to read this PR?

Four files changed (`git diff crewrig/main --stat`): two 1-line workflow guards, a 2-citation refresh in `ci/ci-capabilities.yml`, and a 34-line addition to `docs/adoption-guide.md`.

1. **`.github/workflows/release-monorepo.yml`** and **`.github/workflows/release-extension.yml`** — read these first. Each adds exactly one line, `if: github.repository == 'crewrig/crewrig'`, at the job level, between `runs-on: ubuntu-latest` and `steps:`.
2. **`ci/ci-capabilities.yml`** — two evidence-citation line-range refreshes caused by the guard lines shifting each workflow file's length by +1. No capability, portability tag, or exception semantics changed.
3. **`docs/adoption-guide.md`** (+34 lines) — a Step-1 callout warning that release automation stays inert on forks, plus a new Troubleshooting entry (`#release-workflow-inert-on-fork`) for adopters whose fork predates this fix.

Non-obvious design decision: the guard is a job-level `if:` condition rather than a step-level early-exit check inside the job body — see *Detailed description* below for why, and PLAN v2's *Alternatives considered and rejected* section for the full rationale.

## How to test this PR?

Prerequisites: `bash`, `git` (both checks below always run). Optional: `actionlint` (`brew install actionlint`) for full workflow lint; `act` + a reachable Docker daemon for the runtime dry-run in step 2.

1. **Static verification** (always runnable):

   ```sh
   bash .github/skills/github-actions/scripts/lint-workflow.sh .github/workflows/release-monorepo.yml
   bash .github/skills/github-actions/scripts/lint-workflow.sh .github/workflows/release-extension.yml
   bash scripts/check-ci-parity.sh
   ```

   Expected: both `lint-workflow.sh` invocations exit 0 (in an environment without `actionlint` installed, each prints `[SKIP] actionlint not found`); `check-ci-parity.sh` prints `OK: reference, GitHub Actions, GitLab agree on the portable capability set; every pipeline job is traceable.` and exits 0.

2. **Runtime dry-run of the guard itself** (needs `act` + Docker):

   ```sh
   # Canonical remote — guard must evaluate true, job runs to completion:
   act push --workflows .github/workflows/release-monorepo.yml   --job release            --dryrun --remote-name crewrig -v
   act push --workflows .github/workflows/release-extension.yml --job package-and-release --dryrun --remote-name crewrig -v
   ```

   Expected for both: `expression 'github.repository == 'crewrig/crewrig'' evaluated to 'true'`, every step runs, ending in `Job succeeded`.

   ```sh
   # Any non-canonical remote — guard must evaluate false, job is skipped:
   act push --workflows .github/workflows/release-monorepo.yml   --job release            --dryrun --remote-name <non-canonical-remote> -v
   act push --workflows .github/workflows/release-extension.yml --job package-and-release --dryrun --remote-name <non-canonical-remote> -v
   ```

   Expected for both: `evaluated to 'false'`, `Skipping job '<id>' due to 'github.repository == ...'`. Drop `-v` and re-run: zero step output beyond `act`'s own startup lines, exit 0 — the "no red run" behavior spec 0072's Scenario 1 requires.

   `--remote-name` selects which local git remote `act` reads to populate the `github.repository` context; this repo's canonical remote is `crewrig` (per `AGENTS.md` → *Agent Team Protocol* worktree convention), so any other configured remote reproduces the false branch.

## Detailed description (for agents)

### Guard design

- Job-level `if: github.repository == 'crewrig/crewrig'` added to the `release` job in `.github/workflows/release-monorepo.yml` and the `package-and-release` job in `.github/workflows/release-extension.yml`, in both cases inserted between `runs-on: ubuntu-latest` and `steps:` (see diff).
- Deliberate choice over a step-level early-exit guard, per PLAN v2's *Alternatives considered and rejected*: a job-level `if:` maps directly onto GitHub Actions' native "skipped" job conclusion, matching spec 0072's "no red run" requirement without requiring every subsequent step to carry its own conditional or a fragile `continue-on-error` chain.

### Evidence-citation refresh (`ci/ci-capabilities.yml`)

The guard's +1-line insertion shifts each workflow's total line count by one, so two evidence citations move: the `release` capability's citation from `lines 9-43` to `lines 9-44` (`release-monorepo.yml`), and the `package-and-release` capability's citation from `lines 69-74` to `lines 70-75` (`release-extension.yml`). Prose-only change; no capability id, portability tag, or `check-ci-parity.sh` traceability rule is affected.

### Documentation (`docs/adoption-guide.md`, +34 lines, no deletions)

A blockquote callout is added immediately after Step 1's first `git push -u origin main` code block, warning that release automation (`release-monorepo.yml`, `release-extension.yml`) is reserved for `crewrig/crewrig` and is expected to stay inert on a fork. A new Troubleshooting subsection, `### Release workflow fails with "Could not resolve to an issue or pull request" {#release-workflow-inert-on-fork}`, is appended after the file's existing terminal `#dirty-core-refusal` entry, in the same Cause/Effect/Resolution shape, offering two resolution paths: sync via `bash scripts/sync-from-upstream.sh` to pick up the guard, or disable the workflow pre-emptively from the fork's Actions tab.

### Verification performed (this DEV session)

- `lint-workflow.sh` against both workflows: `[SKIP] actionlint not found — install: brew install actionlint`, exit 0 for both (`actionlint` is not installed in this environment, so the script's skip-if-missing path is what ran).
- `scripts/check-ci-parity.sh` from the repo root: `OK: reference, GitHub Actions, GitLab agree on the portable capability set; every pipeline job is traceable.`, exit 0 — confirms the guard insertion doesn't break the existing 3-way CI-parity harness.
- A real `act` dry-run (act 0.2.89, Docker via a local Rancher Desktop daemon), both directions, both jobs:
  - `--remote-name crewrig` (canonical): guard `evaluated to 'true'` for both `release` and `package-and-release`; both jobs ran every step through to `Job succeeded`.
  - `--remote-name hcross` (this repo's own configured non-canonical fork remote): guard `evaluated to 'false'` for both jobs; both reported `Skipping job '<id>' due to 'github.repository == ...'`. Re-run without `-v`: zero step output beyond `act`'s own startup lines (docker-host selection notice and an unrelated Apple-silicon architecture warning), exit 0 for both.
  - This independently re-confirms, during DEV, the same real `act` dry-run the cold PLAN reviewer already performed and reported in the PLAN-v2 APPROVE review before DEV started: https://github.com/crewrig/crewrig/issues/491#issuecomment-4995323549

### Non-triggers verified (not just claimed)

- **No build output regenerated** — none of the 4 changed paths (`.github/workflows/release-monorepo.yml`, `.github/workflows/release-extension.yml`, `ci/ci-capabilities.yml`, `docs/adoption-guide.md`) is under `artifacts/` or produced by `scripts/build-components.sh`.
- **No `provenance.version` bump** — `docs/version-bump-convention.md`'s affected-paths list is limited to `artifacts/{core,library,community}/skills/*/SKILL.md`, `artifacts/{core,library,community}/agents/*/AGENT.md`, and their `extensions/{core,library}/{skills,agents}/*` counterparts; none of the 4 changed paths match.
- **No `docs/cli-matrix.md` update** — `AGENTS.md` → *CLI Matrix Maintenance*'s trigger list (`.claude/**`, `.gemini/**`, `artifacts/**`, `extensions/**`, `hooks/*-transcript-hooks.json`, `config/claude/**`, `config/gemini/**`, `scripts/build-components.sh`, `scripts/{build,install,setup,import,manage}-*.sh`, `.github/workflows/claude.yml`/`.github/workflows/gemini.yml`, `CLAUDE.md`, `GEMINI.md`, CLI-prefixed `Taskfile.yml` entries) matches none of the 4 changed paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
