### PR TITLE
📝 Add spec 0088 delta-01 — extend scope to the transcript-hook client

### DIFF
--- a/specs/0088-http-wrapper-pool-bound.delta-01.md
+++ b/specs/0088-http-wrapper-pool-bound.delta-01.md
@@ -1,0 +1,143 @@
+---
+id: "0088"
+slug: http-wrapper-pool-bound
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 588
+version: 1.1.0
+---
+
+# MemPalace HTTP wrapper connection-pool bound
+
+## ADDED
+
+1. **New requirement (R9) — shared connection-ceiling override.** The
+   environment variables introduced to override the connection ceiling
+   (per R3) SHALL be shared verbatim between
+   `scripts/lib/mempalace-http-wrapper.py` and
+   `hooks/mempalace-transcript.sh` — a single override value tunes both
+   components' ceilings identically, mirroring the shared
+   `MEMPALACE_CHROMA_HOST` / `MEMPALACE_CHROMA_PORT` pattern the hook
+   already reuses from the wrapper (see the hook's own header comment
+   and spec 0073 R2).
+2. **New requirement (R10) — hook's soft-skip behavior unchanged.**
+   `hooks/mempalace-transcript.sh`'s existing behavior of soft-skipping
+   persistence — printing a `DAEMON_UNREACHABLE:` message and exiting
+   with status 4, per spec 0073 R3-R4 — when the shared daemon is
+   unreachable SHALL remain unchanged by the ceiling introduced by this
+   delta, mirroring R6's protection of the wrapper's own unrelated
+   failure behavior.
+3. **New scenario — transcript hook's per-invocation clients also stay
+   within the connection ceiling.** To be read into a future cumulative
+   `## Scenarios` reading of spec 0088, alongside the parent's existing
+   three scenarios:
+
+   ```text
+   **Scenario:** Transcript hook's per-invocation clients also stay
+   within the connection ceiling
+
+   Given the shared Chroma daemon is running and
+         `MEMPALACE_TRANSCRIPT_ENABLED=1`
+   When  `hooks/mempalace-transcript.sh` is invoked for a
+         persistence-eligible event (`UserPromptSubmit`, `Stop`,
+         `SessionStart`, or `SessionEnd`) and its Python subprocess
+         constructs both the heartbeat reachability-probe `HttpClient`
+         (around line 199) and the patched-`PersistentClient`-factory
+         `HttpClient` (around line 187)
+   Then  both clients are constructed with the same total- and
+         idle-connection-ceiling `settings` as the wrapper (8 total / 4
+         idle by default, or the shared environment-variable override
+         added by R9)
+   and   the hook's existing `DAEMON_UNREACHABLE:` soft-skip behavior
+         (spec 0073 R3-R4) is unchanged by the ceiling
+   ```
+
+4. **New out-of-scope items.**
+   - Changing `hooks/mempalace-transcript.sh`'s existing non-blocking,
+     soft-skip behavior on daemon-unreachable (`DAEMON_UNREACHABLE:` /
+     exit 4, spec 0073 R3-R4) to match the wrapper's fail-loud startup
+     behavior (R6) — the two components' failure semantics are
+     deliberately different (a per-event fire-and-forget hook vs. an
+     MCP-session startup gate), and this delta only bounds
+     connection-pool size, not error-handling philosophy.
+   - Asserting R5's queuing behavior (excess demand waits rather than
+     fails) against `hooks/mempalace-transcript.sh` — each invocation
+     is a short-lived subprocess making at most two Chroma calls, well
+     under the ceiling, so the queuing path is never exercised in
+     practice for this component. A synthetic-burst regression test
+     forcing that path for the hook is not required by this delta.
+   - Any change to `hooks/mempalace-transcript.sh`'s event-type
+     filtering (the `PostToolUse` skip), its room-id derivation, or its
+     content-truncation logic — the connection ceiling introduced by
+     this delta is orthogonal to those behaviors.
+
+## MODIFIED
+
+Requirement 1 is broadened to name both call sites rather than the
+wrapper alone.
+
+- Original R1:
+
+  > The per-session connection footprint that
+  > `scripts/lib/mempalace-http-wrapper.py` holds open against the
+  > shared Chroma daemon SHALL be capped to an explicit, fixed ceiling
+  > instead of the current default that leaves it effectively
+  > unconstrained.
+
+- Replacement R1:
+
+  > The connection footprint against the shared Chroma daemon that
+  > `scripts/lib/mempalace-http-wrapper.py` holds open for the lifetime
+  > of an MCP session, and that each invocation of
+  > `hooks/mempalace-transcript.sh` holds open for the lifetime of that
+  > invocation, SHALL each be capped to an explicit, fixed ceiling
+  > instead of the current default that leaves both effectively
+  > unconstrained.
+
+Requirement 4 is broadened to enumerate the hook's two call sites
+alongside the wrapper's.
+
+- Original R4:
+
+  > The ceiling SHALL apply to every connection the wrapper opens
+  > against the shared daemon, including the startup reachability check
+  > and the connection(s) used for the running MCP session — no code
+  > path SHALL be exempt from it.
+
+- Replacement R4:
+
+  > The ceiling SHALL apply to every connection either component opens
+  > against the shared daemon — for
+  > `scripts/lib/mempalace-http-wrapper.py`, including the startup
+  > reachability check and the connection(s) used for the running MCP
+  > session; for `hooks/mempalace-transcript.sh`, including both the
+  > heartbeat reachability-probe client (around line 199) and the
+  > patched-`PersistentClient`-factory client used to persist the
+  > transcript entry (around line 187) — no code path in either
+  > component SHALL be exempt from it.
+
+Requirement 8 is broadened so the mandated regression test covers both
+components.
+
+- Original R8:
+
+  > A regression test SHALL assert that the wrapper's connection(s) to
+  > the shared daemon carry the bounded ceiling, so a later refactor
+  > cannot silently drop it back to the unconstrained default.
+
+- Replacement R8:
+
+  > A regression test SHALL assert that
+  > `scripts/lib/mempalace-http-wrapper.py`'s connection(s) and
+  > `hooks/mempalace-transcript.sh`'s two `HttpClient(...)` call sites
+  > (the heartbeat probe and the patched-`PersistentClient` factory)
+  > carry the bounded ceiling, so a later refactor cannot silently drop
+  > either back to the unconstrained default.
+
+## REMOVED
+
+(None. This delta only broadens R1, R4, and R8 — see `## MODIFIED` —
+and adds new requirements, a scenario, and out-of-scope items — see
+`## ADDED`. No requirement, scenario, or out-of-scope item from the
+parent spec is deleted.)


