### PR TITLE
🔒 Purge machine-specific home paths and maintainer login from tracked files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,12 @@ jobs:
       - name: Test setup validation-backend helper regression (spec 0080)
         run: bash scripts/tests/test-setup-validation-backend.sh
 
+      - name: Check no machine-specific home paths (spec 0081)
+        run: bash scripts/check-no-machine-paths.sh
+
+      - name: Test check-no-machine-paths regression (spec 0081)
+        run: bash scripts/tests/test-check-no-machine-paths.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,8 @@ check-components:
     - "bash scripts/tests/test-e2e-runner.sh"
     - "bash scripts/tests/test-e2e-toml-merge.sh"
     - "bash scripts/tests/test-setup-validation-backend.sh"
+    - "bash scripts/check-no-machine-paths.sh"
+    - "bash scripts/tests/test-check-no-machine-paths.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -101,6 +101,8 @@ capabilities:
       - bash scripts/tests/test-e2e-runner.sh
       - bash scripts/tests/test-e2e-toml-merge.sh
       - bash scripts/tests/test-setup-validation-backend.sh
+      - bash scripts/check-no-machine-paths.sh
+      - bash scripts/tests/test-check-no-machine-paths.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"

--- a/docs/research/artifacts/147/baseline.fs.txt
+++ b/docs/research/artifacts/147/baseline.fs.txt
@@ -1,77 +1,77 @@
 === ~/.gemini (top-level + selected dirs, excl. antigravity/caches) ===
