### PR TITLE
✅ Make test-e2e-runner hermetic and realign stale assertions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,9 @@ jobs:
       - name: Test e2e lib README budget (spec 0077)
         run: bash scripts/tests/test-e2e-libs-readme.sh
 
+      - name: Test e2e runner regression (spec 0078)
+        run: bash scripts/tests/test-e2e-runner.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,7 @@ check-components:
     - "bash scripts/tests/test-e2e-versions-lock.sh"
     - "bash scripts/tests/test-e2e-readme.sh"
     - "bash scripts/tests/test-e2e-libs-readme.sh"
+    - "bash scripts/tests/test-e2e-runner.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -98,6 +98,7 @@ capabilities:
       - bash scripts/tests/test-e2e-versions-lock.sh
       - bash scripts/tests/test-e2e-readme.sh
       - bash scripts/tests/test-e2e-libs-readme.sh
+      - bash scripts/tests/test-e2e-runner.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"

--- a/ci/test-wiring-exemptions.txt
+++ b/ci/test-wiring-exemptions.txt
@@ -24,5 +24,4 @@ test-e2e-auth-scripts.sh	exercises scripts/e2e/auth-copilot.sh, which e2e_die's 
 # Each entry below names a follow-up issue tracked from #534. The fix belongs to
 # a separate ticket (spec 0076 wires tests and guards wiring; it does not own the
 # code the tests exercise). Remove the entry once the follow-up is fixed + wired.
-test-e2e-runner.sh	quarantined: expectations are stale — asserts the pre-#80 `1..0 # no scenarios` TAP plan and a `--keep` report-retention behavior that no longer hold now that scenarios exist; runner realignment is out of scope for spec 0076 — tracked in #543 (follow-up from #534).
 test-e2e-toml-merge.sh	quarantined: merging an empty local over defaults emits an extra `env_keys: []` the fixture does not expect (genuine merge/fixture drift); out of scope for spec 0076 — tracked in #544 (follow-up from #534).

--- a/scripts/tests/test-e2e-runner.sh
+++ b/scripts/tests/test-e2e-runner.sh
@@ -4,12 +4,16 @@
 # Locks ADR 0003's v1 contract for the runner:
 #   - --dry-run never spawns containers
 #   - report dir <ts>-<rand> is created with effective.json
-#   - TAP 13 header + `1..0 # no scenarios defined yet (waiting for #80)` line
+#   - TAP 13 header + a `1..11` plan line — defaults.toml defines 4 scenarios
+#     which expand to 11 (scenario,cli) pairs; every pair dry-run-SKIPs, so the
+#     plan line and exit 0 hold whether or not CLI auth is configured
 #   - --keep N prunes older report dirs
 #   - --cli <invalid> and unknown flag fail with usage hint
 #   - the runner sources scripts/e2e/lib/auth-common.sh
 #
-# No docker.
+# Hermetic: runs entirely under a throwaway E2E_REPORTS_ROOT (temp dir, swept on
+# EXIT). It never reads, creates, or deletes under the committed
+# tests/e2e/reports/ fixtures. No docker.
 
 set -uo pipefail
 
@@ -23,17 +27,30 @@ note_skip() { echo "# SKIP $1: $2"; SKIP=$((SKIP + 1)); }
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUN_SH="${REPO_DIR}/tests/e2e/run.sh"
-REPORTS="${REPO_DIR}/tests/e2e/reports"
+
+# Hermetic reports root (spec 0078): run.sh honours E2E_REPORTS_ROOT and falls
+# back to tests/e2e/reports/ only when it is unset. Point it at a throwaway temp
+# dir and export it so the runner writes there too — no case reads, creates, or
+# deletes under the committed tests/e2e/reports/ fixtures.
+export E2E_REPORTS_ROOT="$(mktemp -d)"
+REPORTS="$E2E_REPORTS_ROOT"
+# Scratch stderr captures live under the temp root too, so a crash mid-run
+# leaves nothing behind at the repo root.
+ERR_DIR="$E2E_REPORTS_ROOT"
 
 # Snapshot of existing report dirs (we only inspect new entries).
 mapfile -t pre_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
