### PR TITLE
🐛 Give pr-reviewer a CLI-only verdict-posting fallback ladder (#595)

### DIFF
--- a/.agents/agents/pr-reviewer/AGENT.md
+++ b/.agents/agents/pr-reviewer/AGENT.md
@@ -1,11 +1,11 @@
 ---
 name: pr-reviewer
-description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the GitHub MCP."
+description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`)."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.4"
+    version: "1.1.5"
 ---
 
 
@@ -30,9 +30,12 @@ On activation:
 4. Activate the `pr-reviewer` skill and follow its six-step protocol
    (check CI status → read conventions → fetch diff → run linters →
    compose review → post).
-5. Post the verdict via the GitHub MCP `pull_request_review_write`
-   tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
-   `COMMENT`).
+5. Post the verdict via the forge CLI, following the skill's step-6
+   fallback ladder: resolve the posting identity (`gh api user` vs the PR
+   author), then either a formal `gh pr review` event when identities
+   differ, or a plain `gh pr comment` opening with a `## Verdict: …` header
+   when they match (the solo-maintainer case). Never post through a forge
+   MCP — the framework ships none (`AGENTS.md` → *Forge Access*).
 6. After completing the review, report the verdict according to the
    invocation context:
    - **If a `team-lead` is addressable (TeamCreate context):** send the
@@ -44,8 +47,9 @@ On activation:
    - **If invoked directly (no `team-lead` addressable):** conclude your
      turn by returning the verdict summary as your final response text.
      Do NOT attempt `SendMessage` and do NOT flag the absence of a
-     team-lead as a failure or protocol violation. The GitHub PR review
-     comment posted in step 5 is the canonical, durable artifact.
+     team-lead as a failure or protocol violation. The verdict posted to
+     the PR in step 5 (a formal review or a plain `## Verdict: …` comment,
+     per the identity ladder) is the canonical, durable artifact.
 
 ## Activation
 

--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.5"
+    version: "1.1.6"
 ---
 
 
@@ -113,8 +113,51 @@ discipline* below.
 
 ### 6. Post the review
 
-Use the GitHub MCP `pull_request_review_write` tool with the
-appropriate event:
+Forge access is CLI-only (`AGENTS.md` → *Forge Access*): the framework
+ships no forge MCP server. Post the verdict through `gh`, following the
+ordered fallback ladder below. **Resolve the posting identity first**, so
+you know which rung applies *before* attempting to post rather than
+discovering a rejection reactively:
+
+```bash
+gh api user --jq .login                                # authenticated identity
+gh pr view <number> --json author --jq .author.login   # PR author
+```
+
+1. **Distinct identities** — the authenticated login differs from the PR
+   author. Post a formal review with the matching event:
+
+   ```bash
+   gh pr review <number> --approve            # or --request-changes / --comment
+   ```
+
+2. **Shared identity** — the authenticated login equals the PR author (the
+   common solo-maintainer case). GitHub rejects `--approve` and
+   `--request-changes` on your own PR (`Can not approve/request changes on
+   your own pull request`), and even the `--comment` *review event* can trip
+   a self-approval permission guard. Do **not** attempt any review-type
+   event. Post a **plain** comment instead, whose body opens with a
+   `## Verdict: …` header:
+
+   ```bash
+   gh pr comment <number> --body "## Verdict: APPROVE
+
+   <the five review sections from step 5>"
+   ```
+
+   Use `## Verdict: APPROVE`, `## Verdict: REQUEST CHANGES`, or
+   `## Verdict: COMMENT`. This plain comment is the canonical, binding
+   verdict artifact for the shared-identity case. (Use `gh issue comment`
+   instead if the verdict is being recorded on the anchoring issue rather
+   than the PR.)
+
+3. **Posting denied** — if even the plain comment is refused (e.g. a
+   stricter permission classifier), do **NOT** ask the orchestrator to post
+   the review on your behalf: that launders a permission you were denied.
+   Return the full verdict and findings to the orchestrator, which records
+   them in the logbook issue.
+
+The three events map as follows:
 
 - `APPROVE` — no blocking issues; minor nits welcome but not required.
 - `REQUEST_CHANGES` — at least one finding that must be fixed before

--- a/.claude/agents/pr-reviewer/AGENT.md
+++ b/.claude/agents/pr-reviewer/AGENT.md
@@ -1,11 +1,11 @@
 ---
 name: pr-reviewer
-description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the GitHub MCP."
+description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`)."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.4"
+    version: "1.1.5"
 ---
 
 
@@ -30,9 +30,12 @@ On activation:
 4. Activate the `pr-reviewer` skill and follow its six-step protocol
    (check CI status → read conventions → fetch diff → run linters →
    compose review → post).
-5. Post the verdict via the GitHub MCP `pull_request_review_write`
-   tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
-   `COMMENT`).
+5. Post the verdict via the forge CLI, following the skill's step-6
+   fallback ladder: resolve the posting identity (`gh api user` vs the PR
+   author), then either a formal `gh pr review` event when identities
+   differ, or a plain `gh pr comment` opening with a `## Verdict: …` header
+   when they match (the solo-maintainer case). Never post through a forge
+   MCP — the framework ships none (`AGENTS.md` → *Forge Access*).
 6. After completing the review, report the verdict according to the
    invocation context:
    - **If a `team-lead` is addressable (TeamCreate context):** send the
@@ -44,8 +47,9 @@ On activation:
    - **If invoked directly (no `team-lead` addressable):** conclude your
      turn by returning the verdict summary as your final response text.
      Do NOT attempt `SendMessage` and do NOT flag the absence of a
-     team-lead as a failure or protocol violation. The GitHub PR review
-     comment posted in step 5 is the canonical, durable artifact.
+     team-lead as a failure or protocol violation. The verdict posted to
+     the PR in step 5 (a formal review or a plain `## Verdict: …` comment,
+     per the identity ladder) is the canonical, durable artifact.
 
 ## Activation
 

--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.5"
+    version: "1.1.6"
 ---
 
 
@@ -118,8 +118,51 @@ discipline* below.
 
 ### 6. Post the review
 
-Use the GitHub MCP `pull_request_review_write` tool with the
-appropriate event:
+Forge access is CLI-only (`AGENTS.md` → *Forge Access*): the framework
+ships no forge MCP server. Post the verdict through `gh`, following the
+ordered fallback ladder below. **Resolve the posting identity first**, so
+you know which rung applies *before* attempting to post rather than
+discovering a rejection reactively:
+
+```bash
+gh api user --jq .login                                # authenticated identity
+gh pr view <number> --json author --jq .author.login   # PR author
+```
+
+1. **Distinct identities** — the authenticated login differs from the PR
+   author. Post a formal review with the matching event:
+
+   ```bash
+   gh pr review <number> --approve            # or --request-changes / --comment
+   ```
+
+2. **Shared identity** — the authenticated login equals the PR author (the
+   common solo-maintainer case). GitHub rejects `--approve` and
+   `--request-changes` on your own PR (`Can not approve/request changes on
+   your own pull request`), and even the `--comment` *review event* can trip
+   a self-approval permission guard. Do **not** attempt any review-type
+   event. Post a **plain** comment instead, whose body opens with a
+   `## Verdict: …` header:
+
+   ```bash
+   gh pr comment <number> --body "## Verdict: APPROVE
+
+   <the five review sections from step 5>"
+   ```
+
+   Use `## Verdict: APPROVE`, `## Verdict: REQUEST CHANGES`, or
+   `## Verdict: COMMENT`. This plain comment is the canonical, binding
+   verdict artifact for the shared-identity case. (Use `gh issue comment`
+   instead if the verdict is being recorded on the anchoring issue rather
+   than the PR.)
+
+3. **Posting denied** — if even the plain comment is refused (e.g. a
+   stricter permission classifier), do **NOT** ask the orchestrator to post
+   the review on your behalf: that launders a permission you were denied.
+   Return the full verdict and findings to the orchestrator, which records
+   them in the logbook issue.
+
+The three events map as follows:
 
 - `APPROVE` — no blocking issues; minor nits welcome but not required.
 - `REQUEST_CHANGES` — at least one finding that must be fixed before

--- a/.gemini/agents/pr-reviewer.md
+++ b/.gemini/agents/pr-reviewer.md
@@ -1,8 +1,8 @@
 ---
 name: pr-reviewer
-description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the GitHub MCP."
+description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`)."
 ---
-<!-- crewrig-provenance: version="1.1.4" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.5" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # PR Reviewer Agent
 
@@ -25,9 +25,12 @@ On activation:
 4. Activate the `pr-reviewer` skill and follow its six-step protocol
    (check CI status → read conventions → fetch diff → run linters →
    compose review → post).
-5. Post the verdict via the GitHub MCP `pull_request_review_write`
-   tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
-   `COMMENT`).
+5. Post the verdict via the forge CLI, following the skill's step-6
+   fallback ladder: resolve the posting identity (`gh api user` vs the PR
+   author), then either a formal `gh pr review` event when identities
+   differ, or a plain `gh pr comment` opening with a `## Verdict: …` header
+   when they match (the solo-maintainer case). Never post through a forge
+   MCP — the framework ships none (`AGENTS.md` → *Forge Access*).
 6. After completing the review, report the verdict according to the
    invocation context:
    - **If a `team-lead` is addressable (TeamCreate context):** send the
@@ -39,8 +42,9 @@ On activation:
    - **If invoked directly (no `team-lead` addressable):** conclude your
      turn by returning the verdict summary as your final response text.
      Do NOT attempt `SendMessage` and do NOT flag the absence of a
-     team-lead as a failure or protocol violation. The GitHub PR review
-     comment posted in step 5 is the canonical, durable artifact.
+     team-lead as a failure or protocol violation. The verdict posted to
+     the PR in step 5 (a formal review or a plain `## Verdict: …` comment,
+     per the identity ladder) is the canonical, durable artifact.
 
 ## Activation
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.5"
+    version: "1.1.6"
 ---
 
 
@@ -113,8 +113,51 @@ discipline* below.
 
 ### 6. Post the review
 
-Use the GitHub MCP `pull_request_review_write` tool with the
-appropriate event:
+Forge access is CLI-only (`AGENTS.md` → *Forge Access*): the framework
+ships no forge MCP server. Post the verdict through `gh`, following the
+ordered fallback ladder below. **Resolve the posting identity first**, so
+you know which rung applies *before* attempting to post rather than
+discovering a rejection reactively:
+
+```bash
+gh api user --jq .login                                # authenticated identity
+gh pr view <number> --json author --jq .author.login   # PR author
+```
+
+1. **Distinct identities** — the authenticated login differs from the PR
+   author. Post a formal review with the matching event:
+
+   ```bash
+   gh pr review <number> --approve            # or --request-changes / --comment
+   ```
+
+2. **Shared identity** — the authenticated login equals the PR author (the
+   common solo-maintainer case). GitHub rejects `--approve` and
+   `--request-changes` on your own PR (`Can not approve/request changes on
+   your own pull request`), and even the `--comment` *review event* can trip
+   a self-approval permission guard. Do **not** attempt any review-type
+   event. Post a **plain** comment instead, whose body opens with a
+   `## Verdict: …` header:
+
+   ```bash
+   gh pr comment <number> --body "## Verdict: APPROVE
+
+   <the five review sections from step 5>"
+   ```
+
+   Use `## Verdict: APPROVE`, `## Verdict: REQUEST CHANGES`, or
+   `## Verdict: COMMENT`. This plain comment is the canonical, binding
+   verdict artifact for the shared-identity case. (Use `gh issue comment`
+   instead if the verdict is being recorded on the anchoring issue rather
+   than the PR.)
+
+3. **Posting denied** — if even the plain comment is refused (e.g. a
+   stricter permission classifier), do **NOT** ask the orchestrator to post
+   the review on your behalf: that launders a permission you were denied.
+   Return the full verdict and findings to the orchestrator, which records
+   them in the logbook issue.
+
+The three events map as follows:
 
 - `APPROVE` — no blocking issues; minor nits welcome but not required.
 - `REQUEST_CHANGES` — at least one finding that must be fixed before

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -1,11 +1,11 @@
 ---
 name: pr-reviewer
-description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the GitHub MCP."
+description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`)."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.4"
+    version: "1.1.5"
 ---
 
 
@@ -30,9 +30,12 @@ On activation:
 4. Activate the `pr-reviewer` skill and follow its six-step protocol
    (check CI status → read conventions → fetch diff → run linters →
    compose review → post).
-5. Post the verdict via the GitHub MCP `pull_request_review_write`
-   tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
-   `COMMENT`).
+5. Post the verdict via the forge CLI, following the skill's step-6
+   fallback ladder: resolve the posting identity (`gh api user` vs the PR
+   author), then either a formal `gh pr review` event when identities
+   differ, or a plain `gh pr comment` opening with a `## Verdict: …` header
+   when they match (the solo-maintainer case). Never post through a forge
+   MCP — the framework ships none (`AGENTS.md` → *Forge Access*).
 6. After completing the review, report the verdict according to the
    invocation context:
    - **If a `team-lead` is addressable (TeamCreate context):** send the
@@ -44,8 +47,9 @@ On activation:
    - **If invoked directly (no `team-lead` addressable):** conclude your
      turn by returning the verdict summary as your final response text.
      Do NOT attempt `SendMessage` and do NOT flag the absence of a
-     team-lead as a failure or protocol violation. The GitHub PR review
-     comment posted in step 5 is the canonical, durable artifact.
+     team-lead as a failure or protocol violation. The verdict posted to
+     the PR in step 5 (a formal review or a plain `## Verdict: …` comment,
+     per the identity ladder) is the canonical, durable artifact.
 
 ## Activation
 

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.5"
+    version: "1.1.6"
 ---
 
 
@@ -113,8 +113,51 @@ discipline* below.
 
 ### 6. Post the review
 
-Use the GitHub MCP `pull_request_review_write` tool with the
-appropriate event:
+Forge access is CLI-only (`AGENTS.md` → *Forge Access*): the framework
+ships no forge MCP server. Post the verdict through `gh`, following the
+ordered fallback ladder below. **Resolve the posting identity first**, so
+you know which rung applies *before* attempting to post rather than
+discovering a rejection reactively:
+
+```bash
+gh api user --jq .login                                # authenticated identity
+gh pr view <number> --json author --jq .author.login   # PR author
+```
+
+1. **Distinct identities** — the authenticated login differs from the PR
+   author. Post a formal review with the matching event:
+
+   ```bash
+   gh pr review <number> --approve            # or --request-changes / --comment
+   ```
+
+2. **Shared identity** — the authenticated login equals the PR author (the
+   common solo-maintainer case). GitHub rejects `--approve` and
+   `--request-changes` on your own PR (`Can not approve/request changes on
+   your own pull request`), and even the `--comment` *review event* can trip
+   a self-approval permission guard. Do **not** attempt any review-type
+   event. Post a **plain** comment instead, whose body opens with a
+   `## Verdict: …` header:
+
+   ```bash
+   gh pr comment <number> --body "## Verdict: APPROVE
+
+   <the five review sections from step 5>"
+   ```
+
+   Use `## Verdict: APPROVE`, `## Verdict: REQUEST CHANGES`, or
+   `## Verdict: COMMENT`. This plain comment is the canonical, binding
+   verdict artifact for the shared-identity case. (Use `gh issue comment`
+   instead if the verdict is being recorded on the anchoring issue rather
+   than the PR.)
+
+3. **Posting denied** — if even the plain comment is refused (e.g. a
+   stricter permission classifier), do **NOT** ask the orchestrator to post
+   the review on your behalf: that launders a permission you were denied.
+   Return the full verdict and findings to the orchestrator, which records
+   them in the logbook issue.
+
+The three events map as follows:
 
 - `APPROVE` — no blocking issues; minor nits welcome but not required.
 - `REQUEST_CHANGES` — at least one finding that must be fixed before

--- a/artifacts/core/agents/pr-reviewer/AGENT.md
+++ b/artifacts/core/agents/pr-reviewer/AGENT.md
@@ -3,13 +3,13 @@ name: pr-reviewer
 description: "Independent PR reviewer agent. Spawns cold — receives only a PR
   number, no authoring-session context. Activates the pr-reviewer skill to audit
   the diff, runs linter scripts against changed files, and posts a structured
-  review verdict via the GitHub MCP."
+  review verdict via the forge CLI (`gh`)."
 type: agent
 metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.4"
+    version: "1.1.5"
 ---
 
 # PR Reviewer Agent
@@ -33,9 +33,12 @@ On activation:
 4. Activate the `pr-reviewer` skill and follow its six-step protocol
    (check CI status → read conventions → fetch diff → run linters →
    compose review → post).
-5. Post the verdict via the GitHub MCP `pull_request_review_write`
-   tool with the appropriate event (`APPROVE`, `REQUEST_CHANGES`, or
-   `COMMENT`).
+5. Post the verdict via the forge CLI, following the skill's step-6
+   fallback ladder: resolve the posting identity (`gh api user` vs the PR
+   author), then either a formal `gh pr review` event when identities
+   differ, or a plain `gh pr comment` opening with a `## Verdict: …` header
+   when they match (the solo-maintainer case). Never post through a forge
+   MCP — the framework ships none (`AGENTS.md` → *Forge Access*).
 6. After completing the review, report the verdict according to the
    invocation context:
    - **If a `team-lead` is addressable (TeamCreate context):** send the
@@ -47,8 +50,9 @@ On activation:
    - **If invoked directly (no `team-lead` addressable):** conclude your
      turn by returning the verdict summary as your final response text.
      Do NOT attempt `SendMessage` and do NOT flag the absence of a
-     team-lead as a failure or protocol violation. The GitHub PR review
-     comment posted in step 5 is the canonical, durable artifact.
+     team-lead as a failure or protocol violation. The verdict posted to
+     the PR in step 5 (a formal review or a plain `## Verdict: …` comment,
+     per the identity ladder) is the canonical, durable artifact.
 
 ## Activation
 

--- a/artifacts/core/skills/pr-reviewer/SKILL.md
+++ b/artifacts/core/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.5"
+    version: "1.1.6"
 claude:
   allowed-tools:
     - Read
@@ -124,8 +124,51 @@ discipline* below.
 
 ### 6. Post the review
 
-Use the GitHub MCP `pull_request_review_write` tool with the
-appropriate event:
+Forge access is CLI-only (`AGENTS.md` → *Forge Access*): the framework
+ships no forge MCP server. Post the verdict through `gh`, following the
+ordered fallback ladder below. **Resolve the posting identity first**, so
+you know which rung applies *before* attempting to post rather than
+discovering a rejection reactively:
+
+```bash
+gh api user --jq .login                                # authenticated identity
+gh pr view <number> --json author --jq .author.login   # PR author
+```
+
+1. **Distinct identities** — the authenticated login differs from the PR
+   author. Post a formal review with the matching event:
+
+   ```bash
+   gh pr review <number> --approve            # or --request-changes / --comment
+   ```
+
+2. **Shared identity** — the authenticated login equals the PR author (the
+   common solo-maintainer case). GitHub rejects `--approve` and
+   `--request-changes` on your own PR (`Can not approve/request changes on
+   your own pull request`), and even the `--comment` *review event* can trip
+   a self-approval permission guard. Do **not** attempt any review-type
+   event. Post a **plain** comment instead, whose body opens with a
+   `## Verdict: …` header:
+
+   ```bash
+   gh pr comment <number> --body "## Verdict: APPROVE
+
+   <the five review sections from step 5>"
+   ```
+
+   Use `## Verdict: APPROVE`, `## Verdict: REQUEST CHANGES`, or
+   `## Verdict: COMMENT`. This plain comment is the canonical, binding
+   verdict artifact for the shared-identity case. (Use `gh issue comment`
+   instead if the verdict is being recorded on the anchoring issue rather
+   than the PR.)
+
+3. **Posting denied** — if even the plain comment is refused (e.g. a
+   stricter permission classifier), do **NOT** ask the orchestrator to post
+   the review on your behalf: that launders a permission you were denied.
+   Return the full verdict and findings to the orchestrator, which records
+   them in the logbook issue.
+
+The three events map as follows:
 
 - `APPROVE` — no blocking issues; minor nits welcome but not required.
 - `REQUEST_CHANGES` — at least one finding that must be fixed before


### PR DESCRIPTION
Moves the PR-verdict posting instruction out of `AGENTS.md` (orchestration-level, invisible to a cold-spawned reviewer) and into the `pr-reviewer` skill/agent sources as an explicit CLI-only fallback ladder. Closes the friction of #595 (recurred 12× after #106/PR #111 patched only the orchestration doc).

## How to read this PR?

Read the two sources first, then the generated outputs:

1. `artifacts/core/skills/pr-reviewer/SKILL.md` — **step 6** is the substance: a preflight identity check (`gh api user` vs PR author) branching into a 3-rung ladder (distinct → formal `gh pr review`; shared → plain `gh pr comment` with a `## Verdict: …` header; denied → return to orchestrator, no permission-laundering).
2. `artifacts/core/agents/pr-reviewer/AGENT.md` — description + step 5 + the canonical-artifact note updated to match; no longer names the dropped GitHub MCP.
3. The 8 generated files under `.claude/`, `.gemini/`, `.github/`, `.agents/` are pure `build-components.sh` output — skim to confirm parity, no hand edits.

**Non-obvious decision:** #595 suggested a 4-rung ladder keeping "GitHub MCP if reachable" as rung 1. Dropped deliberately — #624 made forge access CLI-only and removed the framework forge MCP (`artifacts/core/rules/60-tools.md`: *"The framework ships no forge MCP server for any CLI"*). Keeping an MCP rung would resurrect a mechanism the architecture explicitly retired.

## How to test this PR?

```sh
git fetch origin && git checkout fix/595-pr-reviewer-posting-fallback

# Version-bump CI gate (both sources bumped)
BASE_REF=origin/main bash scripts/check-skill-versions.sh   # expect: OK

# Build is deterministic — regenerating must yield no diff
bash scripts/build-components.sh && git status --short       # expect: clean

# Ladder is present in the generated Claude output
grep -c "Shared identity" .claude/skills/pr-reviewer/SKILL.md # expect: >= 1
```

## Detailed description (for agents)

**Modified sources (2):**

- `artifacts/core/skills/pr-reviewer/SKILL.md` — step 6 rewritten from the unconditional "Use the GitHub MCP `pull_request_review_write` tool" into a CLI-only ladder with an up-front identity resolution. Version `1.1.5` → `1.1.6` (PATCH — friction fix).
- `artifacts/core/agents/pr-reviewer/AGENT.md` — frontmatter `description` (l.6) and step 5 no longer name the GitHub MCP; the "canonical artifact" note (l.51) generalized to cover both a formal review and a plain `## Verdict:` comment. Version `1.1.4` → `1.1.5` (PATCH).

**Regenerated outputs (8):** `.claude/`, `.gemini/`, `.github/`, `.agents/` skill+agent for `pr-reviewer`, via `scripts/build-components.sh`. No hand edits.

**Not changed, by design:**

- `docs/agent-team-protocol.md` Template 1 shared-identity paragraph (from PR #111) is kept as a cross-reference, not the sole home — per #595's suggested resolution point 2.
- `docs/cli-matrix.md` — **consulted, no update required.** The change aligns skill/agent prose to the already-recorded spec-0090 CLI-only forge policy (row 7c: *"no forge MCP — CLI-only forge access"*) and introduces no CLI asymmetry: the `gh` posting path is identical across all four CLIs. No new row, edited cell, or parity-gap entry applies.

**Scope note:** provisioning a second bot reviewer identity (raised by 2 of the 12 reports) is left out of scope per #595 — a larger infra change.

Refs #595.