### PR TITLE
♻️ Align pr-logbook and harness-curator to CLI-first forge access

### DIFF
--- a/.agents/skills/pr-logbook/SKILL.md
+++ b/.agents/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 
@@ -74,8 +74,12 @@ deletions, and the rationale for each.>
 an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
 `Resolves #N` patterns). If a feature issue exists:
 
-1. Append the logbook entry to that issue as a comment via the GitHub MCP
-   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+1. Append the logbook entry to that issue as a comment through the forge
+   CLI: `gh issue comment <N> --body "..."` on GitHub, or the equivalent
+   `glab`/`tea` note command on GitLab/Gitea. Forge access is CLI-only
+   (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
+   server, so a host-provided one is an optional convenience, not the
+   default.
 2. Ensure the issue carries the `logbook` label — add it with
    `gh issue edit <N> --add-label logbook` if absent.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
@@ -126,17 +130,20 @@ Text-only tooling silently drops file metadata. Verify before pushing:
 
 - If the diff touches shell scripts, confirm executable bits survived
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
-  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  not `100644`. Any text-only file-write path can drop the exec bit,
+  whereas native `git add`/`git push` preserve it. Restore a lost bit
   with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ### 7. Post-merge cleanup
 
 After the squash-merge commit lands on the target branch:
 
-1. Close the logbook issue:
-   `gh issue close <logbook-issue-number> --reason completed`
-   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
-   `state_reason: "completed"`.
+1. Close the logbook issue through the forge CLI:
+   `gh issue close <logbook-issue-number> --reason completed` on GitHub,
+   or the equivalent `glab`/`tea` close command on GitLab/Gitea. Forge
+   access is CLI-only (`AGENTS.md` → *Forge Access*); the framework ships
+   no forge MCP server, so a host-provided one is an optional convenience,
+   not the default.
 2. If the PR also closes a feature issue (detected via `Closes #N` /
    `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
    — GitHub auto-closes on merge when the keyword is in the PR body,

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 
@@ -78,8 +78,12 @@ deletions, and the rationale for each.>
 an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
 `Resolves #N` patterns). If a feature issue exists:
 
-1. Append the logbook entry to that issue as a comment via the GitHub MCP
-   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+1. Append the logbook entry to that issue as a comment through the forge
+   CLI: `gh issue comment <N> --body "..."` on GitHub, or the equivalent
+   `glab`/`tea` note command on GitLab/Gitea. Forge access is CLI-only
+   (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
+   server, so a host-provided one is an optional convenience, not the
+   default.
 2. Ensure the issue carries the `logbook` label — add it with
    `gh issue edit <N> --add-label logbook` if absent.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
@@ -130,17 +134,20 @@ Text-only tooling silently drops file metadata. Verify before pushing:
 
 - If the diff touches shell scripts, confirm executable bits survived
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
-  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  not `100644`. Any text-only file-write path can drop the exec bit,
+  whereas native `git add`/`git push` preserve it. Restore a lost bit
   with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ### 7. Post-merge cleanup
 
 After the squash-merge commit lands on the target branch:
 
-1. Close the logbook issue:
-   `gh issue close <logbook-issue-number> --reason completed`
-   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
-   `state_reason: "completed"`.
+1. Close the logbook issue through the forge CLI:
+   `gh issue close <logbook-issue-number> --reason completed` on GitHub,
+   or the equivalent `glab`/`tea` close command on GitLab/Gitea. Forge
+   access is CLI-only (`AGENTS.md` → *Forge Access*); the framework ships
+   no forge MCP server, so a host-provided one is an optional convenience,
+   not the default.
 2. If the PR also closes a feature issue (detected via `Closes #N` /
    `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
    — GitHub auto-closes on merge when the keyword is in the PR body,

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 
@@ -74,8 +74,12 @@ deletions, and the rationale for each.>
 an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
 `Resolves #N` patterns). If a feature issue exists:
 
-1. Append the logbook entry to that issue as a comment via the GitHub MCP
-   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+1. Append the logbook entry to that issue as a comment through the forge
+   CLI: `gh issue comment <N> --body "..."` on GitHub, or the equivalent
+   `glab`/`tea` note command on GitLab/Gitea. Forge access is CLI-only
+   (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
+   server, so a host-provided one is an optional convenience, not the
+   default.
 2. Ensure the issue carries the `logbook` label — add it with
    `gh issue edit <N> --add-label logbook` if absent.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
@@ -126,17 +130,20 @@ Text-only tooling silently drops file metadata. Verify before pushing:
 
 - If the diff touches shell scripts, confirm executable bits survived
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
-  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  not `100644`. Any text-only file-write path can drop the exec bit,
+  whereas native `git add`/`git push` preserve it. Restore a lost bit
   with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ### 7. Post-merge cleanup
 
 After the squash-merge commit lands on the target branch:
 
-1. Close the logbook issue:
-   `gh issue close <logbook-issue-number> --reason completed`
-   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
-   `state_reason: "completed"`.
+1. Close the logbook issue through the forge CLI:
+   `gh issue close <logbook-issue-number> --reason completed` on GitHub,
+   or the equivalent `glab`/`tea` close command on GitLab/Gitea. Forge
+   access is CLI-only (`AGENTS.md` → *Forge Access*); the framework ships
+   no forge MCP server, so a host-provided one is an optional convenience,
+   not the default.
 2. If the PR also closes a feature issue (detected via `Closes #N` /
    `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
    — GitHub auto-closes on merge when the keyword is in the PR body,

--- a/.github/skills/pr-logbook/SKILL.md
+++ b/.github/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 
@@ -74,8 +74,12 @@ deletions, and the rationale for each.>
 an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
 `Resolves #N` patterns). If a feature issue exists:
 
-1. Append the logbook entry to that issue as a comment via the GitHub MCP
-   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+1. Append the logbook entry to that issue as a comment through the forge
+   CLI: `gh issue comment <N> --body "..."` on GitHub, or the equivalent
+   `glab`/`tea` note command on GitLab/Gitea. Forge access is CLI-only
+   (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
+   server, so a host-provided one is an optional convenience, not the
+   default.
 2. Ensure the issue carries the `logbook` label — add it with
    `gh issue edit <N> --add-label logbook` if absent.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
@@ -126,17 +130,20 @@ Text-only tooling silently drops file metadata. Verify before pushing:
 
 - If the diff touches shell scripts, confirm executable bits survived
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
-  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  not `100644`. Any text-only file-write path can drop the exec bit,
+  whereas native `git add`/`git push` preserve it. Restore a lost bit
   with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ### 7. Post-merge cleanup
 
 After the squash-merge commit lands on the target branch:
 
-1. Close the logbook issue:
-   `gh issue close <logbook-issue-number> --reason completed`
-   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
-   `state_reason: "completed"`.
+1. Close the logbook issue through the forge CLI:
+   `gh issue close <logbook-issue-number> --reason completed` on GitHub,
+   or the equivalent `glab`/`tea` close command on GitLab/Gitea. Forge
+   access is CLI-only (`AGENTS.md` → *Forge Access*); the framework ships
+   no forge MCP server, so a host-provided one is an optional convenience,
+   not the default.
 2. If the PR also closes a feature issue (detected via `Closes #N` /
    `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
    — GitHub auto-closes on merge when the keyword is in the PR body,

--- a/artifacts/core/skills/pr-logbook/SKILL.md
+++ b/artifacts/core/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.6"
+    version: "1.1.7"
 claude:
   allowed-tools:
     - Read
@@ -82,8 +82,12 @@ deletions, and the rationale for each.>
 an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
 `Resolves #N` patterns). If a feature issue exists:
 
-1. Append the logbook entry to that issue as a comment via the GitHub MCP
-   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+1. Append the logbook entry to that issue as a comment through the forge
+   CLI: `gh issue comment <N> --body "..."` on GitHub, or the equivalent
+   `glab`/`tea` note command on GitLab/Gitea. Forge access is CLI-only
+   (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
+   server, so a host-provided one is an optional convenience, not the
+   default.
 2. Ensure the issue carries the `logbook` label — add it with
    `gh issue edit <N> --add-label logbook` if absent.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
@@ -134,17 +138,20 @@ Text-only tooling silently drops file metadata. Verify before pushing:
 
 - If the diff touches shell scripts, confirm executable bits survived
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
-  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  not `100644`. Any text-only file-write path can drop the exec bit,
+  whereas native `git add`/`git push` preserve it. Restore a lost bit
   with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ### 7. Post-merge cleanup
 
 After the squash-merge commit lands on the target branch:
 
-1. Close the logbook issue:
-   `gh issue close <logbook-issue-number> --reason completed`
-   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
-   `state_reason: "completed"`.
+1. Close the logbook issue through the forge CLI:
+   `gh issue close <logbook-issue-number> --reason completed` on GitHub,
+   or the equivalent `glab`/`tea` close command on GitLab/Gitea. Forge
+   access is CLI-only (`AGENTS.md` → *Forge Access*); the framework ships
+   no forge MCP server, so a host-provided one is an optional convenience,
+   not the default.
 2. If the PR also closes a feature issue (detected via `Closes #N` /
    `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
    — GitHub auto-closes on merge when the keyword is in the PR body,

--- a/artifacts/library/skills/harness-curator/SKILL.md
+++ b/artifacts/library/skills/harness-curator/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.6.1"
+    version: "1.6.2"
 claude:
   allowed-tools:
     - Read
@@ -130,10 +130,14 @@ Two paths, equivalent in outcome:
   script opens one issue per cluster via `gh issue create`, with all
   three labels from the JSON (`harness-feedback`, `room:<x>`,
   `severity:<y>`).
-- **Open them yourself**: iterate the JSON, use the GitHub MCP (or
-  `gh`) per cluster. Use this path when you want to enrich the body
-  before opening (e.g. linking a recent `logbook` issue you noticed
-  while reviewing).
+- **Open them yourself**: iterate the JSON and run `gh issue create
+  --repo <owner>/<repo> --title <title> --body <body> --label <...>`
+  per cluster (the same argv `apply.py` builds), or the `glab`/`tea`
+  equivalent on GitLab/Gitea. Forge access is CLI-only (`AGENTS.md` →
+  *Forge Access*); the framework ships no forge MCP server, so a
+  host-provided one is an optional convenience, not the default. Use
+  this path when you want to enrich the body before opening (e.g.
+  linking a recent `logbook` issue you noticed while reviewing).
 
 Either way: **one issue per cluster**. Resist bundling — independent
 clusters deserve independent triage.


### PR DESCRIPTION
Two framework skills still described a GitHub-MCP-first path for their forge writes, which does not exist in any post-0090 CLI-only deployment. This realigns `pr-logbook` and `harness-curator` to lead with the forge CLI (`gh`, with `glab`/`tea` analogues), demoting a host-provided MCP to an optional-if-present convenience.

## How to read this PR?

Two source edits carry the whole change; the four `pr-logbook` outputs are mechanical rebuilds.

1. Start with `artifacts/core/skills/pr-logbook/SKILL.md` — three spots: §4 (logbook-append), §6 (pre-push exec-bit note), §7 (Rule C close).
2. Then `artifacts/library/skills/harness-curator/SKILL.md` — the single "Open them yourself" bullet.
3. The four deployed `pr-logbook` outputs (`.agents/`, `.claude/`, `.gemini/`, `.github/`) are `build-components.sh` regenerations of source #1 with identical wording — skim one, trust the rest (parity is checked in CI).

Non-obvious decisions:

- **`harness-curator` is library-tier**: it builds to a gitignored `dist/`, so there is no committed deployed output to stage — only the source changes.
- **§6 push_files generalization** is an in-file consistency cleanup riding along. The exec-bit-loss note previously named the MCP `push_files` tool as the culprit; it was the last MCP-transport assumption left in the file, so it is generalized to transport-agnostic wording rather than left as a lone stale reference.
- **pr-reviewer is out of scope**: it carried the same stale mandate but was already realigned in #634, so this PR does not touch it. The wording here mirrors what #634 applied there.

## How to test this PR?

Prerequisites: `gh` authenticated, `markdownlint-cli` installed, branch checked out at head `c5ffcff`.

```sh
# 1. Version-bump gate — both modified sources must bump
bash scripts/check-skill-versions.sh                    # expect PASS

# 2. Build drift — deployed outputs match sources
bash scripts/build-components.sh --target all --check   # expect clean (no drift)

# 3. CLI parity
bash scripts/check-ci-parity.sh                         # expect OK

# 4. Lint the two changed sources
markdownlint artifacts/core/skills/pr-logbook/SKILL.md \
             artifacts/library/skills/harness-curator/SKILL.md   # expect clean

# 5. No residual forge-MCP mandate on the changed sources
git grep -n 'forge MCP' -- artifacts/core/skills/pr-logbook/SKILL.md \
                            artifacts/library/skills/harness-curator/SKILL.md
# expect only "ships no forge MCP server" optional-if-present asides
```

## Detailed description (for agents)

Six files, +84/−45 (`git diff --stat crewrig/main..refactor/0629-cli-first-components`). One commit: `c5ffcff`.

**Sources (2):**

- `artifacts/core/skills/pr-logbook/SKILL.md` — `metadata.provenance.version` `1.1.6` → `1.1.7` (PATCH, wording change):
  - **§4 step 1** (logbook-append) now leads with `gh issue comment <N> --body "..."` plus the `glab`/`tea` note analogues. The prior MCP `add_issue_comment` mandate is dropped; MCP is demoted to optional-if-present with a pointer to `AGENTS.md` → *Forge Access*.
  - **§6** (pre-push sanity check) no longer names the MCP `push_files` tool as the exec-bit-stripping culprit. Reworded to "Any text-only file-write path can drop the exec bit, whereas native `git add`/`git push` preserve it."
  - **§7 step 1** (post-merge cleanup / Rule C close) now leads with `gh issue close <N> --reason completed` plus the `glab`/`tea` analogues. The prior MCP `issue_write` mandate is dropped; MCP demoted to optional-if-present.
- `artifacts/library/skills/harness-curator/SKILL.md` — `metadata.provenance.version` `1.6.1` → `1.6.2` (PATCH, wording change):
  - The "Open them yourself" path now leads with `gh issue create --repo <owner>/<repo> --title <title> --body <body> --label <...>` — the same argv `apply.py` already builds — plus the `glab`/`tea` equivalent. MCP demoted to optional-if-present.

**Regenerated outputs (4)** — `build-components.sh` rebuilds of the `pr-logbook` source, identical wording, all carrying `1.1.7`:

- `.agents/skills/pr-logbook/SKILL.md`
- `.claude/skills/pr-logbook/SKILL.md`
- `.gemini/skills/pr-logbook/SKILL.md`
- `.github/skills/pr-logbook/SKILL.md`

Every surviving "MCP" mention on the changed sources is either an optional-if-present aside ("the framework ships no forge MCP server, so a host-provided one is an optional convenience") or the unrelated MemPalace batch-read carve-out in `harness-curator` — no mandated forge-MCP dependency remains.

Closes #629
