### PR TITLE
📝 Add Rule 5 — orchestrator edit-fence for delegated deliverables

### DIFF
--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -317,7 +317,7 @@ non-blocking observation, not a blocking finding.
 
 ## Team Communication
 
-Four rules govern how teammates report back inside a team and how the team-lead interprets their signals.
+Five rules govern how teammates report back inside a team and how the team-lead interprets their signals.
 
 **Rule 1 — Report before idle.** Every agent operating inside a team
 (delegated via `Agent` and tracked via `TaskCreate`) MUST send a message to

--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -408,6 +408,41 @@ In no mode may a finding be deferred to a follow-up ticket without
 authorization appropriate to that mode — the user's explicit decision in
 FULL, never silently in INTERMEDIATE / MINIMAL / AUTO.
 
+**Rule 5 — Edit fence for delegated deliverables.** While a deliverable
+file is delegated to a sub-agent — i.e. the sub-agent's brief names that
+file as its task target — the team-lead (orchestrator) SHALL NOT edit
+that file itself until the sub-agent's completion has been confirmed,
+either (a) via the sub-agent's own `SendMessage` result per Rule 1, or
+(b) via the observable-side-effect check described in Rule 3 step 2. An
+`idle_notification` alone is NOT a completion signal: the team-lead MUST
+NOT treat receipt of an idle notification, by itself, as license to edit
+a file still delegated to that sub-agent.
+
+Rule 5 is the write-side counterpart to Rule 3. Rule 3 already
+establishes that an idle notification does not prove a teammate skipped
+its Rule 1 report; Rule 5 draws the corresponding consequence for the
+team-lead's own edits — the same unreliable signal that must not be
+mistaken for completion proof when reading a teammate's status also
+must not be acted upon when writing to a file that teammate still owns.
+
+If the team-lead determines that a delegated file needs an additional
+change while the sub-agent is still live, it MUST NOT edit the file
+directly. Instead it SHALL either:
+
+1. Instruct the still-live sub-agent, via `SendMessage`, to make the
+   change itself, rather than taking the edit on directly, or
+2. Confirm, per the conclusion check in *Team Shutdown*, that the
+   sub-agent has concluded its work — a landed Rule 1 result message, or
+   a confirmed side-effect per Rule 3 step 2 — before the team-lead takes
+   ownership of the file and edits it directly.
+
+This closes the race observed twice in practice — ticket #569 and the
+Harness Curator's `concurrent-deliverable-edit` friction cluster
+(issue #602) — where the orchestrator's own completion edits landed on
+a file the sub-agent was still editing, on the strength of an idle
+notification alone, producing duplicate content that required manual
+reconciliation.
+
 ## Team Shutdown
 
 On Claude Code's single implicit session team there is no team record to


### PR DESCRIPTION
Adds Rule 5 to `docs/agent-team-protocol.md` → *Team Communication*, fencing the orchestrator from editing a deliverable file still delegated to a sub-agent until completion is actually confirmed. Realizes spec `specs/0095-orchestrator-deliverable-edit-fence.md` (spec-PR #647, merged) per PLAN v2 (user-validated: https://github.com/crewrig/crewrig/issues/602#issuecomment-5049538090).

## How to read this PR?

Single-file diff: `docs/agent-team-protocol.md`. Read the new Rule 5 block in place, right after the existing Rule 4 and before *Team Shutdown* (`docs/agent-team-protocol.md`, +35/-0 — see diff). Rule 5 is the write-side counterpart to Rule 3: Rule 3 already establishes that an idle notification does not prove a teammate skipped its Rule 1 report on the *read* side; Rule 5 draws the corresponding consequence for the orchestrator's own edits on the *write* side — the same unreliable idle-notification signal must not be acted upon either. The remediation path for a still-needed change to a still-delegated file is two-pronged: instruct the live sub-agent via `SendMessage` to make the change itself, or confirm conclusion (a landed Rule 1 result, or a Rule 3 step 2 side-effect check) before the orchestrator takes ownership directly.

## How to test this PR?

This is a documentation-only behavioral rule with no runtime behavior to execute. Verification is a read-through: open `docs/agent-team-protocol.md` and confirm Rule 5 reads coherently in context against Rule 1 (`SendMessage` result reporting), Rule 3 (idle-notification unreliability, side-effect check), and *Team Shutdown* (conclusion check) — the cross-references it depends on.

## Detailed description (for agents)

Closes the `concurrent-deliverable-edit` friction cluster (issue #602): a Harness Curator report of an incident (ticket #569) where the orchestrator's own completion edits raced a delegated sub-agent's edits to the same file, producing duplicate content requiring manual reconciliation.

- `docs/agent-team-protocol.md` → *Team Communication*: new Rule 5, inserted immediately after Rule 4 and before *Team Shutdown*. States that while a deliverable file is delegated to a sub-agent, the team-lead SHALL NOT edit that file itself until the sub-agent's completion is confirmed via (a) its own `SendMessage` result per Rule 1, or (b) the Rule 3 step 2 observable-side-effect check. An `idle_notification` alone is explicitly not a completion signal. If an additional change is needed to a still-delegated file, the team-lead must either instruct the live sub-agent to make the change, or confirm conclusion before taking ownership.
- No other file changes. Not under `artifacts/`, so no build-output regeneration; carries no `metadata.provenance.version` field, so no version bump; matches none of the `AGENTS.md` → *CLI Matrix Maintenance* trigger patterns.

Closes #602
