### PR TITLE
🐛 Route transcript hook through shared ChromaDB daemon

### DIFF
--- a/hooks/mempalace-transcript.sh
+++ b/hooks/mempalace-transcript.sh
@@ -187,7 +187,7 @@ chromadb.PersistentClient = _http_factory
 # existing IMPORT_ERROR:/2 and ADD_FAILED:/3 convention.
 try:
     chromadb.HttpClient(host=_host, port=_port).heartbeat()
-except Exception as e:
+except Exception as e:  # acknowledged-exception: broad except intentional — any HttpClient.heartbeat() failure (connection refused, DNS, protocol) means the daemon is unreachable and must soft-skip this persistence attempt (spec 0073 R3); it does not block startup like the wrapper's probe, so it must not be silently swallowed or misclassified either
     print(f"DAEMON_UNREACHABLE: {_host}:{_port} — {e}", file=sys.stderr)
     sys.exit(4)
 

--- a/hooks/mempalace-transcript.sh
+++ b/hooks/mempalace-transcript.sh
@@ -11,6 +11,10 @@
 #   MEMPALACE_TRANSCRIPT_ENABLED - set to "1" to enable (default: disabled)
 #   MEMPALACE_PYTHON             - Python binary with mempalace installed
 #                                  (default: python3)
+#   MEMPALACE_CHROMA_HOST        - shared ChromaDB HTTP daemon host (ADR-0006)
+#                                  (default: 127.0.0.1)
+#   MEMPALACE_CHROMA_PORT        - shared ChromaDB HTTP daemon port (ADR-0006)
+#                                  (default: 8001)
 #   GEMINI_SESSION_ID / CLAUDE_SESSION_ID / COPILOT_SESSION_ID - session id
 #   GEMINI_PROJECT_DIR / CLAUDE_PROJECT_DIR - project directory
 #   (GitHub Copilot CLI does NOT export a $COPILOT_PROJECT_DIR — the project
@@ -153,6 +157,40 @@ if [ -n "$CONTENT" ]; then
     TRANSCRIPT_AGENT="$TRANSCRIPT_AGENT" \
     ${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5} "$MEMPALACE_PYTHON" - 2>"$_HOOK_ERR" <<'PYEOF'
 import os, sys
+
+# ADR-0006 routing: patch chromadb.PersistentClient -> HttpClient BEFORE
+# `mempalace.mcp_server` resolves the symbol (same technique as
+# scripts/lib/mempalace-http-wrapper.py's _http_factory). Reuses that
+# wrapper's own MEMPALACE_CHROMA_HOST / MEMPALACE_CHROMA_PORT env vars
+# and defaults verbatim (spec 0073 R2).
+try:
+    import chromadb
+except ImportError as e:
+    print(f"IMPORT_ERROR: {e}", file=sys.stderr)
+    sys.exit(2)
+
+_host = os.environ.get("MEMPALACE_CHROMA_HOST", "127.0.0.1")
+_port = int(os.environ.get("MEMPALACE_CHROMA_PORT", "8001"))
+
+
+def _http_factory(path=None, settings=None, **kwargs):
+    return chromadb.HttpClient(host=_host, port=_port)
+
+
+chromadb.PersistentClient = _http_factory
+
+# Soft, logged, non-blocking skip on daemon-unreachable (spec 0073 R3/R4)
+# — deliberately NOT the wrapper's fail-loud sys.exit(1): this is a
+# per-event fire-and-forget attempt bounded by the outer bash `timeout 5`
+# wrapper, not an MCP server startup gate. Distinct exit code (4) and
+# stderr prefix (DAEMON_UNREACHABLE:) keep it greppable alongside the
+# existing IMPORT_ERROR:/2 and ADD_FAILED:/3 convention.
+try:
+    chromadb.HttpClient(host=_host, port=_port).heartbeat()
+except Exception as e:
+    print(f"DAEMON_UNREACHABLE: {_host}:{_port} — {e}", file=sys.stderr)
+    sys.exit(4)
+
 try:
     from mempalace.mcp_server import tool_add_drawer
 except ImportError as e:

--- a/scripts/tests/test-mempalace-transcript-hook.sh
+++ b/scripts/tests/test-mempalace-transcript-hook.sh
@@ -24,6 +24,14 @@
 #   #94 — No timeout (explicit `timeout` keyword check).
 #         The Python invocation line MUST be prefixed with `timeout `.
 #
+#   spec 0073 / issue #508 — Route through the shared ChromaDB HTTP daemon.
+#         The heredoc's Python payload MUST route through
+#         `chromadb.HttpClient` (ADR-0006) instead of constructing a
+#         `chromadb.PersistentClient` against the on-disk palace, and MUST
+#         degrade to a soft, logged, non-blocking skip (exit 4,
+#         `DAEMON_UNREACHABLE:` on stderr) when the daemon is unreachable —
+#         never falling back to `PersistentClient`.
+#
 # Usage:
 #   bash scripts/tests/test-mempalace-transcript-hook.sh
 #
