### PR TITLE
📝 Transition spec 0080 to implemented

### DIFF
--- a/specs/0080-configurable-validation-backend.md
+++ b/specs/0080-configurable-validation-backend.md
@@ -1,7 +1,7 @@
 ---
 id: "0080"
 slug: configurable-validation-backend
-status: draft
+status: implemented
 complexity: large
 interaction-mode: INTERMEDIATE
 related-issue: 557


### PR DESCRIPTION
Metadata-only status flip `draft → implemented` recording the merge of impl PR #560 (issue #557). Only the parent spec's frontmatter `status` field changes; the `delta-01` keeps its `status` per the delta convention (cf. spec 0069).