### PR TITLE
📝 Add spec 0085 — Gemini overlay enrollment guard

### DIFF
--- a/specs/0085-gemini-overlay-enrollment-guard.md
+++ b/specs/0085-gemini-overlay-enrollment-guard.md
@@ -1,0 +1,125 @@
+---
+id: "0085"
+slug: gemini-overlay-enrollment-guard
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 579
+version: 1.0.0
+---
+
+# Every deployed Gemini overlay is enrolled in the context manifest
+
+## Intent
+
+After this change, the project's continuous integration guarantees that every
+user-level context overlay the Gemini setup flow deploys to the Gemini home
+directory is also enrolled in the manifest Gemini actually reads, so a deployed
+overlay can no longer be silently ignored the way the priority-65 and
+priority-66 overlays were before their fix. When a future overlay is added to
+the deploy set but left out of enrollment, the build fails and names the missing
+overlay, instead of the omission surviving until a manual audit. The check also
+surfaces the reverse drift — an overlay left enrolled but no longer deployed — as
+a non-blocking warning, while treating the repository-root agent-rules file,
+which Gemini reads directly rather than having it deployed, as a legitimate
+exception that never fails or warns.
+
+## Requirements
+
+1. A continuous-integration check SHALL fail the build whenever an overlay that
+   `scripts/setup-gemini-interactive.sh` deploys to the Gemini home directory is
+   absent from the `context.fileName` list in `config/gemini/settings.json`, and
+   SHALL name the offending overlay or overlays in its output.
+2. The check SHALL derive both the set of deployed overlays and the set of
+   enrolled overlays from the project's own sources — the setup script and the
+   settings file — rather than from a hard-coded list, so that an overlay added
+   later is covered without editing the check.
+3. The check SHALL recognize a deployed overlay whether its deployment names the
+   target filename directly or through an intermediate target, so that the
+   user-profile overlay — whose deployment target is expressed indirectly — is
+   not missed.
+4. The check SHALL recognize a deployed overlay even when its deployment is
+   conditionally guarded, so that the priority-66 org-rules overlay, deployed
+   only when the organization-rules file is present, is covered.
+5. The check SHALL treat the repository-root `AGENTS.md` entry in
+   `context.fileName` as a legitimate enrolled-but-not-deployed exception,
+   neither failing nor warning on it.
+6. The check SHALL emit a non-blocking warning when an enrolled entry other than
+   the `AGENTS.md` exception is not deployed by the setup script, and SHALL NOT
+   fail the build on that condition alone.
+7. The check SHALL pass on the current tip of `main`, where every deployed
+   overlay is enrolled.
+8. The check SHALL run in the project's continuous integration on every pull
+   request, and its wiring SHALL be consistent across every maintained
+   continuous-integration surface the project generates.
+9. A regression test SHALL accompany the check and SHALL demonstrate both that
+   the check fails against the pre-fix state — the priority-65 and priority-66
+   overlays removed from `context.fileName` — and that it passes against the
+   enrolled state.
+
+## Scenarios
+
+**Scenario:** current tip of main is fully enrolled (happy path)
+
+```text
+Given a clean checkout of `main` after this specification is realized,
+When   the enrollment check runs over the setup script's deployed-overlay set
+       and the `context.fileName` list,
+Then   every deployed overlay is found enrolled and the check passes.
+```
+
+**Scenario:** a deployed overlay is not enrolled (failure path)
+
+```text
+Given a state in which the setup script deploys an overlay that is absent from
+      `context.fileName` (for example the pre-fix state with the priority-65 and
+      priority-66 overlays removed from enrollment),
+When   the enrollment check runs,
+Then   the check fails, names the missing overlay or overlays, and the build is
+       red.
+```
+
+**Scenario:** an overlay with an indirect deployment target is still covered (coverage)
+
+```text
+Given the setup script deploys the user-profile overlay through an intermediate
+      target rather than naming the target filename directly,
+When   the enrollment check computes the deployed-overlay set,
+Then   the user-profile overlay is present in that set and is checked for
+       enrollment like any other overlay.
+```
+
+**Scenario:** an enrolled overlay is no longer deployed (non-blocking warning)
+
+```text
+Given an entry in `context.fileName`, other than the `AGENTS.md` exception, that
+      the setup script does not deploy,
+When   the enrollment check runs,
+Then   the check emits a warning naming that entry, does not fail the build, and
+       emits no warning for the `AGENTS.md` entry.
+```
+
+## Out of scope
+
+- Removing the drift at its source by generating `context.fileName` from the
+  setup script's deploy set (or vice versa) so the two lists cannot diverge; this
+  spec adds a guard against the divergence, it does not eliminate the two-list
+  design. The single-source-of-truth refactor is deferred to a future ticket.
+- The three other CLIs (Claude Code, Copilot, Antigravity), which auto-discover a
+  directory or concatenate all overlays and therefore have no enrollment list
+  that can drift; the guard is Gemini-specific by construction.
+- End-to-end verification that Gemini actually loads the enrolled overlays at
+  session time; that runtime property is covered by the layered-context
+  end-to-end pillar. This check asserts enrollment, not runtime loading.
+- Any change to what the setup script deploys or to what `context.fileName`
+  enrolls; this spec adds a guard over the existing deploy and enrollment sets
+  and alters neither.
+- The realization mechanism of the check — its language, the technique it uses to
+  read the two sources, and its exit-status scheme — which is a PLAN and DEV
+  concern.
+
+## Open questions
+
+- None. The reverse-check scope (a non-blocking warning with the `AGENTS.md`
+  entry as the sole enrolled-but-not-deployed exception) and the complexity tier
+  (`small`) were resolved with the user during authoring.


