### PR TITLE
📝 Trim e2e READMEs within budget and de-quarantine their tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,12 @@ jobs:
       - name: Test e2e versions-lock regression (spec 0076 wiring)
         run: bash scripts/tests/test-e2e-versions-lock.sh
 
+      - name: Test e2e README budget (spec 0077)
+        run: bash scripts/tests/test-e2e-readme.sh
+
+      - name: Test e2e lib README budget (spec 0077)
+        run: bash scripts/tests/test-e2e-libs-readme.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,8 @@ check-components:
     - "bash scripts/tests/test-e2e-structural-lib.sh"
     - "bash scripts/tests/test-e2e-taskfile.sh"
     - "bash scripts/tests/test-e2e-versions-lock.sh"
+    - "bash scripts/tests/test-e2e-readme.sh"
+    - "bash scripts/tests/test-e2e-libs-readme.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -96,6 +96,8 @@ capabilities:
       - bash scripts/tests/test-e2e-structural-lib.sh
       - bash scripts/tests/test-e2e-taskfile.sh
       - bash scripts/tests/test-e2e-versions-lock.sh
+      - bash scripts/tests/test-e2e-readme.sh
+      - bash scripts/tests/test-e2e-libs-readme.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"

--- a/ci/test-wiring-exemptions.txt
+++ b/ci/test-wiring-exemptions.txt
@@ -24,7 +24,5 @@ test-e2e-auth-scripts.sh	exercises scripts/e2e/auth-copilot.sh, which e2e_die's 
 # Each entry below names a follow-up issue tracked from #534. The fix belongs to
 # a separate ticket (spec 0076 wires tests and guards wiring; it does not own the
 # code the tests exercise). Remove the entry once the follow-up is fixed + wired.
-test-e2e-libs-readme.sh	quarantined: asserts a 200-line budget on lib/README.md (now 203) and tests/e2e/README.md (now 289), both over budget; content trim / budget review is out of scope for spec 0076 — tracked in #542 (follow-up from #534).
-test-e2e-readme.sh	quarantined: asserts tests/e2e/README.md within a 200-line budget (now 289); same root cause as test-e2e-libs-readme.sh — tracked in #542 (follow-up from #534).
 test-e2e-runner.sh	quarantined: expectations are stale — asserts the pre-#80 `1..0 # no scenarios` TAP plan and a `--keep` report-retention behavior that no longer hold now that scenarios exist; runner realignment is out of scope for spec 0076 — tracked in #543 (follow-up from #534).
 test-e2e-toml-merge.sh	quarantined: merging an empty local over defaults emits an extra `env_keys: []` the fixture does not expect (genuine merge/fixture drift); out of scope for spec 0076 — tracked in #544 (follow-up from #534).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,137 +2,87 @@
 
 ## Overview
 
-This directory hosts CrewRig's end-to-end (e2e) testing harness: real CLI
-agents (Claude Code, Gemini CLI, GitHub Copilot CLI) driven against scripted
-pillar scenarios inside isolated Docker containers, with a shared MemPalace
-sidecar for cross-tool memory checks. The framework proves that the five
-CrewRig pillars — layered context, cross-tool memory, skill/agent build,
-harness loop, and multi-CLI parity — hold under real CLI execution, not just
-unit-tested in isolation. Output is TAP, one subtest per scenario × CLI.
+Real CLI agents (Claude Code, Gemini CLI, GitHub Copilot CLI) driven against scripted pillar scenarios
+in isolated Docker containers, with a shared MemPalace sidecar for cross-tool memory checks. The harness
+proves the five CrewRig pillars — layered context, cross-tool memory, skill/agent build, harness loop,
+multi-CLI parity — hold under real CLI execution. Output is TAP, one subtest per scenario × CLI.
 
 ## Prerequisites
 
