### PR TITLE
📝 Transition spec 0081 to implemented

### DIFF
--- a/specs/0081-purge-machine-specific-paths.md
+++ b/specs/0081-purge-machine-specific-paths.md
@@ -1,7 +1,7 @@
 ---
 id: "0081"
 slug: purge-machine-specific-paths
-status: draft
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 562


### PR DESCRIPTION
Metadata-only status flip `draft → implemented` recording the merge of impl PR #564 (issue #562). Only the frontmatter `status` field changes.