### PR TITLE
📝 Transition spec 0082 to implemented

### DIFF
--- a/specs/0082-mempalace-3-6-support.md
+++ b/specs/0082-mempalace-3-6-support.md
@@ -1,7 +1,7 @@
 ---
 id: "0082"
 slug: mempalace-3-6-support
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 566


### PR DESCRIPTION
Metadata-only status flip `draft → implemented` recording the merge of impl PR #572 (issue #566). Only the parent spec's frontmatter `status` changes; `delta-01` and `delta-02` keep their status per the delta convention.