### PR TITLE
📝 Transition spec 0073 to approved

### DIFF
--- a/specs/0073-transcript-hook-chroma-lock.md
+++ b/specs/0073-transcript-hook-chroma-lock.md
@@ -1,7 +1,7 @@
 ---
 id: "0073"
 slug: transcript-hook-chroma-lock
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 508


### PR DESCRIPTION
Metadata-only status transition for specs/0073-transcript-hook-chroma-lock.md, following the PLAN stage's cold-review APPROVE verdict on issue #508 (AUTO mode, zero findings, central claim independently re-verified and reproduced).

## How to read this PR?

Single-line frontmatter change: `status: draft` → `status: approved`. Same pattern as PR #525 (spec 0072's equivalent transition).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0073-transcript-hook-chroma-lock.md frontmatter `status` field bumped from `draft` to `approved`, reflecting that the PLAN stage for issue #508 completed with a cold-review APPROVE verdict (https://github.com/crewrig/crewrig/issues/508#issuecomment-4996543169). No normative content changed — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.