### PR TITLE
✅ Fix false-negative timeout checks in transcript-hook test and wire it into CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Test build-docs-index regression (spec 0027)
         run: bash scripts/tests/test-build-docs-index.sh
 
+      - name: Test mempalace-transcript hook regression (issue #530)
+        run: bash scripts/tests/test-mempalace-transcript-hook.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,7 @@ check-components:
     - "bash scripts/tests/test-artifact-build-install-scope.sh"
     - "bash scripts/build-docs-index.sh --check"
     - "bash scripts/tests/test-build-docs-index.sh"
+    - "bash scripts/tests/test-mempalace-transcript-hook.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -71,6 +71,7 @@ capabilities:
       - bash scripts/tests/test-artifact-build-install-scope.sh
       - bash scripts/build-docs-index.sh --check
       - bash scripts/tests/test-build-docs-index.sh
+      - bash scripts/tests/test-mempalace-transcript-hook.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"

--- a/scripts/tests/test-mempalace-transcript-hook.sh
+++ b/scripts/tests/test-mempalace-transcript-hook.sh
@@ -209,13 +209,18 @@ EOF
   # invoked (guards against a regression that stops the Stop event from
   # reaching the Python call — which would return in ~0s and otherwise
   # PASS a bare upper bound, a silent false-positive). The lower bound
-  # (>=4s) proves the 5s budget was genuinely waited out, and the upper
-  # bound (<=8s) proves the guard then fired instead of hanging 15s.
-  if [ -f "$MARKER_T5" ] && [ "$ELAPSED_T5" -ge 4 ] && [ "$ELAPSED_T5" -le 8 ]; then
+  # (>=4s) proves the 5s budget was genuinely waited out; the upper bound
+  # proves the guard then fired instead of hanging for the full 15s sleep.
+  # The ceiling is set to 12s (not a tight 8s): the discriminating property
+  # is "well before the 15s sleep", so the extra headroom absorbs fork/exec
+  # and scheduling jitter on a loaded CI runner without weakening the test
+  # (a non-firing guard still lands at ~15s > 12s). The >=4s floor stays the
+  # meaningful half.
+  if [ -f "$MARKER_T5" ] && [ "$ELAPSED_T5" -ge 4 ] && [ "$ELAPSED_T5" -le 12 ]; then
     record PASS "issue-94: timeout guard fires at runtime (5s budget)"
   else
     record FAIL "issue-94: timeout guard fires at runtime (5s budget)" \
-      "marker=$([ -f "$MARKER_T5" ] && echo yes || echo no) elapsed=${ELAPSED_T5}s (want marker=yes, 4<=elapsed<=8: the slow Python must be reached AND the 5s timeout must fire)"
+      "marker=$([ -f "$MARKER_T5" ] && echo yes || echo no) elapsed=${ELAPSED_T5}s (want marker=yes, 4<=elapsed<=12: the slow Python must be reached AND the 5s timeout must fire before the 15s sleep)"
   fi
 else
   record SKIP "issue-94: timeout guard fires at runtime (5s budget)" \

--- a/scripts/tests/test-mempalace-transcript-hook.sh
+++ b/scripts/tests/test-mempalace-transcript-hook.sh
@@ -185,9 +185,11 @@ TMPDIR_T5="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_T2" "$TMPDIR_T5"' EXIT
 
 if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+  MARKER_T5="$TMPDIR_T5/python-was-called"
   SLOW_PY="$TMPDIR_T5/slow-python"
-  cat > "$SLOW_PY" <<'EOF'
+  cat > "$SLOW_PY" <<EOF
 #!/bin/bash
+touch "$MARKER_T5"          # prove the hung Python path was actually reached
 cat >/dev/null   # drain the heredoc so it does not deadlock
 sleep 15
 echo "OK"
@@ -203,11 +205,17 @@ EOF
   ) || true
   ELAPSED_T5=$(( $(date +%s) - START_T5 ))
 
