### PR TITLE
📝 Transition spec 0079 to implemented

### DIFF
--- a/specs/0079-toml-merge-env-keys.md
+++ b/specs/0079-toml-merge-env-keys.md
@@ -1,7 +1,7 @@
 ---
 id: "0079"
 slug: toml-merge-env-keys
-status: draft
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 544


### PR DESCRIPTION
Metadata-only status flip `draft → implemented` recording the merge of impl PR #554 (issue #544). Only the frontmatter `status` field changes.