### PR TITLE
🐛 Raise open-file limit before launching the ad-hoc Chroma daemon

### DIFF
--- a/docs/runbooks/chroma-http-server.md
+++ b/docs/runbooks/chroma-http-server.md
@@ -83,6 +83,22 @@ open-file limit:
 
 Both should report `65536` (or higher) once the reload completes.
 
+### File-descriptor floor on the manual launch path
+
+`scripts/start-chroma-server.sh` — the ad-hoc path used to bring up the
+daemon outside the installed supervisor — raises the daemon process's
+open-file soft limit to `10240` (`MEMPALACE_CHROMA_ULIMIT_FLOOR`
+overrides the default) immediately before launching it. This floor is
+**deliberately different from, and independent of, the supervised path's
+`65536` floor documented above** — do not confuse the two: raising or
+lowering one has no effect on the other, and a manually-started daemon
+never inherits the supervisor units' resource limits.
+
+If the raise fails (e.g. the host's file-descriptor hard ceiling is fixed
+below the requested floor), the script prints a warning to standard error
+naming the ceiling that remains in effect and continues launching the
+daemon rather than aborting.
+
 ## Migrating from the legacy `PersistentClient` setup
 
 If you upgraded a working CrewRig install across the #98 boundary:

--- a/scripts/start-chroma-server.sh
+++ b/scripts/start-chroma-server.sh
@@ -58,6 +58,17 @@ if [ ! -x "${CHROMA_BIN}" ]; then
   exit 1
 fi
 
+# ── Raise open-file limit (spec 0087) ───────────────────────────────────────
+# Scoped to this script's process: `ulimit -n` here only affects the shell
+# running this script, and the daemon inherits it as a child of that shell
+# (via `nohup ... &` below, no intervening subshell) — the invoking caller's
+# shell and any other process are left untouched. Guarded because `set -e`
+# (line 7) would otherwise abort the whole script on a fixed-below-floor
+# hard ceiling (e.g. an unprivileged container default).
+if ! ulimit -n "${MEMPALACE_CHROMA_ULIMIT_FLOOR:-10240}" 2>/dev/null; then
+  echo "WARNING: could not raise open-file limit to ${MEMPALACE_CHROMA_ULIMIT_FLOOR:-10240}; current hard ceiling is $(ulimit -Hn)." >&2
+fi
+
 # ── Launch daemon ───────────────────────────────────────────────────────────
 nohup "${PYTHON_BIN}" "${CHROMA_BIN}" run \
   --path "${PALACE_DIR}" \

--- a/scripts/tests/test-chroma-health-race.sh
+++ b/scripts/tests/test-chroma-health-race.sh
@@ -10,9 +10,10 @@
 # then the daemon is up.
 #
 # This test locks in the contract that the health check MUST poll the
-# status script (mirroring the 15s / 0.3s pattern of
-# `scripts/start-chroma-server.sh` lines 65-80) instead of relying on
-# a single invocation.
+# status script (mirroring the 15s / 0.3s pattern of the health-check
+# loop in `scripts/start-chroma-server.sh` — the
+# `# ── Health-check loop` block) instead of relying on a single
+# invocation.
 #
 # Strategy
 # --------
@@ -107,8 +108,8 @@ fi
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 1 — Behavioral: the health-check block must survive a 2-second
 # slow start. Against the one-shot code on main this fails; once the
-# developer adds a retry loop (mirroring start-chroma-server.sh lines
-# 65-80), it passes.
+# developer adds a retry loop (mirroring the `# ── Health-check loop`
+# block in start-chroma-server.sh), it passes.
 # ─────────────────────────────────────────────────────────────────────────────
 HARNESS="$(mktemp -t chroma-health-race-harness.XXXXXX.sh)"
 trap 'rm -rf "$SANDBOX" "$HARNESS"' EXIT INT TERM
@@ -149,7 +150,8 @@ fi
 #   - a `while`/`until` loop in the health-check block
 #   - a `for` loop in the health-check block
 #   - a recognizable `deadline=` / `SECONDS` budget marker
-#     (matches the convention used by scripts/start-chroma-server.sh)
+#     (matches the convention used by the `# ── Health-check loop`
+#     block in scripts/start-chroma-server.sh)
 # ─────────────────────────────────────────────────────────────────────────────
 if echo "$BLOCK" | grep -Eq '(\bwhile\b|\buntil\b|\bfor\b|deadline=|SECONDS)'; then
   note_pass "health-check block contains a polling construct"

--- a/scripts/tests/test-chroma-server.sh
+++ b/scripts/tests/test-chroma-server.sh
@@ -4,6 +4,7 @@
 #
 # Locks the contracts of:
 #   - scripts/start-chroma-server.sh   (idempotent start, PID-file lifecycle)
