### PR TITLE
📝 Add byte-accounting discipline to architect skill

### DIFF
--- a/.agents/skills/architect/SKILL.md
+++ b/.agents/skills/architect/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.2.0"
 ---
 
 
@@ -79,7 +79,43 @@ A change with a one-way blast radius gets an ADR. A change with an
 awkward blast radius gets a migration plan. A trivial change gets
 neither — do not over-document.
 
-### 4. Output formats
+### 4. Byte-accounting discipline (size/budget-constrained plans)
+
+Applies whenever a plan claims to bring something under a size, byte,
+or token budget (e.g. a file-size CI gate) by relocating, trimming, or
+rewriting content.
+
+Every claimed savings figure MUST be based on an empirical measurement
+of the actual candidate span — `wc -c` on the exact line range being
+moved, dropped, or rewritten — taken **before** the figure is committed
+to the plan. Do not estimate savings from line counts, prose-length
+heuristics, or "architect-level approximation."
+
+```text
+# before committing a savings figure to the plan
+sed -n '42,88p' docs/target-file.md | wc -c
+# 1103 → this is the number the plan may cite, not a guess
+```
+
+The plan must land on an explicit safety margin between the projected
+post-change size and the budget line — not clear it exactly. A plan
+that projects landing 3 bytes under budget has no margin for the next
+edit and should not ship as if it were safe.
+
+**Self-check before finalizing.** Sum every section's *measured* (not
+estimated) savings, compare the total against the actual gap-to-budget,
+and check the resulting margin against an explicit threshold the plan
+states. If the margin is thinner than that threshold, either add more
+headroom (an additional candidate section, a larger margin) or flag the
+risk explicitly in the plan's Risks section — do not ship a thin,
+unverified plan as if it were safe.
+
+If a genuinely unmeasured figure must appear — a rough
+order-of-magnitude scoping estimate before line ranges are even
+identified — label it as an estimate, not a committed savings figure.
+Same cite-or-downgrade discipline as "## Grounding discipline" below.
+
+### 5. Output formats
 
 | Output | When | Where |
 |---|---|---|
@@ -91,7 +127,7 @@ ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
 
-### 5. Briefing sub-agents (call-graph context)
+### 6. Briefing sub-agents (call-graph context)
 
 When delegating a focused task (tester, security, doc-writer, etc.) to a
 sub-agent, the brief MUST include the **call-graph context** of any file

--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.2.0"
 ---
 
 
@@ -85,7 +85,43 @@ A change with a one-way blast radius gets an ADR. A change with an
 awkward blast radius gets a migration plan. A trivial change gets
 neither — do not over-document.
 
-### 4. Output formats
+### 4. Byte-accounting discipline (size/budget-constrained plans)
+
+Applies whenever a plan claims to bring something under a size, byte,
+or token budget (e.g. a file-size CI gate) by relocating, trimming, or
+rewriting content.
+
+Every claimed savings figure MUST be based on an empirical measurement
+of the actual candidate span — `wc -c` on the exact line range being
+moved, dropped, or rewritten — taken **before** the figure is committed
+to the plan. Do not estimate savings from line counts, prose-length
+heuristics, or "architect-level approximation."
+
+```text
+# before committing a savings figure to the plan
+sed -n '42,88p' docs/target-file.md | wc -c
+# 1103 → this is the number the plan may cite, not a guess
+```
+
+The plan must land on an explicit safety margin between the projected
+post-change size and the budget line — not clear it exactly. A plan
+that projects landing 3 bytes under budget has no margin for the next
+edit and should not ship as if it were safe.
+
+**Self-check before finalizing.** Sum every section's *measured* (not
+estimated) savings, compare the total against the actual gap-to-budget,
+and check the resulting margin against an explicit threshold the plan
+states. If the margin is thinner than that threshold, either add more
+headroom (an additional candidate section, a larger margin) or flag the
+risk explicitly in the plan's Risks section — do not ship a thin,
+unverified plan as if it were safe.
+
+If a genuinely unmeasured figure must appear — a rough
+order-of-magnitude scoping estimate before line ranges are even
+identified — label it as an estimate, not a committed savings figure.
+Same cite-or-downgrade discipline as "## Grounding discipline" below.
+
+### 5. Output formats
 
 | Output | When | Where |
 |---|---|---|
