### PR TITLE
✨ Bound the shared Chroma daemon's per-session connection pool

### DIFF
--- a/docs/runbooks/chroma-http-server.md
+++ b/docs/runbooks/chroma-http-server.md
@@ -99,6 +99,32 @@ below the requested floor), the script prints a warning to standard error
 naming the ceiling that remains in effect and continues launching the
 daemon rather than aborting.
 
+### Client-side connection-pool ceiling
+
+Each client that connects to the shared daemon — every
+`scripts/lib/mempalace-http-wrapper.py`-backed MCP session, including its
+own startup heartbeat probe — caps its own connection footprint against
+the daemon instead of leaving it unbounded (spec 0088). The ceiling bounds
+two independent limits:
+
+- **Total connections** — the maximum number of connections a single
+  session holds open against the daemon at once. Default: **8**. Override
+  with `MEMPALACE_CHROMA_MAX_CONNECTIONS`.
+- **Idle keep-alive connections** — the maximum number of idle connections
+  retained between requests. Default: **4**. Override with
+  `MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS`.
+
+When a session's momentary demand exceeds the ceiling, excess requests
+wait for a connection to free rather than failing outright. This is a
+purely client-side, in-process bound — it complements, but is independent
+of, the daemon's own file-descriptor floor documented above (spec 0087 /
+issue #587): this ceiling keeps each session frugal so that floor is
+approached far more slowly as concurrent sessions accumulate.
+`hooks/mempalace-transcript.sh`'s per-invocation clients honor this exact
+same ceiling and the exact same two environment variables — not a
+separate pair — so tuning one env var affects both components (spec 0088
+delta-01 R9).
+
 ## Migrating from the legacy `PersistentClient` setup
 
 If you upgraded a working CrewRig install across the #98 boundary:

--- a/hooks/mempalace-transcript.sh
+++ b/hooks/mempalace-transcript.sh
@@ -18,6 +18,16 @@
 #                                  (default: 127.0.0.1)
 #   MEMPALACE_CHROMA_PORT        - shared ChromaDB HTTP daemon port (ADR-0006)
 #                                  (default: 8001)
+#   MEMPALACE_CHROMA_MAX_CONNECTIONS            - ceiling on total connections
+#                                  held open against the daemon (spec 0088,
+#                                  shared verbatim with
+#                                  scripts/lib/mempalace-http-wrapper.py)
+#                                  (default: 8)
+#   MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS  - ceiling on idle keep-alive
+#                                  connections retained between requests
+#                                  (spec 0088, shared verbatim with
+#                                  scripts/lib/mempalace-http-wrapper.py)
+#                                  (default: 4)
 #   GEMINI_SESSION_ID / CLAUDE_SESSION_ID / COPILOT_SESSION_ID - session id
 #   GEMINI_PROJECT_DIR / CLAUDE_PROJECT_DIR - project directory
 #   (GitHub Copilot CLI does NOT export a $COPILOT_PROJECT_DIR — the project
@@ -181,10 +191,24 @@ except ImportError as e:
 
 _host = os.environ.get("MEMPALACE_CHROMA_HOST", "127.0.0.1")
 _port = int(os.environ.get("MEMPALACE_CHROMA_PORT", "8001"))
+_max_connections = int(os.environ.get("MEMPALACE_CHROMA_MAX_CONNECTIONS", "8"))
+_max_keepalive_connections = int(
+    os.environ.get("MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS", "4")
+)
+
+
+def _build_pool_settings():
+    # Fresh Settings per call, not a shared singleton — chromadb.HttpClient()
+    # mutates its settings argument in place (spec 0088; same reasoning as
+    # scripts/lib/mempalace-http-wrapper.py's _build_pool_settings()).
+    return chromadb.Settings(
+        chroma_http_max_connections=_max_connections,
+        chroma_http_max_keepalive_connections=_max_keepalive_connections,
+    )
 
 
 def _http_factory(path=None, settings=None, **kwargs):
