### PR TITLE
📝 Transition spec 0088 to implemented

### DIFF
--- a/specs/0088-http-wrapper-pool-bound.md
+++ b/specs/0088-http-wrapper-pool-bound.md
@@ -1,7 +1,7 @@
 ---
 id: "0088"
 slug: http-wrapper-pool-bound
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 588


### PR DESCRIPTION
Metadata-only status transition: spec 0088's implementation PR (#614) merged to `main`, closing related issue #588.

## How to read this PR?

Single-line frontmatter change in `specs/0088-http-wrapper-pool-bound.md`: `status: draft` → `status: implemented`. Per `docs/spec-format.md`'s Lifecycle states table, this is the metadata-only edit the format explicitly carves out of the append-only rule — no normative content (Intent/Requirements/Scenarios/Out of scope/Open questions) changes. The delta-01 file is untouched — per existing convention (see spec 0082's delta files), only the parent spec tracks the lifecycle `status` field.

## How to test this PR?

Confirm the diff touches only the `status` field: `git diff main -- specs/0088-http-wrapper-pool-bound.md`.

## Detailed description (for agents)

`specs/0088-http-wrapper-pool-bound.md` frontmatter: `status: draft` → `status: implemented`. No other field or body content changed. `id`, `slug`, `complexity`, `interaction-mode`, `related-issue`, and `version` are all untouched, per the Recording a status transition rule.