### PR TITLE
📝 Transition spec 0072 to implemented

### DIFF
--- a/specs/0072-fork-release-workflow-guard.md
+++ b/specs/0072-fork-release-workflow-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0072"
 slug: fork-release-workflow-guard
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 491


### PR DESCRIPTION
Metadata-only status transition for specs/0072-fork-release-workflow-guard.md, following DEV-stage PR #526 (merged 244110e) and its REVIEW-stage APPROVE verdict.

## How to read this PR?

Single-line frontmatter change: `status: approved` → `status: implemented`. Same pattern as PR #523 (the equivalent transition on the sibling ticket, #421/spec 0071).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0072-fork-release-workflow-guard.md frontmatter `status` field bumped from `approved` to `implemented`, closing out the full SPECS→PLAN→DEV→REVIEW lifecycle for issue #491 (closed, completed), run end-to-end in AUTO mode. DEV PR #526 added a job-level `if: github.repository == 'crewrig/crewrig'` guard to both release workflows, refreshed evidence citations in ci/ci-capabilities.yml, and added an adoption-guide warning + troubleshooting entry; REVIEW posted APPROVE after independently reproducing the guard's runtime behavior via a real `act` dry-run in both directions. No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.