@@ -97,7 +133,7 @@ ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
 
-### 5. Briefing sub-agents (call-graph context)
+### 6. Briefing sub-agents (call-graph context)
 
 When delegating a focused task (tester, security, doc-writer, etc.) to a
 sub-agent, the brief MUST include the **call-graph context** of any file

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.2.0"
 ---
 
 
@@ -79,7 +79,43 @@ A change with a one-way blast radius gets an ADR. A change with an
 awkward blast radius gets a migration plan. A trivial change gets
 neither — do not over-document.
 
-### 4. Output formats
+### 4. Byte-accounting discipline (size/budget-constrained plans)
+
+Applies whenever a plan claims to bring something under a size, byte,
+or token budget (e.g. a file-size CI gate) by relocating, trimming, or
+rewriting content.
+
+Every claimed savings figure MUST be based on an empirical measurement
+of the actual candidate span — `wc -c` on the exact line range being
+moved, dropped, or rewritten — taken **before** the figure is committed
+to the plan. Do not estimate savings from line counts, prose-length
+heuristics, or "architect-level approximation."
+
+```text
+# before committing a savings figure to the plan
+sed -n '42,88p' docs/target-file.md | wc -c
+# 1103 → this is the number the plan may cite, not a guess
+```
+
+The plan must land on an explicit safety margin between the projected
+post-change size and the budget line — not clear it exactly. A plan
+that projects landing 3 bytes under budget has no margin for the next
+edit and should not ship as if it were safe.
+
+**Self-check before finalizing.** Sum every section's *measured* (not
+estimated) savings, compare the total against the actual gap-to-budget,
+and check the resulting margin against an explicit threshold the plan
+states. If the margin is thinner than that threshold, either add more
+headroom (an additional candidate section, a larger margin) or flag the
+risk explicitly in the plan's Risks section — do not ship a thin,
+unverified plan as if it were safe.
+
+If a genuinely unmeasured figure must appear — a rough
+order-of-magnitude scoping estimate before line ranges are even
+identified — label it as an estimate, not a committed savings figure.
+Same cite-or-downgrade discipline as "## Grounding discipline" below.
+
+### 5. Output formats
 
 | Output | When | Where |
 |---|---|---|
@@ -91,7 +127,7 @@ ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
 
-### 5. Briefing sub-agents (call-graph context)
+### 6. Briefing sub-agents (call-graph context)
 
 When delegating a focused task (tester, security, doc-writer, etc.) to a
 sub-agent, the brief MUST include the **call-graph context** of any file

--- a/.github/skills/architect/SKILL.md
+++ b/.github/skills/architect/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.2.0"
 ---
 
 
@@ -79,7 +79,43 @@ A change with a one-way blast radius gets an ADR. A change with an
 awkward blast radius gets a migration plan. A trivial change gets
 neither — do not over-document.
 
