### PR TITLE
🐛 Preserve env_keys declaration order in e2e toml merge

### DIFF
--- a/scripts/tests/test-e2e-toml-merge.sh
+++ b/scripts/tests/test-e2e-toml-merge.sh
@@ -97,6 +97,27 @@ else
   note_fail "scalar override" "got: $(echo "$out" | jq -c .cli.claude)"
 fi
 
+# --- Case 3b: env_keys dedup preserves declaration order (spec 0079 R2) ----
+# Deliberately UNSORTED input: defaults declare [Z, A], local appends [A, M].
+# First-seen order-preserving dedup MUST yield [Z, A, M]. A sorting dedup
+# (e.g. jq unique) would wrongly yield [A, M, Z], so this case discriminates.
+c3b_d="$TMP/c3b-defaults.toml"
+c3b_l="$TMP/c3b-local.toml"
+cat > "$c3b_d" <<'TOML'
+[cli.claude]
+env_keys = ["Z", "A"]
+TOML
+cat > "$c3b_l" <<'TOML'
+[cli.claude]
+env_keys = ["A", "M"]
+TOML
+out="$(bash "$MERGER" "$c3b_d" "$c3b_l" 2>/dev/null)"
+if echo "$out" | jq -e '.cli.claude.env_keys == ["Z", "A", "M"]' >/dev/null; then
+  note_pass "env_keys dedup — declaration order preserved [Z,A,M]"
+else
+  note_fail "env_keys dedup order" "got: $(echo "$out" | jq -c '.cli.claude.env_keys') expected [\"Z\",\"A\",\"M\"]"
+fi
+
 # --- Case 4: key add in local --------------------------------------------
 c4_d="$TMP/c4-defaults.toml"
 c4_l="$TMP/c4-local.toml"

--- a/scripts/tests/test-e2e-toml-merge.sh
+++ b/scripts/tests/test-e2e-toml-merge.sh
@@ -205,10 +205,14 @@ cat > "$c7_l" <<'TOML'
 [cli.claude]
 image = "Y"
 TOML
+# Approximate /tmp entry count is intentional; Case 7 tolerates ±1, so ls (vs find) is fine here.
+# shellcheck disable=SC2012
 before="$(ls /tmp 2>/dev/null | wc -l | tr -d ' ')"
 bash "$MERGER" "$c7_d" "$c7_l" >/dev/null 2>&1
 # Allow for the merger to make a tmp dir during execution, but it must be
 # cleaned by its EXIT trap before this snapshot.
+# Approximate /tmp entry count is intentional; Case 7 tolerates ±1, so ls (vs find) is fine here.
+# shellcheck disable=SC2012
 after="$(ls /tmp 2>/dev/null | wc -l | tr -d ' ')"
 # Tolerate ±1 (other processes may create transient files during the test).
 delta=$((after - before))

--- a/tests/e2e/lib/toml_merge.sh
+++ b/tests/e2e/lib/toml_merge.sh
@@ -55,14 +55,20 @@ if [[ -n "$LOCAL" && -f "$LOCAL" ]]; then
   # Phase 2 — post-merge fixups:
   #   command   : semantically a full replacement; if local.toml defines it for
   #               a CLI the appended result is wrong — take local's value verbatim.
