### PR TITLE
📝 Realize spec 0094 — shared-logbook carve-out for the spec-PR Independence rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,15 +408,12 @@ triggers that require an immediate logbook comment.
 
 ### Rule C — Close immediately after merge
 
-Once the PR is merged and the changes verified, **close the linked issue
-immediately** (`state_reason: completed`). Do not defer closing to a
-later cleanup pass — stale open issues accumulate and obscure the actual
-state of work in flight.
-
-When the linked issue is also the ticket's spec-PR `related-issue`, see
-[`docs/spec-pr-workflow.md`](docs/spec-pr-workflow.md) → *Independence rule*
-for the spec-PR-time exception that keeps this issue open until the
-implementation-PR merges.
+Close the linked issue immediately once merged and verified
+(`state_reason: completed`); rationale in
+[`docs/logbook-issues.md`](docs/logbook-issues.md) → *Rule C*. Spec-PR
+exception:
+[`docs/spec-pr-workflow.md`](docs/spec-pr-workflow.md) → *Independence
+rule*.
 
 ## Forge Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,11 @@ immediately** (`state_reason: completed`). Do not defer closing to a
 later cleanup pass — stale open issues accumulate and obscure the actual
 state of work in flight.
 
+When the linked issue is also the ticket's spec-PR `related-issue`, see
+[`docs/spec-pr-workflow.md`](docs/spec-pr-workflow.md) → *Independence rule*
+for the spec-PR-time exception that keeps this issue open until the
+implementation-PR merges.
+
 ## Forge Access
 
 Forge access is CLI-only. Forge operations (issues, PRs/MRs, branch protection, releases) route through the forge's own CLI — `gh` (GitHub), `glab` (GitLab), `tea` (Gitea) — with authentication delegated to that CLI; the framework ships no forge MCP server. Native `git` remains the tool for ordinary version control and is unchanged. See `artifacts/core/rules/60-tools.md` → *Forge Access* for the per-CLI `auth login` details.

--- a/docs/logbook-issues.md
+++ b/docs/logbook-issues.md
@@ -17,3 +17,26 @@ resolution — not after the PR is opened.
 - Scope changes or requirement pivots mid-ticket
 - Rebase operations that resolve conflicts (one comment per rebase, summarizing the conflict and resolution)
 - Architectural course corrections (an ADR-worthy decision made inline)