-  if [ "$ELAPSED_T5" -le 8 ]; then
+  # Two-sided assertion: the marker proves the slow Python was actually
+  # invoked (guards against a regression that stops the Stop event from
+  # reaching the Python call — which would return in ~0s and otherwise
+  # PASS a bare upper bound, a silent false-positive). The lower bound
+  # (>=4s) proves the 5s budget was genuinely waited out, and the upper
+  # bound (<=8s) proves the guard then fired instead of hanging 15s.
+  if [ -f "$MARKER_T5" ] && [ "$ELAPSED_T5" -ge 4 ] && [ "$ELAPSED_T5" -le 8 ]; then
     record PASS "issue-94: timeout guard fires at runtime (5s budget)"
   else
     record FAIL "issue-94: timeout guard fires at runtime (5s budget)" \
-      "hook ran ${ELAPSED_T5}s — the 5s timeout did not fire"
+      "marker=$([ -f "$MARKER_T5" ] && echo yes || echo no) elapsed=${ELAPSED_T5}s (want marker=yes, 4<=elapsed<=8: the slow Python must be reached AND the 5s timeout must fire)"
   fi
 else
   record SKIP "issue-94: timeout guard fires at runtime (5s budget)" \

--- a/scripts/tests/test-mempalace-transcript-hook.sh
+++ b/scripts/tests/test-mempalace-transcript-hook.sh
@@ -4,8 +4,10 @@
 # Pins the contracts surfaced by issues #90–#94:
 #
 #   #90 — Direct Python import causes SQLite contention.
-#         The Python invocation MUST be wrapped by `timeout` (or equivalent
-#         guard) so a hung MemPalace lock cannot stall the calling CLI.
+#         The Python invocation MUST be guarded by the resolved timeout
+#         wrapper (`${_HOOK_TIMEOUT:+... 5}`, resolved at init to `timeout`
+#         or `gtimeout`) so a hung MemPalace lock cannot stall the calling
+#         CLI. Checked structurally against that wrapper shape (PR #211).
 #
 #   #91 — Hook fires on every PostToolUse — too frequent for parallel agents.
 #         When the hook event is `PostToolUse`, the script MUST exit 0
@@ -21,8 +23,13 @@
 #         `2>&1` — that hides import errors and MemPalace failures from
 #         the log line.
 #
-#   #94 — No timeout (explicit `timeout` keyword check).
-#         The Python invocation line MUST be prefixed with `timeout `.
+#   #94 — No timeout guard at runtime.
+#         The timeout applied to the Python call is now conditional and
+#         portable (PR #211): the guard fires when a `timeout`/`gtimeout`
+#         binary is available, and degrades to a deliberate, logged no-op
+#         when neither is on PATH. The check is behavioral — it proves the
+#         guard actually kills a hung Python within the 5s budget — and
+#         SKIPs gracefully on hosts where no timeout binary exists.
 #
 #   spec 0073 / issue #508 — Route through the shared ChromaDB HTTP daemon.
 #         The heredoc's Python payload MUST route through
@@ -50,6 +57,7 @@ fi
 
 pass=0
 fail=0
