### PR TITLE
🐛 Exclude .github/copilot/settings.json from strict sync guard

### DIFF
--- a/.crewrig/core-paths.txt
+++ b/.crewrig/core-paths.txt
@@ -81,6 +81,13 @@ artifacts/library
 .gemini/commands
 .github/copilot-instructions.md
 .github/copilot
+# `.github/copilot/settings.json` is deliberately rewritten locally with an
+# absolute hook path by the transcript-hooks opt-in in
+# setup-copilot-interactive.sh (ADR-0001 Discovery finding #8) — that local
+# mutation is the intended behavior of the opt-in, not drift. Nested
+# exclusion under the strict `.github/copilot` parent (spec 0097 / issue
+# #605) keeps the rest of `.github/copilot/` (e.g. extension.json) guarded.
+.github/copilot/settings.json	excluded
 .github/skills
 .github/agents
 .github/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ CLAUDE.local.md
 .github/copilot/settings.local.json
 copilot-instructions.local.md
 
+# Timestamped backup left by backup_file() next to settings.json during the
+# transcript-hooks opt-in merge (spec 0097 / issue #605) — scoped narrowly to
+# that one file, not the whole .github/copilot directory
+.github/copilot/settings.json.bak.*
+
 # e2e runner — local overrides and per-run reports (issue #78)
 tests/e2e/local.toml
 tests/e2e/reports/*

--- a/docs/adr/0001-copilot-cli-integration-strategy.md
+++ b/docs/adr/0001-copilot-cli-integration-strategy.md
@@ -169,3 +169,23 @@ making them the direct equivalent of `~/.claude/rules/` and `~/.gemini/`.
 files from `config/` to `~/.copilot/instructions/` using the naming
 convention `<priority>-<slug>.instructions.md`. The `[GAP]` for user-level
 layered context recorded in checklist item #7 is hereby resolved.
+
+## Addendum — 2026-07-23: Strict-sync carve-out for the hook-merge mutation
+
+Discovery finding #8 above records that the transcript-hooks opt-in in
+`setup-copilot-interactive.sh` deliberately rewrites the committed
+`.github/copilot/settings.json` locally with an absolute hook path — the
+committed file ships with `"hooks": []` by design, and the opt-in is what
+populates it. `.crewrig/core-paths.txt` did not account for this: the whole
+`.github/copilot` directory was `strict`, so that same designed-in mutation
+made `scripts/sync-from-upstream.sh` abort on every subsequent sync, and the
+`.bak.<timestamp>` file `backup_file()` leaves alongside it showed up as
+untracked noise in `git status`.
+
+`.github/copilot/settings.json` is now reclassified `excluded`, nested
+under the still-`strict` `.github/copilot` parent (spec 0097 / issue #605).
+This does not change where the opt-in writes its hook merge, nor any other
+decision recorded above — it only stops the manifest from treating that one
+file's intended local mutation as upstream drift. Sibling members of
+`.github/copilot/` (e.g. `extension.json`) are unaffected and continue to
+abort the sync on a local diff, exactly as before.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -165,6 +165,7 @@ exist, how org artifacts integrate) is defined in spec 0012 sub-spec E2.
 | `.github/copilot-instructions.md` | Copilot system prompt built from `AGENTS.md`. |
 | `.github/workflows/` | CI/CD pipeline definitions. |
 | `.github/copilot/` | GitHub Copilot workspace configuration. |
+| `.github/copilot/settings.json` | Committed workspace settings, `strict` by default as a member of `.github/copilot/` above — except its `hooks` key, which the transcript-hooks opt-in in `setup-copilot-interactive.sh` deliberately rewrites locally with an absolute path (ADR-0001 Discovery finding #8). Reclassified `excluded`, nested under the strict `.github/copilot/` parent (spec 0097 / issue #605), so that designed-in local mutation no longer aborts `scripts/sync-from-upstream.sh`; sibling members such as `extension.json` remain `strict` and still abort on a local diff. |
 
 ### Extension distribution channel
 

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -1519,7 +1519,7 @@ run_case_stderr() {
 
   # Mutate settings.json only, representative of the transcript-hooks
   # hook-merge opt-in rewriting it locally with an absolute hook path.
-  printf '{"hooks": ["/Users/adopter/.claude/hooks/transcript-hook.sh"]}' \
+  printf '{"hooks": ["/Users/agent/.claude/hooks/transcript-hook.sh"]}' \
     > "$adopter/.github/copilot/settings.json"
 
   actual_exit=0
@@ -1532,7 +1532,7 @@ run_case_stderr() {
     ok=0
   fi
   settings_after="$(cat "$adopter/.github/copilot/settings.json" 2>/dev/null)"
-  if [ "$settings_after" != '{"hooks": ["/Users/adopter/.claude/hooks/transcript-hook.sh"]}' ]; then
+  if [ "$settings_after" != '{"hooks": ["/Users/agent/.claude/hooks/transcript-hook.sh"]}' ]; then
     echo "FAIL  case-z: settings.json hook-merge mutation was reverted by sync: '$settings_after'"
     ok=0
   fi

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -84,6 +84,23 @@
 #      via the same path_is_governed() carve-out, independently of the nested
 #      form covered by case x.
 #
+# Spec-0097 Copilot settings.json workspace-scope carve-out cases (issue #605):
+#   z. R8 — a local content mutation confined to
+#      `.github/copilot/settings.json` (an `excluded` entry nested under the
+#      still-`strict` `.github/copilot` parent), representative of the
+#      transcript-hooks hook-merge opt-in, does NOT abort the strict
+#      dirty-guard for `.github/copilot`, and the mutated content survives
+#      the sync's restore step untouched.
+#  aa. R9 — a local content mutation confined to the sibling
+#      `.github/copilot/extension.json` (still `strict`, no exclusion) DOES
+#      abort the strict dirty-guard for `.github/copilot`, exactly as before
+#      the carve-out — guards against the narrow-scope fix silently widening
+#      to the whole directory.
+#  bb. R10 — the real repo's own `.gitignore` matches a representative
+#      `.github/copilot/settings.json.bak.<timestamp>` filename in the shape
+#      produced by `backup_file()`, and does NOT match the sibling
+#      `extension.json` (pattern stayed narrow).
+#
 # Usage:
 #   bash scripts/tests/test-sync-from-upstream.sh
 
@@ -1472,6 +1489,145 @@ run_case_stderr() {
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case z — spec 0097 R8 / issue #605: a local mutation confined to
+# .github/copilot/settings.json (excluded child nested under the strict
+# .github/copilot parent) does not abort the strict dirty-guard, and the
+# mutated content is left untouched by the restore step (the excluded child
+# is skipped in both passes — same mechanism already covered generically by
+# case s, exercised here against the real spec-0097 manifest shape).
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    ".github/copilot/settings.json" '{"hooks": []}' \
+    ".github/copilot/extension.json" '{"name": "upstream-ext"}'
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf '.github/copilot\n.github/copilot/settings.json\texcluded\n' \
+    > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    ".github/copilot/settings.json" '{"hooks": []}' \
+    ".github/copilot/extension.json" '{"name": "upstream-ext"}'
+
+  # Mutate settings.json only, representative of the transcript-hooks
+  # hook-merge opt-in rewriting it locally with an absolute hook path.
+  printf '{"hooks": ["/Users/adopter/.claude/hooks/transcript-hook.sh"]}' \
+    > "$adopter/.github/copilot/settings.json"
+
+  actual_exit=0
+  stderr_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" 2>&1 >/dev/null)" || actual_exit=$?
+
+  ok=1
+  if [ "$actual_exit" -ne 0 ]; then
+    echo "FAIL  case-z: expected exit 0, got $actual_exit"
+    echo "      actual stderr: $stderr_out"
+    ok=0
+  fi
+  settings_after="$(cat "$adopter/.github/copilot/settings.json" 2>/dev/null)"
+  if [ "$settings_after" != '{"hooks": ["/Users/adopter/.claude/hooks/transcript-hook.sh"]}' ]; then
+    echo "FAIL  case-z: settings.json hook-merge mutation was reverted by sync: '$settings_after'"
+    ok=0
+  fi
+  ext_after="$(cat "$adopter/.github/copilot/extension.json" 2>/dev/null)"
+  if [ "$ext_after" != '{"name": "upstream-ext"}' ]; then
+    echo "FAIL  case-z: unmodified sibling extension.json unexpectedly changed: '$ext_after'"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-z: settings.json mutation does not abort .github/copilot strict guard, content preserved"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case aa — spec 0097 R9 / issue #605: a local mutation confined to the
+# sibling .github/copilot/extension.json (still strict, not excluded) still
+# aborts the strict dirty-guard for .github/copilot, exactly as it did before
+# the settings.json carve-out — proves the fix's scope stayed narrow to
+# settings.json alone and did not silently widen to the whole directory.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    ".github/copilot/settings.json" '{"hooks": []}' \
+    ".github/copilot/extension.json" '{"name": "upstream-ext"}'
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf '.github/copilot\n.github/copilot/settings.json\texcluded\n' \
+    > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    ".github/copilot/settings.json" '{"hooks": []}' \
+    ".github/copilot/extension.json" '{"name": "upstream-ext"}'
+
+  # Mutate extension.json only — settings.json stays untouched.
+  printf '{"name": "locally-edited-ext"}' > "$adopter/.github/copilot/extension.json"
+
+  run_case_stderr \
+    "case-aa extension.json mutation still aborts .github/copilot strict guard" \
+    "$adopter" \
+    1 \
+    ".github/copilot"
+
+  # Working tree must still contain the local modification (unchanged by script).
+  ext_after="$(cat "$adopter/.github/copilot/extension.json" 2>/dev/null)"
+  if [ "$ext_after" = '{"name": "locally-edited-ext"}' ]; then
+    echo "PASS  case-aa: extension.json working-tree edit unchanged (abort happened before restore)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-aa: extension.json was unexpectedly modified by the aborted sync"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case bb — spec 0097 R10 / issue #605: the real repo's committed .gitignore
+# ignores a representative .github/copilot/settings.json.bak.<timestamp>
+# filename in the exact shape produced by backup_file() in
+# scripts/lib/common.sh (`cp -P "$target" "${target}.bak.${stamp}"`,
+# `stamp="$(date +%Y%m%d-%H%M%S)"`). Unlike every other case in this file,
+# this checks the actual repo's own .gitignore (via `git check-ignore`
+# against the real REPO_ROOT) rather than a synthetic fixture — .gitignore
+# is not an input to sync-from-upstream.sh, so there is nothing to
+# synthesize; the pattern under test either ships in this repo's .gitignore
+# or it does not.
+# ---------------------------------------------------------------------------
+{
+  REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+  representative_path=".github/copilot/settings.json.bak.20260723-203351"
+
+  if git -C "$REPO_ROOT" check-ignore -q "$representative_path"; then
+    echo "PASS  case-bb: $representative_path is gitignored"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-bb: $representative_path is NOT gitignored (git check-ignore returned non-zero)"
+    fail=$((fail + 1))
+  fi
+
+  # Negative control: the narrow pattern must not widen to cover the
+  # sibling extension.json, which is still `strict` and must keep aborting
+  # the sync on a local diff (case aa) rather than silently disappearing
+  # from git status.
+  if git -C "$REPO_ROOT" check-ignore -q ".github/copilot/extension.json"; then
+    echo "FAIL  case-bb: sibling extension.json is unexpectedly gitignored (pattern too wide)"
+    fail=$((fail + 1))
+  else
+    echo "PASS  case-bb: sibling extension.json is NOT gitignored (pattern stayed narrow)"
+    pass=$((pass + 1))
   fi
 }
 


### PR DESCRIPTION
Realizes spec 0097 (`specs/0097-copilot-settings-workspace-scope.md`, merged in #653): stops `scripts/sync-from-upstream.sh` from aborting on the transcript-hooks opt-in's designed-in local mutation of `.github/copilot/settings.json`, and stops the resulting `.bak.<timestamp>` file from cluttering `git status`.

Closes #605

## How to read this PR?

Two commits. `dc96637` is the fix itself — four small edits: `.crewrig/core-paths.txt` nests `.github/copilot/settings.json` as `excluded` under the still-`strict` `.github/copilot` parent (same syntax already used for `specs/org` under `specs`); `.gitignore` adds a narrow `.github/copilot/settings.json.bak.*` pattern; `docs/layers.md` gets a row documenting the carve-out; `docs/adr/0001-copilot-cli-integration-strategy.md` gets a short informational addendum (no normative change) explaining why this one file is treated differently from its sibling `extension.json`. `a3464ab` adds regression coverage for the fix in `scripts/tests/test-sync-from-upstream.sh` (cases z, aa, bb), reusing that file's existing synthetic-fixture pattern for nested-`excluded`-under-`strict` scenarios rather than introducing a new test style. Read `specs/0097-copilot-settings-workspace-scope.md` on `main` first for the full normative Requirements this PR realizes.

## How to test this PR?

1. `bash scripts/check-core-paths.sh` — should print `OK: all 50 strict/adopt-on-edit core-paths entries resolve at HEAD.` (the new `excluded` entry is skipped by the phantom-check, per that script's own `[ "$policy" = "excluded" ] && continue` logic).
2. `/opt/homebrew/bin/bash scripts/tests/test-sync-from-upstream.sh` (needs bash >= 4 for `mapfile`; the system default `/bin/bash` 3.2 on macOS fails on pre-existing cases too, unrelated to this diff) — expect `Results: 57/57 passed`, including new cases `z` (settings.json mutation does not abort), `aa` (sibling `extension.json` mutation still aborts), and `bb` (`.gitignore` pattern matches the real `backup_file()` filename shape without widening to the sibling).
3. `/opt/homebrew/bin/bash scripts/tests/test-e2e-gitignore.sh` — expect `6 passed / 0 failed / 0 skipped` (no regression from the `.gitignore` edit).

## Detailed description (for agents)

Friction issue #605 reported that opting into GitHub Copilot CLI transcript hooks during `setup-copilot-interactive.sh` leaves the working tree unable to run `scripts/sync-from-upstream.sh` — the opt-in merges an absolute hook path into the tracked `.github/copilot/settings.json`, and `.crewrig/core-paths.txt` classified the whole `.github/copilot` directory `strict`, so that designed-in mutation (ADR-0001 Discovery finding #8: "the committed settings.json has hooks: [] by design" — the opt-in is what populates it) was indistinguishable from upstream drift. Spec 0097 (#653) established this is a manifest/gitignore maintenance gap, not a design defect, and scoped the fix to exactly four files, explicitly leaving `scripts/setup-copilot-interactive.sh` and the Claude/Gemini setup scripts untouched (both of the latter write only under the operator's home directory and were confirmed unaffected).

This PR is the realization: `.crewrig/core-paths.txt` gains a nested `.github/copilot/settings.json	excluded` line (comment explains the ADR-0001 rationale and cites spec 0097 / issue #605); `.gitignore` gains `.github/copilot/settings.json.bak.*` next to the existing `.github/copilot/settings.local.json` carve-out; `docs/layers.md` documents the new row per `AGENTS.md` → *Core-paths manifest co-maintenance*; `docs/adr/0001-copilot-cli-integration-strategy.md` gets a dated addendum (informational only, mirroring the ADR's existing addendum style). Regression coverage: `scripts/tests/test-sync-from-upstream.sh` case `z` asserts a `.github/copilot/settings.json` mutation no longer aborts the sync and survives the restore pass untouched; case `aa` asserts a mutation confined to sibling `.github/copilot/extension.json` still aborts the sync (proving the carve-out did not silently widen to the whole directory); case `bb` checks the real repo's own `.gitignore` (via `git check-ignore`, since `.gitignore` isn't an input to the script under test) against a representative `settings.json.bak.20260723-203351` filename, confirming the pattern stays narrow and the sibling `extension.json` remains untouched by it.

`docs/cli-matrix.md` is out of scope per the spec — this PR touches neither `.crewrig/core-paths.txt` nor `.gitignore`'s entries in the CLI Matrix Maintenance trigger list, and modifies no `scripts/setup-*.sh` file.