### PR TITLE
📝 Add spec 0088 — bound the MemPalace HTTP wrapper's connection pool

### DIFF
--- a/specs/0088-http-wrapper-pool-bound.md
+++ b/specs/0088-http-wrapper-pool-bound.md
@@ -1,0 +1,120 @@
+---
+id: "0088"
+slug: http-wrapper-pool-bound
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 588
+version: 1.0.0
+---
+
+# MemPalace HTTP wrapper connection-pool bound
+
+## Intent
+
+A CrewRig user running several concurrent agent CLI sessions against the
+shared MemPalace Chroma daemon (ADR-0006) currently sees an individual
+session's connection footprint against that daemon climb into the dozens
+under load, with no fixed ceiling on how large a single session's footprint
+can grow. Realizing this spec keeps each session's footprint small and
+predictable, so the daemon's total connection and file-descriptor load —
+the sum across every concurrent session — grows slowly as sessions
+accumulate instead of compounding without limit, complementing the
+server-side floor already raised for the same failure mode in issue #587.
+
+## Requirements
+
+1. The per-session connection footprint that
+   `scripts/lib/mempalace-http-wrapper.py` holds open against the shared
+   Chroma daemon SHALL be capped to an explicit, fixed ceiling instead of
+   the current default that leaves it effectively unconstrained.
+2. The ceiling SHALL bound both the total number of connections a session
+   holds open to the daemon and the number of idle (keep-alive)
+   connections it retains between requests, as two independently
+   enforced limits.
+3. The default ceiling SHALL be no greater than 8 total connections and
+   no greater than 4 idle keep-alive connections per session — a small
+   fraction of the roughly 28 connections observed for an active session
+   under load — and SHALL remain overridable through dedicated
+   environment variables, mirroring the wrapper's existing
+   `MEMPALACE_CHROMA_HOST` / `MEMPALACE_CHROMA_PORT` override pattern.
+4. The ceiling SHALL apply to every connection the wrapper opens against
+   the shared daemon, including the startup reachability check and the
+   connection(s) used for the running MCP session — no code path SHALL
+   be exempt from it.
+5. When a session's momentary demand exceeds the ceiling, the wrapper
+   SHALL let the excess requests wait for a connection to free rather
+   than failing them outright.
+6. The wrapper's existing behavior of exiting with a non-zero status and
+   a host/port/restart-command error when the shared daemon is
+   unreachable at startup SHALL remain unchanged by the ceiling.
+7. `docs/runbooks/chroma-http-server.md` SHALL document the new ceiling,
+   its default values, and the environment variables that override them,
+   alongside the wrapper's existing documentation.
+8. A regression test SHALL assert that the wrapper's connection(s) to the
+   shared daemon carry the bounded ceiling, so a later refactor cannot
+   silently drop it back to the unconstrained default.
+
+## Scenarios
+
+**Scenario:** Single active session stays within the connection ceiling
+
+Given the shared Chroma daemon is running and no other MemPalace session
+is connected
+When one MCP session performs a sustained burst of drawer reads and
+writes through `scripts/lib/mempalace-http-wrapper.py`
+Then the daemon-side connection count attributable to that session stays
+at or below the documented ceiling (8 total / 4 idle keep-alive)
+And the session's `mempalace_add_drawer` / `mempalace_search` calls
+complete successfully throughout the burst
+
+**Scenario:** Daemon unreachable at startup still fails loud
+
+Given the shared Chroma daemon is not running, or unreachable at the
+configured host and port
+When an MCP session starts and the wrapper's startup reachability probe
+runs
+Then the wrapper exits with a non-zero status and prints an error naming
+the host, the port, and the command to start the daemon
+And no connection-ceiling change introduced by this spec suppresses or
+alters that exit behavior
+
+**Scenario:** Momentary demand above the ceiling queues instead of failing
+
+Given a single session has already reached its configured maximum of
+concurrently open connections to the daemon
+When that session issues more concurrent Chroma requests than the
+ceiling allows in the same instant
+Then the excess requests wait for a connection to free and complete
+successfully
+And none of the excess requests raise a connection-pool-exhausted error
+to the caller
+
+## Out of scope
+
+- Raising the shared Chroma daemon's own resource ceiling (open-file /
+  connection headroom on the server side) — the companion fix, already
+  speced in merged spec 0087 and tracked in issue #587, currently being
+  implemented separately.
+- Reaping orphaned wrapper processes or the connections they leave open
+  — already covered by spec 0029 (R4-R5); this spec only bounds the pool
+  of a live, correctly-reaped session.
+- Any change to the daemon's topology, bind host/port, transport, or the
+  on-disk index format, or to the pinned `chromadb` version floor already
+  declared in the wrapper.
+- Automatically tuning the connection ceiling from live measured
+  concurrency — a fixed, documented default with an environment-variable
+  override is in scope; adaptive or self-tuning sizing is not.
+- Any change to how the three supported CLIs (Claude Code, Gemini CLI,
+  Copilot CLI) invoke the shared wrapper script — the wrapper remains the
+  single, CLI-agnostic module it already is.
+
+## Open questions
+
+- None. Grounding against the pinned production dependency — the
+  `mempalace` pipx virtual environment's installed `chromadb==1.5.9`,
+  matching the wrapper's own declared `>=1.5.9` floor — confirmed the
+  connection-pool hook the issue asked to verify: `chromadb.HttpClient`'s
+  `settings` parameter accepts a configuration object exposing dedicated
+  total- and keep-alive-connection-limit fields, so R1-R4 are realizable
+  against the real API without constructing a custom transport client.


