### PR TITLE
📝 Add spec 0094 — reconcile spec-PR Independence rule with shared-logbook Rule C

### DIFF
--- a/specs/0094-spec-pr-shared-logbook-closing-keyword.md
+++ b/specs/0094-spec-pr-shared-logbook-closing-keyword.md
@@ -1,0 +1,127 @@
+---
+id: "0094"
+slug: spec-pr-shared-logbook-closing-keyword
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 597
+version: 1.0.0
+---
+
+# Reconcile the spec-PR Independence rule with the shared-logbook Rule C when the related issue is both
+
+## Intent
+
+After this change, an author writing a spec-PR whose related issue is
+also the ticket's shared logbook issue (the common case under Logbook
+Issues → Rule A) references that issue without triggering GitHub's
+automatic issue-closing behavior on merge. The shared logbook issue
+stays open through PLAN, DEV, and REVIEW, and closes only when the
+implementation-PR merges, exactly as Rule C already intends. A reader
+of the Independence rule finds the shared-logbook case named explicitly,
+including the concrete phrasing that avoids an accidental auto-close,
+instead of discovering the contradiction only after a spec-PR merge
+closes a logbook issue mid-ticket.
+
+## Requirements
+
+1. `docs/spec-pr-workflow.md` → *Independence rule* SHALL state a
+   carve-out for the case where the spec's `related-issue` is the same
+   issue serving as the ticket's shared logbook issue (the Logbook
+   Issues → Rule A common case): the spec-PR body SHALL NOT carry any
+   closing-keyword directive for that issue — no `Closes #<N>`,
+   `Fixes #<N>`, or `Resolves #<N>`, in any phrasing.
+2. The carve-out SHALL state explicitly that rewording the sentence
+   around the closing keyword (e.g. a negated sentence such as "this
+   spec-PR closes no issue on merge") does not prevent GitHub from
+   auto-closing the referenced issue, because GitHub's closing-keyword
+   parser matches on the literal adjacent token pattern
+   (`close|fix|resolve #<N>`) regardless of the surrounding sentence's
+   meaning. The carve-out SHALL cite this as the reason phrasing
+   workarounds are rejected outright rather than merely discouraged.
+3. The carve-out SHALL prescribe the non-adjacent reference pattern the
+   spec-PR body uses instead — for example "Related #<N>" or "the
+   implementation PR (tracking #<N>) will close it on merge" — i.e. any
+   phrasing that keeps a closing keyword and the issue number from
+   appearing adjacently.
+4. The carve-out SHALL state, unchanged from today's rule, that only
+   the implementation-PR carries the closing directive for the shared
+   logbook issue, consistent with Logbook Issues → Rule C ("close
+   immediately after merge" of the implementation-PR).
+5. When the spec's `related-issue` is NOT the ticket's shared logbook
+   issue (an uncommon case: a dedicated logbook issue exists separately
+   per Rule A's second paragraph), the existing Independence rule text
+   SHALL continue to apply unchanged — each PR closes its own
+   `related-issue` via its own closing directive.
+6. `AGENTS.md` → *Spec-PR workflow* SHALL retain its existing one-line
+   pointer to `docs/spec-pr-workflow.md` for the Independence rule's
+   full text; this spec SHALL NOT duplicate the carve-out's normative
+   content into `AGENTS.md` itself.
+7. `AGENTS.md` → *Logbook Issues → Rule C* SHALL gain a one-line
+   cross-reference pointing to the `docs/spec-pr-workflow.md` →
+   *Independence rule* carve-out, so a reader who lands on Rule C first
+   discovers the spec-PR-time exception without independently
+   rediscovering the contradiction this spec resolves.
+8. This spec SHALL NOT introduce, request, or describe any CI check,
+   spec linter rule, or pre-commit hook that detects an adjacent
+   closing-keyword token in a spec-PR body. That enforcement mechanism
+   is explicitly deferred to a separate follow-up ticket.
+
+## Scenarios
+
+**Scenario:** Spec-PR for a shared-logbook ticket merges without
+auto-closing the logbook issue
+
+Given a ticket whose GitHub issue #<N> is both the spec's
+`related-issue` and the ticket's shared logbook issue per Rule A
+Given the spec-PR body references issue #<N> using the non-adjacent
+pattern prescribed by Requirement 3 (e.g. "Related #<N>" or "the
+implementation PR, tracking #<N>, will close it on merge")
+When the spec-PR is merged to `main`
+Then issue #<N> remains open, because no closing-keyword token was
+adjacent to `#<N>` anywhere in the merged PR body
+
+**Scenario:** A spec-PR that still carries an adjacent closing-keyword
+token is caught before merge
+
+Given a spec-PR body for a shared-logbook ticket that contains a
+closing-keyword token adjacent to the issue number — including a
+negated-sentence attempt such as "this spec-PR closes no issue on
+merge; the implementation PR will close #<N>" — which Requirement 2
+identifies as still triggering GitHub's auto-close regardless of the
+surrounding prose
+When a human reviewer checks the spec-PR body against the carve-out
+in `docs/spec-pr-workflow.md` → *Independence rule* before approving
+Then the reviewer requests changes to remove the adjacent token pattern
+before merge; this scenario is a manual-verification check, since an
+automated linter for this pattern is out of scope per Requirement 8
+
+## Out of scope
+
+- An automated CI check or spec linter rule that fails a `spec/*` PR
+  whose body contains a closing-keyword token adjacent to an issue
+  number — a valuable follow-up, tracked as a separate ticket, not
+  qualified by this spec.
+- Any change to the Independence rule's treatment of the
+  implementation-PR's own closing directive — Requirement 4 keeps that
+  behavior exactly as it stands today.
+- Any change to Logbook Issues → Rule A or → Rule B — this spec touches
+  only the cross-reference addition to Rule C described in
+  Requirement 7.
+- Retroactively auditing or relabeling any already-merged spec-PR that
+  may have auto-closed a shared logbook issue under the old,
+  contradictory rule text (the three lived instances cited in issue
+  #597 among them) — this spec qualifies the go-forward rule, not a
+  historical remediation pass.
+- Any change to `docs/spec-format.md`'s frontmatter schema or mandatory
+  body sections — this ticket is scoped entirely to the Independence
+  rule's prose in `docs/spec-pr-workflow.md` and the single
+  cross-reference line in `AGENTS.md`.
+
+## Open questions
+
+- None — the resolution (tighten the Independence rule with an explicit
+  shared-logbook carve-out, rather than relax Rule C's trigger) was
+  decided upstream of this spec-authoring session per the curator's
+  consolidated report on issue #597, and the scope is narrow enough
+  that no ambiguity survived drafting the Requirements above.

--- a/specs/0094-spec-pr-shared-logbook-closing-keyword.md
+++ b/specs/0094-spec-pr-shared-logbook-closing-keyword.md
@@ -40,8 +40,8 @@ closes a logbook issue mid-ticket.
    meaning. The carve-out SHALL cite this as the reason phrasing
    workarounds are rejected outright rather than merely discouraged.
 3. The carve-out SHALL prescribe the non-adjacent reference pattern the
-   spec-PR body uses instead — for example "Related #<N>" or "the
-   implementation PR (tracking #<N>) will close it on merge" — i.e. any
+   spec-PR body uses instead — for example "Related `#<N>`" or "the
+   implementation PR (tracking `#<N>`) will close it on merge" — i.e. any
    phrasing that keeps a closing keyword and the issue number from
    appearing adjacently.
 4. The carve-out SHALL state, unchanged from today's rule, that only
@@ -72,13 +72,13 @@ closes a logbook issue mid-ticket.
 **Scenario:** Spec-PR for a shared-logbook ticket merges without
 auto-closing the logbook issue
 
-Given a ticket whose GitHub issue #<N> is both the spec's
+Given a ticket whose GitHub issue `#<N>` is both the spec's
 `related-issue` and the ticket's shared logbook issue per Rule A
-Given the spec-PR body references issue #<N> using the non-adjacent
-pattern prescribed by Requirement 3 (e.g. "Related #<N>" or "the
-implementation PR, tracking #<N>, will close it on merge")
+Given the spec-PR body references issue `#<N>` using the non-adjacent
+pattern prescribed by Requirement 3 (e.g. "Related `#<N>`" or "the
+implementation PR, tracking `#<N>`, will close it on merge")
 When the spec-PR is merged to `main`
-Then issue #<N> remains open, because no closing-keyword token was
+Then issue `#<N>` remains open, because no closing-keyword token was
 adjacent to `#<N>` anywhere in the merged PR body
 
 **Scenario:** A spec-PR that still carries an adjacent closing-keyword
@@ -87,7 +87,7 @@ token is caught before merge
 Given a spec-PR body for a shared-logbook ticket that contains a
 closing-keyword token adjacent to the issue number — including a
 negated-sentence attempt such as "this spec-PR closes no issue on
-merge; the implementation PR will close #<N>" — which Requirement 2
+merge; the implementation PR will close `#<N>`" — which Requirement 2
 identifies as still triggering GitHub's auto-close regardless of the
 surrounding prose
 When a human reviewer checks the spec-PR body against the carve-out


### PR DESCRIPTION
Qualifies the WHAT for the spec-PR / shared-logbook contradiction reported in issue #597. Related #597 — per the very rule this spec introduces, this spec-PR does not carry a closing directive for #597 since it is the ticket's shared logbook issue; the implementation-PR will close it once merged.

## How to read this PR?

Single file: `specs/0094-spec-pr-shared-logbook-closing-keyword.md`. Read `## Intent` first for the WHAT, then `## Requirements` 1–4 for the actual carve-out text to be realized in `docs/spec-pr-workflow.md`, then `## Requirements` 6–7 for the (minimal) `AGENTS.md` touch. `## Scenarios` gives the happy-path (non-adjacent reference, issue stays open) and failure-path (adjacent-token attempt, including the negated-sentence trap, caught by human review since a CI linter is explicitly out of scope per Requirement 8).

## How to test this PR?

This is a documentation-qualifying spec, not code — there is nothing to run. Verify instead that:
1. `specs/0094-spec-pr-shared-logbook-closing-keyword.md` is the only file in the diff (one-file rule).
2. Frontmatter conforms to `docs/spec-format.md` (`id: "0094"`, `related-issue: 597`, `complexity: small`).
3. This PR body itself follows Requirement 1–3's prescribed phrasing (`Related #597`, no adjacent closing keyword) — a live demonstration of the rule being qualified.

## Detailed description (for agents)

Adds `specs/0094-spec-pr-shared-logbook-closing-keyword.md`, the sole SPECS-stage artifact for issue #597 (a consolidated harness-friction report evidencing 3 lived instances of the contradiction: crewrig/crewrig PR #486, PR #591, and crewrig-hcross Gitea PR #7).

The spec qualifies a carve-out to `docs/spec-pr-workflow.md` → *Independence rule*: when a spec's `related-issue` is also the ticket's shared logbook issue (the common case per `AGENTS.md` → *Logbook Issues → Rule A*), the spec-PR body must not carry any closing-keyword directive (`Closes/Fixes/Resolves #N`) for that issue — including no negated-sentence workaround, since GitHub's parser matches the literal adjacent token regardless of surrounding prose (proven by PR #511). The prescribed phrasing instead is a non-adjacent reference such as "Related #N". Only the implementation-PR keeps the closing directive, per Rule C, unchanged. `AGENTS.md` → *Logbook Issues → Rule C* gains a one-line cross-reference to this carve-out for discoverability.

Explicitly out of scope: an automated CI/spec-linter check for the adjacent-token pattern (deferred to a follow-up ticket), and any retroactive relabeling of the three already-merged PRs cited as evidence.

No PLAN, DEV, or code changes are included in this PR per the one-file rule — those follow in the implementation-PR once this spec-PR merges.