-/Users/hoanicross/.gemini/.env|Regular File|1521|May 25 11:16:22 2026|-rw-r--r--
-/Users/hoanicross/.gemini/.selected_expertise|Regular File|13|May 26 14:51:00 2026|-rw-r--r--
-/Users/hoanicross/.gemini/.selected_level|Regular File|7|May 26 14:51:01 2026|-rw-r--r--
-/Users/hoanicross/.gemini/.selected_team|Regular File|6|May 26 14:50:59 2026|-rw-r--r--
-/Users/hoanicross/.gemini/00_SOUL.md.bak|Regular File|2620|Feb 24 17:02:05 2026|-rw-r--r--
-/Users/hoanicross/.gemini/00_SOUL.md|Regular File|3855|May 26 14:50:53 2026|-rw-r--r--
-/Users/hoanicross/.gemini/10_USER_LEVEL.md|Regular File|4301|May 26 14:51:01 2026|-rw-r--r--
-/Users/hoanicross/.gemini/20_ORGANIZATION.md|Regular File|1428|May 26 14:50:53 2026|-rw-r--r--
-/Users/hoanicross/.gemini/30_USER_PROFILE.md.ori|Regular File|1589|Feb 24 22:14:24 2026|-rw-r--r--
-/Users/hoanicross/.gemini/30_USER_PROFILE.md|Regular File|1712|May 26 14:51:01 2026|-rw-r--r--
-/Users/hoanicross/.gemini/40_USER_EXPERTISE.md|Regular File|546|May 26 14:51:00 2026|-rw-r--r--
-/Users/hoanicross/.gemini/50_USER_TEAM.md.ori|Regular File|6471|Feb 24 19:01:55 2026|-rw-r--r--
-/Users/hoanicross/.gemini/50_USER_TEAM.md|Regular File|2221|May 26 14:50:59 2026|-rw-r--r--
-/Users/hoanicross/.gemini/60_TOOLS.md|Regular File|27130|May 26 14:50:53 2026|-rw-r--r--
-/Users/hoanicross/.gemini/60_USER_TOOLS.md.ori|Regular File|696|Feb 26 11:30:04 2026|-rw-r--r--
-/Users/hoanicross/.gemini/acknowledgments|Directory|96|May 20 23:14:49 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/antigravity|Directory|544|May 27 18:39:48 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/commands|Directory|128|Mar  5 09:58:28 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/extension_integrity.json|Regular File|306|Apr 29 13:56:20 2026|-rw-------
-/Users/hoanicross/.gemini/extensions|Directory|160|May  5 14:09:42 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/gemini-credentials.json|Regular File|326|Apr 29 13:56:20 2026|-rw-------
-/Users/hoanicross/.gemini/GEMINI.md|Regular File|844|Dec 27 13:58:45 2025|-rw-r--r--
-/Users/hoanicross/.gemini/google_account_id|Regular File|21|Oct  2 21:30:47 2025|-rw-r--r--
-/Users/hoanicross/.gemini/google_accounts.json|Regular File|79|May 20 22:52:44 2026|-rw-r--r--
-/Users/hoanicross/.gemini/history|Directory|896|May 21 12:10:09 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/hooks|Directory|96|Apr 29 00:49:42 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/installation_id|Regular File|36|Jul  2 13:33:21 2025|-rw-r--r--
-/Users/hoanicross/.gemini/mcp-server-enablement.json|Regular File|2|Feb 10 19:34:25 2026|-rw-r--r--
-/Users/hoanicross/.gemini/mcp|Directory|96|Feb 11 15:23:45 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/oauth_creds.json|Regular File|1802|May 30 14:15:23 2026|-rw-------
-/Users/hoanicross/.gemini/policies|Directory|160|Apr  9 10:17:19 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/projects.json|Regular File|1518|May 21 12:10:09 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-003507|Regular File|1087|Apr 29 00:35:07 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-003933|Regular File|2344|Apr 29 00:39:33 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-003942|Regular File|1087|Apr 29 00:39:42 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-004935|Regular File|2544|Apr 29 00:49:35 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-004942|Regular File|1087|Apr 29 00:49:42 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-210330|Regular File|2560|Apr 29 21:03:30 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260429-210339|Regular File|1087|Apr 29 21:03:39 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260430-221446|Regular File|2560|Apr 30 22:14:46 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260430-221547|Regular File|2560|Apr 30 22:15:47 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260430-221559|Regular File|1087|Apr 30 22:15:59 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260503-211950|Regular File|2486|May  3 21:19:50 2026|-rw-------
-/Users/hoanicross/.gemini/settings.json.bak.20260503-212124|Regular File|1087|May  3 21:21:24 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260504-082640|Regular File|2344|May  4 08:26:40 2026|-rw-------
-/Users/hoanicross/.gemini/settings.json.bak.20260504-082654|Regular File|1087|May  4 08:26:54 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260504-111534|Regular File|2560|May  4 11:15:34 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260504-111549|Regular File|1087|May  4 11:15:49 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260526-094145|Regular File|2373|May 26 09:41:45 2026|-rw-------
-/Users/hoanicross/.gemini/settings.json.bak.20260526-094201|Regular File|1144|May 26 09:42:01 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260526-145036|Regular File|2617|May 26 14:50:36 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260526-145045|Regular File|1144|May 26 14:50:45 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260526-145050|Regular File|1144|May 26 14:50:50 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260526-145053|Regular File|2617|May 26 14:50:53 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.bak.20260526-145104|Regular File|1144|May 26 14:51:04 2026|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json.ori|Regular File|1134|Apr 28 23:13:12 2026|-rw-------
-/Users/hoanicross/.gemini/settings.json.orig|Regular File|64|Jul  2 13:36:45 2025|-rw-r--r--
-/Users/hoanicross/.gemini/settings.json|Regular File|2479|May 27 18:39:48 2026|-rw-------
-/Users/hoanicross/.gemini/skills|Directory|224|May  4 14:14:26 2026|drwxr-xr-x
-/Users/hoanicross/.gemini/state.json|Regular File|268|May 20 23:14:31 2026|-rw-r--r--
-/Users/hoanicross/.gemini/trustedFolders.json|Regular File|964|Apr 29 13:54:45 2026|-rw-------
+$HOME/.gemini/.env|Regular File|1521|May 25 11:16:22 2026|-rw-r--r--
+$HOME/.gemini/.selected_expertise|Regular File|13|May 26 14:51:00 2026|-rw-r--r--
+$HOME/.gemini/.selected_level|Regular File|7|May 26 14:51:01 2026|-rw-r--r--
+$HOME/.gemini/.selected_team|Regular File|6|May 26 14:50:59 2026|-rw-r--r--
+$HOME/.gemini/00_SOUL.md.bak|Regular File|2620|Feb 24 17:02:05 2026|-rw-r--r--
+$HOME/.gemini/00_SOUL.md|Regular File|3855|May 26 14:50:53 2026|-rw-r--r--
+$HOME/.gemini/10_USER_LEVEL.md|Regular File|4301|May 26 14:51:01 2026|-rw-r--r--
+$HOME/.gemini/20_ORGANIZATION.md|Regular File|1428|May 26 14:50:53 2026|-rw-r--r--
+$HOME/.gemini/30_USER_PROFILE.md.ori|Regular File|1589|Feb 24 22:14:24 2026|-rw-r--r--
+$HOME/.gemini/30_USER_PROFILE.md|Regular File|1712|May 26 14:51:01 2026|-rw-r--r--
+$HOME/.gemini/40_USER_EXPERTISE.md|Regular File|546|May 26 14:51:00 2026|-rw-r--r--
+$HOME/.gemini/50_USER_TEAM.md.ori|Regular File|6471|Feb 24 19:01:55 2026|-rw-r--r--
+$HOME/.gemini/50_USER_TEAM.md|Regular File|2221|May 26 14:50:59 2026|-rw-r--r--
+$HOME/.gemini/60_TOOLS.md|Regular File|27130|May 26 14:50:53 2026|-rw-r--r--
+$HOME/.gemini/60_USER_TOOLS.md.ori|Regular File|696|Feb 26 11:30:04 2026|-rw-r--r--
+$HOME/.gemini/acknowledgments|Directory|96|May 20 23:14:49 2026|drwxr-xr-x
+$HOME/.gemini/antigravity|Directory|544|May 27 18:39:48 2026|drwxr-xr-x
+$HOME/.gemini/commands|Directory|128|Mar  5 09:58:28 2026|drwxr-xr-x
+$HOME/.gemini/extension_integrity.json|Regular File|306|Apr 29 13:56:20 2026|-rw-------
+$HOME/.gemini/extensions|Directory|160|May  5 14:09:42 2026|drwxr-xr-x
+$HOME/.gemini/gemini-credentials.json|Regular File|326|Apr 29 13:56:20 2026|-rw-------
+$HOME/.gemini/GEMINI.md|Regular File|844|Dec 27 13:58:45 2025|-rw-r--r--
+$HOME/.gemini/google_account_id|Regular File|21|Oct  2 21:30:47 2025|-rw-r--r--
+$HOME/.gemini/google_accounts.json|Regular File|79|May 20 22:52:44 2026|-rw-r--r--
+$HOME/.gemini/history|Directory|896|May 21 12:10:09 2026|drwxr-xr-x
+$HOME/.gemini/hooks|Directory|96|Apr 29 00:49:42 2026|drwxr-xr-x
+$HOME/.gemini/installation_id|Regular File|36|Jul  2 13:33:21 2025|-rw-r--r--
+$HOME/.gemini/mcp-server-enablement.json|Regular File|2|Feb 10 19:34:25 2026|-rw-r--r--
+$HOME/.gemini/mcp|Directory|96|Feb 11 15:23:45 2026|drwxr-xr-x
+$HOME/.gemini/oauth_creds.json|Regular File|1802|May 30 14:15:23 2026|-rw-------
+$HOME/.gemini/policies|Directory|160|Apr  9 10:17:19 2026|drwxr-xr-x
+$HOME/.gemini/projects.json|Regular File|1518|May 21 12:10:09 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-003507|Regular File|1087|Apr 29 00:35:07 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-003933|Regular File|2344|Apr 29 00:39:33 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-003942|Regular File|1087|Apr 29 00:39:42 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-004935|Regular File|2544|Apr 29 00:49:35 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-004942|Regular File|1087|Apr 29 00:49:42 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-210330|Regular File|2560|Apr 29 21:03:30 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260429-210339|Regular File|1087|Apr 29 21:03:39 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260430-221446|Regular File|2560|Apr 30 22:14:46 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260430-221547|Regular File|2560|Apr 30 22:15:47 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260430-221559|Regular File|1087|Apr 30 22:15:59 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260503-211950|Regular File|2486|May  3 21:19:50 2026|-rw-------
+$HOME/.gemini/settings.json.bak.20260503-212124|Regular File|1087|May  3 21:21:24 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260504-082640|Regular File|2344|May  4 08:26:40 2026|-rw-------
+$HOME/.gemini/settings.json.bak.20260504-082654|Regular File|1087|May  4 08:26:54 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260504-111534|Regular File|2560|May  4 11:15:34 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260504-111549|Regular File|1087|May  4 11:15:49 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260526-094145|Regular File|2373|May 26 09:41:45 2026|-rw-------
+$HOME/.gemini/settings.json.bak.20260526-094201|Regular File|1144|May 26 09:42:01 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260526-145036|Regular File|2617|May 26 14:50:36 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260526-145045|Regular File|1144|May 26 14:50:45 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260526-145050|Regular File|1144|May 26 14:50:50 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260526-145053|Regular File|2617|May 26 14:50:53 2026|-rw-r--r--
+$HOME/.gemini/settings.json.bak.20260526-145104|Regular File|1144|May 26 14:51:04 2026|-rw-r--r--
+$HOME/.gemini/settings.json.ori|Regular File|1134|Apr 28 23:13:12 2026|-rw-------
+$HOME/.gemini/settings.json.orig|Regular File|64|Jul  2 13:36:45 2025|-rw-r--r--
+$HOME/.gemini/settings.json|Regular File|2479|May 27 18:39:48 2026|-rw-------
+$HOME/.gemini/skills|Directory|224|May  4 14:14:26 2026|drwxr-xr-x
+$HOME/.gemini/state.json|Regular File|268|May 20 23:14:31 2026|-rw-r--r--
+$HOME/.gemini/trustedFolders.json|Regular File|964|Apr 29 13:54:45 2026|-rw-------
 
 === ~/.gemini/history (file count + latest entries) ===