### PR DESCRIPTION
Spec-PR for issue #579: qualifies a CI guard that fails the build when a user-level overlay deployed by `setup-gemini-interactive.sh` is not enrolled in `context.fileName` (`config/gemini/settings.json`). This is the SPECS-stage artifact only — one spec file, to be merged before the implementation branch is cut, per the spec-PR workflow.

## How to read this PR?

One file: `specs/0085-gemini-overlay-enrollment-guard.md`. Read it top to bottom.

- `## Intent` — the WHAT: Gemini is the only CLI that loads context from an explicit enrollment list, so a deployed-but-unenrolled overlay is silently dropped (the issue #576 regression class).
- `## Requirements` — R2 (derive both sets from the repo's own sources, no hard-coded list) and R8 (wiring consistent across every maintained CI surface) are the two load-bearing lines. R3 and R4 encode the two subtle coverage traps: an overlay whose deploy target is expressed indirectly (the user-profile overlay), and a conditionally-guarded deploy (the priority-66 org-rules overlay). R5/R6 fix the reverse-check scope: `AGENTS.md` is a legitimate enrolled-but-not-deployed exception, and reverse drift is a non-blocking warning, not a failure.
- `## Out of scope` — the single-source-of-truth refactor (generate `context.fileName` from the deploy set) is deferred; this spec guards the divergence, it does not remove the two-list design.

## How to test this PR?

This is a spec-only PR — no runnable code. Validate the artifact:

1. Markdown lint: `markdownlint specs/0085-gemini-overlay-enrollment-guard.md`.
2. Frontmatter parses and carries every required field:
   ```sh
   python3 -c "import yaml,io,sys; f=open('specs/0085-gemini-overlay-enrollment-guard.md').read().split('---')[1]; d=yaml.safe_load(io.StringIO(f)); print(d)"
   ```
   Expected: `id="0085"`, `slug=gemini-overlay-enrollment-guard`, `status=draft`, `complexity=small`, `interaction-mode=INTERMEDIATE`, `related-issue=579`, `version=1.0.0`.
3. The five mandatory H2 sections are present in order: Intent, Requirements, Scenarios, Out of scope, Open questions.

## Detailed description (for agents)

**Origin.** Follow-up to the cold review of PR #578 (finding #2, class `tech`, non-blocking), which fixed issue #576. Gemini CLI loads user-level context strictly from the `context.fileName` list (empirically confirmed by `docs/research/gemini-cli-auth-blackbox.md`, Test F), unlike Claude Code / Copilot (read a whole directory) and Antigravity (concatenate all overlays). No automated check linked the setup script's deploy set to the enrollment list, so the regression class can recur.

**Artifact.** One new file, `specs/0085-gemini-overlay-enrollment-guard.md`, `status: draft`, `complexity: small`, `interaction-mode: INTERMEDIATE`. Authored via the `spec-author` skill; user-gated via the `user-validate` skill (internal backend), outcome `approved`.

**Two corrections to the issue's phrasing are baked into the requirements** (both surfaced during codebase grounding):

- R3 — the issue says "parse the `install_file` calls", but `30_USER_PROFILE.md` is deployed through a `$TARGET` variable (`setup-gemini-interactive.sh:249`), not as a literal in its `install_file` call. Parsing only `install_file` lines would miss it; the requirement is phrased at the WHAT level ("directly or through an intermediate target") so DEV greps the literal `$GEMINI_HOME/NN_*.md` pattern across the whole script.
- R8 — the issue names only `build.yml`, but the repo's meta-guards (`check-test-wiring.sh` spec 0076, `check-ci-parity.sh` spec 0049, `gitlab-ci-check` spec 0048) require the new step to also be mirrored in `ci/ci-capabilities.yml` and the generated `.gitlab-ci.yml`. R8 mandates consistency across every maintained CI surface.

**Scope decisions taken with the user during authoring:** reverse-check (enrolled-but-not-deployed) is a non-blocking warning with `AGENTS.md` as the sole legitimate exception; complexity tier `small`.

**Lifecycle.** SPECS stage of the ADR-0010 lifecycle. Merging this spec-PR moves the spec to `approved`; the implementation branch (`fix/579-…` or equivalent) is cut only after this merges, per the spec-PR ordering rule.

Refs #579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
