### PR TITLE
📝 Transition spec 0073 to implemented

### DIFF
--- a/specs/0073-transcript-hook-chroma-lock.md
+++ b/specs/0073-transcript-hook-chroma-lock.md
@@ -1,7 +1,7 @@
 ---
 id: "0073"
 slug: transcript-hook-chroma-lock
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 508


### PR DESCRIPTION
Metadata-only status transition for specs/0073-transcript-hook-chroma-lock.md, following DEV-stage PR #531 (merged 97a2cb5) and its REVIEW-stage APPROVE verdict after one fix iteration.

## How to read this PR?

Single-line frontmatter change: `status: approved` → `status: implemented`. Same pattern as PR #527 (the equivalent transition on the sibling ticket, #491/spec 0072).

## How to test this PR?

N/A — no executable behavior, no build output affected.

## Detailed description (for agents)

specs/0073-transcript-hook-chroma-lock.md frontmatter `status` field bumped from `approved` to `implemented`, closing out the full SPECS→PLAN→DEV→REVIEW lifecycle for issue #508 (closed, completed), run end-to-end in AUTO mode. DEV PR #531 routed the transcript hook's persistence path through the shared ChromaDB HTTP daemon (ADR-0006's already-accepted pattern, previously applied only to the MCP-server code path), with a soft non-blocking skip on daemon-unreachable; REVIEW caught one real `class: tech` CI-blocking finding (a missing `# acknowledged-exception:` annotation per docs/scripting-conventions.md Rule 1), which was fixed and independently re-verified before APPROVE. A pre-existing, unrelated test regression (2 stale checks broken since commit 799ff15) was discovered during DEV and filed separately as issue #530, deliberately kept out of this diff's scope. No normative content changed in this transition PR — editorial/lifecycle-metadata edit only, per docs/spec-format.md's exemption for status transitions.