### PR TITLE
📝 Add spec 0080 delta-01 — reword R16 (machine-local config, not overlay)

### DIFF
--- a/specs/0080-configurable-validation-backend.delta-01.md
+++ b/specs/0080-configurable-validation-backend.delta-01.md
@@ -1,0 +1,46 @@
+---
+id: "0080"
+slug: configurable-validation-backend
+status: draft
+complexity: large
+interaction-mode: INTERMEDIATE
+related-issue: 557
+version: 1.0.1
+---
+
+# Configurable user-gate validation backend
+
+## ADDED
+
+_None._
+
+## MODIFIED
+
+Requirement 16 is reworded to resolve an internal inconsistency surfaced by the
+PLAN cold review (issue #557). The original R16 mandated persistence "in the
+overlay layer", but `docs/layers.md` defines the overlay layer as adopter-owned
+*committed repo paths*; per-user, machine-local selections cannot live in a
+committed overlay path without being shared across all fork clones. The original
+R16 also contradicted the spec's own OQ2, which blessed "a dedicated config file"
+as a candidate. This is a wording fix: the reworded R16 preserves the substantive
+intent (selections live outside the core layer and are deterministically
+discoverable at gate time) and only removes the impossible "overlay layer"
+placement — hence a PATCH bump (1.0.0 → 1.0.1), no requirement is added or
+removed.
+
+- Original R16:
+
+  > Per-user selections SHALL be persisted in the overlay layer by the
+  > `setup-*-interactive.sh` scripts and SHALL be discoverable by the agent at
+  > gate time.
+
+- Replacement R16:
+
+  > Per-user selections SHALL be persisted by the `setup-*-interactive.sh`
+  > scripts in a per-user, machine-local configuration OUTSIDE the core layer —
+  > not a committed layer file — and SHALL be deterministically discoverable by
+  > the agent at gate time.
+
+## REMOVED
+
+_None._

--- a/specs/0080-configurable-validation-backend.delta-01.md
+++ b/specs/0080-configurable-validation-backend.delta-01.md
@@ -19,7 +19,7 @@ _None._
 Requirement 16 is reworded to resolve an internal inconsistency surfaced by the
 PLAN cold review (issue #557). The original R16 mandated persistence "in the
 overlay layer", but `docs/layers.md` defines the overlay layer as adopter-owned
-*committed repo paths*; per-user, machine-local selections cannot live in a
+_committed repo paths_; per-user, machine-local selections cannot live in a
 committed overlay path without being shared across all fork clones. The original
 R16 also contradicted the spec's own OQ2, which blessed "a dedicated config file"
 as a candidate. This is a wording fix: the reworded R16 preserves the substantive


### PR DESCRIPTION
Reword requirement R16 of spec 0080 to resolve an internal inconsistency
surfaced by the PLAN cold review (issue #557). Wording fix only — no requirement
added or removed (PATCH, 1.0.0 → 1.0.1).

## How to read this PR?

Single file: `specs/0080-configurable-validation-backend.delta-01.md`. Read the
`## MODIFIED` block — it quotes the original R16 and the replacement, with the
rationale. The other two delta sections (`## ADDED`, `## REMOVED`) are `_None._`.

## How to test this PR?

```sh
markdownlint-cli specs/0080-configurable-validation-backend.delta-01.md
```
Expected: clean. Verify the three H2 delta sections are present, the frontmatter
`id`/`slug` match the parent spec and the branch name, and `version` is `1.0.1`.

## Detailed description (for agents)

- **Added** `specs/0080-configurable-validation-backend.delta-01.md`
  (delta-spec, status `draft`, version `1.0.1`).
- **R16 change:** from "persisted in the overlay layer … discoverable" to
  "persisted … in a per-user, machine-local configuration OUTSIDE the core
  layer — not a committed layer file — and … deterministically discoverable at
  gate time." `docs/layers.md` defines the overlay layer as adopter-owned
  *committed* repo paths, which cannot hold per-user machine-local data without
  sharing it across all fork clones; the original wording also contradicted the
  spec's own OQ2 ("a dedicated config file"). Intent preserved (outside core +
  discoverable), so PATCH.
- **Why now:** the PLAN cold review raised a `spec`-class finding; per the
  finding-routing rule (`spec` → SPECS) this delta-spec must merge before the
  PLAN is finalized and DEV begins.

Logbook: #557 (remains open through PLAN → DEV → REVIEW; this delta-spec-PR does
not close it).