-- **Docker** with BuildKit support (Docker Desktop on macOS, Docker Engine
-  20.10+ on Linux). The harness pulls and builds five images locally.
+- **Docker** with BuildKit (Docker Desktop on macOS, Engine 20.10+ on Linux); builds five images.
 - **[Task](https://taskfile.dev/)** v3+ for the `task e2e:*` entry points.
-- **`jq`** for JSON probing in assertions and the runner's `effective.json`
-  resolution.
-- **`yq`** (Go version, mikefarah's) for TOML merging in
-  `tests/e2e/lib/toml_merge.sh`.
+- **`jq`** for JSON probing in assertions and `effective.json` resolution.
+- **`yq`** (mikefarah's Go version) for TOML merging in `lib/toml_merge.sh`.
 - **`gh`** (GitHub CLI) for harness-loop scenarios and PAT minting.
-- **Bash 4+**. macOS ships Bash 3.2 by default — install via Homebrew
-  (`brew install bash`) or rely on the containerized execution path.
+- **Bash 4+**. macOS ships 3.2 — `brew install bash` or use the container path.
 
-**Host OS caveat — Gitmoji checks.** `assert_gitmoji_title` in
-`structural.sh` uses `grep -P` (PCRE). PCRE is present in the Debian-based
-e2e images (GNU grep 3.8) but **not** in BSD grep on macOS hosts. Run any
-Gitmoji-related smoke inside the e2e images, not on the host.
+**Host OS caveat — Gitmoji checks.** `assert_gitmoji_title` in `structural.sh` uses `grep -P`
+(PCRE), present in the Debian-based e2e images (GNU grep 3.8) but **not** in BSD grep on macOS.
+Run Gitmoji smokes inside the e2e images.
 
 ## One-off setup
 
 Two steps, per developer and per workstation:
 
 ```sh
-# 1. Build (or rebuild) the e2e images.
-task e2e:build
-
-# 2. Authenticate the dedicated test account, once per CLI.
-task e2e:auth:claude
-task e2e:auth:gemini
+task e2e:build              # 1. Build (or rebuild) the e2e images.
+task e2e:auth:claude        # 2. Authenticate the dedicated test account,
+task e2e:auth:gemini        #    once per CLI.
 task e2e:auth:copilot
 ```
 
-`task e2e:build` produces `crewrig/e2e-base`, `crewrig/e2e-claude`,
-`crewrig/e2e-gemini`, `crewrig/e2e-copilot`, and `crewrig/e2e-mempalace`
-(all `:latest`). Use the per-image targets (`task e2e:build:claude`, etc.)
-when iterating on a single Dockerfile.
+`task e2e:build` produces `crewrig/e2e-{base,claude,gemini,copilot,mempalace}` (all `:latest`).
+Use per-image targets (`task e2e:build:claude`, etc.) when iterating on a single Dockerfile.
 
 ### `~/.crewrig-e2e/` layout
 
-The auth scripts write credentials into a dedicated host directory that the
-scenario runner mounts read-only at execution time:
+The auth scripts write credentials into a dedicated host directory the runner mounts read-only
+at scenario time:
 
 ```text
 ~/.crewrig-e2e/
-├── claude/
-│   ├── .credentials.json   # OAuth tokens (load-bearing)
-│   └── .claude.json        # session metadata (also required)
-├── gemini/                 # mode 0700 — bundle holds a long-lived OAuth refresh token
-│   ├── oauth_creds.json    # OAuth tokens (load-bearing)
-│   ├── settings.json       # selected auth type (load-bearing)
-│   ├── google_accounts.json
-│   ├── google_account_id
-│   ├── installation_id
-│   ├── gemini-credentials.json
-│   ├── extension_integrity.json
-│   ├── trustedFolders.json
-│   ├── projects.json
-│   ├── state.json
-│   ├── acknowledgments/
-│   ├── history/
-│   └── …                   # full ~/.gemini minus antigravity*, tmp/, *.bak|*.ori|*.orig
-└── copilot/                # empty by design — token lives in $COPILOT_GITHUB_TOKEN
+├── claude/     # .credentials.json (OAuth tokens) + .claude.json (session
+│               #   metadata) — BOTH load-bearing.
+├── gemini/     # mode 0700; full ~/.gemini bundle minus antigravity*, tmp/,
+│               #   *.bak|*.ori|*.orig. oauth_creds.json + settings.json are
+│               #   load-bearing; bundle holds a long-lived OAuth refresh token.
+└── copilot/    # empty by design — token lives in $COPILOT_GITHUB_TOKEN.
 ```
 
-> ⚠️ **Treat `~/.crewrig-e2e/gemini/` like `~/.ssh/`.** The captured bundle
-> is **not encrypted at rest**: `oauth_creds.json` carries a long-lived
-> Google refresh token. The directory is `chmod 0700` by `auth-gemini.sh`
-> but lives in plaintext on disk. Never sync it to cloud storage, never
-> ship it inside a container image, never copy it to a shared filesystem.
-> The bundle is a developer-machine artifact only; for CI use a fresh
-> dedicated-account login per runner.
+> ⚠️ **Treat `~/.crewrig-e2e/gemini/` like `~/.ssh/`.** Not encrypted at rest: `oauth_creds.json`
+> carries a long-lived Google refresh token. `auth-gemini.sh` sets `chmod 0700`, but it lives in
+> plaintext — never sync it to cloud storage, ship it in an image, or copy it to a shared
+> filesystem. It is a developer-machine artifact; for CI, use a fresh dedicated-account login per
+> runner.
 
-Override the root with `CREWRIG_E2E_HOME=/path/to/parent` (the auth
-scripts and the runner both honor it). This matters on shared CI runners
-where `$HOME` is multi-tenant.
-
-At scenario run time the runner mounts the host bundle **read-only** at
-`/run/gemini-creds` inside the container, and a `bash -c` wrapper in
-`tests/e2e/defaults.toml [cli.gemini].command` copies it to
-`/home/agent/.gemini` before `exec gemini`. The writable copy lets the
-CLI perform atomic writes (`projects.json`, etc.) without mutating the
-host bundle. See issue #147 §5 and the #148 design note for the
-rationale.
+Override the root with `CREWRIG_E2E_HOME=/path/to/parent` (auth scripts and runner both honor it) on
+multi-tenant CI. At run time the bundle mounts **read-only** at `/run/gemini-creds`; a wrapper in
+`defaults.toml [cli.gemini].command` copies it to `/home/agent/.gemini` before `exec gemini`, so the
+CLI's atomic writes (`projects.json`, etc.) never mutate the host bundle (issue #147 §5, #148 note).
 
 ### Per-CLI auth notes
 
-- **Claude Code** — interactive `claude /login` inside the
-  `crewrig/e2e-claude` image. Both `.credentials.json` AND `.claude.json`
-  must end up under `~/.crewrig-e2e/claude/`; persisting only the former
-  causes the CLI to treat the next session as a fresh install.
-  Headless override: export `CLAUDE_CODE_OAUTH_TOKEN` or
-  `ANTHROPIC_API_KEY` in your host shell.
-- **Gemini CLI** — interactive `gemini` launch inside the
-  `crewrig/e2e-gemini` image. Pick **"Login with Google"** and `/quit`
-  once you reach the welcome prompt. Both `oauth_creds.json` and
-  `settings.json` must land under `~/.crewrig-e2e/gemini/`. Headless
-  override: `GEMINI_API_KEY` (or `GOOGLE_API_KEY` for Vertex).
-- **GitHub Copilot CLI** — env-var PAT path (no on-disk file). The
-  script prints the PAT-creation URL, the recommended fine-grained
-  scopes (resource owner = test account; Copilot = Read & write), the
-  `export COPILOT_GITHUB_TOKEN=…` line for your shell rc, and a
-  **90-day** expiry reminder. If the token is already exported, the
-  script runs a 5-second container sanity check.
+- **Claude Code** — interactive `claude /login` inside `crewrig/e2e-claude`. Both `.credentials.json`
+  AND `.claude.json` must land under `~/.crewrig-e2e/claude/` (only the former makes the CLI treat the
+  next session as a fresh install). Headless override: `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`.
+- **Gemini CLI** — interactive `gemini` inside `crewrig/e2e-gemini`. Pick **"Login with Google"**
+  and `/quit` at the welcome prompt. Both `oauth_creds.json` and `settings.json` must land under
+  `~/.crewrig-e2e/gemini/`. Headless override: `GEMINI_API_KEY` (or `GOOGLE_API_KEY` for Vertex).
+- **GitHub Copilot CLI** — env-var PAT path (no on-disk file). The script prints the PAT-creation URL,
+  recommended fine-grained scopes (resource owner = test account; Copilot = Read & write), the
+  `export COPILOT_GITHUB_TOKEN=…` line, and a **90-day** expiry reminder, then sanity-checks the token.
 
-See [ADR 0002](../../docs/adr/0002-e2e-auth-flow.md) for the auth flow
-contract and `scripts/e2e/auth-{claude,gemini,copilot}.sh` for the
-scripts themselves.
+See [ADR 0002](../../docs/adr/0002-e2e-auth-flow.md) and `scripts/e2e/auth-{claude,gemini,copilot}.sh`.
 
 ## Running tests
 
 ```sh
-# Run every scenario × every configured CLI.
-task e2e:test
-
-# Run one scenario across all CLIs.
-task e2e:test:scenario -- 01-layered-context
-
-# Run all scenarios against a single CLI.
-task e2e:test:cli -- claude
+task e2e:test                                 # every scenario × every CLI
+task e2e:test:scenario -- 01-layered-context  # one scenario, all CLIs
+task e2e:test:cli -- claude                   # all scenarios, one CLI
 ```
 
-Useful flags passed through `--` to the runner
-(`tests/e2e/run.sh`):
+Useful flags passed through `--` to the runner (`tests/e2e/run.sh`):
 
 | Flag | Meaning |
 |---|---|
@@ -142,25 +92,16 @@ Useful flags passed through `--` to the runner
 | `--scenario <name>` | Limit to one scenario. |
 | `--cli <name>` | Limit to one CLI (`claude` \| `gemini` \| `copilot` \| `all`). |
 
-Exit code is `0` on success (or when no scenarios are defined) and
-non-zero when at least one scenario fails (TAP `not ok`). Per-run output
-lands in `tests/e2e/reports/<run-id>/`, with one subdirectory per
-`<cli>/<scenario>/` carrying `scenario.tap`, captured stdout/stderr,
-and (when invoked) `judge.count`.
+Exit code is `0` on success (or when no scenarios are defined), non-zero when at least one scenario
+fails (TAP `not ok`). Output lands in `reports/<run-id>/`, one `<cli>/<scenario>/` subdir per case
+with `scenario.tap`, captured stdout/stderr, and (when invoked) `judge.count`.
 
 ## Override file
 
-`tests/e2e/local.toml` is the gitignored override file deep-merged over
-`defaults.toml` at run time. The merge rules (see
-[ADR 0003](../../docs/adr/0003-e2e-runner-toml.md) Decision 2):
-
-- **Arrays APPEND.**
-- **Scalars REPLACE.**
-- **New tables graft in.**
-
-Copy `tests/e2e/local.toml.example` to `tests/e2e/local.toml` to start.
-The example routes Copilot through Ollama Cloud so local validation
-does not burn real Copilot quota:
+`tests/e2e/local.toml` is the gitignored override deep-merged over `defaults.toml` at run time.
+Merge rules (see [ADR 0003](../../docs/adr/0003-e2e-runner-toml.md) Decision 2): **arrays APPEND,
+scalars REPLACE, new tables graft in.** Copy `local.toml.example` to `local.toml` to start. The
+example routes Copilot through Ollama Cloud so local validation does not burn real Copilot quota:
 
 ```toml
 [cli.copilot]
@@ -168,25 +109,18 @@ command  = ["ollama", "launch", "copilot", "--model", "deepseek-v4-pro:cloud", "
 env_keys = ["COPILOT_GITHUB_TOKEN", "OLLAMA_HOST"]
 ```
 
-When the Ollama Cloud override is active, run `task e2e:auth:ollama` once
-before invoking any scenario. This registers the dedicated test account's
-Ed25519 keypair under `~/.crewrig-e2e/ollama/` and makes it available
-inside the copilot container as a read-only bind mount. Without this step,
-`ollama launch` will fail with an authentication error.
-
-The runner writes the merged result to `effective.json` at the top of
-each run; inspect it under the run's report directory when debugging
-config resolution.
+With that override active, run `task e2e:auth:ollama` once first: it registers the test account's
+Ed25519 keypair under `~/.crewrig-e2e/ollama/` and bind-mounts it read-only into the copilot container
+— without it, `ollama launch` fails with an auth error. The runner writes the merged `effective.json`
+at the top of each run; inspect it under the report directory when debugging config resolution.
 
 ## Adding a new scenario
 
-Each scenario is a host-side orchestrator that drives Docker itself.
-See [`scenarios/README.md`](scenarios/README.md) for the full contract;
-the short version:
+Each scenario is a host-side orchestrator that drives Docker itself. See
+[`scenarios/README.md`](scenarios/README.md) for the full contract; the short version:
 
-1. Create `tests/e2e/scenarios/<name>/` with an executable `run.sh`
-   (copy any existing scenario as a starting template) plus any
-   supporting fixtures.
+1. Create `scenarios/<name>/` with an executable `run.sh` (copy an existing scenario as a
+   template) plus any fixtures.
 2. Source the assertion helpers via the runner-exported `E2E_LIB_DIR`:
 
    ```bash
@@ -197,87 +131,61 @@ the short version:
    source "${E2E_LIB_DIR}/llm_judge.sh"
    ```
 
-3. Emit a TAP subtest plan to `${E2E_REPORT_DIR}/scenario.tap`. Exit
-   codes follow the runner convention: `0` → ok, `78` → skip (with a
-   diagnostic line on stdout), anything else → not ok.
-4. Add a `[scenarios.<name>]` table to `tests/e2e/defaults.toml` with
-   `description` and `applies_to`.
+3. Emit a TAP subtest plan to `${E2E_REPORT_DIR}/scenario.tap`. Exit codes: `0` → ok, `78` → skip
+   (with a stdout diagnostic), anything else → not ok.
+4. Add a `[scenarios.<name>]` table to `defaults.toml` (`description`, `applies_to`).
 5. Add one row per CLI × scenario to `docs/cli-matrix.md`.
 
-No runner change is needed — scenario discovery is by file presence
-plus the TOML table.
-
-The full env-var contract (`E2E_LIB_DIR`, `E2E_REPORT_DIR`, `E2E_CLI`,
-`E2E_IMAGE`, `E2E_EFFECTIVE_JSON`, `E2E_CREWRIG_E2E_HOME`,
-`E2E_SCENARIO_DIR`, `E2E_RUN_ID`) is documented in
-[`scenarios/README.md`](scenarios/README.md). The assertion API
-reference lives in [`lib/README.md`](lib/README.md).
+Discovery is by file presence plus the TOML table — no runner change needed. The full env-var contract
+(`E2E_LIB_DIR`, `E2E_REPORT_DIR`, `E2E_CLI`, `E2E_IMAGE`, `E2E_EFFECTIVE_JSON`, `E2E_CREWRIG_E2E_HOME`,
+`E2E_SCENARIO_DIR`, `E2E_RUN_ID`) is documented in [`scenarios/README.md`](scenarios/README.md); the
+assertion API reference lives in [`lib/README.md`](lib/README.md).
 
 ## Authentication strategy
 
-The harness is built around a **dedicated test account** per CLI provider
-(GitHub, Google, Anthropic). Three properties follow from that choice:
+The harness uses a **dedicated test account** per provider (GitHub, Google, Anthropic). Three
+properties follow:
 
-- **Isolation from your personal CLI state.** Credentials are written
-  under `~/.crewrig-e2e/<cli>/`, never into `~/.claude`, `~/.gemini`, or
-  `~/.copilot`. Personal transcript history and quota stay clean.
-- **Read-only volume mounts at scenario time.** Once authenticated, the
-  scenario runner bind-mounts each per-CLI dir with `:ro`. A deliberate
-  write attempt from inside the container must fail with "Read-only
-  file system" — one of the assertions the runner ships with.
-- **No API keys on disk.** `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
-  `GH_TOKEN`, `COPILOT_GITHUB_TOKEN`, `ANTHROPIC_JUDGE_API_KEY`, and the
-  Ollama Cloud token are read from your host shell and passed via
-  `docker run -e <NAME>`. They MUST NEVER be written under
-  `~/.crewrig-e2e/`. The auth scripts refuse to proceed if they detect
-  key material in a credential file.
+- **Isolation from personal CLI state.** Credentials live under `~/.crewrig-e2e/<cli>/`, never in
+  `~/.claude`, `~/.gemini`, or `~/.copilot`; personal transcript history and quota stay clean.
+- **Read-only volume mounts at scenario time.** Once authenticated, the runner bind-mounts each per-CLI
+  dir with `:ro`; a deliberate write inside the container must fail with "Read-only file system" — one
+  of the shipped assertions.
+- **No API keys on disk.** `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GH_TOKEN`, `COPILOT_GITHUB_TOKEN`,
+  `ANTHROPIC_JUDGE_API_KEY`, and the Ollama Cloud token are read from the host shell and passed via
+  `docker run -e <NAME>` — NEVER written under `~/.crewrig-e2e/` (the auth scripts refuse key material).
 
-**PAT rotation.** Fine-grained GitHub PATs default to **90 days**.
-Without a calendar reminder the Copilot leg silently starts failing.
-Rotate quarterly: mint a fresh PAT at
-<https://github.com/settings/personal-access-tokens/new> with the same
-scopes, update the export in your shell rc, then re-run
-`task e2e:auth:copilot` to confirm.
+**PAT rotation.** Fine-grained GitHub PATs default to **90 days**; without a calendar reminder the Copilot
+leg silently starts failing. Rotate quarterly at <https://github.com/settings/personal-access-tokens/new>
+with the same scopes, update the shell-rc export, then re-run `task e2e:auth:copilot`.
 
-**OAuth refresh under `:ro`.** Both Claude and Gemini refresh access
-tokens by overwriting their credential file. Under the read-only mount,
-that write fails silently; scenarios that outlive the access-token TTL
-(~1 hour) will error mid-run. Keep scenarios short, or use the headless
-env-var overrides for long ones. Tracked as open risk #1 in ADR 0002.
-
-Foundations: [ADR 0001 — Docker images](../../docs/adr/0001-e2e-docker-images.md)
-and [ADR 0002 — Auth flow](../../docs/adr/0002-e2e-auth-flow.md).
+**OAuth refresh under `:ro`.** Claude and Gemini refresh access tokens by overwriting their credential
+file; under the read-only mount that write fails silently, so scenarios outliving the access-token TTL
+(~1 h) error mid-run. Keep scenarios short, or use headless overrides. Open risk #1 in ADR 0002.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `image 'crewrig/e2e-<cli>:latest' is not present locally` | You skipped `task e2e:build`. | Run `task e2e:build` (or the per-CLI target). |
-| Claude prompts for login on every run | `.claude.json` is missing alongside `.credentials.json`. | Re-run `task e2e:auth:claude` and complete the login fully. |
-| `Permission denied` on first `/login` (macOS) | One-shot chown bootstrap was skipped — only happens if you hand-rolled `docker run`. | Re-run `task e2e:auth:<cli>` — the bootstrap is always-on inside the script. |
-| `copilot` complains about a malformed token | PAT expired, was revoked, or was pasted with surrounding whitespace. | Mint a fresh PAT, re-export, re-run `task e2e:auth:copilot`. |
-| Scenario fails mid-run with auth error after ~1 h | OAuth access token expired and the RO mount blocked the refresh write. | Set `CLAUDE_CODE_OAUTH_TOKEN` / `GEMINI_API_KEY` in your shell for long scenarios. |
-| `llm_judge` returns `MISSING_KEY` | `ANTHROPIC_JUDGE_API_KEY` is unset on the host. | Export it (may share its value with `ANTHROPIC_API_KEY`; the split is for accounting, not secrecy). |
-| Ollama Cloud override hangs or 401s | Ed25519 keypair missing, or `OLLAMA_HOST` / `COPILOT_GITHUB_TOKEN` not exported on the host. | First-time setup: run `task e2e:auth:ollama` to register the Ed25519 keypair. Then verify that `OLLAMA_HOST` and `COPILOT_GITHUB_TOKEN` are both exported before invoking `task e2e:test`. |
-| `--dry-run` reports success but no containers ran | Expected behavior. | `--dry-run` resolves config + writes `effective.json` only; drop the flag to execute. |
-| `assert_gitmoji_title` fails only on macOS | BSD grep lacks PCRE. | Run the assertion inside the e2e image, not on the host. |
-
-For deeper debugging, every run writes `effective.json`, per-case
-`scenario.tap`, and captured stdout/stderr under
-`tests/e2e/reports/<run-id>/<cli>/<scenario>/`.
+| `image 'crewrig/e2e-<cli>:latest' is not present locally` | Skipped `task e2e:build`. | Run `task e2e:build` (or the per-CLI target). |
+| Claude prompts for login on every run | `.claude.json` missing alongside `.credentials.json`. | Re-run `task e2e:auth:claude` and complete the login fully. |
+| `Permission denied` on first `/login` (macOS) | chown bootstrap skipped — only if you hand-rolled `docker run`. | Re-run `task e2e:auth:<cli>`; the bootstrap is always-on. |
+| `copilot` complains about a malformed token | PAT expired, revoked, or pasted with whitespace. | Mint a fresh PAT, re-export, re-run `task e2e:auth:copilot`. |
+| Scenario fails mid-run with auth error after ~1 h | OAuth token expired; the RO mount blocked the refresh write. | Set `CLAUDE_CODE_OAUTH_TOKEN` / `GEMINI_API_KEY` for long scenarios. |
+| `llm_judge` returns `MISSING_KEY` | `ANTHROPIC_JUDGE_API_KEY` unset on the host. | Export it (may share its value with `ANTHROPIC_API_KEY`; split is for accounting). |
+| Ollama Cloud override hangs or 401s | Ed25519 keypair missing, or `OLLAMA_HOST` / `COPILOT_GITHUB_TOKEN` not exported. | Run `task e2e:auth:ollama` once; verify both vars are exported. |
+| `--dry-run` reports success but no containers ran | Expected — resolves config + writes `effective.json` only. | Drop the flag to execute. |
+| `assert_gitmoji_title` fails only on macOS | BSD grep lacks PCRE. | Run the assertion inside the e2e image. |
 
 ## CI integration
 
-Nightly CI execution is a deliberate follow-up. The current scope is
-**local developer runs**: the harness is wired for fast iteration on a
-workstation, not yet for unattended scheduled execution. The TAP output
-and the `--keep` retention flag are designed with a future CI runner in
-mind, but no GitHub Actions workflow ships in this round.
+Nightly scenario execution is a deliberate follow-up. Current scope is **local developer runs** — wired
+for fast workstation iteration, not unattended scheduled execution. The TAP output and `--keep` retention
+flag anticipate a future CI runner, but no scenario-running workflow ships in this round.
 
 ## References
 
-- Design ADRs:
-  [0001 — Docker images](../../docs/adr/0001-e2e-docker-images.md),
+- Design ADRs: [0001 — Docker images](../../docs/adr/0001-e2e-docker-images.md),
   [0002 — Auth flow](../../docs/adr/0002-e2e-auth-flow.md),
   [0003 — Runner & TOML](../../docs/adr/0003-e2e-runner-toml.md),
   [0004 — Assertion libs](../../docs/adr/0004-e2e-assertion-libs.md),

--- a/tests/e2e/lib/README.md
+++ b/tests/e2e/lib/README.md
@@ -1,8 +1,7 @@
 # Assertion libraries
 
-Three sourceable bash libraries that scenarios reach for to make claims
-about a CLI's behavior. Governed by
-[ADR 0004](../../../docs/adr/0004-e2e-assertion-libs.md).
+Three sourceable bash libraries that scenarios reach for to make claims about a CLI's behavior.
+Governed by [ADR 0004](../../../docs/adr/0004-e2e-assertion-libs.md).
 
 | Lib | When to use |
 |---|---|
@@ -10,10 +9,9 @@ about a CLI's behavior. Governed by
 | `structural.sh` | **Second choice.** Structural shape probes: regex over stdout, JSON paths via `jq`, gitmoji-formatted titles. Use when the assertion is about the shape of an artifact, not its existence. |
 | `llm_judge.sh` | **Last resort.** LLM-as-judge oracle for qualitative criteria a regex cannot express. Each call burns budget and adds non-determinism — reach for it only when the first two cannot answer the question. |
 
-Every assertion returns `0` on PASS, `1` on FAIL, and PASS is silent.
-FAIL emits a single TAP-compatible diagnostic block to stderr — a
-`# FAIL` header line plus `expected`, `actual`, and `report` lines,
-each truncated to 200 chars. The runner captures scenario stderr under
+Every assertion returns `0` on PASS, `1` on FAIL; PASS is silent. FAIL emits a single TAP-compatible
+diagnostic block to stderr — a `# FAIL` header line plus `expected`, `actual`, and `report` lines, each
+truncated to 200 chars. The runner captures scenario stderr under
 `${E2E_REPORT_DIR}/<cli>/<scenario>/stderr`.
 
 ## Sourcing pattern
@@ -109,12 +107,10 @@ _llm_judge_driver_<backend>_call \
           HTTP error (caller records the slot as UNCERTAIN).
 ```
 
-The `<auth>` positional is opaque to the core — drivers that need no
-secret (e.g. local Ollama) accept and ignore it. Drivers MUST emit a
-`# WARN` line on stderr when `temperature != 0.0` is passed but the
-backend does not honor it. Adding a new backend means dropping a new
-driver file under `llm_judge_drivers/` and pointing `[judge].backend` at
-it — no changes to `llm_judge.sh` core. See ADR 0007 for the rationale.
+The `<auth>` positional is opaque to the core — drivers that need no secret (e.g. local Ollama) accept
+and ignore it. Drivers MUST emit a `# WARN` line on stderr when `temperature != 0.0` is passed but the
+backend does not honor it. Adding a new backend means dropping a driver file under `llm_judge_drivers/`
+and pointing `[judge].backend` at it — no changes to `llm_judge.sh` core. See ADR 0007 for the rationale.
 
 #### `ollama-cloud` backend
 
@@ -197,7 +193,6 @@ UNCERTAIN verdicts to hard failures — useful for the gating leg of CI.
 
 #### OAuth via `claude-code` backend
 
-To avoid minting a separate `ANTHROPIC_JUDGE_API_KEY`, set
-`[judge].backend = "claude-code"` + `[judge].auth_mode = "oauth"` to
-re-use the OAuth token minted by `task e2e:auth:claude`. See
+To avoid minting a separate `ANTHROPIC_JUDGE_API_KEY`, set `[judge].backend = "claude-code"` +
+`[judge].auth_mode = "oauth"` to re-use the OAuth token minted by `task e2e:auth:claude`. See
 [ADR 0008](../../../docs/adr/0008-judge-oauth-auth-mode.md).


### PR DESCRIPTION
Brings `tests/e2e/README.md` (289→197) and `tests/e2e/lib/README.md` (203→198) back within their #78-locked 200-line budget by prose-tightening only, then de-quarantines and wires their two content-guarantee tests into CI. Implements spec 0077; `Closes #542`.

## How to read this PR?

`tests/e2e/README.md` and `tests/e2e/lib/README.md` are condensed (reflow + tighter prose; no guaranteed fact dropped — only two ADR links duplicated verbatim in References were removed). `ci/test-wiring-exemptions.txt` loses the two `#542` quarantine lines. `.github/workflows/build.yml` + `ci/ci-capabilities.yml` gain the two test steps (identical order, after `test-e2e-versions-lock.sh`); `.gitlab-ci.yml` is regenerated via `scripts/build-ci.sh`.

## How to test this PR?

```bash
bash scripts/tests/test-e2e-readme.sh        # 8 passed
bash scripts/tests/test-e2e-libs-readme.sh   # 11 passed
wc -l tests/e2e/README.md tests/e2e/lib/README.md   # 197, 198 (≤200)
bash scripts/check-test-wiring.sh            # 44 wired + 4 exempted; honest
bash scripts/build-ci.sh --check             # clean
bash scripts/check-ci-parity.sh              # agree
```

## Detailed description (for agents)

- **Modified `tests/e2e/README.md`** (289→197) and **`tests/e2e/lib/README.md`** (203→198) — prose condensation preserving every asserted guarantee: 3 CLI flows (`claude`/`gemini`/`copilot`), the single-line `90`+PAT-rotation reminder, the read-only/`:ro` posture, an `#75/#78/#80/#81` cross-ref, the lib pointer; and for the lib README the 3 helpers, `ANTHROPIC_JUDGE_API_KEY`+accounting rationale, `max_calls`, macOS/BSD grep caveat. MD013 is disabled repo-wide, so wider wrapping is used alongside word-level tightening to meet the line-count budget.
- **`ci/test-wiring-exemptions.txt`** — removed the two `#542` quarantine entries (`#543`/`#544` + the 2 env entries untouched).
- **CI wiring** — `test-e2e-readme.sh` then `test-e2e-libs-readme.sh` appended to `check-components` in `build.yml` + `ci-capabilities.yml` (identical order); `.gitlab-ci.yml` regenerated.
- **Governance:** no version bump; no `build-components.sh`; not a CLI-matrix trigger; no core-paths change. Guard end state: 44 wired + 4 exempted = 48.

The 200-line budget is intentional (locked by #78) and was NOT raised. Follow-up from the #534 test-wiring guard; #543/#544 remain open.