### PR TITLE
📝 Transition spec 0075 to implemented

### DIFF
--- a/specs/0075-system-context-trust-provisioning.md
+++ b/specs/0075-system-context-trust-provisioning.md
@@ -1,7 +1,7 @@
 ---
 id: "0075"
 slug: system-context-trust-provisioning
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 509


### PR DESCRIPTION
Flips spec 0075 status `draft → implemented`, recording that implementation PR #539 (issue #509) merged to main. Metadata-only; no normative content changes.

## How to read this PR?

One-line diff on `specs/0075-system-context-trust-provisioning.md` frontmatter: `status: draft` → `status: implemented`. This is the lifecycle status transition mandated by `docs/spec-format.md` → *Recording a status transition* (metadata-only carve-out; `id`, `slug`, `version`, and all body sections untouched).

## How to test this PR?

```bash
git diff --stat   # expect: 1 file changed, 1 insertion(+), 1 deletion(-)
markdownlint specs/0075-system-context-trust-provisioning.md   # expect: clean
```

Confirm the only change is the `status` field.

## Detailed description (for agents)

- **Modified:** `specs/0075-system-context-trust-provisioning.md` — frontmatter `status: draft` → `status: implemented`, nothing else.
- **Trigger:** implementation PR #539 merged to `main` (closed issue #509), which is the `implemented` transition trigger per the spec-format lifecycle table.
- **Authority:** implementation team (pr-logbook role).
- **Carve-out compliance:** the append-only rule freezes normative content and `id`/`slug`/`version`; the `status` field is explicitly exempt as lifecycle-tracking metadata. This diff touches only that field.