-drwxr-xr-x hoanicross staff 896 B  Thu May 21 12:10:09 2026 .
-drwxr-xr-x hoanicross staff 2.1 KB Sat May 30 14:23:33 2026 ..
-drwxr-xr-x hoanicross staff 160 B  Tue Feb 10 07:14:39 2026 11e84dea0497f5332e233c17dd6a7637184535114f2ba0e59cf64ae3d326beb6
-drwxr-xr-x hoanicross staff 192 B  Tue Feb 24 09:34:53 2026 15b18364e8e6405325b84f6c176c226afb49a7bfab5f1b91d0d7ae513597948a
-drwxr-xr-x hoanicross staff 160 B  Sun Feb 15 10:45:04 2026 3b27f888f6ae20a4c13d87745f4be486897c5790cc1f7788c0ae4d4c784c0a1b
-drwxr-xr-x hoanicross staff 160 B  Tue Feb 10 14:07:43 2026 58556acf3b6ba5e3bd601083595bd698dda00353c8e1ed951eff09ea6946d540
-drwxr-xr-x hoanicross staff 192 B  Fri Mar 20 12:59:06 2026 749a16e25a9c2ed5e688c501251bba1c0486ce69c4491df38e386df9d650faa8
-drwxr-xr-x hoanicross staff 192 B  Mon Mar 23 13:05:07 2026 8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1
-drwxr-xr-x hoanicross staff 192 B  Tue Feb 24 09:42:03 2026 926025a8733b67f376ff095f1242ffb4679c0366bf6dcdbde0a12ec762165ffd
-drwxr-xr-x hoanicross staff 160 B  Sat Feb  7 00:30:26 2026 c79c3bb2191decb286a6144667b45d2496287cf487a71d3f7679a416f2b175c3
+drwxr-xr-x <user> staff 896 B  Thu May 21 12:10:09 2026 .
+drwxr-xr-x <user> staff 2.1 KB Sat May 30 14:23:33 2026 ..
+drwxr-xr-x <user> staff 160 B  Tue Feb 10 07:14:39 2026 11e84dea0497f5332e233c17dd6a7637184535114f2ba0e59cf64ae3d326beb6
+drwxr-xr-x <user> staff 192 B  Tue Feb 24 09:34:53 2026 15b18364e8e6405325b84f6c176c226afb49a7bfab5f1b91d0d7ae513597948a
+drwxr-xr-x <user> staff 160 B  Sun Feb 15 10:45:04 2026 3b27f888f6ae20a4c13d87745f4be486897c5790cc1f7788c0ae4d4c784c0a1b
+drwxr-xr-x <user> staff 160 B  Tue Feb 10 14:07:43 2026 58556acf3b6ba5e3bd601083595bd698dda00353c8e1ed951eff09ea6946d540
+drwxr-xr-x <user> staff 192 B  Fri Mar 20 12:59:06 2026 749a16e25a9c2ed5e688c501251bba1c0486ce69c4491df38e386df9d650faa8
+drwxr-xr-x <user> staff 192 B  Mon Mar 23 13:05:07 2026 8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1
+drwxr-xr-x <user> staff 192 B  Tue Feb 24 09:42:03 2026 926025a8733b67f376ff095f1242ffb4679c0366bf6dcdbde0a12ec762165ffd
+drwxr-xr-x <user> staff 160 B  Sat Feb  7 00:30:26 2026 c79c3bb2191decb286a6144667b45d2496287cf487a71d3f7679a416f2b175c3
 
 === ~/.gemini/acknowledgments ===
-/Users/hoanicross/.gemini/acknowledgments/agents.json
+$HOME/.gemini/acknowledgments/agents.json

--- a/docs/research/artifacts/147/baseline.library.txt
+++ b/docs/research/artifacts/147/baseline.library.txt
@@ -1,33 +1,33 @@
 === ~/Library/Application Support (gemini/google) ===
-/Users/hoanicross/Library/Application Support/com.google.GeminiMacOS
-/Users/hoanicross/Library/Application Support/com.google.GeminiMacOS.launcher
-/Users/hoanicross/Library/Application Support/Google
-/Users/hoanicross/Library/Application Support/Gemini 2
-/Users/hoanicross/Library/Application Support/google-vscode-extension
-/Users/hoanicross/Library/Application Support/Google/GoogleUpdater
-/Users/hoanicross/Library/Application Support/CrashReporter/Google Drive_0995C32C-49E1-5401-8672-4400242A1E33.plist
-/Users/hoanicross/Library/Application Support/JetBrains/Air/.gemini
-/Users/hoanicross/Library/Application Support/Code/CachedExtensionVSIXs/google.geminicodeassist-2.82.0
+$HOME/Library/Application Support/com.google.GeminiMacOS
+$HOME/Library/Application Support/com.google.GeminiMacOS.launcher
+$HOME/Library/Application Support/Google
+$HOME/Library/Application Support/Gemini 2
+$HOME/Library/Application Support/google-vscode-extension
+$HOME/Library/Application Support/Google/GoogleUpdater
+$HOME/Library/Application Support/CrashReporter/Google Drive_0995C32C-49E1-5401-8672-4400242A1E33.plist
+$HOME/Library/Application Support/JetBrains/Air/.gemini
+$HOME/Library/Application Support/Code/CachedExtensionVSIXs/google.geminicodeassist-2.82.0
 
 === ~/Library/Preferences (gemini/google plists) ===