+skip=0
 
 record() {
   local outcome="$1"
@@ -58,6 +66,9 @@ record() {
   if [ "$outcome" = "PASS" ]; then
     echo "PASS  $name${detail:+ — $detail}"
     pass=$((pass + 1))
+  elif [ "$outcome" = "SKIP" ]; then
+    echo "SKIP  $name${detail:+ — $detail}"
+    skip=$((skip + 1))
   else
     echo "FAIL  $name${detail:+ — $detail}"
     fail=$((fail + 1))
@@ -65,18 +76,20 @@ record() {
 }
 
 # -------------------------------------------------------------------------
-# Test 1 — Issue #90: Python call must be guarded by a timeout wrapper.
+# Test 1 — Issue #90: Python call must be fronted by the resolved timeout
+# wrapper.
 #
-# Heuristic: locate the line that invokes "$MEMPALACE_PYTHON" and assert
-# that `timeout` appears on (or immediately before) that line. The fix may
-# inline `timeout 5 "$MEMPALACE_PYTHON" ...` or use a variable, both are
-# accepted.
+# Structural check: PR #211 replaced the literal `timeout ` keyword with a
+# portable wrapper, `${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5}`, resolved at script
+# init to `timeout` or `gtimeout` (portable detection). Assert that the
+# Python invocation is fronted by that wrapper carrying a numeric budget,
+# rather than grepping for a literal `timeout` keyword that no longer exists.
 # -------------------------------------------------------------------------
-if grep -nE '(^|[[:space:]])timeout[[:space:]].*\$MEMPALACE_PYTHON|(^|[[:space:]])timeout[[:space:]].*"\$MEMPALACE_PYTHON"' "$HOOK" >/dev/null; then
-  record PASS "issue-90: Python invocation guarded by timeout wrapper"
+if grep -nE '\$\{_HOOK_TIMEOUT:\+[^}]*[0-9]+[^}]*\}[[:space:]]+"\$MEMPALACE_PYTHON"' "$HOOK" >/dev/null; then
+  record PASS "issue-90: Python invocation fronted by resolved timeout wrapper"
 else
-  record FAIL "issue-90: Python invocation guarded by timeout wrapper" \
-    "no \`timeout ... \$MEMPALACE_PYTHON\` pattern found in $HOOK"
+  record FAIL "issue-90: Python invocation fronted by resolved timeout wrapper" \
+    "no \`\${_HOOK_TIMEOUT:+... <n>} \"\$MEMPALACE_PYTHON\"\` pattern found in $HOOK"
 fi
 
 # -------------------------------------------------------------------------
@@ -150,35 +163,55 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Test 5 — Issue #94: explicit `timeout ` prefix on the Python call line.
+# Test 5 — Issue #94: the timeout guard must actually fire at runtime.
 #
-# Stricter than test 1: this asserts the canonical `timeout <seconds>`
-# shape immediately preceding the Python binary, not just the presence of
-# the word `timeout` somewhere nearby. This guards against partial fixes
-# (e.g. a comment that mentions timeout but no actual wrapper).
+# Behavioral test (replaces the old static `timeout <n>` grep, which PR #211
+# invalidated by resolving the guard through the `${_HOOK_TIMEOUT:+... 5}`
+# wrapper instead of a literal keyword). We prove the guard behaviorally,
+# modeled on test 2's fake-python + stdin feed and test 6's `date +%s`
+# timing:
+#
+#   - Point MEMPALACE_PYTHON at a fake that drains stdin then sleeps 15s —
+#     well past the hook's 5s budget.
+#   - Feed a `Stop` event so CONTENT is set and the Python call is reached.
+#   - When a `timeout`/`gtimeout` binary is available, measure wall-clock:
+#     the guard must return in well under the sleep → PASS; otherwise FAIL
+#     with the elapsed time.
+#   - When neither binary is on PATH, the runtime guard is intentionally
+#     absent (logged degradation — PR #211), so SKIP rather than run the
+#     15s sleep and hang the suite.
 # -------------------------------------------------------------------------
-if grep -nE '^[[:space:]]*timeout[[:space:]]+[0-9]+' "$HOOK" | grep -q '$MEMPALACE_PYTHON\|"\$MEMPALACE_PYTHON"'; then
-  record PASS "issue-94: explicit \`timeout <n>\` prefix on Python call"
-else
-  # Allow the timeout to be on a preceding continuation line; check that
-  # any line starting with `timeout <digits>` exists in the file.
-  if grep -nE '^[[:space:]]*timeout[[:space:]]+[0-9]+' "$HOOK" >/dev/null; then
-    # Verify it actually fronts the Python call by checking the next
-    # non-blank/non-comment line references $MEMPALACE_PYTHON.
-    if awk '
-      /^[[:space:]]*timeout[[:space:]]+[0-9]+/ { found=1; next }
-      found && /\$MEMPALACE_PYTHON/ { print "match"; exit 0 }
-      found && !/^[[:space:]]*(#|$)/ && !/\\$/ { found=0 }
-    ' "$HOOK" | grep -q match; then
-      record PASS "issue-94: explicit \`timeout <n>\` prefix on Python call"
-    else
-      record FAIL "issue-94: explicit \`timeout <n>\` prefix on Python call" \
-        "\`timeout <n>\` present but not fronting \$MEMPALACE_PYTHON"
-    fi
+TMPDIR_T5="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T2" "$TMPDIR_T5"' EXIT
+
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+  SLOW_PY="$TMPDIR_T5/slow-python"
+  cat > "$SLOW_PY" <<'EOF'
+#!/bin/bash
+cat >/dev/null   # drain the heredoc so it does not deadlock
+sleep 15
+echo "OK"
+EOF
+  chmod +x "$SLOW_PY"
+
+  STOP_JSON='{"hook_event_name":"Stop"}'
+  START_T5=$(date +%s)
+  (
+    export MEMPALACE_TRANSCRIPT_ENABLED=1
+    export MEMPALACE_PYTHON="$SLOW_PY"
+    printf '%s' "$STOP_JSON" | bash "$HOOK" >/dev/null 2>&1
+  ) || true
+  ELAPSED_T5=$(( $(date +%s) - START_T5 ))
+
+  if [ "$ELAPSED_T5" -le 8 ]; then
+    record PASS "issue-94: timeout guard fires at runtime (5s budget)"
   else
-    record FAIL "issue-94: explicit \`timeout <n>\` prefix on Python call" \
-      "no \`timeout <n>\` line found in $HOOK"
+    record FAIL "issue-94: timeout guard fires at runtime (5s budget)" \
+      "hook ran ${ELAPSED_T5}s — the 5s timeout did not fire"
   fi
+else
+  record SKIP "issue-94: timeout guard fires at runtime (5s budget)" \
+    "no timeout/gtimeout on PATH; runtime guard intentionally absent per hook fallback (PR #211)"
 fi
 
 # -------------------------------------------------------------------------
@@ -197,7 +230,7 @@ fi
 # runtime (the daemon-unreachable path must not hang).
 # -------------------------------------------------------------------------
 SANDBOX_T6="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_T2" "$SANDBOX_T6"' EXIT
+trap 'rm -rf "$TMPDIR_T2" "$TMPDIR_T5" "$SANDBOX_T6"' EXIT
 
 # Extract the real heredoc (between <<'PYEOF' and the closing PYEOF).
 sed -n "/<<.PYEOF./,/^PYEOF$/p" "$HOOK" | sed '1d;$d' > "$SANDBOX_T6/heredoc.py"
@@ -241,7 +274,7 @@ fi
 # Summary
 # -------------------------------------------------------------------------
 echo
-echo "Summary: $pass passed, $fail failed"
+echo "Summary: $pass passed, $fail failed, $skip skipped"
 
 if [ "$fail" -gt 0 ]; then
   exit 1


### PR DESCRIPTION
Fixes the two stale timeout regression checks (`issue-90`, `issue-94`) in `test-mempalace-transcript-hook.sh` that PR #211 turned into false negatives, and wires the test into CI so the gap that hid this can't recur.

## How to read this PR?

Two files, read in this order:

1. `scripts/tests/test-mempalace-transcript-hook.sh` — the core change. Test 1 (`issue-90`) becomes a **structural** assertion of the resolved `${_HOOK_TIMEOUT:+... 5}` wrapper; test 5 (`issue-94`) becomes a **behavioral** runtime proof (fake slow Python + wall-clock) with a graceful **SKIP** when no `timeout`/`gtimeout` binary is present. A `skip` counter is added to `record()` and the Summary.
2. `.github/workflows/build.yml` — a single new step wiring the test into the `check-components` job.

Key design point: PR #211 changed the guarantee from *"timeout always present"* to *"timeout present when a binary is available, else a deliberate logged degradation"*. The tests now pin two distinct facets (wrapper **applied** vs guard **fires at runtime**) instead of re-matching a literal `timeout ` keyword that no longer exists. `hooks/mempalace-transcript.sh` is intentionally **not** modified — its behavior is correct.

## How to test this PR?

```bash
git fetch origin fix/0530-transcript-hook-timeout-test
git checkout fix/0530-transcript-hook-timeout-test
bash scripts/tests/test-mempalace-transcript-hook.sh; echo "EXIT=$?"
```

Expected:
- On a host **with** GNU `timeout` (or `gtimeout`, e.g. CI ubuntu-latest): `Summary: 6 passed, 0 failed, 0 skipped`, `EXIT=0` — test 5 runs behaviorally and proves the 5s guard fires.
- On a host **without** either binary (e.g. bare macOS): `Summary: 5 passed, 0 failed, 1 skipped`, `EXIT=0` — test 5 SKIPs, hang-free.

Sanity-check the new structural regex matches the shipped hook line:

```bash
grep -nE '\$\{_HOOK_TIMEOUT:\+[^}]*[0-9]+[^}]*\}[[:space:]]+"\$MEMPALACE_PYTHON"' hooks/mempalace-transcript.sh
```

## Detailed description (for agents)

**Root cause.** PR #211 (`799ff15`) replaced the literal `timeout 5 "$MEMPALACE_PYTHON"` with runtime detection (`timeout` → `gtimeout` → logged fallback) and the `${_HOOK_TIMEOUT:+$_HOOK_TIMEOUT 5}` parameter-expansion wrapper (`hooks/mempalace-transcript.sh:158`). Tests 1 and 5 still grepped the literal `timeout ` prefix, which no longer matches → both FAIL despite an intact runtime guarantee. The failure was invisible because the test is wired into no CI workflow.

**Changes:**
- `scripts/tests/test-mempalace-transcript-hook.sh`
  - Header comments (`#90`, `#94`) reframed to the PR #211 contract.
  - `skip=0` added; `record()` gains a `SKIP` branch (increments neither pass nor fail); Summary prints `$pass passed, $fail failed, $skip skipped`. Exit logic unchanged (exit 1 iff `$fail > 0`).
  - Test 1 (`issue-90`): grep rewritten to assert `${_HOOK_TIMEOUT:+... <n>}` fronts `"$MEMPALACE_PYTHON"` — deterministic, no binary dependency.
  - Test 5 (`issue-94`): entire static grep/awk block replaced by a behavioral test (fake Python draining stdin then `sleep 15`, fed a `Stop` event, wall-clock via `date +%s`). PASS if elapsed ≤ 8s when a timeout binary exists; SKIP (fast, no sleep) otherwise. Traps extended so `TMPDIR_T5` is cleaned alongside `TMPDIR_T2`/`SANDBOX_T6`.
- `.github/workflows/build.yml`: new step "Test mempalace-transcript hook regression (issue #530)" in the `check-components` job, registered in `ci/ci-capabilities.yml` and mirrored into `.gitlab-ci.yml` via `scripts/build-ci.sh` (ubuntu-latest provides `jq`, `python3`, GNU `timeout`, so all 6 tests execute for real).

**Out of scope / follow-up:** 28 of 47 `scripts/tests/*.sh` are unwired from CI (mostly `test-e2e-*`). A separate issue tracks auditing that gap.

**Spec-0049 parity:** the capability manifest `ci/ci-capabilities.yml` (source of truth) carries the new command; `.gitlab-ci.yml` was regenerated to match. `check-ci-parity` is green.

**Lifecycle:** `tech`-class (test correctness + CI wiring, no *WHAT* change) → no spec-PR. No skill/agent source touched → no version bump. `build.yml` is outside the CLI-matrix trigger list → no `docs/cli-matrix.md` update.

Closes #530