-    return chromadb.HttpClient(host=_host, port=_port)
+    return chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings())
 
 
 chromadb.PersistentClient = _http_factory
@@ -194,9 +218,12 @@ chromadb.PersistentClient = _http_factory
 # per-event fire-and-forget attempt bounded by the outer bash `timeout 5`
 # wrapper, not an MCP server startup gate. Distinct exit code (4) and
 # stderr prefix (DAEMON_UNREACHABLE:) keep it greppable alongside the
-# existing IMPORT_ERROR:/2 and ADD_FAILED:/3 convention.
+# existing IMPORT_ERROR:/2 and ADD_FAILED:/3 convention. Passing settings=
+# here (spec 0088 R4/delta-01) only changes this call's arguments — the
+# try/except control flow below, and R10's soft-skip behavior, are
+# unchanged.
 try:
-    chromadb.HttpClient(host=_host, port=_port).heartbeat()
+    chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings()).heartbeat()
 except Exception as e:  # acknowledged-exception: broad except intentional — any HttpClient.heartbeat() failure (connection refused, DNS, protocol) means the daemon is unreachable and must soft-skip this persistence attempt (spec 0073 R3); it does not block startup like the wrapper's probe, so it must not be silently swallowed or misclassified either
     print(f"DAEMON_UNREACHABLE: {_host}:{_port} — {e}", file=sys.stderr)
     sys.exit(4)

--- a/scripts/lib/mempalace-http-wrapper.py
+++ b/scripts/lib/mempalace-http-wrapper.py
@@ -19,6 +19,10 @@ Configuration
 -------------
 - ``MEMPALACE_CHROMA_HOST`` (default ``127.0.0.1``) — daemon host (loopback only).
 - ``MEMPALACE_CHROMA_PORT`` (default ``8001``) — daemon port.
+- ``MEMPALACE_CHROMA_MAX_CONNECTIONS`` (default ``8``) — ceiling on the total
+  number of connections this session holds open against the daemon.
+- ``MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS`` (default ``4``) — ceiling on
+  the number of idle keep-alive connections retained between requests.
 
 If the daemon is unreachable at startup we ``exit 1`` with the installer
 command on stderr. Silent fallback to ``PersistentClient`` is forbidden by
@@ -58,27 +62,48 @@ import chromadb as _chromadb
 
 _host = os.environ.get("MEMPALACE_CHROMA_HOST", "127.0.0.1")
 _port = int(os.environ.get("MEMPALACE_CHROMA_PORT", "8001"))
+_max_connections = int(os.environ.get("MEMPALACE_CHROMA_MAX_CONNECTIONS", "8"))
+_max_keepalive_connections = int(
+    os.environ.get("MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS", "4")
+)
+
+
+def _build_pool_settings() -> "_chromadb.Settings":
+    """Build a fresh connection-pool ``Settings`` object for one ``HttpClient``.
+
+    Always returns a new instance — never a shared singleton.
+    ``chromadb.HttpClient()`` mutates its ``settings`` argument in place
+    (``chroma_api_impl``/``chroma_server_host``/``chroma_server_http_port``),
+    so reusing one object across the probe and every ``_http_factory()``
+    call risks field bleed between independently constructed clients.
+    """
+    return _chromadb.Settings(
+        chroma_http_max_connections=_max_connections,
+        chroma_http_max_keepalive_connections=_max_keepalive_connections,
+    )
 
 
 def _http_factory(path=None, settings=None, **kwargs):
     """Drop-in replacement for ``chromadb.PersistentClient``.
 
-    Ignores ``path`` and ``settings`` — the HTTP daemon owns the index. All
-    callers in MemPalace pass these but they are meaningless once routing
-    goes over the wire.
+    Ignores the caller-supplied ``path``/``settings`` — the HTTP daemon owns
+    the index. All callers in MemPalace pass these but they are meaningless
+    once routing goes over the wire.
     """
