### PR TITLE
✨ Add MEMPALACE_TRANSCRIPT_QUIET to silence transcript success logs

### DIFF
--- a/hooks/mempalace-transcript.sh
+++ b/hooks/mempalace-transcript.sh
@@ -9,6 +9,9 @@
 #
 # Environment:
 #   MEMPALACE_TRANSCRIPT_ENABLED - set to "1" to enable (default: disabled)
+#   MEMPALACE_TRANSCRIPT_QUIET   - set to "1" to silence success logging;
+#                                  failures are still logged
+#                                  (default: disabled / success logs shown)
 #   MEMPALACE_PYTHON             - Python binary with mempalace installed
 #                                  (default: python3)
 #   MEMPALACE_CHROMA_HOST        - shared ChromaDB HTTP daemon host (ADR-0006)
@@ -212,7 +215,9 @@ PYEOF
   STATUS_RC=$?
   set -e
   if [ "$STATUS_RC" -eq 0 ]; then
-    echo "mempalace-transcript: persisted ${ENTRY_TYPE} to transcripts/${ROOM_ID}" >&2
+    if [ "${MEMPALACE_TRANSCRIPT_QUIET:-0}" != "1" ]; then
+      echo "mempalace-transcript: persisted ${ENTRY_TYPE} to transcripts/${ROOM_ID}" >&2
+    fi
   else
     echo "mempalace-transcript: FAILED to persist ${ENTRY_TYPE} (rc=$STATUS_RC): $STATUS" >&2
     if [ -s "$_HOOK_ERR" ]; then

--- a/scripts/tests/test-mempalace-transcript-hook.sh
+++ b/scripts/tests/test-mempalace-transcript-hook.sh
@@ -284,6 +284,98 @@ else
 fi
 
 # -------------------------------------------------------------------------