+#       * raises the open-file limit to a floor before launching (spec 0087)
 #   - scripts/stop-chroma-server.sh    (graceful stop, cleans PID file)
 #   - scripts/status-chroma-server.sh  (exit 0 healthy / exit 1 otherwise)
 #   - scripts/lib/mempalace-http-wrapper.py
@@ -85,6 +86,73 @@ if [[ -f "$WRAPPER_PY" ]]; then
   fi
 else
   note_fail "wrapper carries chromadb version pin" "missing $WRAPPER_PY"
+fi
+
+# Tests 9-11 anchor on `if ! ulimit -n` rather than the plain substring
+# `ulimit -n`: the guard's own explanatory comment above it also contains
+# the literal text `ulimit -n` (and a separate comment mentions `nohup`),
+# so a bare substring grep would key off prose instead of code. `if ! ulimit
+# -n` and `^nohup` are each unique in the file today and identify the real
+# guarded call and the real daemon launch, not the comments describing them.
+
+# Test 9 — start script must raise the open-file limit (spec 0087 R1) BEFORE
+# launching the daemon (spec 0087 R6): the guarded `ulimit -n` call must sit
+# at a lower line number than the `nohup` daemon launch.
+if [[ -f "$START_SH" ]]; then
+  ulimit_line="$(grep -n "if ! ulimit -n" "$START_SH" | head -1 | cut -d: -f1)"
+  nohup_line="$(grep -n "^nohup" "$START_SH" | head -1 | cut -d: -f1)"
+  if [[ -z "$ulimit_line" ]]; then
+    note_fail "start script raises open-file limit before nohup" \
+      "no guarded 'ulimit -n' call found"
+  elif [[ -z "$nohup_line" ]]; then
+    note_fail "start script raises open-file limit before nohup" \
+      "no 'nohup' daemon launch found"
+  elif (( ulimit_line < nohup_line )); then
+    note_pass "start script raises open-file limit before nohup (ulimit L${ulimit_line} < nohup L${nohup_line})"
+  else
+    note_fail "start script raises open-file limit before nohup" \
+      "ulimit (L${ulimit_line}) is NOT before nohup (L${nohup_line})"
+  fi
+else
+  note_fail "start script raises open-file limit before nohup" "missing $START_SH"
+fi
+
+# Test 10 — the ulimit call carries both the literal default floor (10240,
+# spec 0087 R1) and the literal override variable name
+# (MEMPALACE_CHROMA_ULIMIT_FLOOR, spec 0087 R2) on that same line, so a
+# refactor cannot silently change the default or rename the override
+# variable without also breaking this assertion.
+if [[ -f "$START_SH" ]]; then
+  ulimit_line_text="$(grep -n "if ! ulimit -n" "$START_SH" | head -1)"
+  if [[ -z "$ulimit_line_text" ]]; then
+    note_fail "ulimit call carries default floor and override variable" \
+      "no guarded 'ulimit -n' call found"
+  elif [[ "$ulimit_line_text" == *"10240"* && "$ulimit_line_text" == *"MEMPALACE_CHROMA_ULIMIT_FLOOR"* ]]; then
+    note_pass "ulimit call carries default floor and override variable"
+  else
+    note_fail "ulimit call carries default floor and override variable" \
+      "line lacks '10240' and/or 'MEMPALACE_CHROMA_ULIMIT_FLOOR': $ulimit_line_text"
+  fi
+else
+  note_fail "ulimit call carries default floor and override variable" "missing $START_SH"
+fi
+
+# Test 11 — the ulimit -n call is guarded (`if ! ulimit -n ...; then`), not a
+# bare statement. Under `set -e` (line 7 of the start script) a bare failing
+# ulimit would abort the whole script the moment a host's fixed-below-floor
+# hard ceiling is hit; the guard is what lets the script warn and continue
+# instead (spec 0087 R3). Locks the guard structurally so a future
+# refactor cannot silently drop it.
+if [[ -f "$START_SH" ]]; then
+  guard_count="$(grep -c "if ! ulimit -n" "$START_SH")"
+  if [[ "$guard_count" -ge 1 ]]; then
+    note_pass "ulimit -n call is guarded against set -e"
+  else
+    note_fail "ulimit -n call is guarded against set -e" \
+      "no 'if ! ulimit -n' guard structure found"
+  fi
+else
+  note_fail "ulimit -n call is guarded against set -e" "missing $START_SH"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Raises the ad-hoc Chroma daemon's open-file soft limit to a configurable floor before launch, closing the fd-exhaustion gap the supervised launch path already had covered by spec 0029. Implements `specs/0087-chroma-launcher-ulimit-floor.md`.

## How to read this PR?

Read in this order:

1. `scripts/start-chroma-server.sh` — the actual fix. A guarded `ulimit -n "${MEMPALACE_CHROMA_ULIMIT_FLOOR:-10240}"` call is inserted immediately before the `# ── Launch daemon ───` block, right before the `nohup` invocation. It is wrapped in `if ! ulimit -n ...; then echo WARNING ...; fi` specifically because the script has `set -e` (line 7) — a bare failing `ulimit` would otherwise abort the whole script the moment a host's fixed-below-floor hard ceiling is hit (e.g. an unprivileged container), which is exactly the failure mode R3 rules out.
2. `docs/runbooks/chroma-http-server.md` — new subsection placed right after the existing documentation of the supervised path's `65536` floor. It explicitly calls out that the two floors (`10240` here vs `65536` for the supervisor units) are independent and unrelated, to head off a reader conflating them.
3. `scripts/tests/test-chroma-server.sh` — three new static assertions (Tests 9-11) in Section A. They anchor on the literal guard string `if ! ulimit -n` rather than a bare `ulimit -n` substring match, because the script's own explanatory comment above the guard also contains that substring — a bare grep would key off prose instead of code. See the new comment block directly above Test 9 in the diff for the full anchoring rationale.

## How to test this PR?

Prerequisites: a POSIX shell with `ulimit` support (macOS/Linux).

1. Run the static test suite: `bash scripts/tests/test-chroma-server.sh`. Tests 9-11 should report pass — they verify (9) the guarded `ulimit -n` call precedes the `nohup` daemon launch, (10) that call's line carries both the literal `10240` default and the literal `MEMPALACE_CHROMA_ULIMIT_FLOOR` override-variable name, and (11) the call is structurally guarded (`if ! ulimit -n`) rather than a bare statement.
2. Golden path: `bash scripts/start-chroma-server.sh`, then inspect the daemon process's open-file soft limit (e.g. `cat /proc/<pid>/limits` on Linux, or the equivalent `ulimit -n` reported from within the daemon's own environment) — it should report at least `10240`.
3. Override path: `MEMPALACE_CHROMA_ULIMIT_FLOOR=20000 bash scripts/start-chroma-server.sh` — the daemon should come up with the higher floor instead.
4. Failure path: on a host whose file-descriptor hard ceiling is fixed below `10240` (e.g. an unprivileged container with a low `RLIMIT_NOFILE` hard limit), run `bash scripts/start-chroma-server.sh` — expect a `WARNING: could not raise open-file limit ...` line on stderr naming the ceiling still in effect, and the daemon should still start successfully rather than the script aborting.

## Detailed description (for agents)

- `scripts/start-chroma-server.sh` (+11 lines): inserted a new guarded block between the existing binary-executability check (`if [ ! -x "${CHROMA_BIN}" ]; then ... fi`) and the `# ── Launch daemon ───` comment. The block raises `ulimit -n` to `${MEMPALACE_CHROMA_ULIMIT_FLOOR:-10240}`, guarded against `set -e` so a failed raise falls through to a stderr warning (naming `$(ulimit -Hn)` as the ceiling still in effect) instead of aborting the script. Because there is no intervening subshell between this `ulimit -n` call and the `nohup ... &` daemon launch further down, the raised limit is inherited by the daemon process only — the invoking caller's shell is untouched (R4).
- `docs/runbooks/chroma-http-server.md` (+16 lines): new `###` subsection "File-descriptor floor on the manual launch path", inserted after the existing subsection documenting the supervised path's `65536` floor and before the "Migrating from the legacy `PersistentClient` setup" section. States the `10240` default, the `MEMPALACE_CHROMA_ULIMIT_FLOOR` override, the warn-and-continue failure behavior, and an explicit note that this floor is independent of the supervised path's floor.
- `scripts/tests/test-chroma-server.sh` (+68 lines): updated the file's header docstring to note the new contract on `scripts/start-chroma-server.sh`, and added Tests 9-11 to Section A ("Static checks, no daemon required"):
  - Test 9: the guarded `ulimit -n` call's line number is lower than the `nohup` call's line number (locks R6 — the raise happens before daemon launch).
  - Test 10: that same line contains both the literal string `10240` and the literal string `MEMPALACE_CHROMA_ULIMIT_FLOOR` (locks R1/R2 — default value and override variable name).
  - Test 11: the call is structurally guarded (`if ! ulimit -n` appears at least once) rather than a bare statement (locks R3 — warn-and-continue instead of abort under `set -e`).

Normative spec: `specs/0087-chroma-launcher-ulimit-floor.md` (already merged to `main`). Plan reviewed cold on issue #587: https://github.com/crewrig/crewrig/issues/587#issuecomment-5033423534. Complexity tier: `small`.

Closes #587
