### PR TITLE
📝 Harden worktree isolation against sub-agent cwd drift

### DIFF
--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -107,6 +107,17 @@ git worktree add -b <branch-name> .worktrees/<ticket-id> crewrig/main
 
 All file edits performed by the team — by every specialist, without exception — **MUST** happen inside `.worktrees/<ticket-id>/`. The main working directory is off-limits for the duration of the ticket; treat it as read-only.
 
+**Cwd verification (every spawned role).** Before issuing its first `Write`, `Edit`, or file-mutating `Bash` call, a sub-agent whose brief names a worktree path (`.worktrees/<ticket-id>/`) as its working location MUST verify that its own working directory resolves inside that worktree. This obligation attaches to the brief's target, not to the role — it applies identically to `developer`, `tester`, `doc-writer`, `architect`, or any other spawned specialist whenever the brief names a worktree path. Embed the following instruction verbatim in the spawned `Agent` prompt whenever the brief targets a worktree:
+
+> Before your first `Write`, `Edit`, or file-mutating `Bash` call, `cd` into `.worktrees/<ticket-id>/` and confirm the resolved working directory (e.g. via `pwd`) actually resolves inside that worktree. If it does not, `cd` into the worktree and re-verify before proceeding — do not issue any mutating call until the check passes.
+
+This is a distinct, actionable check from the "treat the main directory as read-only" expectation above: that sentence states the constraint, this is the step that catches a session whose working directory silently defaulted to the main checkout before any file lands there.
+
+**Stray-file discovery — no unilateral action.** Discovering a file on the main repository checkout that appears misplaced from a worktree-scoped ticket — whether the discoverer is the orchestrator or a sibling sub-agent — does NOT trigger deletion of that file, on sight or by any other means. A file's location does not establish its provenance: a sibling agent's own in-flight write may be transiting through that same path at the moment of discovery, and location alone cannot distinguish an abandoned stray from a write still in progress. Instead:
+
+1. **Flag, don't act.** The discoverer flags the file to the orchestrator (or `team-lead`) for adjudication.
+2. **Relocate only after provenance is confirmed.** The file is moved into the correct worktree path only once its provenance has been confirmed — it is never deleted or relocated unilaterally by the discoverer.
+
 Before pushing, always rebase the worktree branch against the upstream main to avoid merge conflicts on shared files:
 
 ```sh


### PR DESCRIPTION
Realizes spec 0093 for friction issue #599: a sub-agent spawned into a ticket worktree now verifies its own cwd before its first mutating call, and a stray file found on the main checkout is flagged for adjudication instead of deleted on sight.

Closes #599

## How to read this PR?

Single file changed: `docs/agent-team-protocol.md` (11 insertions, no deletions — see diff). The new text lands directly after the existing `Worktree Isolation` `git worktree add` example and adds two paragraphs:

1. **Cwd verification (every spawned role)** — the actionable `cd`-and-`pwd`-verify instruction to embed verbatim in a spawned `Agent` prompt whenever the brief names a worktree path, plus the note that it attaches to the brief's target, not the role.
2. **Stray-file discovery — no unilateral action** — the flag-don't-act rule and the reason (a sibling agent's in-flight write may be transiting the same path), followed by the two-step remediation path (flag to orchestrator/`team-lead`, relocate only once provenance is confirmed).

Read `specs/0093-worktree-subagent-cwd-guard.md` → `## Requirements` first if you want the traceability: requirements 2-4 map to paragraph 1, requirements 5-7 map to paragraph 2, requirement 8 is why the diff touches only this one section.

## How to test this PR?

This is a documentation-only change — no build or test suite to run.

1. `git show` the single commit on this branch and confirm it touches only `docs/agent-team-protocol.md`.
2. Read the new text in place inside `docs/agent-team-protocol.md` → *Worktree Isolation* and check it against `specs/0093-worktree-subagent-cwd-guard.md` → `## Scenarios`: the cwd-check scenario, the misroute-caught scenario, the stray-file-flagged scenario, and the reject-blind-deletion scenario should all read as satisfied by the added text.
3. Confirm no other section of `docs/agent-team-protocol.md` changed (Solo work prohibition, Standard Team Templates, Team sizing by complexity, Team Communication, Team Shutdown) — per spec requirement 8, this PR is scoped to *Worktree Isolation* only.

## Detailed description (for agents)

Adds two paragraphs to `docs/agent-team-protocol.md` → *Worktree Isolation*, right after the existing `git worktree add -b <branch-name> .worktrees/<ticket-id> crewrig/main` example:

- **Added**: "Cwd verification (every spawned role)" — states the obligation attaches to the brief's target (any spawned specialist whose brief names a worktree path), not to the role, and gives the verbatim instruction to embed in the spawned `Agent` prompt: `cd` into the worktree, verify the resolved directory with `pwd`, re-verify after correcting a mismatch, and do not issue any mutating call until the check passes. Distinguishes this from the pre-existing "treat the main directory as read-only" sentence by framing it as the concrete step that catches a session whose cwd silently defaulted to the main checkout.
- **Added**: "Stray-file discovery — no unilateral action" — states that discovering a misplaced-looking file on the main checkout (by orchestrator or sibling sub-agent) never triggers on-sight deletion, because location alone cannot distinguish an abandoned stray from a sibling's write still in progress. Specifies the two-step remediation: (1) flag to the orchestrator/`team-lead` for adjudication, (2) relocate into the correct worktree path only after provenance is confirmed — never unilaterally.
- **Nothing removed or modified** elsewhere in the file; no other file in the repository is touched by this PR (see diff).

This closes the loop opened by the Harness Curator's friction cluster on issue #599 ("Worktree-scoped sub-agents' Write tool resolves paths against the main repo, not the worktree"), which spec 0093 (merged via PR #640) qualified. Per `docs/spec-pr-workflow.md` → *Independence rule*, the spec-PR and this implementation-PR each close their own issue independently; this is the implementation-PR, so it is the one that carries `Closes #599`.