-/Users/hoanicross/Library/Preferences/com.google.chat.plist
-/Users/hoanicross/Library/Preferences/com.google.Keystone.Agent.plist
-/Users/hoanicross/Library/Preferences/com.google.drivefs.helper.renderer.plist
-/Users/hoanicross/Library/Preferences/com.google.GeminiMacOS.launcher.plist
-/Users/hoanicross/Library/Preferences/com.googlecode.iterm2.private.plist
-/Users/hoanicross/Library/Preferences/com.google.drivefs.plist
-/Users/hoanicross/Library/Preferences/com.google.GeminiMacOS.shareddata.plist
-/Users/hoanicross/Library/Preferences/com.google.Chrome.plist
-/Users/hoanicross/Library/Preferences/com.google.GeminiMacOS.plist
-/Users/hoanicross/Library/Preferences/com.googlecode.iterm2.plist
-/Users/hoanicross/Library/Preferences/com.google.android.mtpviewer.plist
-/Users/hoanicross/Library/Preferences/com.macpaw.site.Gemini2.plist
-/Users/hoanicross/Library/Preferences/com.google.android.studio.plist
-/Users/hoanicross/Library/Preferences/com.google.gct.plist
-/Users/hoanicross/Library/Preferences/com.google.drivefs.settings.plist
-/Users/hoanicross/Library/Preferences/com.google.antigravity.plist
-/Users/hoanicross/Library/Preferences/com.apple.FileProvider/com.google.drivefs.fpext
-/Users/hoanicross/Library/Preferences/ByHost/com.google.antigravity.ShipIt.0995C32C-49E1-5401-8672-4400242A1E33.plist
+$HOME/Library/Preferences/com.google.chat.plist
+$HOME/Library/Preferences/com.google.Keystone.Agent.plist
+$HOME/Library/Preferences/com.google.drivefs.helper.renderer.plist
+$HOME/Library/Preferences/com.google.GeminiMacOS.launcher.plist
+$HOME/Library/Preferences/com.googlecode.iterm2.private.plist
+$HOME/Library/Preferences/com.google.drivefs.plist
+$HOME/Library/Preferences/com.google.GeminiMacOS.shareddata.plist
+$HOME/Library/Preferences/com.google.Chrome.plist
+$HOME/Library/Preferences/com.google.GeminiMacOS.plist
+$HOME/Library/Preferences/com.googlecode.iterm2.plist
+$HOME/Library/Preferences/com.google.android.mtpviewer.plist
+$HOME/Library/Preferences/com.macpaw.site.Gemini2.plist
+$HOME/Library/Preferences/com.google.android.studio.plist
+$HOME/Library/Preferences/com.google.gct.plist
+$HOME/Library/Preferences/com.google.drivefs.settings.plist
+$HOME/Library/Preferences/com.google.antigravity.plist
+$HOME/Library/Preferences/com.apple.FileProvider/com.google.drivefs.fpext
+$HOME/Library/Preferences/ByHost/com.google.antigravity.ShipIt.0995C32C-49E1-5401-8672-4400242A1E33.plist
 
 === ~/.config/gemini* / ~/.config/google* ===
-/Users/hoanicross/.config/configstore/update-notifier-@google
+$HOME/.config/configstore/update-notifier-@google

--- a/docs/research/artifacts/147/trace.txt
+++ b/docs/research/artifacts/147/trace.txt
@@ -5,23 +5,23 @@ prompt: quelle est la couleur du cheval blanc dHenri IV ?
 === gemini stdout/stderr ===
 MCP issues detected. Run /mcp list for status.
 Hook system message: mempalace-transcript: FAILED to persist user-prompt (rc=127): 
-/Users/hoanicross/.gemini/hooks/mempalace-transcript.sh: ligne 157: timeout: commande introuvable
+$HOME/.gemini/hooks/mempalace-transcript.sh: ligne 157: timeout: commande introuvable
 Blanc.
 Hook system message: mempalace-transcript: FAILED to persist session-lifecycle (rc=127): 
-/Users/hoanicross/.gemini/hooks/mempalace-transcript.sh: ligne 157: timeout: commande introuvable
+$HOME/.gemini/hooks/mempalace-transcript.sh: ligne 157: timeout: commande introuvable
 
 === gemini exit code: 0 ===
 
 === REG files opened during run (under HOME or /tmp, deduped) ===
-/Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/147-gemini-auth-blackbox/docs/research/artifacts/147/trace.txt
+$HOME/devel/perso/genai/framework/crewrig/.worktrees/147-gemini-auth-blackbox/docs/research/artifacts/147/trace.txt
 
 === sockets observed ===
 (ESTABLISHED)
 
 === files MODIFIED under ~/.gemini since trace start ===
-/Users/hoanicross/.gemini/projects.json
-/Users/hoanicross/.gemini/history/147-gemini-auth-blackbox/.project_root
+$HOME/.gemini/projects.json
+$HOME/.gemini/history/147-gemini-auth-blackbox/.project_root
 
 === files NEWLY CREATED under ~/.gemini (size+mtime) ===
-/Users/hoanicross/.gemini/history/147-gemini-auth-blackbox/.project_root|89|May 30 14:41:01 2026
-/Users/hoanicross/.gemini/projects.json|1643|May 30 14:41:01 2026
+$HOME/.gemini/history/147-gemini-auth-blackbox/.project_root|89|May 30 14:41:01 2026
+$HOME/.gemini/projects.json|1643|May 30 14:41:01 2026

--- a/docs/research/system-context-sandbox-probe.md
+++ b/docs/research/system-context-sandbox-probe.md
@@ -83,9 +83,9 @@ This machine's accumulated grants **would have produced a false PASS** had the
 probe run only from the working tree. Confirmed by inspection during the probe:
 
 - `~/.gemini/trustedFolders.json` trusts