-### 4. Output formats
+### 4. Byte-accounting discipline (size/budget-constrained plans)
+
+Applies whenever a plan claims to bring something under a size, byte,
+or token budget (e.g. a file-size CI gate) by relocating, trimming, or
+rewriting content.
+
+Every claimed savings figure MUST be based on an empirical measurement
+of the actual candidate span — `wc -c` on the exact line range being
+moved, dropped, or rewritten — taken **before** the figure is committed
+to the plan. Do not estimate savings from line counts, prose-length
+heuristics, or "architect-level approximation."
+
+```text
+# before committing a savings figure to the plan
+sed -n '42,88p' docs/target-file.md | wc -c
+# 1103 → this is the number the plan may cite, not a guess
+```
+
+The plan must land on an explicit safety margin between the projected
+post-change size and the budget line — not clear it exactly. A plan
+that projects landing 3 bytes under budget has no margin for the next
+edit and should not ship as if it were safe.
+
+**Self-check before finalizing.** Sum every section's *measured* (not
+estimated) savings, compare the total against the actual gap-to-budget,
+and check the resulting margin against an explicit threshold the plan
+states. If the margin is thinner than that threshold, either add more
+headroom (an additional candidate section, a larger margin) or flag the
+risk explicitly in the plan's Risks section — do not ship a thin,
+unverified plan as if it were safe.
+
+If a genuinely unmeasured figure must appear — a rough
+order-of-magnitude scoping estimate before line ranges are even
+identified — label it as an estimate, not a committed savings figure.
+Same cite-or-downgrade discipline as "## Grounding discipline" below.
+
+### 5. Output formats
 
 | Output | When | Where |
 |---|---|---|
@@ -91,7 +127,7 @@ ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
 
-### 5. Briefing sub-agents (call-graph context)
+### 6. Briefing sub-agents (call-graph context)
 
 When delegating a focused task (tester, security, doc-writer, etc.) to a
 sub-agent, the brief MUST include the **call-graph context** of any file

--- a/artifacts/core/skills/architect/SKILL.md
+++ b/artifacts/core/skills/architect/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.2"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read
@@ -89,7 +89,43 @@ A change with a one-way blast radius gets an ADR. A change with an
 awkward blast radius gets a migration plan. A trivial change gets
 neither — do not over-document.
 
-### 4. Output formats
+### 4. Byte-accounting discipline (size/budget-constrained plans)
+
+Applies whenever a plan claims to bring something under a size, byte,
+or token budget (e.g. a file-size CI gate) by relocating, trimming, or
+rewriting content.
+
+Every claimed savings figure MUST be based on an empirical measurement
+of the actual candidate span — `wc -c` on the exact line range being
+moved, dropped, or rewritten — taken **before** the figure is committed
+to the plan. Do not estimate savings from line counts, prose-length
+heuristics, or "architect-level approximation."
+
+```text
+# before committing a savings figure to the plan
+sed -n '42,88p' docs/target-file.md | wc -c
+# 1103 → this is the number the plan may cite, not a guess
+```
+
+The plan must land on an explicit safety margin between the projected
+post-change size and the budget line — not clear it exactly. A plan
+that projects landing 3 bytes under budget has no margin for the next
+edit and should not ship as if it were safe.
+
+**Self-check before finalizing.** Sum every section's *measured* (not
+estimated) savings, compare the total against the actual gap-to-budget,
+and check the resulting margin against an explicit threshold the plan
+states. If the margin is thinner than that threshold, either add more
+headroom (an additional candidate section, a larger margin) or flag the
+risk explicitly in the plan's Risks section — do not ship a thin,
+unverified plan as if it were safe.
+
+If a genuinely unmeasured figure must appear — a rough
+order-of-magnitude scoping estimate before line ranges are even
+identified — label it as an estimate, not a committed savings figure.
+Same cite-or-downgrade discipline as "## Grounding discipline" below.
+
+### 5. Output formats
 
 | Output | When | Where |
 |---|---|---|
@@ -101,7 +137,7 @@ ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
 
-### 5. Briefing sub-agents (call-graph context)
+### 6. Briefing sub-agents (call-graph context)
 
 When delegating a focused task (tester, security, doc-writer, etc.) to a
 sub-agent, the brief MUST include the **call-graph context** of any file


