### PR TITLE
📝 Transition spec 0077 to implemented

### DIFF
--- a/specs/0077-e2e-readme-budget.md
+++ b/specs/0077-e2e-readme-budget.md
@@ -1,7 +1,7 @@
 ---
 id: "0077"
 slug: e2e-readme-budget
-status: draft
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 542


### PR DESCRIPTION
Metadata-only status flip `draft → implemented` recording the merge of impl PR #548 (issue #542). No normative content changed — only the frontmatter `status` field, per `docs/spec-format.md` → *Recording a status transition*.