-  `/Users/hoanicross/devel/perso/genai/framework` (a direct ancestor of the
-  crewrig tree) **and** `/users/hoanicross/devel` (case-insensitive on macOS →
-  effectively all of `~/devel`).
+  `$HOME/devel/perso/genai/framework` (a direct ancestor of the
+  crewrig tree) **and** a case-variant `$HOME/devel` entry (macOS paths are
+  case-insensitive → effectively all of `~/devel`).
 - `~/.copilot/config.json` `trustedFolders` lists the exact crewrig repo path.
 - `~/.copilot/permissions-config.json` `locations` has an approvals entry keyed
   to the exact crewrig repo path.

--- a/scripts/check-no-machine-paths.sh
+++ b/scripts/check-no-machine-paths.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# check-no-machine-paths.sh — Reject machine-specific home paths in tracked files.
+#
+# Per spec 0081 (Requirements 5 and 6), continuous integration MUST fail a pull
+# request when any tracked file reintroduces a machine-specific absolute
+# home-directory path — the `/Users/<user>/…` or `/home/<user>/…` shape — and
+# the check MUST name the offending path in its output. The guard MUST detect
+# reintroduction through a GENERIC pattern and MUST NOT hard-code any specific
+# login value, so the guard itself never carries a login into a tracked file
+# (R6).
+#
+# Design:
+#   - Deny the generic shape `/(Users|home)/<owner>/`. The owner character class
+#     excludes `<`, `$`, `{`, so neutral placeholders like `/Users/<user>/`,
+#     `$HOME/…`, or `${HOME}/…` never match and stay legal.
+#   - Subtract a single benign owner, `agent` — the only non-machine-specific
+#     owner present in the tracked tree: the e2e container's non-root user
+#     created in `docker/e2e/base.Dockerfile` (`debian:bookworm-slim`, uid/gid
+#     1000). Every other owner is machine-specific and is flagged.
+#   - Match with a per-token pass (grep -oE), NOT a whole-line filter: a line
+#     that holds both a benign `/home/agent/…` path and a real leak must still
+#     surface the leak.
+#
+# Usage:
+#   bash scripts/check-no-machine-paths.sh
+#
+# Exits 0 when no non-benign home path is present (prints an OK line), non-zero
+# (with a per-offender `path:line: <path>` list on stderr) otherwise.
+
+set -euo pipefail
+
+REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
+
+# Generic machine-specific home-path shape. Owner class excludes '<', '$', '{'
+# so placeholders and shell-variable forms fall out for free.
+PATTERN='/(Users|home)/[A-Za-z0-9._-]+/'
+
+# Sole benign owner present in the tracked tree (docker/e2e/base.Dockerfile).
+BENIGN_OWNER='agent'
+
+failures=0
+while IFS= read -r hit; do
+  # git grep -n emits `path:line:content`; split off path and line number.
+  file="${hit%%:*}"
+  rest="${hit#*:}"
+  lineno="${rest%%:*}"
+  content="${rest#*:}"
+
+  # Extract each home-path token on this line and check its owner segment.
+  while IFS= read -r token; do
+    [ -z "$token" ] && continue
+    owner="${token#/*/}"    # strip '/Users/' or '/home/' prefix
+    owner="${owner%%/*}"    # keep the owner segment only
+    if [ "$owner" != "$BENIGN_OWNER" ]; then
+      echo "$file:$lineno: $token" >&2
+      failures=$((failures + 1))
+    fi
+  done < <(printf '%s\n' "$content" | grep -oE "$PATTERN")
+done < <(git -C "$REPO_DIR" grep -nE "$PATTERN" -- \
+           . \
+           ':(exclude)scripts/check-no-machine-paths.sh' \
+           ':(exclude)scripts/tests/test-check-no-machine-paths.sh' || true)
+
+if [ "$failures" -gt 0 ]; then
+  echo "" >&2
+  echo "FAILED: $failures machine-specific home-directory path(s) in tracked files (spec 0081)." >&2
+  echo "" >&2
+  echo "Tracked files must not contain absolute /Users/<user>/ or /home/<user>/ paths." >&2
+  echo "Replace them with a neutral placeholder (\$HOME, <user>, <repo>). The benign" >&2
+  echo "container owner '$BENIGN_OWNER' (docker/e2e/base.Dockerfile) is allowed; a new" >&2
+  echo "benign owner requires a one-line, commented addition citing its source." >&2
+  exit 1
+fi
+
+echo "OK: no machine-specific home-directory paths in tracked files."

--- a/scripts/check-no-machine-paths.sh
+++ b/scripts/check-no-machine-paths.sh
@@ -32,8 +32,11 @@ set -euo pipefail
 REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
 
 # Generic machine-specific home-path shape. Owner class excludes '<', '$', '{'
-# so placeholders and shell-variable forms fall out for free.
-PATTERN='/(Users|home)/[A-Za-z0-9._-]+/'
+# so placeholders and shell-variable forms fall out for free. The trailing
+# delimiter is tolerant — a slash OR end-of-token/line — so a slash-less home
+# root (e.g. `export HOME=/Users/alice` at end of line) is caught too, not just
+# paths that continue past the owner segment.
+PATTERN='/(Users|home)/[A-Za-z0-9._-]+(/|$)'
 
 # Sole benign owner present in the tracked tree (docker/e2e/base.Dockerfile).
 BENIGN_OWNER='agent'