-# Track every dir we create so we can clean up after ourselves.
+# Track every dir we create so we can clean up after ourselves. The temp root
+# itself is swept unconditionally on EXIT — that is the authoritative
+# hermeticity guarantee; the per-dir tracking is kept for parity with the
+# original idiom.
 CREATED=()
 cleanup() {
   for d in "${CREATED[@]}"; do
     [[ -n "$d" && -d "$d" ]] && rm -rf -- "$d"
   done
+  [[ -n "${E2E_REPORTS_ROOT:-}" && -d "$E2E_REPORTS_ROOT" ]] && rm -rf -- "$E2E_REPORTS_ROOT"
 }
 trap cleanup EXIT
 
@@ -45,12 +62,12 @@ fi
 note_pass "run.sh exists"
 
 # --- Case 1: dry-run exits 0 in a clean shell -----------------------------
-out1="$(bash "$RUN_SH" --dry-run 2>"$REPO_DIR/.test-runner.err")"
+out1="$(bash "$RUN_SH" --dry-run 2>"$ERR_DIR/.test-runner.err")"
 rc1=$?
 if [[ $rc1 -eq 0 ]]; then
   note_pass "dry-run exit 0"
 else
-  note_fail "dry-run exit 0" "rc=$rc1 stderr=$(tr '\n' '|' < "$REPO_DIR/.test-runner.err")"
+  note_fail "dry-run exit 0" "rc=$rc1 stderr=$(tr '\n' '|' < "$ERR_DIR/.test-runner.err")"
 fi
 
 # Identify the new report dir produced by case 1.
@@ -84,10 +101,10 @@ if grep -q '^TAP version 13$' <<< "$out1"; then
 else
   note_fail "TAP version 13 header" "stdout: $(echo "$out1" | head -3 | tr '\n' '|')"
 fi
-if grep -q '^1\.\.0 # no scenarios defined yet (waiting for #80)$' <<< "$out1"; then
-  note_pass "1..0 directive line present (waiting for #80)"
+if grep -q '^1\.\.11$' <<< "$out1"; then
+  note_pass "1..11 plan line present (4 scenarios → 11 (scenario,cli) pairs)"
 else
-  note_fail "1..0 directive line" "stdout: $(echo "$out1" | tr '\n' '|')"
+  note_fail "1..11 plan line" "stdout: $(echo "$out1" | tr '\n' '|')"
 fi
 
 # --- Case 5: --keep N prunes older report dirs ----------------------------
@@ -142,7 +159,7 @@ else
 fi
 
 # --- Case 6: --cli <invalid> fails with clear message --------------------
-err6_file="$REPO_DIR/.test-runner-c6.err"
+err6_file="$ERR_DIR/.test-runner-c6.err"
 if bash "$RUN_SH" --dry-run --cli bogus >/dev/null 2>"$err6_file"; then
   note_fail "--cli invalid — non-zero exit" "exited 0"
 else
@@ -163,7 +180,7 @@ for d in "${post6_dirs[@]}"; do
 done
 
 # --- Case 7: unknown flag fails -----------------------------------------
-err7_file="$REPO_DIR/.test-runner-c7.err"
+err7_file="$ERR_DIR/.test-runner-c7.err"
 if bash "$RUN_SH" --no-such-flag >/dev/null 2>"$err7_file"; then
   note_fail "unknown flag — non-zero exit" "exited 0"
 else
@@ -182,16 +199,18 @@ else
   note_fail "runner sources auth-common.sh" "no reference found in run.sh"
 fi
 
-# --- Case 9: --scenario all-equivalent (empty config) still emits 1..0 ---
-# With no scenarios defined, requesting any scenario name should fail (not
-# found), but the default (no --scenario) yields 1..0. We assert the default
-# behavior because there's no "all" sentinel in v1 — the default IS "all".
+# --- Case 9: default scenario set (all) enumerates every (scenario,cli) pair ---
+# Scenarios are now populated in defaults.toml, so the default (no --scenario)
+# enumerates all (scenario,cli) pairs and yields the 1..11 plan. We assert the
+# default behavior because there's no "all" sentinel in v1 — the default IS
+# "all". Every pair dry-run-SKIPs, so the plan line and exit 0 are identical
+# whether or not CLI auth is configured (CI has none).
 out9="$(bash "$RUN_SH" --dry-run 2>/dev/null)"
 rc9=$?
-if [[ $rc9 -eq 0 ]] && grep -q '^1\.\.0 # no scenarios defined yet (waiting for #80)$' <<< "$out9"; then
-  note_pass "default scenario set (all) → 1..0 with directive"
+if [[ $rc9 -eq 0 ]] && grep -q '^1\.\.11$' <<< "$out9"; then
+  note_pass "default scenario set (all) → 1..11 plan line"
 else
