### PR TITLE
📝 Transition spec 0083 to implemented

### DIFF
--- a/specs/0083-user-validate-to-library.md
+++ b/specs/0083-user-validate-to-library.md
@@ -1,7 +1,7 @@
 ---
 id: "0083"
 slug: user-validate-to-library
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 570


### PR DESCRIPTION
Flip spec 0083 `status: draft → implemented` now that its implementation PR #580 (relocate `user-validate` to the library tier) has merged on `main`. Metadata-only edit; no normative content changes.

## How to read this PR?

- Single-line frontmatter change in `specs/0083-user-validate-to-library.md`: `status: draft` → `status: implemented`.
- Governed by `docs/spec-format.md` → *Recording a status transition* (the lifecycle-metadata carve-out to the append-only rule): only `status` changes; `id`, `slug`, `version`, and every body section are untouched.

## How to test this PR?

```sh
git show --stat        # exactly one file, 1 insertion / 1 deletion
npx markdownlint-cli specs/0083-user-validate-to-library.md   # exit 0
```

Expected: the diff touches only the `status:` line.

## Detailed description (for agents)

Lifecycle bookkeeping closing out issue #570. The implementation landed at merge commit `7a10778`; per the recent convention (spec transitions ship as their own metadata PR, e.g. #565, #574), the status flip is isolated from the implementation diff to keep the spec's normative content append-only. No `artifacts/` change, no rebuild, no version bump (metadata carve-out).

Refs #570