### PR TITLE
📝 Transition spec 0092 to implemented

### DIFF
--- a/specs/0092-claude-code-implicit-team-model.md
+++ b/specs/0092-claude-code-implicit-team-model.md
@@ -1,7 +1,7 @@
 ---
 id: "0092"
 slug: claude-code-implicit-team-model
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 596


### PR DESCRIPTION
Metadata-only status transition: spec 0092's implementation PR (#638) merged to `main`, closing related issue #596.

## How to read this PR?

Single-line frontmatter change in `specs/0092-claude-code-implicit-team-model.md`: `status: draft` → `status: implemented`. Per `docs/spec-format.md`'s Lifecycle states table, this is the metadata-only edit the format explicitly carves out of the append-only freeze — no normative content (Intent/Requirements/Scenarios/Out of scope/Open questions) changes.

## How to test this PR?

Confirm the diff touches only the `status` field: `git diff main -- specs/0092-claude-code-implicit-team-model.md`.

## Detailed description (for agents)

`specs/0092-claude-code-implicit-team-model.md` frontmatter: `status: draft` → `status: implemented`. No other field or body content changed. `id`, `slug`, `complexity`, `interaction-mode`, `related-issue`, and `version` are untouched, per the *Recording a status transition* rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)