### PR DESCRIPTION
Qualifies the WHAT for issue #588: cap the per-session connection footprint that `scripts/lib/mempalace-http-wrapper.py` holds against the shared MemPalace Chroma daemon (ADR-0006), instead of today's effectively unbounded default. This is the SPECS-stage artifact only — no implementation in this PR.

## How to read this PR?

Read `specs/0088-http-wrapper-pool-bound.md` top to bottom — it is the only file in the diff, per the one-file spec-PR rule (`docs/spec-pr-workflow.md`).

- `## Intent` states the user-facing WHAT with no implementation detail.
- `## Requirements` (R1-R8) are the normative, independently-testable obligations — note R1-R6 bound the pool and preserve the existing ADR-0006 fail-loud contract, R7-R8 cover documentation and regression-test coverage.
- `## Scenarios` gives one happy-path (single session stays within ceiling), and two failure/edge paths (daemon-unreachable-at-startup regression guard, and burst-demand backpressure).
- `## Out of scope` explicitly excludes the companion server-side fix (issue #587 / spec 0087, already merged, currently being implemented separately) and four other adjacent behaviors.
- `## Open questions` is empty — the issue's own open question (whether `chromadb>=1.5.9`'s `HttpClient` exposes a connection-limit hook at all) was resolved during authoring by inspecting the actual pinned `chromadb==1.5.9` installed in the `mempalace` pipx virtual environment: `HttpClient`'s `settings` parameter accepts a configuration object carrying dedicated total- and keep-alive-connection-limit fields, so R1-R4 are realizable without a custom transport client.

## How to test this PR?

This PR carries no code — validation is spec-format conformance:

1. `python3 -c "import yaml; yaml.safe_load(open('specs/0088-http-wrapper-pool-bound.md').read().split('---')[1])"` parses the frontmatter cleanly.
2. `npx markdownlint-cli specs/0088-http-wrapper-pool-bound.md` exits 0.
3. Confirm the five mandatory `## ` headings (`Intent`, `Requirements`, `Scenarios`, `Out of scope`, `Open questions`) appear in that order, verbatim, per `docs/spec-format.md`.
4. Read the spec body and confirm `related-issue: 588` and `complexity: small` are defendable given the single-file, well-diagnosed scope (mirrors the sibling spec 0087's tier for the companion server-side ticket).

## Detailed description (for agents)

Added `specs/0088-http-wrapper-pool-bound.md`, the sole file in this diff:

- **Frontmatter**: `id: "0088"`, `slug: http-wrapper-pool-bound`, `status: draft`, `complexity: small`, `interaction-mode: INTERMEDIATE`, `related-issue: 588`, `version: 1.0.0`.
- **`## Intent`**: user-facing WHAT — a single session's connection footprint against the shared Chroma daemon should stay small and predictable instead of climbing into the dozens, since daemon-side total load is the sum across every concurrent session (ADR-0006). Cross-references the companion server-side ticket (#587).
- **`## Requirements`** (8, all SHALL): bound total and idle-keepalive connections independently (R1-R2); concrete default ceiling of 8 total / 4 keep-alive, overridable via environment variables mirroring the wrapper's existing `MEMPALACE_CHROMA_HOST`/`MEMPALACE_CHROMA_PORT` pattern (R3); the ceiling applies to every connection the wrapper opens, including the startup probe (R4); momentary burst demand queues rather than fails (R5); the existing ADR-0006 fail-loud-on-daemon-unreachable contract is preserved unchanged (R6); runbook documentation update (R7); a regression test locking the bound in place (R8).
- **`## Scenarios`**: one happy path (sustained single-session load stays within ceiling) and two failure/edge paths (daemon-unreachable startup regression guard; burst-demand backpressure without pool-exhaustion errors).
- **`## Out of scope`**: server-side daemon resource ceiling (spec 0087/#587, separate and already merged), orphaned-wrapper reaping (spec 0029), daemon topology/version/transport changes, adaptive/self-tuning pool sizing, and any per-CLI wrapper-invocation changes.
- **`## Open questions`**: empty, with the resolution note explaining how the issue's own flagged uncertainty (does `chromadb>=1.5.9`'s `HttpClient` expose a limits hook) was closed by inspecting the real installed package rather than left for a downstream stage to discover.

Investigation performed (not part of the diff, but load-bearing for the spec content): read `scripts/lib/mempalace-http-wrapper.py` end-to-end; read ADR-0006 and `docs/runbooks/chroma-http-server.md`; inspected `chromadb.HttpClient` and `chromadb.api.base_http_client.BaseHTTPClient._build_limits` source in the `mempalace` pipx virtual environment (`chromadb==1.5.9`, matching the wrapper's declared floor); confirmed `mempalace`'s `backends/chroma.py` caches one client per palace path per process (so bounding the wrapper's single client bounds the whole session); read the companion spec 0087 for tier and `## Out of scope` cross-reference precedent.

Closes #588 is intentionally NOT included here — per the spec-PR independence rule (`docs/spec-pr-workflow.md`), this spec-PR and the future implementation-PR are independent; the implementation-PR will close #588.