### PR TITLE
📝 Transition spec 0078 to implemented

### DIFF
--- a/specs/0078-e2e-runner-hermetic.md
+++ b/specs/0078-e2e-runner-hermetic.md
@@ -1,7 +1,7 @@
 ---
 id: "0078"
 slug: e2e-runner-hermetic
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 543


### PR DESCRIPTION
Metadata-only status flip `draft → implemented` recording the merge of impl PR #551 (issue #543). Only the frontmatter `status` field changes.