-  note_fail "default scenario set → 1..0" "rc=$rc9 stdout=$(echo "$out9" | tr '\n' '|')"
+  note_fail "default scenario set → 1..11" "rc=$rc9 stdout=$(echo "$out9" | tr '\n' '|')"
 fi
 mapfile -t post9_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 for d in "${post9_dirs[@]}"; do
@@ -200,7 +219,7 @@ for d in "${post9_dirs[@]}"; do
   if [[ $known -eq 0 ]]; then CREATED+=("$d"); fi
 done
 
-rm -f "$REPO_DIR/.test-runner.err"
+rm -f "$ERR_DIR/.test-runner.err"
 
 echo "# $PASS passed / $FAIL failed / $SKIP skipped"
 if [[ $FAIL -gt 0 ]]; then exit 1; fi

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -30,7 +30,7 @@ export E2E_CREWRIG_E2E_HOME="$(e2e_e2e_home)"
 DEFAULTS_TOML="${SCRIPT_DIR}/defaults.toml"
 LOCAL_TOML="${SCRIPT_DIR}/local.toml"
 MERGE_SH="${SCRIPT_DIR}/lib/toml_merge.sh"
-REPORTS_ROOT="${SCRIPT_DIR}/reports"
+REPORTS_ROOT="${E2E_REPORTS_ROOT:-${SCRIPT_DIR}/reports}"
 
 # --------------------------------------------------------------------------
 # Defaults + arg parsing (named flags only — Taskfile `--` forwarding does


### PR DESCRIPTION
Adds a backward-compatible `E2E_REPORTS_ROOT` override to `tests/e2e/run.sh` so the runner regression test can run in a temp reports dir instead of mutating committed `tests/e2e/reports/` fixtures, then rewrites `test-e2e-runner.sh` to be hermetic, realigns its stale pre-#80 TAP assertions to current behavior, and de-quarantines it. Implements spec 0078; `Closes #543`.

## How to read this PR?

`tests/e2e/run.sh` — one line: `REPORTS_ROOT="${E2E_REPORTS_ROOT:-${SCRIPT_DIR}/reports}"` (default unchanged when the var is unset). `scripts/tests/test-e2e-runner.sh` — now exports `E2E_REPORTS_ROOT=$(mktemp -d)` with an EXIT-trap cleanup so no case touches the committed reports tree; Case 4/9's stale `1..0 # … waiting for #80` expectation is realigned to the current `1..11` plan (defaults.toml now defines 4 scenarios = 11 pairs). `ci/test-wiring-exemptions.txt` loses the `#543` line; the test is wired into `check-components`; `.gitlab-ci.yml` regenerated.

## How to test this PR?

```bash
bash scripts/tests/test-e2e-runner.sh        # 11 passed
git status --short tests/e2e/reports/        # empty — hermeticity proof
bash scripts/check-test-wiring.sh            # 45 wired + 3 exempted; honest
bash scripts/build-ci.sh --check             # clean
bash scripts/check-ci-parity.sh              # agree
```

## Detailed description (for agents)

- **`tests/e2e/run.sh`** (+1 line): `E2E_REPORTS_ROOT` override on the reports root; additive, backward-compatible (unset → byte-identical prior behavior). No other run.sh change — its actual TAP/prune BEHAVIOR is unchanged.
- **`scripts/tests/test-e2e-runner.sh`**: rewritten hermetic (temp `E2E_REPORTS_ROOT` + trap; never reads/writes committed `tests/e2e/reports/`). Assertions realigned to run.sh's empirically-captured current output: TAP plan `1..11` (auth-independent — every dry-run pair SKIPs regardless of `e2e_auth_ready`, so the test keys only on the stable `TAP version 13` / `1..11` invariants). Case 5 (`--keep N`) logic preserved, now operating in the temp root.
- **De-quarantine + wiring**: `#543` exemption removed; test appended to `check-components` in `build.yml` + `ci-capabilities.yml` (identical order, after `test-e2e-libs-readme.sh`); `.gitlab-ci.yml` regenerated. Guard end state: 45 wired + 3 exempted = 48.
- **Governance**: no version bump; no `build-components.sh`; not a CLI-matrix trigger; no core-paths change.

Fixes the data-loss vector that deleted committed `reports/{148,149,153}` fixtures during #534. Follow-up from the #534 test-wiring guard; #544 remains open.