+# Test 7/8 — spec 0074 / issue #510 (R1/R2): success logging is gated by
+# MEMPALACE_TRANSCRIPT_QUIET.
+#
+# Behavioral test, modeled on test 2's fake-python + stdin feed. We point
+# MEMPALACE_PYTHON at a fake that drains stdin, prints "OK", and exits 0 so
+# the hook reaches the success branch (STATUS_RC == 0). A `Stop` event sets
+# CONTENT so the Python call is reached.
+#
+#   - R1: with MEMPALACE_TRANSCRIPT_QUIET=1, the "persisted ..." success
+#     line MUST be ABSENT from stderr.
+#   - R2: with MEMPALACE_TRANSCRIPT_QUIET unset, the "persisted ..." success
+#     line MUST be PRESENT on stderr (default behavior preserved).
+# -------------------------------------------------------------------------
+TMPDIR_T7="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T2" "$TMPDIR_T5" "$SANDBOX_T6" "$TMPDIR_T7"' EXIT
+
+OK_PY="$TMPDIR_T7/ok-python"
+cat > "$OK_PY" <<'EOF'
+#!/bin/bash
+cat >/dev/null   # drain the heredoc so it does not deadlock
+echo "OK"
+exit 0
+EOF
+chmod +x "$OK_PY"
+
+STOP_JSON_T7='{"hook_event_name":"Stop"}'
+
+# R1 — quiet enabled: success line suppressed.
+STDERR_QUIET="$TMPDIR_T7/stderr-quiet"
+(
+  export MEMPALACE_TRANSCRIPT_ENABLED=1
+  export MEMPALACE_TRANSCRIPT_QUIET=1
+  export MEMPALACE_PYTHON="$OK_PY"
+  printf '%s' "$STOP_JSON_T7" | bash "$HOOK" >/dev/null 2>"$STDERR_QUIET"
+) || true
+
+if grep -q 'mempalace-transcript: persisted' "$STDERR_QUIET"; then
+  record FAIL "issue-510-r1: success log suppressed when MEMPALACE_TRANSCRIPT_QUIET=1" \
+    "found 'persisted' line on stderr: $(grep 'mempalace-transcript: persisted' "$STDERR_QUIET")"
+else
+  record PASS "issue-510-r1: success log suppressed when MEMPALACE_TRANSCRIPT_QUIET=1"
+fi
+
+# R2 — quiet unset: success line present (default preserved).
+STDERR_DEFAULT="$TMPDIR_T7/stderr-default"
+(
+  export MEMPALACE_TRANSCRIPT_ENABLED=1
+  unset MEMPALACE_TRANSCRIPT_QUIET
+  export MEMPALACE_PYTHON="$OK_PY"
+  printf '%s' "$STOP_JSON_T7" | bash "$HOOK" >/dev/null 2>"$STDERR_DEFAULT"
+) || true
+
+if grep -q 'mempalace-transcript: persisted' "$STDERR_DEFAULT"; then
+  record PASS "issue-510-r2: success log present when MEMPALACE_TRANSCRIPT_QUIET unset"
+else
+  record FAIL "issue-510-r2: success log present when MEMPALACE_TRANSCRIPT_QUIET unset" \
+    "no 'persisted' line on stderr: $(cat "$STDERR_DEFAULT")"
+fi
+
+# -------------------------------------------------------------------------
+# Test 9 — spec 0074 / issue #510 (R3): failure logging is UNCONDITIONAL.
+#
+# Behavioral test. We point MEMPALACE_PYTHON at a fake that drains stdin
+# then exits non-zero so the hook reaches the failure branch
+# (STATUS_RC != 0). Even with MEMPALACE_TRANSCRIPT_QUIET=1, the
+# "FAILED to persist" line MUST still be emitted — the quiet flag gates
+# ONLY the success log, never failures.
+# -------------------------------------------------------------------------
+FAIL_PY="$TMPDIR_T7/fail-python"
+cat > "$FAIL_PY" <<'EOF'
+#!/bin/bash
+cat >/dev/null   # drain the heredoc so it does not deadlock
+exit 3
+EOF
+chmod +x "$FAIL_PY"
+
+STDERR_FAIL="$TMPDIR_T7/stderr-fail"
+(
+  export MEMPALACE_TRANSCRIPT_ENABLED=1
+  export MEMPALACE_TRANSCRIPT_QUIET=1
+  export MEMPALACE_PYTHON="$FAIL_PY"
+  printf '%s' "$STOP_JSON_T7" | bash "$HOOK" >/dev/null 2>"$STDERR_FAIL"
+) || true
+
+if grep -q 'mempalace-transcript: FAILED to persist' "$STDERR_FAIL"; then
+  record PASS "issue-510-r3: failure log still emitted when MEMPALACE_TRANSCRIPT_QUIET=1"
+else
+  record FAIL "issue-510-r3: failure log still emitted when MEMPALACE_TRANSCRIPT_QUIET=1" \
+    "no 'FAILED to persist' line on stderr: $(cat "$STDERR_FAIL")"
+fi
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo


### PR DESCRIPTION
Introduces an opt-in `MEMPALACE_TRANSCRIPT_QUIET` environment variable that silences the transcript hook's per-event success log line while leaving failure and error logs untouched. Implements spec 0074; the default behavior is unchanged, so existing setups keep seeing success logs.

Closes #510

## How to read this PR?

Two files, read the hook first:

1. `hooks/mempalace-transcript.sh` — the load-bearing change. The success branch (`STATUS_RC == 0`) previously emitted `mempalace-transcript: persisted ...` unconditionally; it is now wrapped in `if [ "${MEMPALACE_TRANSCRIPT_QUIET:-0}" != "1" ]; then ... fi` (R1). The `:-0` default and the `!= "1"` test mean any value other than `1` — including unset — preserves the log (R2). The failure branch (`mempalace-transcript: FAILED to persist ...`) is deliberately left outside the guard so errors are always reported (R3). The header `Environment:` block gains a `MEMPALACE_TRANSCRIPT_QUIET` entry documenting the flag (R4).

2. `scripts/tests/test-mempalace-transcript-hook.sh` — three behavioral cases appended after the existing suite (tests 7/8 for R1/R2, test 9 for R3). They reuse the established fake-`MEMPALACE_PYTHON` + stdin-feed pattern from test 2: an `ok-python` stub drains stdin and exits 0 to reach the success branch, a `fail-python` stub exits 3 to reach the failure branch. Existing tests 1–6 are untouched.