@@ -170,6 +178,62 @@ else
   else
     record FAIL "issue-94: explicit \`timeout <n>\` prefix on Python call" \
       "no \`timeout <n>\` line found in $HOOK"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Test 6 — spec 0073 / issue #508: daemon-unreachable path must degrade
+# gracefully through the shared ChromaDB HTTP daemon (ADR-0006 routing).
+#
+# Behavioral test against the REAL, shipped Python heredoc — not a
+# paraphrase of it. We extract the live heredoc body from the hook (same
+# "extract the live source" technique
+# scripts/tests/test-chroma-health-race.sh uses on scripts/lib/common.sh)
+# and execute it under a fully-mocked `chromadb` module on PYTHONPATH
+# whose `HttpClient.heartbeat()` always raises (simulating an unreachable
+# daemon) and whose `PersistentClient` is a poison pill that fails the
+# test the moment it is ever constructed. Assert: exit code 4,
+# `DAEMON_UNREACHABLE:` on stderr, no `POISON` marker, and a bounded
+# runtime (the daemon-unreachable path must not hang).
+# -------------------------------------------------------------------------
+SANDBOX_T6="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T2" "$SANDBOX_T6"' EXIT
+
+# Extract the real heredoc (between <<'PYEOF' and the closing PYEOF).
+sed -n "/<<.PYEOF./,/^PYEOF$/p" "$HOOK" | sed '1d;$d' > "$SANDBOX_T6/heredoc.py"
+
+mkdir -p "$SANDBOX_T6/chromadb"
+cat > "$SANDBOX_T6/chromadb/__init__.py" <<'MOCK'
+class HttpClient:
+    def __init__(self, host=None, port=None):
+        pass
+
+    def heartbeat(self):
+        raise ConnectionError("mock: connection refused")
+
+
+def PersistentClient(*a, **kw):
+    import sys
+    print("POISON: PersistentClient constructed", file=sys.stderr)
+    raise AssertionError("PersistentClient must never be constructed")
+MOCK
+
+if [ ! -s "$SANDBOX_T6/heredoc.py" ]; then
+  record FAIL "spec-0073-r6: daemon-unreachable path exits 4, never constructs PersistentClient, stays bounded" \
+    "could not extract Python heredoc from $HOOK"
+else
+  START_T6=$(date +%s)
+  PYTHONPATH="$SANDBOX_T6" TRANSCRIPT_ROOM=x TRANSCRIPT_CONTENT=x TRANSCRIPT_AGENT=x \
+    python3 "$SANDBOX_T6/heredoc.py" >"$SANDBOX_T6/stdout" 2>"$SANDBOX_T6/stderr"
+  RC_T6=$?
+  ELAPSED_T6=$(( $(date +%s) - START_T6 ))
+
+  if [ "$RC_T6" -eq 4 ] && grep -q "DAEMON_UNREACHABLE:" "$SANDBOX_T6/stderr" \
+     && ! grep -q "POISON" "$SANDBOX_T6/stderr" && [ "$ELAPSED_T6" -le 3 ]; then
+    record PASS "spec-0073-r6: daemon-unreachable path exits 4, never constructs PersistentClient, stays bounded"
+  else
+    record FAIL "spec-0073-r6: daemon-unreachable path exits 4, never constructs PersistentClient, stays bounded" \
+      "rc=$RC_T6 elapsed=${ELAPSED_T6}s stderr=$(cat "$SANDBOX_T6/stderr" 2>/dev/null)"
   fi
 fi
 


### PR DESCRIPTION
Routes the shared `mempalace-transcript.sh` hook through the same ChromaDB HTTP daemon ADR-0006 already mandates for the MCP-server path, instead of opening its own `PersistentClient` against the on-disk palace. Closes #508.

## How to read this PR?

Two files, +102 lines total, no deletions (`git diff crewrig/main --stat`):

1. **`hooks/mempalace-transcript.sh`** (+38) — read this first. The change is entirely inside the existing Python heredoc (lines 158-210): a `chromadb.PersistentClient` → `HttpClient` monkey-patch is inserted before the `mempalace.mcp_server` import resolves the symbol, mirroring the pattern `scripts/lib/mempalace-http-wrapper.py` already uses for the MCP-server code path (ADR-0006). Immediately after the patch, a `heartbeat()` probe against the daemon either succeeds (persistence proceeds as before) or fails and exits `4` with a `DAEMON_UNREACHABLE:` stderr line — a new, distinct code alongside the existing `IMPORT_ERROR:`/2 and `ADD_FAILED:`/3 convention. Two new env-var doc lines (`MEMPALACE_CHROMA_HOST` / `MEMPALACE_CHROMA_PORT`) were added to the header comment.
2. **`scripts/tests/test-mempalace-transcript-hook.sh`** (+64) — read second. Adds "Test 6": it extracts the real, shipped heredoc out of the hook file (`sed -n "/<<.PYEOF./,/^PYEOF$/p"`) and runs it under a fully-mocked `chromadb` module whose `HttpClient.heartbeat()` always raises and whose `PersistentClient` is a poison pill that fails the test the instant it's ever constructed. This proves the daemon-unreachable path never falls back to `PersistentClient`, exits 4, prints `DAEMON_UNREACHABLE:`, and stays bounded (≤3s).

