### PR TITLE
📝 Add spec 0074 — MEMPALACE_TRANSCRIPT_QUIET to silence transcript success logs

### DIFF
--- a/specs/0074-transcript-quiet-logging.md
+++ b/specs/0074-transcript-quiet-logging.md
@@ -1,0 +1,86 @@
+---
+id: "0074"
+slug: transcript-quiet-logging
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 510
+version: 1.0.0
+---
+
+# Silence transcript-hook success logs behind an opt-in quiet switch
+
+## Intent
+
+A user who runs the shared `hooks/mempalace-transcript.sh` transcript hook in
+a fast-paced interactive CLI session (Claude Code, Gemini CLI, GitHub Copilot
+CLI, or Antigravity CLI) can opt in to silencing the per-entry success
+notification that the hook currently prints after nearly every persisted user
+prompt, tool use, or agent response. The opt-in is the environment variable
+`MEMPALACE_TRANSCRIPT_QUIET` set to `1`, which suppresses only the success log
+lines; failure and error notifications remain visible so real persistence
+problems are never hidden. When the variable is unset or holds any other
+value, the hook behaves exactly as it does today, so the change is backward
+compatible for every existing user.
+
+## Requirements
+
+1. When the environment variable `MEMPALACE_TRANSCRIPT_QUIET` is set to `1`,
+   the transcript hook SHALL NOT emit any success persistence log line to
+   stderr for a persisted transcript entry.
+2. When `MEMPALACE_TRANSCRIPT_QUIET` is unset, or is set to any value other
+   than `1`, the transcript hook SHALL emit a success persistence log line to
+   stderr for each persisted transcript entry, exactly as it does today
+   (unchanged, backward-compatible default behavior).
+3. Regardless of the value of `MEMPALACE_TRANSCRIPT_QUIET`, the transcript
+   hook SHALL still write every failure or error notification for a
+   persistence attempt to stderr.
+4. The `MEMPALACE_TRANSCRIPT_QUIET` variable — its `1` activation value and
+   its default of showing success logs — SHALL be documented in the
+   `Environment:` block of the `hooks/mempalace-transcript.sh` header comment.
+
+## Scenarios
+
+**Scenario:** Quiet mode suppresses the success log line.
+
+Given the transcript hook is enabled and `MEMPALACE_TRANSCRIPT_QUIET` is set
+to `1`
+When a transcript entry is persisted successfully
+Then the hook writes no success persistence log line to stderr
+And the transcript entry is still persisted unchanged.
+
+**Scenario:** Quiet mode still surfaces a persistence failure.
+
+Given the transcript hook is enabled and `MEMPALACE_TRANSCRIPT_QUIET` is set
+to `1`
+When a transcript-persistence attempt fails
+Then the hook still writes the failure notification for that attempt to
+stderr, despite quiet mode being active.
+
+**Scenario:** Default behavior is preserved when quiet mode is unset.
+
+Given the transcript hook is enabled and `MEMPALACE_TRANSCRIPT_QUIET` is unset
+When a transcript entry is persisted successfully
+Then the hook writes the success persistence log line to stderr exactly as it
+does today.
+
+## Out of scope
+
+- Any change to the semantics of `MEMPALACE_TRANSCRIPT_ENABLED`; the quiet
+  switch only affects success-log output for an already-enabled hook and does
+  not gate whether the hook runs or persists.
+- Silencing, suppressing, or altering failure and error log output under any
+  value of `MEMPALACE_TRANSCRIPT_QUIET`; error visibility is preserved
+  unconditionally.
+- Introducing verbosity levels, log-level tiers, or any control surface
+  beyond the single binary quiet toggle described here.
+- Changing what content is persisted, which hook events trigger a persistence
+  attempt, or the format of the success log line itself when it is shown.
+- Per-entry-type or per-event filtering of success logs (for example,
+  silencing only `tool-use` lines while keeping `session-lifecycle` lines);
+  the toggle is all-or-nothing for success logs.
+- Any change to the four per-CLI hook registration files
+  (`hooks/*-transcript-hooks.json`); the toggle lives entirely inside the one
+  shared script they all invoke.
+
+## Open questions


### PR DESCRIPTION
Adds spec 0074, qualifying the WHAT for issue #510: an opt-in `MEMPALACE_TRANSCRIPT_QUIET` switch that silences the transcript hook's per-entry success logs while keeping error logs visible. This is the SPECS-stage artifact; it merges before the implementation branch is cut, per the Spec-PR workflow.

## How to read this PR?

Single new file: `specs/0074-transcript-quiet-logging.md`. Read top to bottom — frontmatter (`complexity: small`, `interaction-mode: AUTO`, `related-issue: 510`), then the five mandatory sections. The four requirements are the contract: quiet suppresses success logs (R1), default behavior is unchanged and backward compatible (R2), error logs are never silenced (R3), and the variable is documented in the hook header (R4).

## How to test this PR?

```bash
markdownlint specs/0074-transcript-quiet-logging.md
```

Expected: exit 0, no findings. Verify the frontmatter carries all required fields from `docs/spec-format.md` and the five H2 sections appear verbatim in order.

## Detailed description (for agents)

- **Added:** `specs/0074-transcript-quiet-logging.md` — original spec (status `draft`, version `1.0.0`).
- **Intent:** users of the shared `hooks/mempalace-transcript.sh` hook can opt in, via `MEMPALACE_TRANSCRIPT_QUIET=1`, to silencing per-entry success notifications; failure/error output stays visible; unset/other values preserve today's behavior.
- **Requirements:** R1 quiet=1 suppresses success log lines; R2 unset/≠1 keeps success log lines (backward compatible); R3 failure/error logs always written regardless of the toggle; R4 the variable is documented in the hook header `Environment:` block.
- **Scenarios:** happy-path (quiet suppresses success line), failure-path (quiet active but persistence fails → error still logged), default-unset (success line shown as today).
- **Out of scope:** no change to `MEMPALACE_TRANSCRIPT_ENABLED` semantics; no silencing of error logs; no verbosity tiers; no change to persisted content or trigger events; no per-entry-type filtering; no change to the four per-CLI `hooks/*-transcript-hooks.json` registration files.
- **Governance:** parity is intrinsic (one shared script for all four CLIs); no version bump (hooks/ is not a skill/agent source); no `build-components.sh` (not under `artifacts/`).

Part of the SPECS → PLAN → DEV → REVIEW lifecycle for #510, interaction mode AUTO.