+
+## Rule C — close immediately after merge
+
+The `AGENTS.md` → *Logbook Issues → Rule C* obligation ("close
+immediately after merge") exists because stale open issues accumulate
+and obscure the actual state of work in flight — an issue left open
+after its PR merged reads as unfinished work to anyone scanning the
+tracker, and erodes trust in the issue list as a source of truth.
+
+**Spec-PR `related-issue` exception.** When the closing issue is also
+the ticket's spec-PR `related-issue` under *Logbook Issues → Rule A*
+(the common case: no separate dedicated logbook issue exists, so the
+shared logbook issue doubles as the spec's `related-issue`), Rule C's
+"close immediately" default does not apply to the spec-PR merge itself.
+The spec-PR body carries no closing-keyword directive (no `Closes #<N>`,
+`Fixes #<N>`, `Resolves #<N>`, in any phrasing) for that issue, so
+merging the spec-PR leaves it open. The issue only closes once the
+implementation-PR merges and the change is verified — closing it at
+spec-PR time would end the journal before PLAN, DEV, and REVIEW have
+even run. See
+[`docs/spec-pr-workflow.md`](docs/spec-pr-workflow.md) → *Independence
+rule* for the full mechanics of why the two PRs close their own issues
+independently.

--- a/docs/logbook-issues.md
+++ b/docs/logbook-issues.md
@@ -26,17 +26,5 @@ and obscure the actual state of work in flight — an issue left open
 after its PR merged reads as unfinished work to anyone scanning the
 tracker, and erodes trust in the issue list as a source of truth.
 
-**Spec-PR `related-issue` exception.** When the closing issue is also
-the ticket's spec-PR `related-issue` under *Logbook Issues → Rule A*
-(the common case: no separate dedicated logbook issue exists, so the
-shared logbook issue doubles as the spec's `related-issue`), Rule C's
-"close immediately" default does not apply to the spec-PR merge itself.
-The spec-PR body carries no closing-keyword directive (no `Closes #<N>`,
-`Fixes #<N>`, `Resolves #<N>`, in any phrasing) for that issue, so
-merging the spec-PR leaves it open. The issue only closes once the
-implementation-PR merges and the change is verified — closing it at
-spec-PR time would end the journal before PLAN, DEV, and REVIEW have
-even run. See
-[`docs/spec-pr-workflow.md`](docs/spec-pr-workflow.md) → *Independence
-rule* for the full mechanics of why the two PRs close their own issues
-independently.
+See [`docs/spec-pr-workflow.md`](docs/spec-pr-workflow.md) → *Independence
+rule* for the spec-PR `related-issue` exception and its full mechanics.

--- a/docs/spec-pr-workflow.md
+++ b/docs/spec-pr-workflow.md
@@ -38,6 +38,34 @@ realization are deliberately separated so that a merged spec can
 outlive a failed implementation attempt and be re-realized by a
 later PR without information loss.
 
+That "closes its own issue" default assumes a dedicated logbook issue
+exists apart from the spec's `related-issue`. When the `related-issue`
+is instead the ticket's shared logbook issue — the common case under
+*Logbook Issues → Rule A*, where no separate dedicated logbook issue
+exists — the spec-PR body SHALL NOT carry any closing-keyword
+directive for that issue: no `Closes #<N>`, `Fixes #<N>`, or
+`Resolves #<N>`, in any phrasing. Merging the spec-PR under that
+directive would close the ticket's own journal mid-flight, well before
+PLAN, DEV, and REVIEW have even run.
+
+Rewording the sentence around the closing keyword does not sidestep
+this. GitHub's closing-keyword parser matches the literal adjacent
+token pattern (`close|fix|resolve #<N>`) regardless of the surrounding
+sentence's meaning, so a negated sentence such as "this spec-PR closes
+no issue on merge; `#<N>` stays open" still auto-closes `#<N>` on
+merge. The carve-out is therefore a hard rule, not a discouraged
+practice: the spec-PR body must instead use a non-adjacent reference —
+"Related `#<N>`" or "the implementation PR (tracking `#<N>`) will
+close it on merge" — anything that keeps a closing keyword and the
+issue number from landing next to each other.
+
+When the spec's `related-issue` is *not* the shared logbook issue — a
+dedicated logbook issue exists separately, per Rule A's second
+paragraph — today's rule continues unchanged: each PR closes its own
+`related-issue` via its own closing directive. Either way, only the
+implementation-PR ever carries the closing directive for the shared
+logbook issue itself, consistent with *Logbook Issues → Rule C*.
+
 ## Delta-spec cumulative rule
 
 A single implementation-PR MAY absorb **N delta-spec PRs** targeting


### PR DESCRIPTION
Realizes the merged spec [`specs/0094-spec-pr-shared-logbook-closing-keyword.md`](https://github.com/crewrig/crewrig/blob/main/specs/0094-spec-pr-shared-logbook-closing-keyword.md): documents the shared-logbook carve-out for the spec-PR Independence rule so a spec-PR never auto-closes a ticket's own shared logbook issue mid-flight. Closes #597.

## How to read this PR?

Three files, +45/-4 lines across 3 commits (`git diff origin/main...HEAD --stat`):

1. **`docs/spec-pr-workflow.md`** (+28) — the substantive change, from commit `03e96a4`. Adds the
   carve-out under the Independence rule: when a spec's `related-issue` is
   also the ticket's shared logbook issue (per `AGENTS.md` → *Logbook Issues
   → Rule A*, no separate dedicated logbook issue), the spec-PR body must
   never carry a closing-keyword directive (`Closes #<N>` / `Fixes #<N>` /
   `Resolves #<N>`, in any phrasing) for that issue — because GitHub's
   closing-keyword parser matches the literal adjacent token pattern
   regardless of the surrounding sentence, so even a negated sentence next
   to the issue number still auto-closes it. It also states the converse:
   when a dedicated logbook issue exists separately, today's rule is
   unchanged, and either way only the implementation-PR ever carries the
   closing directive for the shared logbook issue (per Rule C).
2. **`AGENTS.md`** (net +6/-4 across commits `03e96a4` and `3936063`) — a
   cross-reference from the *Logbook Issues → Rule C* closing paragraph
   pointing at the new carve-out in `docs/spec-pr-workflow.md`. The initial
   one-line addition (`03e96a4`) pushed `AGENTS.md` over the 22000-byte
   `check-agents-size.sh` threshold, so `3936063` shortened Rule C's inline
   text and moved its rationale to `docs/logbook-issues.md`, mirroring the
   extraction pattern already used for Rule B.
3. **`docs/logbook-issues.md`** (+11, commits `3936063` and `cb39e2d`) — new
   `## Rule C — close immediately after merge` section: the rationale
   extracted from `AGENTS.md`, plus a pointer to `docs/spec-pr-workflow.md`
   for the exception's full mechanics. Iteration-2 REVIEW trimmed an
   earlier draft that duplicated those mechanics inline (`cb39e2d`), so the
   carve-out's normative text now lives exactly once.

No code, scripts, or tests are touched by this PR — see diff.

## How to test this PR?

This is a documentation-only change; there is no runtime behavior to
exercise.

1. Read `docs/spec-pr-workflow.md` → *Independence rule* and confirm the
   new carve-out paragraph is consistent with `AGENTS.md` → *Logbook Issues
   → Rule A* and *Rule C* (no contradiction between "spec-PR closes its own
   issue by default" and "spec-PR must not close the shared logbook
   issue").
2. Confirm the two PRs on this ticket follow the rule they document: the
   spec-PR (#644) used `Related #597` in its body, not a closing keyword;
   this implementation-PR uses `Closes #597` — consistent with the
   carve-out's statement that only the implementation-PR closes the shared
   logbook issue.
3. Run `bash scripts/check-agents-size.sh` — should pass at 21904 bytes
   (threshold 22000).
4. Run `bash scripts/check-skill-versions.sh` (or `task
   check-skill-versions`) if available — this PR touches no
   `artifacts/core/skills/*/SKILL.md` or `artifacts/core/agents/*/AGENT.md`
   source, so no version bump is expected and the check should pass
   unaffected.

## Detailed description (for agents)

**Problem addressed.** The spec-PR Independence rule previously implied
every spec-PR closes its own `related-issue` on merge. That default
collides with `AGENTS.md` → *Logbook Issues → Rule A*: when the ticket has
no separate dedicated logbook issue, the spec's `related-issue` doubles as
the shared logbook issue, and a spec-PR closing directive would close that
issue — and end the logbook — before PLAN, DEV, and REVIEW even run.

**Change 1 — `docs/spec-pr-workflow.md` (+28 lines, commit `03e96a4`).**
Inserted after the existing Independence-rule paragraph (before the
pre-existing "Delta-spec cumulative rule" section):

- States the carve-out condition: `related-issue` is the shared logbook
  issue and no dedicated logbook issue exists (Rule A's common case).
- Prohibits any closing-keyword directive in the spec-PR body under that
  condition, in any phrasing — explains why rewording doesn't help
  (GitHub's parser matches the literal `close|fix|resolve #<N>` adjacency,
  not sentence semantics), and prescribes the alternative: a non-adjacent
  reference such as "Related `#<N>`" or "the implementation PR (tracking
  `#<N>`) will close it on merge".
- States the complementary case: when a dedicated logbook issue exists
  separately (Rule A's second paragraph), the pre-existing rule is
  unaffected — each PR closes its own `related-issue`.
- Closes with the cross-reference to Rule C: only the implementation-PR
  ever carries the closing directive for the shared logbook issue.

**Change 2 — `AGENTS.md` (commits `03e96a4`, `3936063`).** Added a pointer
at the end of the *Logbook Issues → Rule C* closing paragraph, directing
readers to the carve-out in `docs/spec-pr-workflow.md`. Mid-DEV, CI's
`check-agents-size` check failed (`AGENTS.md` at 22126 bytes, over the
22000-byte threshold) because `AGENTS.md` on `main` already had only 120
bytes of headroom before this PR. Fixed by shortening Rule C's paragraph
in `AGENTS.md` and moving its rationale sentence to `docs/logbook-issues.md`
(commit `3936063`), the same extraction pattern already used for Rule B.
Final size: 21904 bytes, 96 bytes under threshold.

**Change 3 — `docs/logbook-issues.md` (commits `3936063`, `cb39e2d`).**
Added a `## Rule C — close immediately after merge` section holding the
rationale moved from `AGENTS.md`. Iteration-1 cold REVIEW (`pr-reviewer`)
flagged a non-blocking `class: tech` finding: the section also restated
the Independence-rule carve-out's mechanics, already fully documented in
`docs/spec-pr-workflow.md`, creating two sources of truth. Commit
`cb39e2d` trimmed the section to rationale-plus-pointer only, resolving
the finding; iteration-2 cold REVIEW confirmed no remaining duplication
and approved.

**Applied precedent in this ticket's own PRs.** The spec-PR for this
ticket (#644) already followed the rule it documents, using `Related #597`
rather than a closing keyword. This implementation-PR is the one that
closes #597, per Rule C and per the carve-out this diff adds — `Closes
#597` in this body is intentional, not an oversight of the rule being
documented.

**Scope note.** `git diff origin/main...HEAD --stat` confirms exactly
these three files, +45/-4 lines, across commits `03e96a4`, `3936063`, and
`cb39e2d`. The second and third commits were CI/REVIEW-driven fixes, not
scope creep — see Change 2 and Change 3 above for why each was necessary.