Non-obvious design decision: the outer bash script's `STATUS_RC` handling (`hooks/mempalace-transcript.sh:212-221`) is untouched — it was already a generic "non-zero → log and continue" branch with no per-code special-casing, so the new Python exit code 4 flows through it for free.

## How to test this PR?

1. `cd` to the repo root (or this worktree) and run:
   ```
   bash scripts/tests/test-mempalace-transcript-hook.sh
   ```
2. Expected output: **4 passed, 2 failed** (exit code 1). The 2 failures (`issue-90`, `issue-94`) are a pre-existing, unrelated regression — see "Detailed description" below. This PR's own new check, `spec-0073-r6` (the daemon-unreachable path), PASSes.
3. To exercise the routing manually against a live daemon: start `chroma run --path ~/.mempalace/palace --host 127.0.0.1 --port 8001` (per ADR-0006), set `MEMPALACE_TRANSCRIPT_ENABLED=1`, and pipe a `Stop`-shaped JSON payload into `hooks/mempalace-transcript.sh`; stderr reports successful persistence. Stop the daemon and repeat — stderr now shows `DAEMON_UNREACHABLE:` and the hook still returns immediately (exit 0 at the bash level, per its existing non-blocking contract).

## Detailed description (for agents)

- **What this applies:** the already-accepted ADR-0006 ChromaDB HTTP-daemon pattern (`docs/adr/0006-chromadb-http-server.md`), already implemented for the MCP-server code path in `scripts/lib/mempalace-http-wrapper.py`, is applied here to a second code path that never received it: the transcript hook. `hooks/mempalace-transcript.sh` is the single shared script all four CLI hook registrations invoke (`hooks/claude-transcript-hooks.json`, `hooks/gemini-transcript-hooks.json`, `hooks/copilot-transcript-hooks.json`, `hooks/antigravity-transcript-hooks.json` — confirmed via `grep -rl mempalace-transcript.sh hooks/*.json`), so this one-file fix covers all four CLI surfaces symmetrically with no per-CLI branch.
- **No outer-script changes needed:** the bash `STATUS_RC`/error-handling logic (`hooks/mempalace-transcript.sh:212-221`) required no changes. It was already a generic non-zero-exit branch (`if [ "$STATUS_RC" -eq 0 ] ... else ... fi`) with no special-casing per Python exit code, so the new exit code 4 flows through the existing generic-failure branch unmodified. This was verified during PLAN and independently re-verified during PLAN's cold review (https://github.com/crewrig/crewrig/issues/508#issuecomment-4996543169).
- **Test verification actually performed:** ran `bash scripts/tests/test-mempalace-transcript-hook.sh` myself on this branch. Observed output: `issue-90` FAIL, `issue-91` PASS, `issue-92` PASS, `issue-93` PASS, `issue-94` FAIL, `spec-0073-r6` PASS — **Summary: 4 passed, 2 failed** (exit code 1). The two failures (`issue-90`, `issue-94`) are a pre-existing, unrelated regression introduced by the portable-timeout refactor in commit `799ff15` (`${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5}` indirection no longer matches those checks' literal `timeout` string grep) — confirmed unrelated to this diff since neither file-diff in this PR touches that invocation line, and independently tracked and root-caused in issue #530 (which itself documents a `git stash` check against unmodified `main` showing the identical two failures). This PR is **not** "all tests passing" — 4/6 pass, 2/6 are the pre-existing #530 regression out of scope here, and this PR's own new check (`spec-0073-r6`, the daemon-unreachable Test 6) passes cleanly.
- **No build output, no version bump, no CLI-matrix cell:** verified against `docs/version-bump-convention.md` — its affected-paths list is scoped to `artifacts/`/`extensions/` skill and agent sources; neither changed file in this PR matches. Verified against `AGENTS.md` → *CLI Matrix Maintenance* — its trigger list names `hooks/*-transcript-hooks.json` (the four per-CLI registration files), not the shared `hooks/mempalace-transcript.sh` script this PR actually touches, so `docs/cli-matrix.md` does not need an update (this is also called out explicitly in spec 0073's "Out of scope" section).

Realizes `specs/0073-transcript-hook-chroma-lock.md` (status: approved) per the cold-reviewed APPROVE plan on #508.