-    # TODO(ADR-0006): ``settings`` is intentionally ignored — ``HttpClient``
-    # has no equivalent parameter. Reconfigure the daemon via the
-    # ``MEMPALACE_CHROMA_HOST`` / ``MEMPALACE_CHROMA_PORT`` environment
-    # variables instead.
-    return _chromadb.HttpClient(host=_host, port=_port)
+    # TODO(ADR-0006): the caller-supplied ``path``/``settings`` are still
+    # ignored — reconfigure the daemon via the ``MEMPALACE_CHROMA_HOST`` /
+    # ``MEMPALACE_CHROMA_PORT`` environment variables instead. ``settings``
+    # is no longer entirely unused, though: an internally-built,
+    # pool-bound ``Settings`` (see ``_build_pool_settings()``) is always
+    # applied to cap this session's connection footprint against the daemon.
+    return _chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings())
 
 
 _chromadb.PersistentClient = _http_factory  # type: ignore[assignment]
 
 # ── Step 2: verify daemon is reachable before handing off to mempalace ───────
 try:
-    _probe = _chromadb.HttpClient(host=_host, port=_port)
+    _probe = _chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings())
     _probe.heartbeat()
 except Exception as _e:  # acknowledged-exception: broad except intentional — any HttpClient failure (connection refused, DNS, auth, protocol) MUST block startup; silent fallback re-introduces the corruption bug ADR-0006 eliminates
     print(

--- a/scripts/tests/test-chroma-server.sh
+++ b/scripts/tests/test-chroma-server.sh
@@ -155,6 +155,67 @@ else
   note_fail "ulimit -n call is guarded against set -e" "missing $START_SH"
 fi
 
+# Test 12 — wrapper's total-connection ceiling env var carries its literal
+# default (spec 0088 R3), in the style of Test 10: assert the literal default
+# (8) and the literal env-var name appear on the same source line, so a
+# refactor cannot silently change the default or rename the override
+# variable without also breaking this assertion.
+if [[ -f "$WRAPPER_PY" ]]; then
+  max_conn_line="$(grep -n "MEMPALACE_CHROMA_MAX_CONNECTIONS" "$WRAPPER_PY" | grep "os.environ.get" | head -1)"
+  if [[ -z "$max_conn_line" ]]; then
+    note_fail "wrapper max-connections env var carries default" \
+      "no 'MEMPALACE_CHROMA_MAX_CONNECTIONS' os.environ.get() line found"
+  elif [[ "$max_conn_line" == *'"8"'* ]]; then
+    note_pass "wrapper max-connections env var carries default (8)"
+  else
+    note_fail "wrapper max-connections env var carries default" \
+      "line lacks literal default '8': $max_conn_line"
+  fi
+else
+  note_fail "wrapper max-connections env var carries default" "missing $WRAPPER_PY"
+fi
+
+# Test 13 — wrapper's idle-keepalive-connection ceiling env var carries its
+# literal default (spec 0088 R3), same style as Test 12.
+if [[ -f "$WRAPPER_PY" ]]; then
+  max_keepalive_line="$(grep -n "MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS" "$WRAPPER_PY" | grep "os.environ.get" | head -1)"
+  if [[ -z "$max_keepalive_line" ]]; then
+    note_fail "wrapper max-keepalive-connections env var carries default" \
+      "no 'MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS' os.environ.get() line found"
+  elif [[ "$max_keepalive_line" == *'"4"'* ]]; then
+    note_pass "wrapper max-keepalive-connections env var carries default (4)"
+  else
+    note_fail "wrapper max-keepalive-connections env var carries default" \
+      "line lacks literal default '4': $max_keepalive_line"
+  fi
+else
+  note_fail "wrapper max-keepalive-connections env var carries default" "missing $WRAPPER_PY"
+fi
+
+# Test 14 — `settings=` MUST appear on BOTH chromadb.HttpClient(...) call
+# sites the wrapper constructs — the startup probe and _http_factory()'s
+# return statement (spec 0088 R4/R8). This is the regression lock: a future
+# refactor that drops `settings=` from either call site re-introduces an
+# unbounded connection pool on that code path.
+if [[ -f "$WRAPPER_PY" ]]; then
+  probe_line="$(grep -n "_probe = _chromadb\.HttpClient(" "$WRAPPER_PY" | head -1)"
+  factory_return_line="$(grep -n "return _chromadb\.HttpClient(" "$WRAPPER_PY" | head -1)"
+  if [[ -z "$probe_line" ]]; then
+    note_fail "settings= applied at both wrapper HttpClient call sites" \
+      "no '_probe = _chromadb.HttpClient(...)' line found"
+  elif [[ -z "$factory_return_line" ]]; then
+    note_fail "settings= applied at both wrapper HttpClient call sites" \
+      "no 'return _chromadb.HttpClient(...)' line found"
+  elif [[ "$probe_line" == *"settings="* && "$factory_return_line" == *"settings="* ]]; then
+    note_pass "settings= applied at both wrapper HttpClient call sites"
+  else
+    note_fail "settings= applied at both wrapper HttpClient call sites" \
+      "probe=[$probe_line] factory_return=[$factory_return_line]"
+  fi
+else
+  note_fail "settings= applied at both wrapper HttpClient call sites" "missing $WRAPPER_PY"
+fi
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section B — Behavioral checks
 # ─────────────────────────────────────────────────────────────────────────────
@@ -195,6 +256,8 @@ if [[ ! -x "$PYTHON_BIN" || ! -x "$CHROMA_BIN" ]]; then
   note_skip "behavioral — stop removes PID file" \
     "mempalace pipx venv not installed"
   note_skip "behavioral — status exits 1 when not running" \
+    "mempalace pipx venv not installed"
+  note_skip "behavioral — connection-pool ceiling applied to real HttpClient" \
     "mempalace pipx venv not installed"
 else
   TMP_HOME="$(mktemp -d -t chroma-server-test.XXXXXX)"
@@ -244,6 +307,8 @@ else
       "first start failed (rc=$start_rc): $start_out"
     note_fail "behavioral — wrapper _http_factory returns ClientAPI" \
       "daemon failed to start"
+    note_fail "behavioral — connection-pool ceiling applied to real HttpClient" \
+      "daemon failed to start"
     note_fail "behavioral — stop removes PID file" \
       "daemon failed to start"
   else
@@ -287,6 +352,44 @@ print('OK')
       else
         note_fail "behavioral — wrapper _http_factory returns ClientAPI" \
           "rc=$factory_rc out=$factory_out"
+      fi
+
+    # Test 15 — spec 0088: the chosen mechanism (chromadb.Settings ->
+    # httpx.Limits) actually bounds the pool on the pinned chromadb version,
+    # not just that the wrapper's source mentions the right numbers. Against
+    # the real test daemon, construct an HttpClient with the wrapper's
+    # documented default settings and assert the resulting client's
+    # http_limits carries both ceilings. Assert the two count fields
+    # INDIVIDUALLY, not full httpx.Limits.__eq__ equality against a bare
+    # two-field Limits(...): chromadb's Settings defaults
+    # chroma_http_keepalive_secs to 40.0, which would make a bare
+    # Limits(max_connections=8, max_keepalive_connections=4) equality
+    # assertion fail on a field this spec never constrains.
+    pool_out="$(MEMPALACE_CHROMA_HOST="$TEST_HOST" \
+                MEMPALACE_CHROMA_PORT="$TEST_PORT" \
+                "$PYTHON_BIN" -c "
+import os, chromadb
+host = os.environ['MEMPALACE_CHROMA_HOST']
+port = int(os.environ['MEMPALACE_CHROMA_PORT'])
+client = chromadb.HttpClient(
+    host=host,
+    port=port,
+    settings=chromadb.Settings(
+        chroma_http_max_connections=8,
+        chroma_http_max_keepalive_connections=4,
+    ),
+)
+limits = client._server.http_limits
+assert limits.max_connections == 8, f'max_connections={limits.max_connections}'
+assert limits.max_keepalive_connections == 4, f'max_keepalive_connections={limits.max_keepalive_connections}'
+print('OK')
+" 2>&1)"
+      pool_rc=$?
+      if (( pool_rc == 0 )) && [[ "$pool_out" == *"OK"* ]]; then
+        note_pass "behavioral — connection-pool ceiling applied to real HttpClient"
+      else
+        note_fail "behavioral — connection-pool ceiling applied to real HttpClient" \
+          "rc=$pool_rc out=$pool_out"
       fi
 
     # Test 7 — stop removes the PID file.

--- a/scripts/tests/test-mempalace-transcript-hook.sh
+++ b/scripts/tests/test-mempalace-transcript-hook.sh
@@ -248,10 +248,25 @@ trap 'rm -rf "$TMPDIR_T2" "$TMPDIR_T5" "$SANDBOX_T6"' EXIT
 # Extract the real heredoc (between <<'PYEOF' and the closing PYEOF).
 sed -n "/<<.PYEOF./,/^PYEOF$/p" "$HOOK" | sed '1d;$d' > "$SANDBOX_T6/heredoc.py"
 
+# spec 0088: the mock's Settings class + HttpClient(settings=...) kwarg
+# capture proves R8 (bounded ceiling) and R10 (soft-skip unaffected)
+# together, on the same execution of the real shipped heredoc source. The
+# mock HttpClient must accept `settings=None` — without it the real
+# heredoc's calls (which now always pass `settings=`) raise TypeError the
+# instant they run under this mock.
+CAPTURED_SETTINGS="$SANDBOX_T6/captured-settings.txt"
 mkdir -p "$SANDBOX_T6/chromadb"
-cat > "$SANDBOX_T6/chromadb/__init__.py" <<'MOCK'
+cat > "$SANDBOX_T6/chromadb/__init__.py" <<MOCK
+class Settings:
+    def __init__(self, chroma_http_max_connections=None, chroma_http_max_keepalive_connections=None):
+        self.chroma_http_max_connections = chroma_http_max_connections
+        self.chroma_http_max_keepalive_connections = chroma_http_max_keepalive_connections
+        with open(r"$CAPTURED_SETTINGS", "a") as f:
+            f.write(f"{chroma_http_max_connections},{chroma_http_max_keepalive_connections}\n")
+
+
 class HttpClient:
-    def __init__(self, host=None, port=None):
+    def __init__(self, host=None, port=None, settings=None):
         pass
 
     def heartbeat(self):
@@ -280,6 +295,27 @@ else
   else
     record FAIL "spec-0073-r6: daemon-unreachable path exits 4, never constructs PersistentClient, stays bounded" \
       "rc=$RC_T6 elapsed=${ELAPSED_T6}s stderr=$(cat "$SANDBOX_T6/stderr" 2>/dev/null)"
+  fi
+
+  # Test — spec 0088 R8: the Settings the real heredoc constructs (via the
+  # heartbeat probe, the only HttpClient call site this daemon-unreachable
+  # path reaches before exiting) carry the documented default ceiling.
+  # Assert the two count fields individually, not full object equality —
+  # mirrors the wrapper suite's own reasoning (chromadb's Settings defaults
+  # a field, chroma_http_keepalive_secs, this spec never constrains).
+  if [ -s "$CAPTURED_SETTINGS" ]; then
+    CAPTURED_LINE="$(head -1 "$CAPTURED_SETTINGS")"
+    CAPTURED_MAX_CONN="$(echo "$CAPTURED_LINE" | cut -d, -f1)"
+    CAPTURED_MAX_KEEPALIVE="$(echo "$CAPTURED_LINE" | cut -d, -f2)"
+    if [ "$CAPTURED_MAX_CONN" = "8" ] && [ "$CAPTURED_MAX_KEEPALIVE" = "4" ]; then
+      record PASS "spec-0088-r8: hook's heartbeat-probe Settings carry the default ceiling (8/4)"
+    else
+      record FAIL "spec-0088-r8: hook's heartbeat-probe Settings carry the default ceiling (8/4)" \
+        "captured max_connections=$CAPTURED_MAX_CONN max_keepalive_connections=$CAPTURED_MAX_KEEPALIVE"
+    fi
+  else
+    record FAIL "spec-0088-r8: hook's heartbeat-probe Settings carry the default ceiling (8/4)" \
+      "no Settings(...) construction captured — real heredoc never built one"
   fi
 fi
 
@@ -373,6 +409,60 @@ if grep -q 'mempalace-transcript: FAILED to persist' "$STDERR_FAIL"; then
 else
   record FAIL "issue-510-r3: failure log still emitted when MEMPALACE_TRANSCRIPT_QUIET=1" \
     "no 'FAILED to persist' line on stderr: $(cat "$STDERR_FAIL")"
+fi
+
+# -------------------------------------------------------------------------
+# Test 10 — spec 0088 R3/R9: the hook's connection-pool ceiling env vars
+# carry their literal defaults, shared verbatim with
+# scripts/lib/mempalace-http-wrapper.py. Static check, same style as the
+# wrapper suite's own default-literal assertions: the literal default and
+# the literal env-var name must appear on the same source line, so a
+# refactor cannot silently change the default or rename the override
+# variable without also breaking this assertion.
+# -------------------------------------------------------------------------
+MAX_CONN_LINE="$(grep -n "MEMPALACE_CHROMA_MAX_CONNECTIONS" "$HOOK" | grep "os.environ.get" || true)"
+if [ -z "$MAX_CONN_LINE" ]; then
+  record FAIL "spec-0088: hook max-connections env var carries default" \
+    "no 'MEMPALACE_CHROMA_MAX_CONNECTIONS' os.environ.get() line found in $HOOK"
+elif echo "$MAX_CONN_LINE" | grep -q '"8"'; then
+  record PASS "spec-0088: hook max-connections env var carries default (8)"
+else
+  record FAIL "spec-0088: hook max-connections env var carries default" \
+    "line lacks literal default '8': $MAX_CONN_LINE"
+fi
+
+MAX_KEEPALIVE_LINE="$(grep -n "MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS" "$HOOK" | grep "os.environ.get" || true)"
+if [ -z "$MAX_KEEPALIVE_LINE" ]; then
+  record FAIL "spec-0088: hook max-keepalive-connections env var carries default" \
+    "no 'MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS' os.environ.get() line found in $HOOK"
+elif echo "$MAX_KEEPALIVE_LINE" | grep -q '"4"'; then
+  record PASS "spec-0088: hook max-keepalive-connections env var carries default (4)"
+else
+  record FAIL "spec-0088: hook max-keepalive-connections env var carries default" \
+    "line lacks literal default '4': $MAX_KEEPALIVE_LINE"
+fi
+
+# -------------------------------------------------------------------------
+# Test 11 — spec 0088 R4/R8: `settings=` MUST appear on BOTH
+# chromadb.HttpClient(...) call sites inside the hook's heredoc — the
+# _http_factory stand-in's return statement and the heartbeat probe. This
+# is the regression lock: a future refactor that drops `settings=` from
+# either call site re-introduces an unbounded connection pool on that code
+# path.
+# -------------------------------------------------------------------------
+FACTORY_RETURN_LINE="$(grep -n "return chromadb\.HttpClient(" "$HOOK" | head -1)"
+PROBE_LINE="$(grep -n "chromadb\.HttpClient(.*)\.heartbeat()" "$HOOK" | head -1)"
+if [ -z "$FACTORY_RETURN_LINE" ]; then
+  record FAIL "spec-0088: settings= applied at both hook HttpClient call sites" \
+    "no 'return chromadb.HttpClient(...)' line found in $HOOK"
+elif [ -z "$PROBE_LINE" ]; then
+  record FAIL "spec-0088: settings= applied at both hook HttpClient call sites" \
+    "no heartbeat-probe 'chromadb.HttpClient(...).heartbeat()' line found in $HOOK"
+elif echo "$FACTORY_RETURN_LINE" | grep -q "settings=" && echo "$PROBE_LINE" | grep -q "settings="; then
+  record PASS "spec-0088: settings= applied at both hook HttpClient call sites"
+else
+  record FAIL "spec-0088: settings= applied at both hook HttpClient call sites" \
+    "factory_return=[$FACTORY_RETURN_LINE] probe=[$PROBE_LINE]"
 fi
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Bounds the per-session connection footprint that `scripts/lib/mempalace-http-wrapper.py` and `hooks/mempalace-transcript.sh` each hold open against the shared MemPalace Chroma daemon, replacing an unconstrained default with a fixed, overridable ceiling. Implements spec 0088 together with delta-01 (which broadened scope from the wrapper alone to also cover the transcript hook), following a PLAN v4 that received a clean APPROVE with zero findings.

## How to read this PR?

1. `specs/0088-http-wrapper-pool-bound.md` and `specs/0088-http-wrapper-pool-bound.delta-01.md` (already merged to `main` via #594/#611) for the WHAT — not part of this diff, but the requirements this PR implements.
2. `scripts/lib/mempalace-http-wrapper.py` — the core mechanism. A new `_build_pool_settings()` helper returns a fresh `chromadb.Settings(chroma_http_max_connections=..., chroma_http_max_keepalive_connections=...)` on every call (never a shared singleton, since `chromadb.HttpClient()` mutates its `settings` argument in place). It is applied to both `_http_factory()`'s `HttpClient(...)` return and the startup heartbeat `_probe` — no call site exempt.
3. `hooks/mempalace-transcript.sh` — the identical mechanism, duplicated inline in the embedded Python heredoc rather than imported from the wrapper. The wrapper runs import-time side effects (an orphan-reap watchdog thread, a fail-loud `sys.exit(1)` daemon probe, a hand-off into `mempalace.mcp_server.main()`) that would be unwanted if triggered from the hook's short-lived per-invocation subprocess — see the PLAN's `Approach` and `Alternatives considered and rejected` sections for the full reasoning. Applied to both the hook's `_http_factory` stand-in and its own heartbeat probe.
4. `docs/runbooks/chroma-http-server.md` — new `### Client-side connection-pool ceiling` subsection documenting the two env vars, their 8/4 defaults, and that the hook shares the identical ceiling and env vars with the wrapper.
5. `scripts/tests/test-chroma-server.sh` and `scripts/tests/test-mempalace-transcript-hook.sh` — the regression locks: static assertions that `settings=` is present at every `HttpClient(...)` call site plus the literal `8`/`4` defaults, and behavioral assertions proving the mechanism actually bounds the pool (against a real daemon for the wrapper, against a mocked `chromadb` module capturing the real heredoc's `Settings(...)` kwargs for the hook).

## How to test this PR?

Prerequisites: the `mempalace` pipx venv installed (for the wrapper suite's live-daemon behavioral section; the hook suite has no live-daemon dependency).

```sh
bash scripts/tests/test-chroma-server.sh
# Results: 15 passed, 0 failed, 0 skipped

bash scripts/tests/test-mempalace-transcript-hook.sh
# Summary: 13 passed, 0 failed, 0 skipped
```

Both suites are already wired into CI (`.github/workflows/build.yml:149` and `:125` respectively).

## Detailed description (for agents)

**`scripts/lib/mempalace-http-wrapper.py`**
- Docstring `Configuration` section: documents the two new env vars, `MEMPALACE_CHROMA_MAX_CONNECTIONS` (default `8`) and `MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS` (default `4`).
- Two new module-level reads: `_max_connections` / `_max_keepalive_connections`, following the existing `_host`/`_port` env-var pattern.
- New `_build_pool_settings()` helper: returns a fresh `_chromadb.Settings(chroma_http_max_connections=_max_connections, chroma_http_max_keepalive_connections=_max_keepalive_connections)` per call.
- `_http_factory()`: `return _chromadb.HttpClient(host=_host, port=_port)` becomes `return _chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings())`; the stale `TODO(ADR-0006)` comment is rewritten to reflect that `settings` is no longer entirely unused.
- Startup probe: `_probe = _chromadb.HttpClient(host=_host, port=_port)` gets the identical `settings=_build_pool_settings()` addition. The existing fail-loud `except`/`sys.exit(1)` behavior on daemon-unreachable is untouched — only the constructor's arguments change.

**`hooks/mempalace-transcript.sh`**
- Header comment `# Environment:` section: documents the same two env vars, cross-referencing the wrapper.
- Inside the embedded Python heredoc: the same two env-var reads and a `_build_pool_settings()` helper, duplicated (not imported) for the reasons above.
- `_http_factory()`: `return chromadb.HttpClient(host=_host, port=_port)` becomes `return chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings())`.
- Heartbeat probe: `chromadb.HttpClient(host=_host, port=_port).heartbeat()` becomes `chromadb.HttpClient(host=_host, port=_port, settings=_build_pool_settings()).heartbeat()` inside the existing `try`/`except` block — the `DAEMON_UNREACHABLE:` / `sys.exit(4)` soft-skip control flow does not move.

**`docs/runbooks/chroma-http-server.md`**
- New `### Client-side connection-pool ceiling` subsection under `## Daily operations`, alongside the existing file-descriptor-floor subsection (#587's server-side counterpart). Documents both limits, their defaults and override variables, the queue-not-fail behavior on momentary demand spikes, and that the hook shares the exact same ceiling and env vars as the wrapper.

**`scripts/tests/test-chroma-server.sh`**
- Test 12/13 (Section A, static): the `MEMPALACE_CHROMA_MAX_CONNECTIONS` / `MEMPALACE_CHROMA_MAX_KEEPALIVE_CONNECTIONS` lines carry their literal `8`/`4` defaults.
- Test 14 (Section A, static): `settings=` appears on both the `_probe = _chromadb.HttpClient(...)` line and `_http_factory()`'s `return _chromadb.HttpClient(...)` line — the regression lock.
- Test 15 (Section B, behavioral, gated on the `mempalace` pipx-venv detection the file already uses): against the real test daemon, constructs a `chromadb.HttpClient(..., settings=chromadb.Settings(chroma_http_max_connections=8, chroma_http_max_keepalive_connections=4))` and asserts `client._server.http_limits.max_connections == 8` and `.max_keepalive_connections == 4` individually (not full `httpx.Limits.__eq__`, which would also compare `keepalive_expiry` — `40.0` here vs. `5.0` on a bare `Limits()`).

**`scripts/tests/test-mempalace-transcript-hook.sh`**
- Test 6 sandbox mock (`chromadb/__init__.py`): adds a `Settings` class that records its two kwargs to a file, and extends the mock `HttpClient.__init__` to accept `settings=None` — without this the mock would raise `TypeError` once the real heredoc's calls start passing `settings=`.
- New assertion in Test 6: the captured `Settings(...)` kwargs from the real heredoc's heartbeat-probe call equal `max_connections=8, max_keepalive_connections=4` — proving R8 (bounded ceiling) and R10 (soft-skip unaffected) together, on the same execution of the real shipped source.
- Test 10/11 (static, new): the same literal-default and `settings=`-presence assertions as the wrapper suite's Test 12-14, applied to the hook's own two `HttpClient(...)` call sites.

**Spec/plan trail**: spec 0088 (issue #588) went through a `class:spec` cold-review finding — `hooks/mempalace-transcript.sh` independently reimplemented the same unbounded-pool pattern against the same daemon and was outside the original spec's named scope — which routed to a delta-spec (delta-01, PR #611) broadening R1/R4/R8 and adding R9/R10 to cover the hook. The PLAN then went through two `REQUEST CHANGES` rounds (a `class:spec` gap before the delta merged, then a `class:arch` finding on a stale "blocking stdin hand-off" claim in the plan's own rationale) before PLAN v4 received APPROVE with zero findings.

Closes #588
