### PR TITLE
🐛 Skip empty catalogue picks instead of aborting setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,9 @@ jobs:
       - name: Test org-level MCP declaration channel regression (spec 0091)
         run: bash scripts/tests/test-setup-org-mcp.sh
 
+      - name: Test setup catalogue-picker regression (spec 0096)
+        run: bash scripts/tests/test-setup-catalogue-picker.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,7 @@ check-components:
     - "bash scripts/tests/test-check-no-machine-paths.sh"
     - "bash scripts/tests/test-setup-mcp-merge.sh"
     - "bash scripts/tests/test-setup-org-mcp.sh"
+    - "bash scripts/tests/test-setup-catalogue-picker.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -108,6 +108,7 @@ capabilities:
       - bash scripts/tests/test-check-no-machine-paths.sh
       - bash scripts/tests/test-setup-mcp-merge.sh
       - bash scripts/tests/test-setup-org-mcp.sh
+      - bash scripts/tests/test-setup-catalogue-picker.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -392,6 +392,48 @@ install_dir() {
   fi
 }
 
+# pick_catalogue_entry <category_dir> <category_label>
+# Shared team/expertise/level picker (spec 0096), replacing the verbatim-
+# duplicated selection block across the four setup-*-interactive.sh scripts.
+#
+# Nullglob-safe: when <category_dir> holds zero *.md files, short-circuits to
+# an empty result BEFORE ever invoking fzf — no literal `*`/`*.md` placeholder
+# reaches the picker (R1). Otherwise pipes the candidate basenames through fzf;
+# the `|| true` on that invocation is load-bearing: it neutralizes fzf's own
+# exit status (1 on decline, 2 on error, 130 on Ctrl-C) so a caller running
+# under `set -e` cannot abort the assignment before the caller's own
+# if/else skip-handling runs (all four setup-*-interactive.sh scripts run
+# under `set -e`).
+#
+# Prints the chosen basename (no .md suffix) to stdout on a normal pick.
+# Prints nothing to stdout, and a category-naming, cause-distinguishing
+# message to stderr, on either an empty catalogue or a declined pick (R4) —
+# the caller only needs to test for an empty result, not which cause fired.
+pick_catalogue_entry() {
+  local category_dir="$1" category_label="$2"
+  local candidates=() f
+  shopt -s nullglob
+  for f in "$category_dir"/*.md; do
+    candidates+=("$(basename "$f" .md)")
+  done
+  shopt -u nullglob
+
+  if [ "${#candidates[@]}" -eq 0 ]; then
+    echo "No $category_label catalogue entries found under $category_dir — skipping $category_label selection." >&2
+    return 0
+  fi
+
+  local choice
+  choice="$(printf '%s\n' "${candidates[@]}" \
+    | fzf --height 40% --preview "head -20 $category_dir/{}.md" || true)"
+  if [ -z "$choice" ]; then
+    echo "No $category_label selected — skipping $category_label selection." >&2
+    return 0
+  fi
+
+  printf '%s\n' "$choice"
+}
+
 mempalace_installed_version() {
   "$1" -c "from importlib.metadata import version; print(version('mempalace'))" 2>/dev/null
 }

--- a/scripts/setup-antigravity-interactive.sh
+++ b/scripts/setup-antigravity-interactive.sh
@@ -260,44 +260,41 @@ if [ "$SKIP_RULES_CONFIG" -ne 1 ]; then
 
 # --- Team selection ---
 echo "Select your team:"
-TEAM=$(for f in "$REPO_DIR"/config/teams/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/teams/{}.md")
-if [ -z "$TEAM" ]; then
-  echo "No team selected. Aborting."
-  exit 1
+TEAM="$(pick_catalogue_entry "$REPO_DIR/config/teams" "team")"
+if [ -n "$TEAM" ]; then
+  install_file "$REPO_DIR/config/teams/${TEAM}.md" "$AGY_HOME/50_USER_TEAM.md" \
+    "teams/${TEAM}.md -> 50_USER_TEAM.md"
+  echo "$TEAM" > "$AGY_HOME/.selected_team"
+  echo "Team: $TEAM"
+else
+  rm -f "$AGY_HOME/.selected_team"
 fi
-install_file "$REPO_DIR/config/teams/${TEAM}.md" "$AGY_HOME/50_USER_TEAM.md" \
-  "teams/${TEAM}.md -> 50_USER_TEAM.md"
-echo "$TEAM" > "$AGY_HOME/.selected_team"
-echo "Team: $TEAM"
 echo ""
 
 # --- Expertise selection ---
 echo "Select your expertise:"
-EXPERTISE=$(for f in "$REPO_DIR"/config/expertise/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/expertise/{}.md")
-if [ -z "$EXPERTISE" ]; then
-  echo "No expertise selected. Aborting."
-  exit 1
+EXPERTISE="$(pick_catalogue_entry "$REPO_DIR/config/expertise" "expertise")"
+if [ -n "$EXPERTISE" ]; then
+  install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$AGY_HOME/40_USER_EXPERTISE.md" \
+    "expertise/${EXPERTISE}.md -> 40_USER_EXPERTISE.md"
+  echo "$EXPERTISE" > "$AGY_HOME/.selected_expertise"
+  echo "Expertise: $EXPERTISE"
+else
+  rm -f "$AGY_HOME/.selected_expertise"
 fi
-install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$AGY_HOME/40_USER_EXPERTISE.md" \
-  "expertise/${EXPERTISE}.md -> 40_USER_EXPERTISE.md"
-echo "$EXPERTISE" > "$AGY_HOME/.selected_expertise"
-echo "Expertise: $EXPERTISE"
 echo ""
 
 # --- Level selection ---
 echo "Select your experience level:"
-LEVEL=$(for f in "$REPO_DIR"/config/level/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/level/{}.md")
-if [ -z "$LEVEL" ]; then
-  echo "No level selected. Aborting."
-  exit 1
+LEVEL="$(pick_catalogue_entry "$REPO_DIR/config/level" "level")"
+if [ -n "$LEVEL" ]; then
+  install_file "$REPO_DIR/config/level/${LEVEL}.md" "$AGY_HOME/10_USER_LEVEL.md" \
+    "level/${LEVEL}.md -> 10_USER_LEVEL.md"
+  echo "$LEVEL" > "$AGY_HOME/.selected_level"
+  echo "Level: $LEVEL"
+else
+  rm -f "$AGY_HOME/.selected_level"
 fi
-install_file "$REPO_DIR/config/level/${LEVEL}.md" "$AGY_HOME/10_USER_LEVEL.md" \
-  "level/${LEVEL}.md -> 10_USER_LEVEL.md"
-echo "$LEVEL" > "$AGY_HOME/.selected_level"
-echo "Level: $LEVEL"
 echo ""
 
 # --- Profile handling ---

--- a/scripts/setup-claude-interactive.sh
+++ b/scripts/setup-claude-interactive.sh
@@ -296,44 +296,41 @@ if [ "$SKIP_RULES_CONFIG" -ne 1 ]; then
 
 # --- Team selection ---
 echo "Select your team:"
-TEAM=$(for f in "$REPO_DIR"/config/teams/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/teams/{}.md")
-if [ -z "$TEAM" ]; then
-  echo "No team selected. Aborting."
-  exit 1
+TEAM="$(pick_catalogue_entry "$REPO_DIR/config/teams" "team")"
+if [ -n "$TEAM" ]; then
+  install_file "$REPO_DIR/config/teams/${TEAM}.md" "$CLAUDE_RULES/50-team.md" \
+    "teams/${TEAM}.md -> rules/50-team.md"
+  echo "$TEAM" > "$CLAUDE_HOME/.selected_team"
+  echo "Team: $TEAM"
+else
+  rm -f "$CLAUDE_HOME/.selected_team"
 fi
-install_file "$REPO_DIR/config/teams/${TEAM}.md" "$CLAUDE_RULES/50-team.md" \
-  "teams/${TEAM}.md -> rules/50-team.md"
-echo "$TEAM" > "$CLAUDE_HOME/.selected_team"
-echo "Team: $TEAM"
 echo ""
 
 # --- Expertise selection ---
 echo "Select your expertise:"
-EXPERTISE=$(for f in "$REPO_DIR"/config/expertise/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/expertise/{}.md")
-if [ -z "$EXPERTISE" ]; then
-  echo "No expertise selected. Aborting."
-  exit 1
+EXPERTISE="$(pick_catalogue_entry "$REPO_DIR/config/expertise" "expertise")"
+if [ -n "$EXPERTISE" ]; then
+  install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$CLAUDE_RULES/40-expertise.md" \
+    "expertise/${EXPERTISE}.md -> rules/40-expertise.md"
+  echo "$EXPERTISE" > "$CLAUDE_HOME/.selected_expertise"
+  echo "Expertise: $EXPERTISE"
+else
+  rm -f "$CLAUDE_HOME/.selected_expertise"
 fi
-install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$CLAUDE_RULES/40-expertise.md" \
-  "expertise/${EXPERTISE}.md -> rules/40-expertise.md"
-echo "$EXPERTISE" > "$CLAUDE_HOME/.selected_expertise"
-echo "Expertise: $EXPERTISE"
 echo ""
 
 # --- Level selection ---
 echo "Select your experience level:"
-LEVEL=$(for f in "$REPO_DIR"/config/level/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/level/{}.md")
-if [ -z "$LEVEL" ]; then
-  echo "No level selected. Aborting."
-  exit 1
+LEVEL="$(pick_catalogue_entry "$REPO_DIR/config/level" "level")"
+if [ -n "$LEVEL" ]; then
+  install_file "$REPO_DIR/config/level/${LEVEL}.md" "$CLAUDE_RULES/10-level.md" \
+    "level/${LEVEL}.md -> rules/10-level.md"
+  echo "$LEVEL" > "$CLAUDE_HOME/.selected_level"
+  echo "Level: $LEVEL"
+else
+  rm -f "$CLAUDE_HOME/.selected_level"
 fi
-install_file "$REPO_DIR/config/level/${LEVEL}.md" "$CLAUDE_RULES/10-level.md" \
-  "level/${LEVEL}.md -> rules/10-level.md"
-echo "$LEVEL" > "$CLAUDE_HOME/.selected_level"
-echo "Level: $LEVEL"
 echo ""
 
 # --- Profile handling ---

--- a/scripts/setup-copilot-interactive.sh
+++ b/scripts/setup-copilot-interactive.sh
@@ -174,44 +174,41 @@ if [ "$SKIP_INSTRUCTIONS_CONFIG" -ne 1 ]; then
 
   # Level
   echo "Select your experience level:"
-  LEVEL=$(for f in "$REPO_DIR"/config/level/*.md; do basename "$f" .md; done \
-    | fzf --height 40% --preview "head -20 $REPO_DIR/config/level/{}.md")
-  if [ -z "$LEVEL" ]; then
-    echo "No level selected. Aborting."
-    exit 1
+  LEVEL="$(pick_catalogue_entry "$REPO_DIR/config/level" "level")"
+  if [ -n "$LEVEL" ]; then
+    install_file "$REPO_DIR/config/level/${LEVEL}.md" "$COPILOT_INSTRUCTIONS/10-level.instructions.md" \
+      "level/${LEVEL}.md -> instructions/10-level.instructions.md"
+    echo "$LEVEL" > "$COPILOT_HOME/.selected_level"
+    echo "Level: $LEVEL"
+  else
+    rm -f "$COPILOT_HOME/.selected_level"
   fi
-  install_file "$REPO_DIR/config/level/${LEVEL}.md" "$COPILOT_INSTRUCTIONS/10-level.instructions.md" \
-    "level/${LEVEL}.md -> instructions/10-level.instructions.md"
-  echo "$LEVEL" > "$COPILOT_HOME/.selected_level"
-  echo "Level: $LEVEL"
   echo ""
 
   # Expertise
   echo "Select your expertise:"
-  EXPERTISE=$(for f in "$REPO_DIR"/config/expertise/*.md; do basename "$f" .md; done \
-    | fzf --height 40% --preview "head -20 $REPO_DIR/config/expertise/{}.md")
-  if [ -z "$EXPERTISE" ]; then
-    echo "No expertise selected. Aborting."
-    exit 1
+  EXPERTISE="$(pick_catalogue_entry "$REPO_DIR/config/expertise" "expertise")"
+  if [ -n "$EXPERTISE" ]; then
+    install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$COPILOT_INSTRUCTIONS/40-expertise.instructions.md" \
+      "expertise/${EXPERTISE}.md -> instructions/40-expertise.instructions.md"
+    echo "$EXPERTISE" > "$COPILOT_HOME/.selected_expertise"
+    echo "Expertise: $EXPERTISE"
+  else
+    rm -f "$COPILOT_HOME/.selected_expertise"
   fi
-  install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$COPILOT_INSTRUCTIONS/40-expertise.instructions.md" \
-    "expertise/${EXPERTISE}.md -> instructions/40-expertise.instructions.md"
-  echo "$EXPERTISE" > "$COPILOT_HOME/.selected_expertise"
-  echo "Expertise: $EXPERTISE"
   echo ""
 
   # Team
   echo "Select your team:"
-  TEAM=$(for f in "$REPO_DIR"/config/teams/*.md; do basename "$f" .md; done \
-    | fzf --height 40% --preview "head -20 $REPO_DIR/config/teams/{}.md")
-  if [ -z "$TEAM" ]; then
-    echo "No team selected. Aborting."
-    exit 1
+  TEAM="$(pick_catalogue_entry "$REPO_DIR/config/teams" "team")"
+  if [ -n "$TEAM" ]; then
+    install_file "$REPO_DIR/config/teams/${TEAM}.md" "$COPILOT_INSTRUCTIONS/50-team.instructions.md" \
+      "teams/${TEAM}.md -> instructions/50-team.instructions.md"
+    echo "$TEAM" > "$COPILOT_HOME/.selected_team"
+    echo "Team: $TEAM"
+  else
+    rm -f "$COPILOT_HOME/.selected_team"
   fi
-  install_file "$REPO_DIR/config/teams/${TEAM}.md" "$COPILOT_INSTRUCTIONS/50-team.instructions.md" \
-    "teams/${TEAM}.md -> instructions/50-team.instructions.md"
-  echo "$TEAM" > "$COPILOT_HOME/.selected_team"
-  echo "Team: $TEAM"
   echo ""
 fi
 

--- a/scripts/setup-gemini-interactive.sh
+++ b/scripts/setup-gemini-interactive.sh
@@ -244,44 +244,41 @@ if [ "$SKIP_RULES_CONFIG" -ne 1 ]; then
 
 # --- Team selection ---
 echo "Select your team:"
-TEAM=$(for f in "$REPO_DIR"/config/teams/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/teams/{}.md")
-if [ -z "$TEAM" ]; then
-  echo "No team selected. Aborting."
-  exit 1
+TEAM="$(pick_catalogue_entry "$REPO_DIR/config/teams" "team")"
+if [ -n "$TEAM" ]; then
+  install_file "$REPO_DIR/config/teams/${TEAM}.md" "$GEMINI_HOME/50_USER_TEAM.md" \
+    "teams/${TEAM}.md -> 50_USER_TEAM.md"
+  echo "$TEAM" > "$GEMINI_HOME/.selected_team"
+  echo "Team: $TEAM"
+else
+  rm -f "$GEMINI_HOME/.selected_team"
 fi
-install_file "$REPO_DIR/config/teams/${TEAM}.md" "$GEMINI_HOME/50_USER_TEAM.md" \
-  "teams/${TEAM}.md -> 50_USER_TEAM.md"
-echo "$TEAM" > "$GEMINI_HOME/.selected_team"
-echo "Team: $TEAM"
 echo ""
 
 # --- Expertise selection ---
 echo "Select your expertise:"
-EXPERTISE=$(for f in "$REPO_DIR"/config/expertise/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/expertise/{}.md")
-if [ -z "$EXPERTISE" ]; then
-  echo "No expertise selected. Aborting."
-  exit 1
+EXPERTISE="$(pick_catalogue_entry "$REPO_DIR/config/expertise" "expertise")"
+if [ -n "$EXPERTISE" ]; then
+  install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$GEMINI_HOME/40_USER_EXPERTISE.md" \
+    "expertise/${EXPERTISE}.md -> 40_USER_EXPERTISE.md"
+  echo "$EXPERTISE" > "$GEMINI_HOME/.selected_expertise"
+  echo "Expertise: $EXPERTISE"
+else
+  rm -f "$GEMINI_HOME/.selected_expertise"
 fi
-install_file "$REPO_DIR/config/expertise/${EXPERTISE}.md" "$GEMINI_HOME/40_USER_EXPERTISE.md" \
-  "expertise/${EXPERTISE}.md -> 40_USER_EXPERTISE.md"
-echo "$EXPERTISE" > "$GEMINI_HOME/.selected_expertise"
-echo "Expertise: $EXPERTISE"
 echo ""
 
 # --- Level selection ---
 echo "Select your experience level:"
-LEVEL=$(for f in "$REPO_DIR"/config/level/*.md; do basename "$f" .md; done \
-  | fzf --height 40% --preview "head -20 $REPO_DIR/config/level/{}.md")
-if [ -z "$LEVEL" ]; then
-  echo "No level selected. Aborting."
-  exit 1
+LEVEL="$(pick_catalogue_entry "$REPO_DIR/config/level" "level")"
+if [ -n "$LEVEL" ]; then
+  install_file "$REPO_DIR/config/level/${LEVEL}.md" "$GEMINI_HOME/10_USER_LEVEL.md" \
+    "level/${LEVEL}.md -> 10_USER_LEVEL.md"
+  echo "$LEVEL" > "$GEMINI_HOME/.selected_level"
+  echo "Level: $LEVEL"
+else
+  rm -f "$GEMINI_HOME/.selected_level"
 fi
-install_file "$REPO_DIR/config/level/${LEVEL}.md" "$GEMINI_HOME/10_USER_LEVEL.md" \
-  "level/${LEVEL}.md -> 10_USER_LEVEL.md"
-echo "$LEVEL" > "$GEMINI_HOME/.selected_level"
-echo "Level: $LEVEL"
 echo ""
 
 # --- Profile handling ---

--- a/scripts/tests/test-setup-catalogue-picker.sh
+++ b/scripts/tests/test-setup-catalogue-picker.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+# test-setup-catalogue-picker.sh — Regression tests for the shared
+# team/expertise/level catalogue picker (spec 0096, issue #603).
+#
+# Unit under test: pick_catalogue_entry() in scripts/lib/common.sh, driven
+# through its hermetic surface (an empty fixture catalogue directory, and a
+# stubbed `fzf` on PATH). The genuine interactive fzf UI is out of scope for
+# an automated test, matching this repo's convention (see
+# scripts/tests/test-setup-validation-backend.sh house style).
+#
+# Contract asserted (spec 0096):
+#   R1  zero *.md files under a catalogue dir -> zero candidates offered to
+#       fzf, no literal `*`/`*.md` placeholder, and fzf is never invoked at
+#       all (nullglob short-circuit).
+#   R2  an empty result (empty catalogue OR declined pick) lets the caller
+#       continue rather than terminate the script.
+#   R3  a skip removes any stale marker file from an earlier run.
+#   R4  the message printed distinguishes an empty catalogue from a declined
+#       pick, naming the affected category in both cases.
+#   R5/R6 identical behavior across all three categories and all four
+#       in-scope setup scripts — asserted structurally (no leftover
+#       `exit 1` inside any team/expertise/level block, and a matching
+#       `rm -f .../.selected_<category>` skip branch at all 12 call sites).
+#   R7  functional smoke test: an empty catalogue lets a real setup script's
+#       selection sequence continue past the skipped step.
+#
+# HERMETIC: every operation runs against mktemp -d fixtures; nothing under
+# the real repo's config/ directories or the real user's CLI home is read or
+# written. PATH is temporarily prefixed with a directory holding stub
+# binaries (fzf) for the calls that need one; the prefix is removed on exit.
+#
+# Usage:
+#   bash scripts/tests/test-setup-catalogue-picker.sh
+
+# -e intentionally omitted: pass/fail counters control the harness, and some
+# probes intentionally check a non-zero/empty result.
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+COMMON_LIB="$REPO_DIR/scripts/lib/common.sh"
+SETUP_DIR="$REPO_DIR/scripts"
+SETUP_SCRIPTS=(setup-claude-interactive.sh setup-gemini-interactive.sh \
+               setup-copilot-interactive.sh setup-antigravity-interactive.sh)
+
+if [ ! -f "$COMMON_LIB" ]; then
+  echo "FATAL: missing $COMMON_LIB" >&2
+  exit 2
+fi
+
+# shellcheck source=scripts/lib/common.sh
+source "$COMMON_LIB"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+ok()  { echo "  ok: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+# ---------------------------------------------------------------------------
+echo "1. Empty catalogue: zero candidates, no fzf invocation, exit 0 (R1)"
+# ---------------------------------------------------------------------------
+
+EMPTY_DIR="$TMP_ROOT/empty-catalogue"
+mkdir -p "$EMPTY_DIR"
+
+# Scrub fzf from PATH entirely for this call: if pick_catalogue_entry ever
+# tried to invoke fzf on an empty catalogue, the call would fail with
+# "command not found" (or, under `set -e` in a caller, abort) rather than
+# returning cleanly — that failure mode is the proof fzf was never reached.
+STRIPPED_PATH="$(printf '%s' "$PATH" | tr ':' '\n' \
+  | while IFS= read -r p; do [ -x "$p/fzf" ] || printf '%s\n' "$p"; done \
+  | tr '\n' ':')"
+STRIPPED_PATH="${STRIPPED_PATH%:}"
+
+out=""
+rc=0
+out="$(PATH="$STRIPPED_PATH" pick_catalogue_entry "$EMPTY_DIR" "team" 2>"$TMP_ROOT/stderr.1")" || rc=$?
+[ "$rc" -eq 0 ] && ok "empty catalogue: returns 0" || bad "empty catalogue: returned $rc"
+[ -z "$out" ] && ok "empty catalogue: stdout is empty" || bad "empty catalogue: stdout was '$out'"
+if grep -qi "command not found" "$TMP_ROOT/stderr.1"; then
+  bad "empty catalogue: fzf was invoked despite zero candidates (PATH had no fzf)"
+else
+  ok "empty catalogue: fzf was never invoked"
+fi
+if grep -q "No team catalogue entries found" "$TMP_ROOT/stderr.1"; then
+  ok "empty catalogue: message names the category and the empty-catalogue cause"
+else
+  bad "empty catalogue: expected empty-catalogue message not found in stderr"
+fi
+
+# ---------------------------------------------------------------------------
+echo "2. Non-empty catalogue: no literal '*'/'*.md' placeholder ever reaches fzf (R1)"
+# ---------------------------------------------------------------------------
+
+ONE_ENTRY_DIR="$TMP_ROOT/one-entry"
+mkdir -p "$ONE_ENTRY_DIR"
+echo "# fixture" > "$ONE_ENTRY_DIR/backend.md"
+
+STUB_DIR="$TMP_ROOT/stubs"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/fzf" <<'EOF'
+#!/bin/bash
+# Records every candidate line fed on stdin, then declines (prints nothing,
+# exits 1) so the caller can be probed for the declined-pick path (R2/R4).
+cat > "$FZF_STDIN_CAPTURE"
+exit 1
+EOF
+chmod +x "$STUB_DIR/fzf"
+
+export FZF_STDIN_CAPTURE="$TMP_ROOT/fzf-stdin.txt"
+out=""
+rc=0
+out="$(PATH="$STUB_DIR:$PATH" pick_catalogue_entry "$ONE_ENTRY_DIR" "expertise" 2>"$TMP_ROOT/stderr.2")" || rc=$?
+[ "$rc" -eq 0 ] && ok "declined pick: returns 0 (fzf exit 1 neutralized by '|| true')" \
+  || bad "declined pick: returned $rc"
+[ -z "$out" ] && ok "declined pick: stdout is empty" || bad "declined pick: stdout was '$out'"
+if grep -qE '^\*$|\*\.md' "$FZF_STDIN_CAPTURE"; then
+  bad "declined pick: a literal '*'/'*.md' placeholder was fed to fzf"
+else
+  ok "declined pick: no literal '*'/'*.md' placeholder fed to fzf"
+fi
+[ "$(cat "$FZF_STDIN_CAPTURE")" = "backend" ] \
+  && ok "declined pick: fzf received exactly the real candidate 'backend'" \
+  || bad "declined pick: fzf stdin was '$(cat "$FZF_STDIN_CAPTURE")', expected 'backend'"
+if grep -q "No expertise selected" "$TMP_ROOT/stderr.2"; then
+  ok "declined pick: message names the category and the declined-pick cause"
+else
+  bad "declined pick: expected declined-pick message not found in stderr"
+fi
+unset FZF_STDIN_CAPTURE
+
+# ---------------------------------------------------------------------------
+echo "3. Normal pick: chosen basename reaches stdout (golden path)"
+# ---------------------------------------------------------------------------
+
+cat > "$STUB_DIR/fzf" <<'EOF'
+#!/bin/bash
+cat > /dev/null
+echo "backend"
+EOF
+chmod +x "$STUB_DIR/fzf"
+
+out=""
+rc=0
+out="$(PATH="$STUB_DIR:$PATH" pick_catalogue_entry "$ONE_ENTRY_DIR" "expertise" 2>/dev/null)" || rc=$?
+[ "$rc" -eq 0 ] && ok "golden path: returns 0" || bad "golden path: returned $rc"
+[ "$out" = "backend" ] && ok "golden path: stdout is the chosen basename" \
+  || bad "golden path: stdout was '$out', expected 'backend'"
+
+# ---------------------------------------------------------------------------
+echo "4. Structural parity across all four setup scripts (R5/R6)"
+# ---------------------------------------------------------------------------
+
+# extract_selection_block <script> <begin-marker> <end-marker>
+# Prints the lines strictly between (not including) the two marker lines —
+# the team/expertise/level selection body of one script — to stdout.
+extract_selection_block() {
+  local script="$1" begin="$2" end="$3"
+  awk -v begin="$begin" -v end="$end" '
+    $0 == begin { capture=1; next }
+    $0 == end   { capture=0 }
+    capture     { print }
+  ' "$script"
+}
+
+for s in "${SETUP_SCRIPTS[@]}"; do
+  path="$SETUP_DIR/$s"
+  if [ ! -f "$path" ]; then
+    bad "$s: script not found at $path"
+    continue
+  fi
+
+  if [ "$s" = "setup-copilot-interactive.sh" ]; then
+    # Copilot orders level -> expertise -> team and nests one level deeper
+    # (spec 0096 explicitly preserves this pre-existing ordering/indent).
+    block="$(extract_selection_block "$path" "  # Level" "  # Team")"
+    block="$block
+$(extract_selection_block "$path" "  # Team" "fi")"
+  else
+    block="$(extract_selection_block "$path" "# --- Team selection ---" "# --- Profile handling ---")"
+  fi
+
+  if [ -z "$block" ]; then
+    bad "$s: could not extract the team/expertise/level selection block"
+    continue
+  fi
+
+  if printf '%s\n' "$block" | grep -qE '^\s*exit 1\s*$'; then
+    bad "$s: a bare 'exit 1' remains inside the selection block"
+  else
+    ok "$s: zero remaining 'exit 1' inside the selection block"
+  fi
+
+  for category in team expertise level; do
+    if printf '%s\n' "$block" | grep -qE "rm -f \"[^\"]*\.selected_${category}\""; then
+      ok "$s: $category skip branch removes the stale .selected_$category marker"
+    else
+      bad "$s: no 'rm -f .../.selected_$category' found on the $category skip branch"
+    fi
+  done
+
+  if printf '%s\n' "$block" | grep -q "pick_catalogue_entry"; then
+    ok "$s: uses the shared pick_catalogue_entry helper"
+  else
+    bad "$s: does not call pick_catalogue_entry"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+echo "5. Functional smoke test: empty catalogue lets a real script continue (R2, R7)"
+# ---------------------------------------------------------------------------
+# Cold-review Finding 2 (folded into this PR): a structural 'no exit 1' grep
+# alone cannot prove the skip actually falls through at runtime. This extracts
+# the VERBATIM team/expertise/level block from setup-claude-interactive.sh
+# and executes it for real, against:
+#   - config/teams/     -> zero *.md files (the empty-catalogue path, R1/R2)
+#   - config/expertise/ -> one *.md file, fzf stub declines it (R2 other cause)
+#   - config/level/     -> one *.md file, fzf stub picks it (proves execution
+#     reached and completed the THIRD category, i.e. it was never aborted)
+# then asserts a marker placed immediately after the extracted block was
+# reached, rather than only asserting the absence of the 'exit 1' string.
+
+CLAUDE_SCRIPT="$SETUP_DIR/setup-claude-interactive.sh"
+SMOKE_BLOCK="$(extract_selection_block "$CLAUDE_SCRIPT" "# --- Team selection ---" "# --- Profile handling ---")"
+
+if [ -z "$SMOKE_BLOCK" ]; then
+  bad "smoke test: could not extract the selection block from setup-claude-interactive.sh"
+else
+  SMOKE_HOME="$TMP_ROOT/smoke-claude-home"
+  SMOKE_REPO="$TMP_ROOT/smoke-repo"
+  mkdir -p "$SMOKE_HOME" "$SMOKE_REPO/config/teams" "$SMOKE_REPO/config/expertise" "$SMOKE_REPO/config/level"
+  echo "# fixture" > "$SMOKE_REPO/config/expertise/backend.md"
+  echo "# fixture" > "$SMOKE_REPO/config/level/junior.md"
+  # config/teams/ is left empty on purpose (R1 empty-catalogue path).
+
+  # Pre-seed stale markers from a "prior run" to prove R3 (skip removes them).
+  echo "stale-team" > "$SMOKE_HOME/.selected_team"
+  echo "stale-expertise" > "$SMOKE_HOME/.selected_expertise"
+
+  SMOKE_STUB_DIR="$TMP_ROOT/smoke-stubs"
+  mkdir -p "$SMOKE_STUB_DIR"
+  SMOKE_COUNTER="$TMP_ROOT/smoke-fzf-count"
+  echo 0 > "$SMOKE_COUNTER"
+  cat > "$SMOKE_STUB_DIR/fzf" <<EOF
+#!/bin/bash
+# Call 1 = expertise (decline: empty catalogue never reaches fzf at all, so
+# the FIRST real fzf call is expertise) -> prints nothing, exit 1.
+# Call 2 = level -> prints the fixture's only entry.
+cat > /dev/null
+n="\$(cat "$SMOKE_COUNTER")"
+n=\$((n + 1))
+echo "\$n" > "$SMOKE_COUNTER"
+if [ "\$n" -eq 1 ]; then
+  exit 1
+else
+  echo "junior"
+fi
+EOF
+  chmod +x "$SMOKE_STUB_DIR/fzf"
+
+  SMOKE_SCRIPT="$TMP_ROOT/smoke-run.sh"
+  {
+    echo "#!/bin/bash"
+    echo "set -e"
+    echo "source '$COMMON_LIB'"
+    echo "REPO_DIR='$SMOKE_REPO'"
+    echo "CLAUDE_HOME='$SMOKE_HOME'"
+    echo "CLAUDE_RULES=\"\${CLAUDE_HOME}/rules\""
+    echo "mkdir -p \"\$CLAUDE_RULES\""
+    printf '%s\n' "$SMOKE_BLOCK"
+    echo 'echo "SMOKE_TEST_CONTINUED_PAST_SKIP"'
+  } > "$SMOKE_SCRIPT"
+
+  smoke_out=""
+  smoke_rc=0
+  smoke_out="$(PATH="$SMOKE_STUB_DIR:$PATH" bash "$SMOKE_SCRIPT" 2>"$TMP_ROOT/smoke-stderr.txt")" || smoke_rc=$?
+
+  [ "$smoke_rc" -eq 0 ] && ok "smoke test: extracted block exits 0 under an empty team catalogue" \
+    || bad "smoke test: extracted block exited $smoke_rc (should have continued, not aborted)"
+
+  if printf '%s' "$smoke_out" | grep -q "SMOKE_TEST_CONTINUED_PAST_SKIP"; then
+    ok "smoke test: execution continued past the team/expertise skips to the trailing marker"
+  else
+    bad "smoke test: trailing marker not reached — script likely aborted on the empty catalogue"
+  fi
+
+  if printf '%s' "$smoke_out" | grep -q "Level: junior"; then
+    ok "smoke test: level selection (third category) still ran and installed 'junior'"
+  else
+    bad "smoke test: level selection output not found — third category was not reached"
+  fi
+
+  [ ! -e "$SMOKE_HOME/.selected_team" ] \
+    && ok "smoke test: stale .selected_team marker removed on the empty-catalogue skip (R3)" \
+    || bad "smoke test: .selected_team marker still present after skip"
+  [ ! -e "$SMOKE_HOME/.selected_expertise" ] \
+    && ok "smoke test: stale .selected_expertise marker removed on the declined-pick skip (R3)" \
+    || bad "smoke test: .selected_expertise marker still present after skip"
+  [ -f "$SMOKE_HOME/.selected_level" ] && [ "$(cat "$SMOKE_HOME/.selected_level")" = "junior" ] \
+    && ok "smoke test: .selected_level marker written for the actually-selected entry" \
+    || bad "smoke test: .selected_level marker missing or wrong content"
+  [ -f "$SMOKE_HOME/rules/10-level.md" ] \
+    && ok "smoke test: level rule file installed to rules/10-level.md" \
+    || bad "smoke test: level rule file was not installed"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
An empty `config/teams/`, `config/expertise/`, or `config/level/` catalogue directory, or a declined `fzf` pick, aborted the entire interactive setup script via `set -e` before it could reach the other selection steps, MCP registration, or hooks wiring. This PR makes each of the three selection categories skip independently instead, across all four in-scope setup scripts.

## How to read this PR?

1. `scripts/lib/common.sh` — the new `pick_catalogue_entry(category_dir, category_label)` helper. Read this first; it is the single source of the fix. Two things matter: the `shopt -s nullglob` loop that guarantees zero candidates (not a literal `*`/`*.md`) reach `fzf` on an empty directory, and the `|| true` on the `fzf` invocation, which is load-bearing — without it, a declined pick's non-zero fzf exit trips `errexit` on the assignment itself, before the caller's own `if [ -z ]` check is ever reached (confirmed in the PLAN review on issue #603 by reproducing the exact control-flow shape in a throwaway script).
2. `scripts/setup-claude-interactive.sh` — read this one call site in full as the reference rewiring; the same shape is repeated in `scripts/setup-gemini-interactive.sh` and `scripts/setup-antigravity-interactive.sh`. Each of the three blocks (team/expertise/level) replaces its old `if [ -z "$X" ]; then echo "..."; exit 1; fi` with an `if`/`else`: non-empty result installs the rule file and writes the `.selected_<category>` marker; empty result removes any stale marker and falls through to the next step.
3. `scripts/setup-copilot-interactive.sh` — same rewiring, but its three blocks are nested one level deeper and ordered level→expertise→team, both preserved verbatim (an existing behavioral detail out of this fix's scope).
4. `scripts/tests/test-setup-catalogue-picker.sh` — new hermetic regression suite. Section 1-3 unit-test `pick_catalogue_entry()` directly (empty catalogue, declined pick, golden path). Section 4 statically greps all four setup scripts for zero remaining `exit 1` inside the selection blocks and a matching `rm -f .../.selected_<category>` on every skip branch. Section 5 is the functional smoke test added to close a PLAN cold-review finding (see below): it extracts the verbatim selection block from `setup-claude-interactive.sh` and actually executes it against an empty `config/teams/` fixture, proving the script continues past the skip rather than only asserting the absence of the `exit 1` string.
5. `.github/workflows/build.yml`, `ci/ci-capabilities.yml`, `.gitlab-ci.yml` — CI wiring for the new test, so `scripts/check-test-wiring.sh` does not flag it as unwired.

## How to test this PR?

Prerequisites: `bash` on `PATH` (no `fzf`/TTY required — the new suite stubs `fzf`).

```sh
bash scripts/tests/test-setup-catalogue-picker.sh
```

Expected: `RESULT: 38 passed, 0 failed`.

Also confirm no CI-wiring or CI-parity regression, and no regression in the neighboring setup-script suites:

```sh
bash scripts/check-test-wiring.sh
bash scripts/check-ci-parity.sh
bash scripts/tests/test-setup-validation-backend.sh
bash scripts/tests/test-tls-delegation.sh
bash scripts/tests/test-setup-mcp-merge.sh
```

Expected: `check-test-wiring.sh` and `check-ci-parity.sh` both print `OK: ...` and exit 0; the three existing suites report `56 passed, 0 failed`, `15 passed, 0 failed`, and `30 passed, 0 failed` respectively.

Note: `scripts/tests/test-setup-org-mcp.sh` fails locally on macOS with `mapfile: command not found` (bash 3.2 lacks `mapfile`) — this is a pre-existing environment issue unrelated to this diff; that file is not touched here.

Failure mode to also exercise manually if desired: point `config/teams/` at an empty directory and run `scripts/setup-claude-interactive.sh` — the script should print a skip message naming "team" and continue to the expertise-selection step rather than exiting.

## Detailed description (for agents)

**Added:**
- `scripts/lib/common.sh` — `pick_catalogue_entry()` (42 lines), inserted after `install_dir`. Builds the candidate list via a nullglob-guarded `for f in "$category_dir"/*.md` loop. Zero candidates → prints a category-naming, empty-catalogue message to stderr and returns 0 with empty stdout, without ever invoking `fzf`. Otherwise pipes candidates through `fzf --height 40% --preview "head -20 $category_dir/{}.md" || true`; empty choice → prints a category-naming, declined-pick message to stderr and returns 0 with empty stdout; non-empty choice → prints the chosen basename to stdout.
- `scripts/tests/test-setup-catalogue-picker.sh` — new hermetic test file (see reading guide above for the 5 sections). Runs entirely against `mktemp -d` fixtures and a stubbed `fzf` on `PATH`; touches no real `config/` directory or CLI home.
- `.github/workflows/build.yml`, `ci/ci-capabilities.yml`, `.gitlab-ci.yml` — one new step/line each wiring the new test into the existing CI jobs.

**Modified — all 12 call sites (4 scripts × team/expertise/level):**
- `scripts/setup-claude-interactive.sh`, `scripts/setup-gemini-interactive.sh`, `scripts/setup-copilot-interactive.sh`, `scripts/setup-antigravity-interactive.sh` — each of the three selection blocks now calls `pick_catalogue_entry` and branches on its result: non-empty installs the rule file via `install_file` and writes the `.selected_<category>` marker; empty removes any stale marker with `rm -f` and prints nothing further (the skip message already came from the helper), then falls through — no `exit 1` remains in any of the 12 blocks. Copilot's pre-existing deeper indentation and level→expertise→team ordering are preserved verbatim, per the PLAN's explicit DEV constraint (out of this fix's scope to normalize).

**Not touched:**
- No `artifacts/` file is touched by this diff, so there is no `metadata.provenance.version` bump trigger (`AGENTS.md` → *Version Bump Convention*) and no `scripts/build-components.sh` run is needed.
- No `docs/cli-matrix.md` edit. Row 7b ("User-level layered context") documents only deployment target paths and priority numbers for the rule files these scripts install — content unaffected by this abort-vs-skip control-flow change. This "no row changes" determination is made explicitly per spec 0096 R8 / `AGENTS.md` → *CLI Matrix Maintenance*, which requires either an update or a recorded no-op determination for any PR touching the four in-scope setup scripts.

**Test evidence gathered before opening this PR** (all commands run against this branch):
- `bash scripts/tests/test-setup-catalogue-picker.sh` → `RESULT: 38 passed, 0 failed`.
- `bash scripts/check-test-wiring.sh` → `OK: all test scripts are wired (54) or exempted with a reason (2); the exemption allowlist is honest.`
- `bash scripts/check-ci-parity.sh` → `OK: reference, GitHub Actions, GitLab agree on the portable capability set; every pipeline job is traceable.`
- `bash scripts/tests/test-setup-validation-backend.sh` → `RESULT: 56 passed, 0 failed`.
- `bash scripts/tests/test-tls-delegation.sh` → `RESULT: 15 passed, 0 failed`.
- `bash scripts/tests/test-setup-mcp-merge.sh` → `RESULT: 30 passed, 0 failed`.
- `bash scripts/tests/test-setup-org-mcp.sh` → fails with `mapfile: command not found` — pre-existing macOS bash-3.2 gap, unrelated to this diff, file not touched.

**Lifecycle:** SPECS (spec 0096, merged via PR #650) → PLAN (posted and cold-reviewed APPROVE on issue #603, both `tech`-class findings folded into this diff) → this DEV-stage PR. Closes #603 per `AGENTS.md` Rule A (the feature issue is its own logbook; the DEV-stage logbook comment was posted on #603 before this PR was opened).

Closes #603