### PR DESCRIPTION
Broadens spec 0088's connection-pool ceiling to also cover `hooks/mempalace-transcript.sh`'s two `chromadb.HttpClient(...)` call sites. This closes a `spec`-class PLAN-review finding on issue #588 that the original spec never surveyed.

## How to read this PR?

Read `specs/0088-http-wrapper-pool-bound.delta-01.md` top to bottom — it is the only changed file. Start with the frontmatter (`version: 1.1.0`, a MINOR bump — additive, no requirement removed or broken). Then:

1. `## ADDED` — two new requirements (R9: the ceiling's environment-variable override is shared verbatim between the wrapper and the hook, not duplicated; R10: the hook's existing non-blocking `DAEMON_UNREACHABLE:` soft-skip behavior, per spec 0073 R3-R4, is explicitly preserved), one new scenario covering the hook's per-invocation clients, and three out-of-scope bullets that fence off adjacent behavior this delta deliberately does not touch.
2. `## MODIFIED` — R1, R4, and R8 are broadened. Each had a file-path anchor (`scripts/lib/mempalace-http-wrapper.py` or "the wrapper") that implicitly excluded the hook's two call sites, simply because the original spec never surveyed `hooks/mempalace-transcript.sh`. The replacement text names both components explicitly, with line references (~187 for the patched-`PersistentClient` factory, ~199 for the heartbeat probe) grounded against the actual file.
3. `## REMOVED` — empty; nothing from the parent is deleted.

For background on why this is a delta rather than a fresh spec: the parent `specs/0088-http-wrapper-pool-bound.md` is merged and immutable per `docs/spec-format.md` → *Delta-spec convention*. The finding is posted at https://github.com/crewrig/crewrig/issues/588#issuecomment-5034020469.

