### PR TITLE
📝 Transition spec 0076 to implemented

### DIFF
--- a/specs/0076-ci-test-wiring-guard.md
+++ b/specs/0076-ci-test-wiring-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0076"
 slug: ci-test-wiring-guard
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 534


### PR DESCRIPTION
Flips spec 0076 status `draft → implemented`, recording that implementation PR #545 (issue #534) merged to main. Metadata-only; no normative content changes.

## How to read this PR?

One-line diff on `specs/0076-ci-test-wiring-guard.md` frontmatter: `status: draft` → `status: implemented`. Lifecycle status transition per `docs/spec-format.md` → *Recording a status transition* (metadata-only carve-out; `id`, `slug`, `version`, and all body sections untouched).

## How to test this PR?

```bash
git diff --stat   # expect: 1 file changed, 1 insertion(+), 1 deletion(-)
markdownlint specs/0076-ci-test-wiring-guard.md   # expect: clean
```

## Detailed description (for agents)

- **Modified:** `specs/0076-ci-test-wiring-guard.md` — frontmatter `status: draft` → `status: implemented`, nothing else.
- **Trigger:** implementation PR #545 merged to `main` (closed issue #534).
- **Authority:** implementation team (pr-logbook role).
- **Carve-out compliance:** the append-only rule freezes normative content and `id`/`slug`/`version`; the `status` field is exempt as lifecycle-tracking metadata. This diff touches only that field.