Non-obvious decision: the guard gates the success log **only**, never the failure log — a quiet transcript hook must still surface persistence failures, otherwise silent data loss becomes possible.

## How to test this PR?

Automated regression suite (the golden path and all three requirements):

```sh
bash scripts/tests/test-mempalace-transcript-hook.sh
```

Expected: `Summary: 9 passed, 0 failed, 0 skipped` and exit code 0. This suite is wired into CI (`.github/workflows/build.yml`, step "Test mempalace-transcript hook regression").

Manual check (R1 — success log suppressed):

```sh
printf '%s' '{"hook_event_name":"Stop"}' \
  | MEMPALACE_TRANSCRIPT_ENABLED=1 MEMPALACE_TRANSCRIPT_QUIET=1 \
    bash hooks/mempalace-transcript.sh
```

Expected: no `mempalace-transcript: persisted ...` line on stderr. Re-running without `MEMPALACE_TRANSCRIPT_QUIET=1` restores the line (R2), and pointing `MEMPALACE_PYTHON` at a stub that exits non-zero still prints `FAILED to persist` even with the quiet flag set (R3).

## Detailed description (for agents)

### `hooks/mempalace-transcript.sh`

- **Header (`Environment:` block).** Added a three-line entry documenting `MEMPALACE_TRANSCRIPT_QUIET` — "set to \"1\" to silence success logging; failures are still logged (default: disabled / success logs shown)". Satisfies R4.
- **Success branch (around line 215).** The single `echo "mempalace-transcript: persisted ${ENTRY_TYPE} to transcripts/${ROOM_ID}" >&2` is now nested inside `if [ "${MEMPALACE_TRANSCRIPT_QUIET:-0}" != "1" ]; then ... fi`. Satisfies R1 (quiet=1 suppresses) and R2 (unset or any non-`1` value preserves the log, backward compatible).
- **Failure branch (unchanged).** The `else` arm emitting `mempalace-transcript: FAILED to persist ...` and the `_HOOK_ERR` diagnostics are outside the guard. Satisfies R3 (error/failure logs always written).

### `scripts/tests/test-mempalace-transcript-hook.sh`

- Appended three behavioral cases after the existing test 6; no existing case modified.
  - **Test 7 (R1):** `ok-python` stub (exit 0) + `MEMPALACE_TRANSCRIPT_QUIET=1` → asserts the `persisted` line is **absent** from stderr.
  - **Test 8 (R2):** `ok-python` stub (exit 0) + `MEMPALACE_TRANSCRIPT_QUIET` unset → asserts the `persisted` line is **present** on stderr.
  - **Test 9 (R3):** `fail-python` stub (exit 3) + `MEMPALACE_TRANSCRIPT_QUIET=1` → asserts the `FAILED to persist` line is **still present** on stderr.
- Each stub drains stdin (`cat >/dev/null`) to avoid the heredoc deadlock, matching the existing pattern. Suite result on this branch: 9 passed, 0 failed, 0 skipped, exit 0.

### Governance

- **No `metadata.provenance.version` bump.** The diff touches `hooks/` and `scripts/tests/`, neither of which is a skill/agent source (`artifacts/core/skills/*/SKILL.md`, `artifacts/core/agents/*/AGENT.md`). The version-bump convention does not apply.
- **No `scripts/build-components.sh` run.** No file under `artifacts/` is touched, so there are no components to regenerate.
- **CLI-matrix not triggered.** The CLI-matrix trigger surface lists `hooks/*-transcript-hooks.json` (the JSON hook configs), not `hooks/mempalace-transcript.sh` (the shell hook). `grep -c MEMPALACE_TRANSCRIPT docs/cli-matrix.md` returns 0, confirming no matrix row references this variable.
- **Parity is intrinsic.** `hooks/mempalace-transcript.sh` is a single shared script invoked by all four CLIs; the change applies uniformly with no per-CLI asymmetry.

### Lifecycle

- Interaction mode: AUTO. Spec-PR was #535 (spec `specs/0074-transcript-quiet-logging.md`, merged to `main`). PLAN was authored and cold-reviewed APPROVE on issue #510. This is the DEV-stage implementation PR.