## How to test this PR?

This is a spec-only PR — no code changes to run. Verification is document conformance:

1. `npx --no-install markdownlint "specs/0088-http-wrapper-pool-bound.delta-01.md"` — passes with no findings.
2. Frontmatter parses as YAML with all required fields (`id: "0088"` matching the parent, `slug: http-wrapper-pool-bound` matching the parent and the filename, `status: draft`, `complexity: small`, `interaction-mode: INTERMEDIATE`, `related-issue: 588`, `version: 1.1.0`).
3. The three delta headings (`## ADDED`, `## MODIFIED`, `## REMOVED`) are present, in order, at H2, with no intermediate wrapper heading under the H1 title.
4. Compare `## MODIFIED`'s "Original Rn" quotes against `specs/0088-http-wrapper-pool-bound.md` on `main` — they match verbatim.

## Detailed description (for agents)

**Why this delta exists.** Issue #588's PLAN stage was cold-reviewed by a second `architect`, who found that `hooks/mempalace-transcript.sh` (lines ~171-200) independently calls `chromadb.HttpClient(host=_host, port=_port)` twice — once at line 187 inside the `_http_factory` function that monkey-patches `chromadb.PersistentClient`, once at line 199 for the startup heartbeat probe — against the same shared Chroma daemon (ADR-0006) that `scripts/lib/mempalace-http-wrapper.py` connects to, with neither call passing a `settings=` argument. This is the identical unbounded-connection-pool anti-pattern spec 0088 fixes in the wrapper, on a second call site the original spec never surveyed. The user gave formal go-ahead to fold this into ticket #588 rather than opening a separate ticket, since it is the same root cause and the same trivial fix.

**What changed, precisely:**

- **R1** (the top-line ceiling requirement) — the phrase "per-session connection footprint that `scripts/lib/mempalace-http-wrapper.py` holds open" is replaced with wording that separately covers the wrapper's session-lifetime footprint and the hook's per-invocation footprint (the hook has no persistent "session" — it is a fresh subprocess per hook event), so the requirement's execution-model assumption stays accurate for both components.
- **R4** (which code paths the ceiling covers) — extended to name the hook's two specific call sites by line number, mirroring how it already enumerates the wrapper's startup-check and MCP-session connections.
- **R8** (the regression-test mandate) — extended so the test must assert the ceiling on both the wrapper's connection(s) and the hook's two `HttpClient(...)` call sites.
- **R9 (new)** — makes explicit that the ceiling's environment-variable overrides are a single shared mechanism across both components, not per-component duplicates, consistent with how the hook already reuses `MEMPALACE_CHROMA_HOST`/`MEMPALACE_CHROMA_PORT` from the wrapper (see the hook's own header comment, spec 0073 R2).
- **R10 (new)** — protects the hook's existing non-blocking failure semantics (spec 0073 R3-R4: print `DAEMON_UNREACHABLE:`, soft-skip, exit 4) from being altered by this delta, mirroring how R6 already protects the wrapper's fail-loud startup behavior. This is deliberate: the two components have different, already-established failure philosophies (an MCP-session startup gate vs. a per-event fire-and-forget hook), and this delta only bounds connection-pool size, not error-handling behavior.

**Scenario decision.** A new scenario was added rather than stretching an existing one's Given/When clause, because the hook's execution model does not fit the parent's existing scenario framing. The parent's "sustained burst" and "momentary demand queues" scenarios assume a persistent MCP session accumulating load over its lifetime; the hook is a short-lived subprocess making at most two Chroma calls per invocation, so neither "sustained burst" nor "queuing under demand" is an observable behavior for it. Forcing the wording to cover both would either misrepresent the hook or produce a scenario no automated test could meaningfully target. The new scenario instead asserts what is actually true and testable for the hook: both of its `HttpClient` instances are constructed with the same bounded `settings` as the wrapper, and its pre-existing soft-skip behavior is untouched.

**No open questions.** The `chromadb==1.5.9` API grounding the parent spec already performed (the `settings` parameter on `chromadb.HttpClient` exposing dedicated total-/keep-alive-connection-limit fields) applies unchanged here — same package, same pinned version, same constructor. No new dependency-surface risk is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)