-  #   env_keys  : array-append can produce duplicates; unique() preserves order.
+  #   env_keys  : array-append can produce duplicates; dedup first-seen,
+  #               preserving declaration order (per spec 0079 R2). NOTE: jq
+  #               unique() SORTS its input, so it MUST NOT be used here.
   jq --slurpfile local "$local_json" '
     .cli |= with_entries(
       .key as $c |
       if ($local[0].cli[$c].command? // null) != null then
         .value.command = $local[0].cli[$c].command
       else . end |
-      .value |= (if has("env_keys") then .env_keys |= unique else . end)
+      .value |= (
+        if has("env_keys")
+        then .env_keys |= reduce .[] as $k ([]; if any(.[]; . == $k) then . else . + [$k] end)
+        else . end
+      )
     )
   ' "$merged_json"
 else

--- a/tests/e2e/lib/toml_merge.sh
+++ b/tests/e2e/lib/toml_merge.sh
@@ -32,6 +32,8 @@ if [[ ! -f "$DEFAULTS" ]]; then
   exit 1
 fi
 
+# $PATH in the message is intentional literal text for the human, not a shell var to expand.
+# shellcheck disable=SC2016
 command -v yq >/dev/null 2>&1 \
   || { printf 'ERROR: yq is required on $PATH (mikefarah/yq >= v4.40).\n' >&2; exit 1; }
 
@@ -48,6 +50,8 @@ if [[ -n "$LOCAL" && -f "$LOCAL" ]]; then
 
   # Phase 1 — deep-merge with array-append (`*+`) for mounts, env_keys, etc.
   merged_json="${TMP_DIR}/merged.json"
+  # The yq program is single-quoted on purpose: $item is a yq variable, it must NOT be shell-expanded.
+  # shellcheck disable=SC2016
   yq eval-all -p=json -o=json \
     '. as $item ireduce ({}; . *+ $item)' \
     "$defaults_json" "$local_json" > "$merged_json"


### PR DESCRIPTION
The e2e config-merge helper `tests/e2e/lib/toml_merge.sh` deduplicated each CLI table's `env_keys` with jq `unique`, which sorts its input and therefore violates spec 0079 R2 ("deduplicated and preserves the original declaration order"). This PR replaces the sorting dedup with a first-seen, order-preserving `reduce`, corrects the misleading inline comment, and adds a discriminating regression test.

## How to read this PR?

Two files, read in this order:

1. **`tests/e2e/lib/toml_merge.sh`** — the fix. In Phase 2 of the merge, the `env_keys` dedup switched from `.env_keys |= unique` to `.env_keys |= reduce .[] as $k ([]; if any(.[]; . == $k) then . else . + [$k] end)`. The `reduce` walks the appended array once and keeps the first occurrence of each key, so declaration order survives. The inline comment above the `jq` block was rewritten: the old text wrongly claimed `unique()` preserves order — it does not, `unique()` sorts, and the new comment says so explicitly and points at spec 0079 R2.
2. **`scripts/tests/test-e2e-toml-merge.sh`** — the guard. New **Case 3b** is inserted after Case 3 (no renumbering of later cases) and is deliberately built to fail against a sorting dedup: defaults declare `["Z", "A"]`, local appends `["A", "M"]`. The correct first-seen result is `["Z", "A", "M"]`; a sorting dedup would yield `["A", "M", "Z"]`, so the case discriminates between the two implementations.

Non-obvious decision: the fix targets the **code**, not the spec. Spec 0079 R2 already mandates order-preserving dedup, so the code was wrong, not the contract — hence no delta-spec accompanies this PR.

## How to test this PR?

```sh
bash scripts/tests/test-e2e-toml-merge.sh
```

Expected final line: `12 passed / 0 failed / 0 skipped` (exit 0). The new Case 3b reports as `# PASS env_keys dedup — declaration order preserved [Z,A,M]`.

## Detailed description (for agents)

**`tests/e2e/lib/toml_merge.sh`** (modified, +8 −2)

- Replaced `.value |= (if has("env_keys") then .env_keys |= unique else . end)` with an order-preserving fold: `.env_keys |= reduce .[] as $k ([]; if any(.[]; . == $k) then . else . + [$k] end)`. Semantics: iterate the post-append `env_keys` array left to right; append a key only if not already present in the accumulator. First-seen order is preserved; duplicates from the array-append are removed.
- Rewrote the `env_keys` line of the Phase 2 comment block. Old text claimed `unique() preserves order`; new text states that dedup is first-seen order-preserving per spec 0079 R2 and warns that `jq unique()` sorts its input and MUST NOT be used here.
- No behavioral change to the `command` full-replacement fixup or any other merge phase.

**`scripts/tests/test-e2e-toml-merge.sh`** (modified, +21 −0)

- Added Case 3b between Case 3 (scalar override) and Case 4 (key add in local), so no existing case was renumbered.
- Case 3b writes an unsorted defaults fixture (`env_keys = ["Z", "A"]`) and a local fixture (`env_keys = ["A", "M"]`), runs the merger, and asserts `.cli.claude.env_keys == ["Z", "A", "M"]` via `jq -e`. On failure it reports the actual value and the expected `["Z","A","M"]`.

**Scope notes**

- No files under `artifacts/` were touched, so `scripts/build-components.sh` was not run, no build outputs changed, no `metadata.provenance.version` bump applies, and `docs/cli-matrix.md` needs no update.
- Executable bits verified: both scripts remain `100755` (`git ls-files --stage`).
- Full suite verified locally: `12 passed / 0 failed / 0 skipped`, exit 0.

Closes #556
