### PR TITLE
🐛 Fix lint-skill.sh false-positive frontmatter findings from whole-file yq parse

### DIFF
--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.agents/skills/pr-reviewer/scripts/lint-skill.sh
+++ b/.agents/skills/pr-reviewer/scripts/lint-skill.sh
@@ -25,11 +25,23 @@ else
   echo "lint-skill.sh: yq not found — using grep fallback for required keys."
 fi
 
+# Extracts the leading ---/--- frontmatter block only. yq must never see the
+# markdown body: a colon or indentation quirk in prose is valid multi-document
+# YAML noise that can make yq error out or silently omit the query result,
+# producing false "missing key" findings on fully-valid frontmatter.
+frontmatter_block() {
+  local file="$1"
+  awk 'NR==1 && /^---[[:space:]]*$/ {f=1; next} f && /^---[[:space:]]*$/ {exit} f {print}' "$file"
+}
+
 check_key() {
   local file="$1" key="$2"
   if [ "$HAS_YQ" -eq 1 ]; then
-    local value
-    value=$(yq -r ".$key // \"\"" "$file" 2>/dev/null)
+    local value fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    value=$(yq -r ".$key // \"\"" "$fm_file" 2>/dev/null)
+    rm -f "$fm_file"
     [ -n "$value" ] && [ "$value" != "null" ]
   else
     # Grep fallback: handle nested keys (last segment).
@@ -41,7 +53,11 @@ check_key() {
 extract_version() {
   local file="$1"
   if [ "$HAS_YQ" -eq 1 ]; then
-    yq -r '.metadata.provenance.version // ""' "$file" 2>/dev/null
+    local fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    yq -r '.metadata.provenance.version // ""' "$fm_file" 2>/dev/null
+    rm -f "$fm_file"
   else
     awk '/^[[:space:]]*version:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$file"
   fi
@@ -58,15 +74,12 @@ for file in "$@"; do
   done
 
   head_version=$(extract_version "$file")
-  base_version=$(git show "${BASE_REF}:${file}" 2>/dev/null | extract_version /dev/stdin 2>/dev/null || true)
-  if [ -z "$base_version" ]; then
-    # Try via temp file because yq on /dev/stdin can misbehave.
-    if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
-      tmp=$(mktemp)
-      printf '%s\n' "$base_blob" > "$tmp"
-      base_version=$(extract_version "$tmp")
-      rm -f "$tmp"
-    fi
+  base_version=""
+  if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
+    tmp=$(mktemp)
+    printf '%s\n' "$base_blob" > "$tmp"
+    base_version=$(extract_version "$tmp")
+    rm -f "$tmp"
   fi
 
   if [ -n "$base_version" ] && [ "$head_version" = "$base_version" ]; then

--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.claude/skills/pr-reviewer/scripts/lint-skill.sh
+++ b/.claude/skills/pr-reviewer/scripts/lint-skill.sh
@@ -25,11 +25,23 @@ else
   echo "lint-skill.sh: yq not found — using grep fallback for required keys."
 fi
 
+# Extracts the leading ---/--- frontmatter block only. yq must never see the
+# markdown body: a colon or indentation quirk in prose is valid multi-document
+# YAML noise that can make yq error out or silently omit the query result,
+# producing false "missing key" findings on fully-valid frontmatter.
+frontmatter_block() {
+  local file="$1"
+  awk 'NR==1 && /^---[[:space:]]*$/ {f=1; next} f && /^---[[:space:]]*$/ {exit} f {print}' "$file"
+}
+
 check_key() {
   local file="$1" key="$2"
   if [ "$HAS_YQ" -eq 1 ]; then
-    local value
-    value=$(yq -r ".$key // \"\"" "$file" 2>/dev/null)
+    local value fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    value=$(yq -r ".$key // \"\"" "$fm_file" 2>/dev/null)
+    rm -f "$fm_file"
     [ -n "$value" ] && [ "$value" != "null" ]
   else
     # Grep fallback: handle nested keys (last segment).
@@ -41,7 +53,11 @@ check_key() {
 extract_version() {
   local file="$1"
   if [ "$HAS_YQ" -eq 1 ]; then
-    yq -r '.metadata.provenance.version // ""' "$file" 2>/dev/null
+    local fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    yq -r '.metadata.provenance.version // ""' "$fm_file" 2>/dev/null
+    rm -f "$fm_file"
   else
     awk '/^[[:space:]]*version:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$file"
   fi
@@ -58,15 +74,12 @@ for file in "$@"; do
   done
 
   head_version=$(extract_version "$file")
-  base_version=$(git show "${BASE_REF}:${file}" 2>/dev/null | extract_version /dev/stdin 2>/dev/null || true)
-  if [ -z "$base_version" ]; then
-    # Try via temp file because yq on /dev/stdin can misbehave.
-    if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
-      tmp=$(mktemp)
-      printf '%s\n' "$base_blob" > "$tmp"
-      base_version=$(extract_version "$tmp")
-      rm -f "$tmp"
-    fi
+  base_version=""
+  if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
+    tmp=$(mktemp)
+    printf '%s\n' "$base_blob" > "$tmp"
+    base_version=$(extract_version "$tmp")
+    rm -f "$tmp"
   fi
 
   if [ -n "$base_version" ] && [ "$head_version" = "$base_version" ]; then

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.gemini/skills/pr-reviewer/scripts/lint-skill.sh
+++ b/.gemini/skills/pr-reviewer/scripts/lint-skill.sh
@@ -25,11 +25,23 @@ else
   echo "lint-skill.sh: yq not found — using grep fallback for required keys."
 fi
 
+# Extracts the leading ---/--- frontmatter block only. yq must never see the
+# markdown body: a colon or indentation quirk in prose is valid multi-document
+# YAML noise that can make yq error out or silently omit the query result,
+# producing false "missing key" findings on fully-valid frontmatter.
+frontmatter_block() {
+  local file="$1"
+  awk 'NR==1 && /^---[[:space:]]*$/ {f=1; next} f && /^---[[:space:]]*$/ {exit} f {print}' "$file"
+}
+
 check_key() {
   local file="$1" key="$2"
   if [ "$HAS_YQ" -eq 1 ]; then
-    local value
-    value=$(yq -r ".$key // \"\"" "$file" 2>/dev/null)
+    local value fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    value=$(yq -r ".$key // \"\"" "$fm_file" 2>/dev/null)
+    rm -f "$fm_file"
     [ -n "$value" ] && [ "$value" != "null" ]
   else
     # Grep fallback: handle nested keys (last segment).
@@ -41,7 +53,11 @@ check_key() {
 extract_version() {
   local file="$1"
   if [ "$HAS_YQ" -eq 1 ]; then
-    yq -r '.metadata.provenance.version // ""' "$file" 2>/dev/null
+    local fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    yq -r '.metadata.provenance.version // ""' "$fm_file" 2>/dev/null
+    rm -f "$fm_file"
   else
     awk '/^[[:space:]]*version:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$file"
   fi
@@ -58,15 +74,12 @@ for file in "$@"; do
   done
 
   head_version=$(extract_version "$file")
-  base_version=$(git show "${BASE_REF}:${file}" 2>/dev/null | extract_version /dev/stdin 2>/dev/null || true)
-  if [ -z "$base_version" ]; then
-    # Try via temp file because yq on /dev/stdin can misbehave.
-    if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
-      tmp=$(mktemp)
-      printf '%s\n' "$base_blob" > "$tmp"
-      base_version=$(extract_version "$tmp")
-      rm -f "$tmp"
-    fi
+  base_version=""
+  if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
+    tmp=$(mktemp)
+    printf '%s\n' "$base_blob" > "$tmp"
+    base_version=$(extract_version "$tmp")
+    rm -f "$tmp"
   fi
 
   if [ -n "$base_version" ] && [ "$head_version" = "$base_version" ]; then

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.github/skills/pr-reviewer/scripts/lint-skill.sh
+++ b/.github/skills/pr-reviewer/scripts/lint-skill.sh
@@ -25,11 +25,23 @@ else
   echo "lint-skill.sh: yq not found — using grep fallback for required keys."
 fi
 
+# Extracts the leading ---/--- frontmatter block only. yq must never see the
+# markdown body: a colon or indentation quirk in prose is valid multi-document
+# YAML noise that can make yq error out or silently omit the query result,
+# producing false "missing key" findings on fully-valid frontmatter.
+frontmatter_block() {
+  local file="$1"
+  awk 'NR==1 && /^---[[:space:]]*$/ {f=1; next} f && /^---[[:space:]]*$/ {exit} f {print}' "$file"
+}
+
 check_key() {
   local file="$1" key="$2"
   if [ "$HAS_YQ" -eq 1 ]; then
-    local value
-    value=$(yq -r ".$key // \"\"" "$file" 2>/dev/null)
+    local value fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    value=$(yq -r ".$key // \"\"" "$fm_file" 2>/dev/null)
+    rm -f "$fm_file"
     [ -n "$value" ] && [ "$value" != "null" ]
   else
     # Grep fallback: handle nested keys (last segment).
@@ -41,7 +53,11 @@ check_key() {
 extract_version() {
   local file="$1"
   if [ "$HAS_YQ" -eq 1 ]; then
-    yq -r '.metadata.provenance.version // ""' "$file" 2>/dev/null
+    local fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    yq -r '.metadata.provenance.version // ""' "$fm_file" 2>/dev/null
+    rm -f "$fm_file"
   else
     awk '/^[[:space:]]*version:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$file"
   fi
@@ -58,15 +74,12 @@ for file in "$@"; do
   done
 
   head_version=$(extract_version "$file")
-  base_version=$(git show "${BASE_REF}:${file}" 2>/dev/null | extract_version /dev/stdin 2>/dev/null || true)
-  if [ -z "$base_version" ]; then
-    # Try via temp file because yq on /dev/stdin can misbehave.
-    if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
-      tmp=$(mktemp)
-      printf '%s\n' "$base_blob" > "$tmp"
-      base_version=$(extract_version "$tmp")
-      rm -f "$tmp"
-    fi
+  base_version=""
+  if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
+    tmp=$(mktemp)
+    printf '%s\n' "$base_blob" > "$tmp"
+    base_version=$(extract_version "$tmp")
+    rm -f "$tmp"
   fi
 
   if [ -n "$base_version" ] && [ "$head_version" = "$base_version" ]; then

--- a/artifacts/core/skills/pr-reviewer/SKILL.md
+++ b/artifacts/core/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.6"
+    version: "1.1.7"
 claude:
   allowed-tools:
     - Read

--- a/artifacts/core/skills/pr-reviewer/scripts/lint-skill.sh
+++ b/artifacts/core/skills/pr-reviewer/scripts/lint-skill.sh
@@ -25,11 +25,23 @@ else
   echo "lint-skill.sh: yq not found — using grep fallback for required keys."
 fi
 
+# Extracts the leading ---/--- frontmatter block only. yq must never see the
+# markdown body: a colon or indentation quirk in prose is valid multi-document
+# YAML noise that can make yq error out or silently omit the query result,
+# producing false "missing key" findings on fully-valid frontmatter.
+frontmatter_block() {
+  local file="$1"
+  awk 'NR==1 && /^---[[:space:]]*$/ {f=1; next} f && /^---[[:space:]]*$/ {exit} f {print}' "$file"
+}
+
 check_key() {
   local file="$1" key="$2"
   if [ "$HAS_YQ" -eq 1 ]; then
-    local value
-    value=$(yq -r ".$key // \"\"" "$file" 2>/dev/null)
+    local value fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    value=$(yq -r ".$key // \"\"" "$fm_file" 2>/dev/null)
+    rm -f "$fm_file"
     [ -n "$value" ] && [ "$value" != "null" ]
   else
     # Grep fallback: handle nested keys (last segment).
@@ -41,7 +53,11 @@ check_key() {
 extract_version() {
   local file="$1"
   if [ "$HAS_YQ" -eq 1 ]; then
-    yq -r '.metadata.provenance.version // ""' "$file" 2>/dev/null
+    local fm_file
+    fm_file=$(mktemp)
+    frontmatter_block "$file" > "$fm_file"
+    yq -r '.metadata.provenance.version // ""' "$fm_file" 2>/dev/null
+    rm -f "$fm_file"
   else
     awk '/^[[:space:]]*version:/ {gsub(/[" ]/,"",$2); print $2; exit}' "$file"
   fi
@@ -58,15 +74,12 @@ for file in "$@"; do
   done
 
   head_version=$(extract_version "$file")
-  base_version=$(git show "${BASE_REF}:${file}" 2>/dev/null | extract_version /dev/stdin 2>/dev/null || true)
-  if [ -z "$base_version" ]; then
-    # Try via temp file because yq on /dev/stdin can misbehave.
-    if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
-      tmp=$(mktemp)
-      printf '%s\n' "$base_blob" > "$tmp"
-      base_version=$(extract_version "$tmp")
-      rm -f "$tmp"
-    fi
+  base_version=""
+  if base_blob=$(git show "${BASE_REF}:${file}" 2>/dev/null); then
+    tmp=$(mktemp)
+    printf '%s\n' "$base_blob" > "$tmp"
+    base_version=$(extract_version "$tmp")
+    rm -f "$tmp"
   fi
 
   if [ -n "$base_version" ] && [ "$head_version" = "$base_version" ]; then


### PR DESCRIPTION
Fixes #604.

`lint-skill.sh` fed the entire SKILL.md — frontmatter plus markdown body — to `yq`, which parsed it as a YAML stream. Prose in the body could trip the parser, either erroring out or silently omitting the query result, which surfaced false "missing required frontmatter key" findings on fully-valid frontmatter.

## How to read this PR?

- `artifacts/core/skills/pr-reviewer/scripts/lint-skill.sh` — the fix. A new `frontmatter_block()` helper extracts only the leading `---`/`---` block via `awk` into a temp file; `check_key()` and `extract_version()` now query that temp file instead of the original SKILL.md. The pre-existing `/dev/stdin` workaround for base-ref version comparison is removed — it's now redundant since `extract_version` always hands `yq` a regular file.
- `artifacts/core/skills/pr-reviewer/SKILL.md` — version bump `1.1.6` → `1.1.7` (PATCH, friction fix) per the version-bump convention.
- The mirrored copies under `.claude/`, `.gemini/`, `.github/`, `.agents/` are the regenerated output of `scripts/build-components.sh`.

## How to test this PR?

```bash
# Before the fix, this undercounted false positives; after, only genuine
# missing-field findings remain (compatibility is legitimately absent on
# several skills, unrelated to this bug).
find artifacts -name SKILL.md | xargs bash artifacts/core/skills/pr-reviewer/scripts/lint-skill.sh
```

Verified locally: reproduced the whole-file yq parse error on a synthetic SKILL.md with body prose that trips YAML multi-document parsing, confirmed it's fixed post-patch, and confirmed the finding count against every real SKILL.md in the repo drops from 33 to 13 (the remaining 13 are genuine missing `compatibility` fields, unrelated to this bug). Also verified the yq-absent grep fallback path is untouched and still passes.

## Detailed description (for agents)

- Added `frontmatter_block(file)`: `awk` extraction of the block between the first two `---` lines.
- `check_key()`: writes the frontmatter block to a `mktemp` file, queries that file with `yq`, removes the temp file.
- `extract_version()`: same pattern for the `metadata.provenance.version` lookup.
- Removed the `git show ... | extract_version /dev/stdin` call and its `/dev/stdin`-misbehavior fallback block (lines previously doing a second `mktemp` dance) — `extract_version` internally routes through a real temp file now regardless of caller, so the special-casing is dead code.
- No changes to the yq-absent grep fallback path.