--- a/scripts/tests/test-check-no-machine-paths.sh
+++ b/scripts/tests/test-check-no-machine-paths.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# test-check-no-machine-paths.sh — Regression tests for check-no-machine-paths.sh
+# (spec 0081).
+#
+# check-no-machine-paths.sh is the CI guard that fails the build when a tracked
+# file reintroduces a machine-specific absolute home path (/Users/<user>/… or
+# /home/<user>/…), naming the offender. This is the parity sibling mandated by
+# the repo convention "every check-*.sh has a test-*.sh".
+#
+# The guard reads tracked content via `git grep`, so each fixture repo is
+# `git init`-ed and the fixture files are committed before the guard runs.
+#
+# Cases:
+#   a. Clean tree (no home paths) → exit 0 with the OK line on stdout.
+#   b. A `/Users/eviluser/secret` line → exit 1 and the path is named on stderr.
+#   c. A `/Users/<user>/` placeholder → not flagged (exit 0): the '<' is outside
+#      the owner character class, so neutral placeholders stay legal.
+#   d. A `/home/agent/x` benign-owner path → not flagged (exit 0).
+#   e. A single line holding BOTH a benign `/home/agent/…` path and a real leak
+#      → exit 1 and the leak is named (token pass, not a whole-line filter).
+#
+# Usage:
+#   bash scripts/tests/test-check-no-machine-paths.sh
+
+# -e intentionally omitted: pass/fail counters control the harness; adding -e
+# would abort on expected non-zero exits from the script under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-no-machine-paths.sh"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# init_git_repo <dir>
+init_git_repo() {
+  local dir="$1"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@example.com"
+  git -C "$dir" config user.name "Test"
+  git -C "$dir" config commit.gpgsign false
+}
+
+# make_initial_commit <repo> [<file> <content>]...
+# Fixtures must be tracked — the guard searches via `git grep`.
+make_initial_commit() {
+  local repo="$1"; shift
+  while [ "$#" -ge 2 ]; do
+    local file="$1" content="$2"; shift 2
+    mkdir -p "$repo/$(dirname "$file")"
+    printf '%s\n' "$content" > "$repo/$file"
+    git -C "$repo" add "$file"
+  done
+  git -C "$repo" commit -q -m "initial"
+}
+
+# run_check <repo>
+# Run the script under test with CREWRIG_REPO_DIR set, capturing stdout, stderr,
+# and exit code into the globals CHECK_EXIT / CHECK_STDOUT / CHECK_STDERR.
+run_check() {
+  local repo="$1" out_file err_file
+  out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
+  err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
+  CHECK_EXIT=0
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  CHECK_STDOUT="$(cat "$out_file")"
+  CHECK_STDERR="$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+}
+
+# ---------------------------------------------------------------------------
+# Case a — Clean tree → exit 0 with the OK line on stdout.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "clean.txt" 'a report using $HOME and <user> placeholders'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-a: clean tree passes the check (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-a: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDOUT" | grep -qF "OK: no machine-specific home-directory paths"; then
+    echo "PASS  case-a: OK line emitted on stdout"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-a: missing OK line"
+    echo "      actual stdout: $CHECK_STDOUT"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case b — A /Users/eviluser/secret line → exit 1, path named on stderr.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "leak.txt" 'config loaded from /Users/eviluser/secret/config.json'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-b: reintroduced home path fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-b: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF "/Users/eviluser/"; then
+    echo "PASS  case-b: stderr names the offending path"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-b: stderr did not name /Users/eviluser/"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case c — A /Users/<user>/ placeholder → not flagged (exit 0).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "placeholder.txt" 'see /Users/<user>/config and $HOME/config'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-c: neutral placeholder is not flagged (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-c: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case d — A /home/agent/x benign-owner path → not flagged (exit 0).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "container.txt" 'container home is /home/agent/workspace here'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-d: benign owner 'agent' is not flagged (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-d: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case e — One line with BOTH a benign path and a real leak → exit 1, leak named
+#          (confirms token extraction, not a whole-line grep -v filter).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "mixed.txt" 'mount /home/agent/data over /Users/eviluser/secret/x'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-e: leak on a mixed line still fails (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-e: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF "/Users/eviluser/"; then
+    echo "PASS  case-e: stderr names the leaked path on the mixed line"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-e: stderr did not name the leak on the mixed line"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+echo "Results: $pass/$total passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/test-check-no-machine-paths.sh
+++ b/scripts/tests/test-check-no-machine-paths.sh
@@ -207,6 +207,37 @@ run_check() {
 }
 
 # ---------------------------------------------------------------------------
+# Case f — A slash-less home root at end of line → exit 1, path named. Guards
+#          the regression where the deny pattern required a trailing slash after
+#          the owner, letting `export HOME=/Users/<user>` (no trailing slash,
+#          EOL) escape. The tolerant `(/|$)` delimiter must catch it.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "envfile.sh" 'export HOME=/Users/eviluser'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-f: slash-less EOL home root fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-f: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF "/Users/eviluser"; then
+    echo "PASS  case-f: stderr names the slash-less offending path"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-f: stderr did not name /Users/eviluser"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -96,6 +96,8 @@ Exit code is `0` on success (or when no scenarios are defined), non-zero when at
 fails (TAP `not ok`). Output lands in `reports/<run-id>/`, one `<cli>/<scenario>/` subdir per case
 with `scenario.tap`, captured stdout/stderr, and (when invoked) `judge.count`.
 
+**Redact before archiving.** Before committing anything under `reports/<run-id>/`, pipe run logs through `sed "s#$HOME#\$HOME#g"` and strip the owner column from `ls`-style probe output, so a fresh capture never re-embeds a machine-specific home path or login. The CI guard `scripts/check-no-machine-paths.sh` (spec 0081) enforces this — the build fails, naming the path, on any committed `/Users/<user>/` or `/home/<user>/` shape that slips through.
+
 ## Override file
 
 `tests/e2e/local.toml` is the gitignored override deep-merged over `defaults.toml` at run time.

--- a/tests/e2e/reports/148/fullsuite.log
+++ b/tests/e2e/reports/148/fullsuite.log
@@ -1,38 +1,38 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/run.sh 
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/run.sh 
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/effective.json
 TAP version 13
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 1 - claude/01-layered-context
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 2 - gemini/01-layered-context
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 not ok 3 - copilot/01-layered-context
 [runner] copilot/01-layered-context failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/copilot/01-layered-context/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/copilot/01-layered-context/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/copilot/01-layered-context/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/copilot/01-layered-context/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 not ok 4 - claude/02-cross-tool-memory
 [runner] claude/02-cross-tool-memory failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/claude/02-cross-tool-memory/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/claude/02-cross-tool-memory/stderr
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/claude/02-cross-tool-memory/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/claude/02-cross-tool-memory/stderr
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 not ok 5 - gemini/02-cross-tool-memory
 [runner] gemini/02-cross-tool-memory failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/gemini/02-cross-tool-memory/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/gemini/02-cross-tool-memory/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/gemini/02-cross-tool-memory/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51/gemini/02-cross-tool-memory/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 6 - claude/03-skill-build
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 7 - gemini/03-skill-build
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 8 - copilot/03-skill-build
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 9 - claude/04-harness-loop
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 10 - gemini/04-harness-loop
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 11 - copilot/04-harness-loop
 1..11
 # pass: 8  fail: 3  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170757Z-2c51
 task: Failed to run task "e2e:test": exit status 1

--- a/tests/e2e/reports/148/run.log
+++ b/tests/e2e/reports/148/run.log
@@ -1,8 +1,8 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/run.sh --scenario 01-layered-context --cli gemini
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170534Z-1f2e/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/run.sh --scenario 01-layered-context --cli gemini
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170534Z-1f2e/effective.json
 TAP version 13
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 1 - gemini/01-layered-context
 1..1
 # pass: 1  fail: 0  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170534Z-1f2e
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/148-gemini-auth-capture/tests/e2e/reports/20260530T170534Z-1f2e

--- a/tests/e2e/reports/148/wall-clock.txt
+++ b/tests/e2e/reports/148/wall-clock.txt
@@ -78,7 +78,7 @@ round, different forgotten edit.
 
 `task e2e:test -- --scenario 01-layered-context --cli gemini`. The
 `${HOME}` token now interpolates correctly: docker invocation shows
-`-v /Users/hoanicross/.gemini:/run/gemini-rules:ro`. Container
+`-v $HOME/.gemini:/run/gemini-rules:ro`. Container
 bootstrap runs and copies all seven layered-context rules into
 `/home/agent/.gemini/` (verified by an isolated bootstrap repro:
 00_SOUL.md, 10_USER_LEVEL.md, 20_ORGANIZATION.md, 30_USER_PROFILE.md,

--- a/tests/e2e/reports/149/fullsuite.log
+++ b/tests/e2e/reports/149/fullsuite.log
@@ -1,38 +1,38 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/run.sh 
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/run.sh 
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/effective.json
 TAP version 13
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 1 - claude/01-layered-context
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 2 - gemini/01-layered-context
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 not ok 3 - copilot/01-layered-context
 [runner] copilot/01-layered-context failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/copilot/01-layered-context/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/copilot/01-layered-context/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/copilot/01-layered-context/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/copilot/01-layered-context/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 not ok 4 - claude/02-cross-tool-memory
 [runner] claude/02-cross-tool-memory failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/claude/02-cross-tool-memory/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/claude/02-cross-tool-memory/stderr
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/claude/02-cross-tool-memory/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/claude/02-cross-tool-memory/stderr
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 not ok 5 - gemini/02-cross-tool-memory
 [runner] gemini/02-cross-tool-memory failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/gemini/02-cross-tool-memory/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/gemini/02-cross-tool-memory/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/gemini/02-cross-tool-memory/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c/gemini/02-cross-tool-memory/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 6 - claude/03-skill-build
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 7 - gemini/03-skill-build
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 8 - copilot/03-skill-build
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 9 - claude/04-harness-loop
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 10 - gemini/04-harness-loop
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 11 - copilot/04-harness-loop
 1..11
 # pass: 8  fail: 3  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/149-gemini-headless-cleanup/tests/e2e/reports/20260530T174208Z-326c
 task: Failed to run task "e2e:test": exit status 1

--- a/tests/e2e/reports/153/gemini-suite.log
+++ b/tests/e2e/reports/153/gemini-suite.log
@@ -1,18 +1,18 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/run.sh --cli gemini
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/run.sh --cli gemini
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277/effective.json
 TAP version 13
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 1 - gemini/01-layered-context
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 not ok 2 - gemini/02-cross-tool-memory
 [runner] gemini/02-cross-tool-memory failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277/gemini/02-cross-tool-memory/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277/gemini/02-cross-tool-memory/stderr
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277/gemini/02-cross-tool-memory/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277/gemini/02-cross-tool-memory/stderr
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 3 - gemini/03-skill-build
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 4 - gemini/04-harness-loop
 1..4
 # pass: 3  fail: 1  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/153-test-gemini-headless/tests/e2e/reports/20260530T184813Z-0277
 task: Failed to run task "e2e:test": exit status 1

--- a/tests/e2e/reports/155/fullsuite.log
+++ b/tests/e2e/reports/155/fullsuite.log
@@ -1,32 +1,32 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/run.sh 
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/run.sh 
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac/effective.json
 TAP version 13
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 1 - claude/01-layered-context
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 2 - gemini/01-layered-context
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 not ok 3 - copilot/01-layered-context
 [runner] copilot/01-layered-context failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac/copilot/01-layered-context/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac/copilot/01-layered-context/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac/copilot/01-layered-context/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac/copilot/01-layered-context/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 4 - claude/02-cross-tool-memory
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 5 - gemini/02-cross-tool-memory
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 6 - claude/03-skill-build
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 7 - gemini/03-skill-build
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 8 - copilot/03-skill-build
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 9 - claude/04-harness-loop
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 10 - gemini/04-harness-loop
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 11 - copilot/04-harness-loop
 1..11
 # pass: 10  fail: 1  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205417Z-70ac
 task: Failed to run task "e2e:test": exit status 1

--- a/tests/e2e/reports/155/targeted.log
+++ b/tests/e2e/reports/155/targeted.log
@@ -1,10 +1,10 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/run.sh --scenario 02-cross-tool-memory
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205346Z-4847/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/run.sh --scenario 02-cross-tool-memory
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205346Z-4847/effective.json
 TAP version 13
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 1 - claude/02-cross-tool-memory
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 2 - gemini/02-cross-tool-memory
 1..2
 # pass: 2  fail: 0  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205346Z-4847
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/155-mempalace-add-drawer/tests/e2e/reports/20260530T205346Z-4847

--- a/tests/e2e/reports/160/fullsuite.log
+++ b/tests/e2e/reports/160/fullsuite.log
@@ -1,35 +1,35 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/run.sh 
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/run.sh 
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/effective.json
 TAP version 13
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 not ok 1 - claude/01-layered-context
 [runner] claude/01-layered-context failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/claude/01-layered-context/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/claude/01-layered-context/stderr
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/claude/01-layered-context/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/claude/01-layered-context/stderr
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 2 - gemini/01-layered-context
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 not ok 3 - copilot/01-layered-context
 [runner] copilot/01-layered-context failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/copilot/01-layered-context/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/copilot/01-layered-context/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/copilot/01-layered-context/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30/copilot/01-layered-context/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 4 - claude/02-cross-tool-memory
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 5 - gemini/02-cross-tool-memory
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 6 - claude/03-skill-build
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 7 - gemini/03-skill-build
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 8 - copilot/03-skill-build
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 9 - claude/04-harness-loop
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 10 - gemini/04-harness-loop
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 11 - copilot/04-harness-loop
 1..11
 # pass: 9  fail: 2  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/160-prebake-chroma/tests/e2e/reports/20260531T095214Z-0b30
 task: Failed to run task "e2e:test": exit status 1

--- a/tests/e2e/reports/161/fullsuite.log
+++ b/tests/e2e/reports/161/fullsuite.log
@@ -1,32 +1,32 @@
-task: [e2e:test] bash /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/run.sh 
-[runner] using defaults.toml (no local.toml present) → /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e/effective.json
+task: [e2e:test] bash $HOME/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/run.sh 
+[runner] using defaults.toml (no local.toml present) → $HOME/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e/effective.json
 TAP version 13
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 1 - claude/01-layered-context
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 2 - gemini/01-layered-context
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 not ok 3 - copilot/01-layered-context
 [runner] copilot/01-layered-context failed: exit 1
-[runner]   stdout: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e/copilot/01-layered-context/stdout
-[runner]   stderr: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e/copilot/01-layered-context/stderr
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[runner]   stdout: $HOME/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e/copilot/01-layered-context/stdout
+[runner]   stderr: $HOME/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e/copilot/01-layered-context/stderr
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 4 - claude/02-cross-tool-memory
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 5 - gemini/02-cross-tool-memory
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 6 - claude/03-skill-build
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 7 - gemini/03-skill-build
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 8 - copilot/03-skill-build
-[claude] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/claude/.credentials.json
+[claude] auth ready: on-disk marker $HOME/.crewrig-e2e/claude/.credentials.json
 ok 9 - claude/04-harness-loop
-[gemini] auth ready: on-disk marker /Users/hoanicross/.crewrig-e2e/gemini/oauth_creds.json
+[gemini] auth ready: on-disk marker $HOME/.crewrig-e2e/gemini/oauth_creds.json
 ok 10 - gemini/04-harness-loop
-[copilot] auth ready: Ollama Cloud keypair present (/Users/hoanicross/.crewrig-e2e/ollama/id_ed25519)
+[copilot] auth ready: Ollama Cloud keypair present ($HOME/.crewrig-e2e/ollama/id_ed25519)
 ok 11 - copilot/04-harness-loop
 1..11
 # pass: 10  fail: 1  skip: 0
-# report dir: /Users/hoanicross/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e
+# report dir: $HOME/devel/perso/genai/framework/crewrig/.worktrees/161-chown-parity/tests/e2e/reports/20260531T111004Z-774e
 task: Failed to run task "e2e:test": exit status 1


### PR DESCRIPTION
Implements spec 0081 (issue #562): removes machine-specific absolute home paths and the maintainer OS login from tracked files, and adds a generic CI guard so they cannot reappear. Git history is deliberately left untouched (out of scope).

## How to read this PR?

1. `scripts/check-no-machine-paths.sh` — the new guard. Denies the generic `/(Users|home)/<owner>/` shape via a token pass (`grep -oE`, not whole-line filtering), subtracts the single benign owner present in the tree (`agent`, the e2e container's non-root user — `docker/e2e/base.Dockerfile`), self-excludes itself and its self-test, and names each offending `path:line`. It hard-codes **no** login (that would reintroduce the leak).
2. `scripts/tests/test-check-no-machine-paths.sh` — 5-case self-test (clean / leak-named / placeholder-ignored / benign-owner-ignored / mixed-line), hermetic via a temp `git init` fixture.
3. The 13 redacted artifacts under `docs/research/**` and `tests/e2e/reports/**` — captured logs/baselines/traces scrubbed in place to `$HOME` / `<user>` placeholders (prose doc `system-context-sandbox-probe.md` hand-edited for coherence). Nothing removed; every citation stays valid.
4. `tests/e2e/README.md` — a capture-time redaction convention (R9).
5. CI wiring: `ci/ci-capabilities.yml`, `.github/workflows/build.yml`, regenerated `.gitlab-ci.yml` (guard + self-test added to `check-components` on all three parity surfaces).

## How to test this PR?

```sh
bash scripts/check-no-machine-paths.sh            # OK: no machine-specific home paths
bash scripts/tests/test-check-no-machine-paths.sh # 8/8 passed
bash scripts/build-ci.sh --check                  # .gitlab-ci.yml matches reference
bash scripts/check-ci-parity.sh                   # reference/GHA/GitLab agree
bash scripts/check-test-wiring.sh                 # all wired/exempted
markdownlint "**/*.md" --ignore node_modules --ignore extension-skeleton --ignore communication --ignore 'extensions/**/commands/*.md'
# Privacy acceptance (run with the maintainer's login):
LOGIN="$(basename "$HOME")"; git grep -nwE "$LOGIN"    # → 0 hits
git grep -nE '/Users/'                                 # → only placeholder /Users/<user> and the self-test fixture
```

## Detailed description (for agents)

- **New (core/strict):** `scripts/check-no-machine-paths.sh`, `scripts/tests/test-check-no-machine-paths.sh`.
- **Redacted (13):** `docs/research/artifacts/147/{baseline.fs.txt,baseline.library.txt,trace.txt}`, `docs/research/system-context-sandbox-probe.md`, `tests/e2e/reports/{148/fullsuite.log,148/run.log,148/wall-clock.txt,149/fullsuite.log,153/gemini-suite.log,155/fullsuite.log,155/targeted.log,160/fullsuite.log,161/fullsuite.log}`. Redaction was an ephemeral, uncommitted `sed` pass (login derived at runtime via `basename "$HOME"`, never committed). Non-ASCII (`→`, `—`) preserved.
- **Docs/CI:** `tests/e2e/README.md` (+2 lines, R9 convention as a bolded-lead paragraph to stay under the spec-0077 200-line budget — a deliberate deviation from the plan's `###` subsection, which would hit 201); `ci/ci-capabilities.yml`, `.github/workflows/build.yml`, regenerated `.gitlab-ci.yml`.
- **Verified:** login and `/Users/<login>/` → 0 hits on the committed tree; guard exit 0; self-test 8/8; CI parity + test-wiring + build-ci `--check` green; markdownlint clean; README 199/200. **R7 audit:** the 13 files held only paths/filenames and `ls`-style owner columns — no secret values, no email addresses.
- **No triggers:** no `artifacts/**` (no component rebuild), no CLI-matrix surface, no core-paths manifest change (new files under existing `scripts`/`tests` entries), no version bump.
- **Out of scope:** git history rewrite; non-tracked/gitignored files.

Logbook: #562 (auto-closes on merge).
