### PR TITLE
📝 Add spec 0095 — orchestrator deliverable-edit fence for sub-agents

### DIFF
--- a/specs/0095-orchestrator-deliverable-edit-fence.md
+++ b/specs/0095-orchestrator-deliverable-edit-fence.md
@@ -1,0 +1,161 @@
+---
+id: "0095"
+slug: orchestrator-deliverable-edit-fence
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 602
+version: 1.0.0
+---
+
+# Orchestrator deliverable-edit fence for delegated sub-agent work
+
+## Intent
+
+After this change, an orchestrator that has delegated a deliverable file to
+a sub-agent no longer edits that same file itself while the sub-agent is
+still working on it. The orchestrator waits for an actual completion
+signal — the sub-agent's own report, or a confirmed observable trace of
+its finished work — before touching the file, instead of treating an idle
+notification as proof the sub-agent is done. A user or reviewer reading
+the Team Communication guidance finds this write-side expectation stated
+as an explicit, numbered rule sitting next to the existing read-side rule
+about idle notifications, so both halves of the same race condition are
+visible together. The concrete symptom this closes is the one already
+observed twice — in ticket #569 and in the Harness Curator's
+`concurrent-deliverable-edit` friction cluster (issue #602) — where an
+orchestrator's own completion edits landed asynchronously alongside a
+sub-agent's parallel edits to the same file, producing duplicate content
+that then had to be manually reconciled.
+
+## Requirements
+
+1. This spec SHALL declare `complexity: standard`, not `small`, because
+   the change modifies `docs/agent-team-protocol.md` itself — an
+   established protocol document that `AGENTS.md` → *Agent Team Protocol*
+   refers every team to. `docs/agent-team-protocol.md` → *Standard Team
+   Templates → Template 2* already mandates inserting `architect` as a
+   DEV-stage step whenever "the documentation change modifies an
+   established protocol, convention, or contract," and that conditional
+   clause SHALL fire for this ticket's own implementation, exactly as it
+   did for the near-identical precedent in
+   [`specs/0093-worktree-subagent-cwd-guard.md`](0093-worktree-subagent-cwd-guard.md)
+   (which amended *Worktree Isolation* rather than *Team Communication*,
+   but under the same Template 2 clause). The `small`-tier team
+   composition in `docs/agent-team-protocol.md` → *Team sizing by
+   complexity* explicitly excludes `architect` ("No `architect` — the
+   spec is its own architectural input"), which would suppress that
+   mandatory review for a change to the protocol document itself;
+   `standard` is therefore the only tier that does not contradict the
+   existing Template 2 clause.
+2. `docs/agent-team-protocol.md` → *Team Communication* SHALL gain a new
+   **Rule 5**, positioned immediately after Rule 4, stating that while a
+   deliverable file is delegated to a sub-agent — i.e. the sub-agent's
+   brief names that file as its target — the orchestrator SHALL NOT edit
+   that file itself until the sub-agent's completion has been confirmed,
+   either (a) via the sub-agent's own `SendMessage` result per Rule 1, or
+   (b) via the observable-side-effect check described in Rule 3 step 2.
+   Rule 5 SHALL state explicitly that an `idle_notification` alone is NOT
+   a completion barrier — the orchestrator SHALL NOT treat receipt of an
+   idle notification, by itself, as license to edit a file still
+   delegated to that sub-agent.
+3. Rule 5 SHALL state the remediation path for the case where the
+   orchestrator determines a delegated file needs a change while the
+   sub-agent is still live: either (a) instruct the still-live sub-agent
+   to make the change itself, rather than editing the file directly, or
+   (b) confirm — per the conclusion check in *Team Shutdown* — that the
+   sub-agent has concluded its work before the orchestrator takes
+   ownership of the file and edits it directly.
+4. Rule 5 SHALL explicitly cross-reference Rule 3 by name and state that
+   Rule 5 is the write-side counterpart to Rule 3's read-side guidance:
+   Rule 3 already establishes that an idle notification does not prove a
+   teammate skipped its Rule 1 report; Rule 5 draws the corresponding
+   consequence for the orchestrator's own edits — the same unreliable
+   signal that must not be mistaken for a completion proof when reading
+   also must not be acted upon when writing.
+5. The rewrite SHALL be scoped to `docs/agent-team-protocol.md` → *Team
+   Communication*, adding Rule 5 only. It SHALL NOT alter the existing
+   text of Rules 1 through 4, the *Worktree Isolation* section, the
+   *Standard Team Templates*, or the *Team sizing by complexity* table,
+   beyond whatever minimal cross-reference touch is needed to keep those
+   surfaces internally consistent with the new rule (e.g. a "see Rule 5"
+   pointer, if the implementer judges one useful — not a restatement of
+   Rule 5's content elsewhere).
+6. This spec SHALL NOT request, imply, or describe any locking
+   mechanism, mutex, file-system-level lock, or other tooling change to
+   enforce the edit fence. The remediation this spec qualifies is a
+   documentation-only behavioral rule — the same posture as
+   [`specs/0093-worktree-subagent-cwd-guard.md`](0093-worktree-subagent-cwd-guard.md)'s
+   Requirement 9 — because this repository does not control harness tool
+   behavior and the fence is meant to be followed, not mechanically
+   enforced.
+
+## Scenarios
+
+**Scenario:** Orchestrator waits for a completion report before editing a
+delegated file
+
+Given an orchestrator has delegated `specs/0084-custom-root-ca-support.md`
+to a `spec-author` sub-agent as its brief's named target
+When the sub-agent sends a `SendMessage` result reporting the file
+complete, per Rule 1
+Then the orchestrator only edits that file after receiving the result
+message, and no concurrent edit from the orchestrator's own turn lands on
+the file while the sub-agent is still working
+
+**Scenario:** Orchestrator receives only an idle notification and
+correctly withholds editing
+
+Given an orchestrator has delegated a deliverable file to a sub-agent, and
+the orchestrator's next turn surfaces only an `idle_notification` for that
+sub-agent, with no result message yet delivered
+When the orchestrator applies Rule 5 together with Rule 3
+Then the orchestrator does NOT treat the idle notification as a completion
+signal and does NOT edit the file on the strength of it alone; instead it
+lets the channel drain and checks the file's observable state (`git
+status`, `git log`) per Rule 3 step 2, or waits for the result message,
+before touching the file itself — contrasting with the #569 incident,
+where the orchestrator's completion edits landed on the same file the
+sub-agent was still editing, asynchronously after an idle notification,
+producing a duplicate persistence scenario and a duplicate Windows
+out-of-scope bullet that then required manual reconciliation
+
+**Scenario:** Orchestrator needs a change to a still-delegated file and
+routes it through the live sub-agent
+
+Given an orchestrator determines that a file still delegated to a live
+sub-agent needs an additional change
+When the orchestrator applies Rule 5's remediation path
+Then the orchestrator instructs the still-live sub-agent to make the
+change itself, rather than editing the file directly, and does not take
+ownership of the file unless the sub-agent's conclusion has first been
+confirmed per *Team Shutdown*
+
+## Out of scope
+
+- Any locking mechanism, mutex, file-system-level lock, or other tooling
+  change that would enforce the edit fence mechanically — Rule 5 is a
+  documented, followed behavioral rule, not an enforced one.
+- Any change to the existing text of Rules 1 through 4, the *Worktree
+  Isolation* section, the *Standard Team Templates*, or the *Team sizing
+  by complexity* table, beyond the minimal cross-reference consistency
+  touch permitted by Requirement 5.
+- Defining the exact `SendMessage` payload schema used to instruct a
+  still-live sub-agent to make a change to its own delegated file, or to
+  confirm its conclusion — left to the implementer's judgment within the
+  existing *Team Communication* and *Team Shutdown* conventions.
+- Retroactive reconciliation of any past incident already resolved
+  manually (e.g. the #569 duplicate-content reconciliation, or the
+  duplicate content once present in
+  `.worktrees/0084-spec/specs/0084-custom-root-ca-support.md`) — this
+  spec qualifies the go-forward protocol, not a one-time cleanup.
+- Any harness-level or tool-level change to how `SendMessage`, idle
+  notifications, or `Agent` spawns are delivered or sequenced — that
+  surface belongs to Anthropic, not to this repository.
+
+## Open questions
+
+- None — this is a scoped, narrow addition of one new rule to one
+  existing section of one documentation file, directly modeled on the
+  precedent set by spec 0093; no ambiguity was identified that the
+  Requirements and Out of scope sections above do not already resolve.


### PR DESCRIPTION
Qualifies (does not close) the fix for the Harness Curator friction cluster in issue #602 — the implementation PR will carry its own closing directive once PLAN, DEV, and REVIEW have run. This is the SPECS-stage artifact only: a new Rule 5 in `docs/agent-team-protocol.md` → *Team Communication* that stops an orchestrator from editing a delegated deliverable file until the sub-agent's completion is actually confirmed.

## How to read this PR?

Single file: `specs/0095-orchestrator-deliverable-edit-fence.md` (161 lines). Read `## Intent` first (lines 13-29), then `## Requirements` (lines 31-91):

- Requirement 1 justifies `complexity: standard` over `small` — the change touches `docs/agent-team-protocol.md` itself, which per that document's own Template 2 clause mandates an `architect` DEV-stage step, a step the `small`-tier team composition would otherwise suppress.
- Requirements 2-4 state the new Rule 5 itself: no orchestrator edit to a delegated file until completion is confirmed via a `SendMessage` result (Rule 1) or the observable-side-effect check (Rule 3 step 2); an `idle_notification` alone is explicitly NOT a completion barrier; and Rule 5 is framed as the write-side counterpart to Rule 3's existing read-side guidance.
- Requirement 3 also states the remediation path when a delegated file needs a change mid-flight: route it through the still-live sub-agent, or wait for a confirmed conclusion per *Team Shutdown*.
- Requirements 5-6 bound the scope: only Rule 5 is added to *Team Communication*, and no locking/mutex/tooling mechanism is requested — the fence is a documented behavioral rule, the same posture spec 0093 took for *Worktree Isolation*.

The direct precedent is `specs/0093-worktree-subagent-cwd-guard.md` (issue #599, spec-PR #640, realized in PR #641) — same document, same `standard`-tier justification, same "documentation only, no enforcement tooling" boundary.

## How to test this PR?

This is a SPECS-stage artifact — no code to run.

1. `git show --stat` the single commit on this branch and confirm it touches only `specs/0095-orchestrator-deliverable-edit-fence.md`, adding 161 lines and nothing else (per the *One-file rule* in `docs/spec-pr-workflow.md`).
2. Check the frontmatter against `docs/spec-format.md`: `id: "0095"`, `slug: orchestrator-deliverable-edit-fence`, `complexity: standard`, `interaction-mode: INTERMEDIATE`, `related-issue: 602`, `version: 1.0.0`.
3. Confirm the five mandatory body sections are present: `## Intent`, `## Requirements`, `## Scenarios`, `## Out of scope`, `## Open questions`.
4. Read `## Scenarios`: a happy-path scenario (orchestrator waits for the sub-agent's `SendMessage` completion result before editing), a failure-path scenario modeled directly on the #569 incident (orchestrator receives only an idle notification and correctly withholds editing), and a remediation scenario (orchestrator routes a needed change through the still-live sub-agent instead of touching the file itself).

## Detailed description (for agents)

Adds `specs/0095-orchestrator-deliverable-edit-fence.md`, the SPECS-stage artifact for the `concurrent-deliverable-edit` friction cluster reported by the Harness Curator in issue #602: an orchestrator's own completion edits raced a delegated sub-agent's edits to the same deliverable file, producing duplicate content — already observed in ticket #569 and, per the spec's Intent section, in `.worktrees/0084-spec/specs/0084-custom-root-ca-support.md`.

The spec proposes a new **Rule 5** in `docs/agent-team-protocol.md` → *Team Communication*, positioned immediately after Rule 4: while a deliverable file is delegated to a sub-agent, the orchestrator SHALL NOT edit that file until the sub-agent's completion is confirmed — via the sub-agent's own `SendMessage` result (Rule 1) or the observable-side-effect check (Rule 3 step 2) — and an idle notification alone is explicitly not sufficient. Rule 5 is the write-side counterpart to Rule 3, which already governs the read-side interpretation of idle notifications.

`complexity: standard` is declared rather than `small` because the change modifies `docs/agent-team-protocol.md` itself, triggering that document's Template 2 clause that mandates an `architect` DEV-stage step for changes to an established protocol document — a clause the `small` tier's team composition would otherwise suppress (per Requirement 1 of the spec). This mirrors the identical justification given in `specs/0093-worktree-subagent-cwd-guard.md`, the direct precedent for this same document.

No implementation lands in this PR — Rule 5's actual text is DEV-stage work, gated behind this spec-PR merging first, per `docs/spec-pr-workflow.md` → *Ordering rule*. No locking, mutex, or other enforcement tooling is proposed anywhere in the spec — Requirement 6 states explicitly that the fence is a documented, followed behavioral rule, not a mechanically enforced one.

Issue #602 is the Harness Curator's auto-generated friction cluster and serves as this ticket's shared logbook issue (per `AGENTS.md` → *Logbook Issues → Rule A*) — there is no separate dedicated logbook issue. Per `docs/spec-pr-workflow.md` → *Independence rule*'s shared-logbook carve-out, this PR body carries no closing-keyword directive for #602; merging this spec-PR does not close it. The implementation PR (tracking #602) will close it on merge, once PLAN, DEV, and REVIEW have all run.
