### PR TITLE
🐛 Stop toml_merge injecting phantom env_keys into keyless cli tables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,9 @@ jobs:
       - name: Test e2e runner regression (spec 0078)
         run: bash scripts/tests/test-e2e-runner.sh
 
+      - name: Test e2e toml-merge regression (spec 0079)
+        run: bash scripts/tests/test-e2e-toml-merge.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,7 @@ check-components:
     - "bash scripts/tests/test-e2e-readme.sh"
     - "bash scripts/tests/test-e2e-libs-readme.sh"
     - "bash scripts/tests/test-e2e-runner.sh"
+    - "bash scripts/tests/test-e2e-toml-merge.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -99,6 +99,7 @@ capabilities:
       - bash scripts/tests/test-e2e-readme.sh
       - bash scripts/tests/test-e2e-libs-readme.sh
       - bash scripts/tests/test-e2e-runner.sh
+      - bash scripts/tests/test-e2e-toml-merge.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"

--- a/ci/test-wiring-exemptions.txt
+++ b/ci/test-wiring-exemptions.txt
@@ -19,9 +19,3 @@
 # --- Environment-dependent (cannot run in the hermetic check-components job) ---
 test-spec-linter.sh	requires the repo's npm-installed node_modules (markdownlint-cli via npx, plus js-yaml/semver) which the hermetic check-components job does not provision; spec-linter.js is exercised on real specs by the lint-specs job via `task spec:lint`.
 test-e2e-auth-scripts.sh	exercises scripts/e2e/auth-copilot.sh, which e2e_die's when ~/.copilot/instructions/ is absent — a `task setup:copilot` side-effect present on a developer host but not in a clean CI HOME; cannot pass in the hermetic check-components job. See follow-up note from #534 on whether the guidance path should print before that precondition.
-
-# --- Quarantined: a genuine pre-existing failure, out of scope for spec 0076 ---
-# Each entry below names a follow-up issue tracked from #534. The fix belongs to
-# a separate ticket (spec 0076 wires tests and guards wiring; it does not own the
-# code the tests exercise). Remove the entry once the follow-up is fixed + wired.
-test-e2e-toml-merge.sh	quarantined: merging an empty local over defaults emits an extra `env_keys: []` the fixture does not expect (genuine merge/fixture drift); out of scope for spec 0076 — tracked in #544 (follow-up from #534).

--- a/tests/e2e/lib/toml_merge.sh
+++ b/tests/e2e/lib/toml_merge.sh
@@ -62,7 +62,7 @@ if [[ -n "$LOCAL" && -f "$LOCAL" ]]; then
       if ($local[0].cli[$c].command? // null) != null then
         .value.command = $local[0].cli[$c].command
       else . end |
-      .value.env_keys = (.value.env_keys // [] | unique)
+      .value |= (if has("env_keys") then .env_keys |= unique else . end)
     )
   ' "$merged_json"
 else


### PR DESCRIPTION
Guards the `env_keys` dedup in `tests/e2e/lib/toml_merge.sh` so a `cli` table that declares no `env_keys` keeps none after merge — restoring the ADR-0003 "empty local → equals defaults" pass-through that a phantom `env_keys: []` injection was breaking. De-quarantines and wires `test-e2e-toml-merge.sh`. Implements spec 0079; `Closes #544`.

## How to read this PR?

One jq predicate in `tests/e2e/lib/toml_merge.sh`: `.value.env_keys = (.value.env_keys // [] | unique)` → `.value |= (if has("env_keys") then .env_keys |= unique else . end)`. The `// []` guard used to inject `env_keys: []` into every cli table; the guarded form dedups only where `env_keys` is present. `ci/test-wiring-exemptions.txt` loses its last quarantine entry; the test is wired into `check-components`; `.gitlab-ci.yml` regenerated.

## How to test this PR?

```bash
bash scripts/tests/test-e2e-toml-merge.sh   # 11 passed (was 10/1: Case 1 failed)
bash scripts/check-test-wiring.sh           # 46 wired + 2 exempted; honest
bash scripts/build-ci.sh --check            # clean
bash scripts/check-ci-parity.sh             # agree
```

## Detailed description (for agents)

- **`tests/e2e/lib/toml_merge.sh`**: the Phase-2 env_keys dedup is guarded by `has("env_keys")` so a keyless cli table stays keyless (spec 0079 R1); dedup where present is unchanged (R2); the `command` full-replacement branch is untouched. yq `*+` Phase-1 never fabricates the key, so the predicate is sound. Consumers already read `.env_keys // []` (`run.sh:318`, `test-e2e-defaults-toml.sh:107`), so removing the injection is invisible downstream.
- **De-quarantine + wiring**: removed the `#544` exemption (and the now-empty Quarantined section header); wired `test-e2e-toml-merge.sh` into `check-components` (build.yml + ci-capabilities.yml, identical order after `test-e2e-runner.sh`); `.gitlab-ci.yml` regenerated. Guard end state: **46 wired + 2 exempted = 48** — all three #534 follow-up bugs (#542/#543/#544) now fixed and wired; only the two environment-dependent exemptions remain.
- **Decision:** fixed the MERGE, not the test fixture — the injection was redundant (consumers tolerate absent env_keys) and violated the ADR-0003 pass-through contract the test locks.
- **Governance:** no version bump; no `build-components.sh`; not a CLI-matrix trigger; no core-paths change.

Last of the three follow-ups from the #534 test-wiring guard.