### PR DESCRIPTION
Adds a byte-accounting discipline step (new "## Operating mode" step 4) to the architect skill so budget-constrained plans cite measured savings — `wc -c` on the actual candidate span — instead of line-count estimates, with an explicit safety margin and a pre-finalization self-check. This closes a harness-friction cluster in which an unmeasured PLAN overshot its budget and forced an unplanned DEV-stage extraction (#498, PR #500).

Closes #601

## How to read this PR?

Start with `artifacts/core/skills/architect/SKILL.md` — the only hand-edited file (39 insertions, 3 deletions per `git diff origin/main HEAD --stat`). The new content sits between the existing "### 3. Ripple-effect analysis" and the renumbered "### 5. Output formats" (was step 4); "### 6. Briefing sub-agents" is the renumbered old step 5. The four mirrors (`.claude/skills/architect/SKILL.md`, `.gemini/skills/architect/SKILL.md`, `.github/skills/architect/SKILL.md`, `.agents/skills/architect/SKILL.md`) are mechanical regenerations via `scripts/build-components.sh` — each shows the identical +39/-3 diff, no hand-editing needed there.

Also note the `provenance.version` bump from `1.1.2` to `1.2.0` (MINOR, additive) in the source file's frontmatter, per AGENTS.md → Version Bump Convention.

## How to test this PR?

1. `git diff origin/main HEAD -- artifacts/core/skills/architect/SKILL.md` and confirm the new "### 4. Byte-accounting discipline (size/budget-constrained plans)" section reads correctly and the old steps 4/5 are renumbered to 5/6.
2. Run `scripts/check-skill-versions.sh` (or `task check-skill-versions`) locally and confirm it passes given the version bump.
3. Diff each of the four mirrored copies under `.claude/`, `.gemini/`, `.github/`, `.agents/` against `artifacts/core/skills/architect/SKILL.md` and confirm they're byte-identical — this is what `scripts/build-components.sh` regenerates; no manual edits are expected there.
4. There is no runtime behavior to exercise: this is a prompt-only change to the architect skill's own instructions, verified in practice by the next PLAN that invokes it.

## Detailed description (for agents)

- `artifacts/core/skills/architect/SKILL.md`: version bumped `1.1.2` → `1.2.0`; new "### 4. Byte-accounting discipline (size/budget-constrained plans)" section inserted into "## Operating mode", requiring: (a) every claimed savings figure be based on an empirical `wc -c` measurement of the actual candidate span, taken before the figure is committed to the plan — no estimating from line counts or "architect-level approximation"; (b) the plan land on an explicit safety margin between projected post-change size and the budget line, not exactly on it; (c) a pre-finalization self-check summing every section's measured savings against the actual gap-to-budget, checked against a stated margin threshold; (d) a cite-or-downgrade rule for any genuinely unmeasured rough estimate, cross-referencing the existing "## Grounding discipline" section. The old "### 4. Output formats" renumbers to "### 5", and old "### 5. Briefing sub-agents (call-graph context)" renumbers to "### 6".
- `.claude/skills/architect/SKILL.md`, `.gemini/skills/architect/SKILL.md`, `.github/skills/architect/SKILL.md`, `.agents/skills/architect/SKILL.md`: regenerated mirrors via `scripts/build-components.sh`, identical +39/-3 diff each, no hand-editing.

Root cause (why this is scoped as a direct fix, not a SPECS→PLAN cycle): issue #601 is a single auto-curated harness-friction report tracing to one concrete incident — PLAN v2 in issue #498 (spec 0067, shrinking AGENTS.md under a 22,000-byte budget) disclosed its stub-size figures as "architect-level estimates, not measured bytes" and projected ~1103 bytes of savings from two fallback extractions; only ~440 bytes were realized once DEV measured the actual extracted spans, leaving the file 735 bytes over budget and forcing an unplanned mid-implementation extraction (`## Plan review protocol` → `docs/plan-review-protocol.md`) in PR #500 to close the gap. PR #500's own body logged this as "Plan deviation (transparent, for REVIEW): PLAN v2's byte accounting was materially optimistic." This PR is a narrow, well-scoped prompt-only addition to one skill file's existing "## Operating mode" sequence — it introduces no new capability and changes no contract — so it follows the same direct bug-fix precedent as PR #642 (which fixed the analogous single-friction issue #600 the same way, without a spec).