### PR TITLE
📝 Transition spec 0084 to implemented (#569)

### DIFF
--- a/specs/0084-custom-root-ca-support.md
+++ b/specs/0084-custom-root-ca-support.md
@@ -1,7 +1,7 @@
 ---
 id: "0084"
 slug: custom-root-ca-support
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 569


### PR DESCRIPTION
Moves spec 0084 from `draft` to `implemented` now that the implementation PR (#586) has merged on `main`. Metadata-only frontmatter edit; no normative content changes.

## How to read this PR?

One-line frontmatter change in `specs/0084-custom-root-ca-support.md` (`status: draft` → `status: implemented`), per `docs/spec-format.md` → *Lifecycle states → Recording a status transition*.

## How to test this PR?

`git diff` shows only the `status:` line changed. `task spec:lint` / `markdownlint` stay green.

## Detailed description (for agents)

Lifecycle bookkeeping closing out ticket #569: SPECS (spec-PR #577) → PLAN (v2 approved) → DEV (impl PR #586, merged) → REVIEW (CI green) → this transition. The append-only rule permits the `status` metadata edit; `id`, `slug`, `version`, and every body section are untouched.