### PR TITLE
🐛 Detect duplicate spec id across files in spec-linter.js

### DIFF
--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -103,12 +103,12 @@ function lintFile(filePath) {
 
     const content = fs.readFileSync(filePath, 'utf8');
     const basename = path.basename(filePath);
+    const isDelta = basename.includes('.delta-');
+    let id;
 
     if (basename === '_template.md' || basename === 'README.md') {
-        return { hasErrors, errors };
+        return { hasErrors, errors, id, isDelta };
     }
-
-    const isDelta = basename.includes('.delta-');
 
     let expectedId = '';
     let expectedSlug = '';
@@ -123,7 +123,7 @@ function lintFile(filePath) {
     const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
     if (!fmMatch) {
         reportError(`Missing YAML frontmatter block`);
-        return { hasErrors, errors };
+        return { hasErrors, errors, id, isDelta };
     }
 
     let fm;
@@ -131,12 +131,12 @@ function lintFile(filePath) {
         fm = yaml.load(fmMatch[1]);
     } catch (e) {
         reportError(`Failed to parse YAML frontmatter: ${e.message}`);
-        return { hasErrors, errors };
+        return { hasErrors, errors, id, isDelta };
     }
 
     if (!fm) {
         reportError(`Frontmatter is empty`);
-        return { hasErrors, errors };
+        return { hasErrors, errors, id, isDelta };
     }
 
     const mandatoryFields = ['id', 'slug', 'status', 'complexity', 'version', 'related-issue'];
@@ -148,6 +148,7 @@ function lintFile(filePath) {
 
     if (fm.id !== undefined) {
         const fmIdStr = typeof fm.id === 'string' ? fm.id : fm.id.toString().padStart(4, '0');
+        id = fmIdStr;
         if (fmIdStr !== expectedId) {
             reportError(`Frontmatter 'id' ("${fmIdStr}") does not match filename prefix ("${expectedId}")`);
         }
@@ -233,7 +234,7 @@ function lintFile(filePath) {
         }
     }
 
-    return { hasErrors, errors };
+    return { hasErrors, errors, id, isDelta };
 }
 
 function run() {
@@ -264,9 +265,11 @@ function run() {
 
     const manifestEntries = loadCorePathsManifest();
 
+    const fileResults = [];
     for (const file of uniqueFiles) {
         if (isExcludedSpecPath(file, manifestEntries)) continue;
-        const { hasErrors, errors } = lintFile(file);
+        const { hasErrors, errors, id, isDelta } = lintFile(file);
+        fileResults.push({ file, id, isDelta });
         if (hasErrors) {
             console.error(`\n[FAIL] ${file}`);
             for (const err of errors) {
@@ -275,7 +278,32 @@ function run() {
             totalErrors++;
         }
     }
-    
+
+    // Cross-file duplicate-`id` check (spec 0098). Groups the already-parsed
+    // `id` from every non-excluded, non-delta file (R4/R5) and reports any
+    // group of size >= 2 as a failure naming every colliding file (R1-R3).
+    // Files whose `id` is `undefined` (frontmatter failed to parse) already
+    // carry their own per-file error above, so they're skipped here rather
+    // than double-reported. Groups of size 1 (or an empty map) satisfy R7 by
+    // construction — no finding is ever emitted for them.
+    const idGroups = new Map();
+    for (const { file, id, isDelta } of fileResults) {
+        if (isDelta || id === undefined) continue;
+        if (!idGroups.has(id)) {
+            idGroups.set(id, []);
+        }
+        idGroups.get(id).push(file);
+    }
+    for (const [id, files] of idGroups) {
+        if (files.length >= 2) {
+            console.error(`\n[FAIL] Duplicate spec id "${id}" across files:`);
+            for (const f of files) {
+                console.error(`  - ${f}`);
+            }
+            totalErrors++;
+        }
+    }
+
     if (totalErrors > 0) {
         console.error(`\nLinting failed: ${totalErrors} files contain errors.`);
         process.exit(1);

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -325,13 +325,31 @@ fi
 # -------------------------------------------------------------------------
 # Case 22 (R9) — two original spec files sharing the same frontmatter `id`
 # but distinct slugs → cross-file duplicate-id failure naming both files,
-# non-zero exit.
+# non-zero exit. R9 requires the failure message to name both colliding
+# files directly — exit code alone (as run_case checks) can't distinguish
+# "failed naming both files" from "failed for an unrelated reason", so this
+# inspects the captured output, mirroring Case 25's technique for the 3-file
+# case.
 # -------------------------------------------------------------------------
 spec22a="0042-collision-a.md"
 spec22b="0042-collision-b.md"
 render_spec "0042" "collision-a" "draft" > "$TMP_ROOT/$spec22a"
 render_spec "0042" "collision-b" "draft" > "$TMP_ROOT/$spec22b"
-run_case "Case 22 — duplicate id across two original specs fails" "$spec22a $spec22b" 1
+
+case22_exit=0
+case22_output=$( ( cd "$TMP_ROOT" && node "$LINTER_JS" $spec22a $spec22b 2>&1 ) ) || case22_exit=$?
+if [ "$case22_exit" -eq 1 ] \
+  && echo "$case22_output" | grep -qF "$spec22a" \
+  && echo "$case22_output" | grep -qF "$spec22b" \
+  && echo "$case22_output" | grep -q 'Duplicate spec id "0042"'; then
+  echo "PASS  Case 22 — duplicate id across two original specs names both files (exit 1)"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 22 — expected exit 1 naming both files and the shared id, got exit $case22_exit"
+  echo "Output:"
+  echo "$case22_output"
+  fail=$((fail + 1))
+fi
 
 # -------------------------------------------------------------------------
 # Case 23 (R10) — a delta-spec file sharing its parent's `id` is NOT a

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -323,6 +323,36 @@ else
 fi
 
 # -------------------------------------------------------------------------
+# Case 22 (R9) — two original spec files sharing the same frontmatter `id`
+# but distinct slugs → cross-file duplicate-id failure naming both files,
+# non-zero exit.
+# -------------------------------------------------------------------------
+spec22a="0042-collision-a.md"
+spec22b="0042-collision-b.md"
+render_spec "0042" "collision-a" "draft" > "$TMP_ROOT/$spec22a"
+render_spec "0042" "collision-b" "draft" > "$TMP_ROOT/$spec22b"
+run_case "Case 22 — duplicate id across two original specs fails" "$spec22a $spec22b" 1
+
+# -------------------------------------------------------------------------
+# Case 23 (R10) — a delta-spec file sharing its parent's `id` is NOT a
+# duplicate-id collision → exit 0.
+# -------------------------------------------------------------------------
+spec23a="0043-parent.md"
+spec23b="0043-parent.delta-01.md"
+render_spec "0043" "parent" "draft" > "$TMP_ROOT/$spec23a"
+render_spec "0043" "parent" "draft" "standard" "" "$(printf "## ADDED\n\n## MODIFIED\n\n## REMOVED")" > "$TMP_ROOT/$spec23b"
+run_case "Case 23 — delta spec sharing parent id is not a duplicate-id failure" "$spec23a $spec23b" 0
+
+# -------------------------------------------------------------------------
+# Case 24 (R11) — all-distinct ids across specs → clean pass, exit 0.
+# -------------------------------------------------------------------------
+spec24a="0044-first.md"
+spec24b="0045-second.md"
+render_spec "0044" "first" "draft" > "$TMP_ROOT/$spec24a"
+render_spec "0045" "second" "draft" > "$TMP_ROOT/$spec24b"
+run_case "Case 24 — distinct ids across specs pass" "$spec24a $spec24b" 0
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -353,6 +353,131 @@ render_spec "0045" "second" "draft" > "$TMP_ROOT/$spec24b"
 run_case "Case 24 — distinct ids across specs pass" "$spec24a $spec24b" 0
 
 # -------------------------------------------------------------------------
+# Case 25 (R2, R3) — three original spec files sharing the same id → the
+# failure names every file in the colliding group, not only the first two
+# encountered. Case 22 only proves the 2-file case; R3 explicitly calls out
+# the 3-or-more case as a distinct requirement, and only checking the exit
+# code (as run_case does) can't prove every path got named, so this case
+# inspects the captured output directly.
+# -------------------------------------------------------------------------
+spec25a="0050-triple-a.md"
+spec25b="0050-triple-b.md"
+spec25c="0050-triple-c.md"
+render_spec "0050" "triple-a" "draft" > "$TMP_ROOT/$spec25a"
+render_spec "0050" "triple-b" "draft" > "$TMP_ROOT/$spec25b"
+render_spec "0050" "triple-c" "draft" > "$TMP_ROOT/$spec25c"
+
+case25_exit=0
+case25_output=$( ( cd "$TMP_ROOT" && node "$LINTER_JS" $spec25a $spec25b $spec25c 2>&1 ) ) || case25_exit=$?
+if [ "$case25_exit" -eq 1 ] \
+  && echo "$case25_output" | grep -qF "$spec25a" \
+  && echo "$case25_output" | grep -qF "$spec25b" \
+  && echo "$case25_output" | grep -qF "$spec25c"; then
+  echo "PASS  Case 25 — three-way id collision names every colliding file (exit 1)"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 25 — expected exit 1 naming all three files, got exit $case25_exit"
+  echo "Output:"
+  echo "$case25_output"
+  fail=$((fail + 1))
+fi
+
+# -------------------------------------------------------------------------
+# Case 26 (R5, cross-file) — a spec file excluded by the core-paths manifest
+# (mirrors Case 20's specs/experimental fixture) shares its id with a real,
+# non-excluded spec. The manifest exclusion must be applied before the
+# fileResults accumulation that feeds the new duplicate-id check, not only
+# in the old per-file loop — so this must NOT be reported as a collision.
+# -------------------------------------------------------------------------
+SCENARIO26_ROOT="$TMP_ROOT/scenario26"
+mkdir -p "$SCENARIO26_ROOT/specs/experimental"
+cp "$ROOT_DIR/.markdownlintrc" "$SCENARIO26_ROOT/"
+ln -s "$ROOT_DIR/node_modules" "$SCENARIO26_ROOT/node_modules"
+render_spec "0071" "real" "draft" > "$SCENARIO26_ROOT/specs/0071-real.md"
+render_spec "0071" "twin" "draft" > "$SCENARIO26_ROOT/specs/experimental/0071-twin.md"
+
+write_core_paths_fixture "$TMP_ROOT/fixture-manifest-26" $'specs/experimental\texcluded\n'
+
+case26_exit=0
+case26_output=$( ( cd "$SCENARIO26_ROOT" && CREWRIG_REPO_DIR="$TMP_ROOT/fixture-manifest-26" node "$LINTER_JS" specs 2>&1 ) ) || case26_exit=$?
+if [ "$case26_exit" -eq 0 ] && ! echo "$case26_output" | grep -q "Duplicate spec id"; then
+  echo "PASS  Case 26 — manifest-excluded file sharing an id with a real spec is not a duplicate (R5)"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 26 — expected exit 0 with no duplicate-id finding, got exit $case26_exit"
+  echo "Output:"
+  echo "$case26_output"
+  fail=$((fail + 1))
+fi
+
+# Negative control for Case 26: same fixture, no manifest override → falls
+# back to the real repo's .crewrig/core-paths.txt, which does not classify
+# specs/experimental as excluded → the id collision IS reported. Proves
+# Case 26 passes because of the exclusion applying to the new check, not
+# because the check is silently broken.
+case26b_exit=0
+case26b_output=$( ( cd "$SCENARIO26_ROOT" && node "$LINTER_JS" specs 2>&1 ) ) || case26b_exit=$?
+if [ "$case26b_exit" -eq 1 ] && echo "$case26b_output" | grep -q 'Duplicate spec id "0071"'; then
+  echo "PASS  Case 26b — negative control: without the exclusion override the 0071 collision is reported"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 26b — expected exit 1 reporting the 0071 collision, got exit $case26b_exit"
+  echo "Output:"
+  echo "$case26b_output"
+  fail=$((fail + 1))
+fi
+
+# -------------------------------------------------------------------------
+# Case 27 — a file whose frontmatter fails to parse (own per-file error) must
+# NOT leak a stale/fallback `id` into the cross-file comparison. Regression
+# guard: if a future change ever defaulted `id` to the filename-derived
+# prefix on a parse failure, this file (filename-prefixed "0072", same as
+# spec27b's real id) would spuriously collide with spec27b. Exit code alone
+# can't distinguish "failed for its own YAML error" from "failed AND wrongly
+# flagged as a duplicate", so this inspects the output for the absence of
+# the duplicate-id message.
+# -------------------------------------------------------------------------
+spec27a="0072-broken.md"
+spec27b="0072-good.md"
+cat <<'EOF' > "$TMP_ROOT/$spec27a"
+---
+id: "0072
+slug: broken
+status: draft
+complexity: standard
+version: 1.0.0
+related-issue: 1
+---
+
+# Title
+
+## Intent
+
+## Requirements
+
+## Scenarios
+
+## Out of scope
+
+## Open questions
+EOF
+render_spec "0072" "good" "draft" > "$TMP_ROOT/$spec27b"
+
+case27_exit=0
+case27_output=$( ( cd "$TMP_ROOT" && node "$LINTER_JS" $spec27a $spec27b 2>&1 ) ) || case27_exit=$?
+if [ "$case27_exit" -eq 1 ] \
+  && echo "$case27_output" | grep -q "Failed to parse YAML frontmatter" \
+  && ! echo "$case27_output" | grep -q "Duplicate spec id"; then
+  echo "PASS  Case 27 — unparseable frontmatter does not leak a stale id into the cross-file check"
+  pass=$((pass + 1))
+else
+  echo "FAIL  Case 27 — expected exit 1 from the per-file YAML error only, got exit $case27_exit"
+  echo "Output:"
+  echo "$case27_output"
+  fail=$((fail + 1))
+fi
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Adds a cross-file duplicate spec-`id` check to `scripts/lib/spec-linter.js`, per `specs/0098-spec-linter-cross-file-id-uniqueness.md`. This closes the friction cluster reported in #606, where two spec files (`specs/0051-mempalace-wakeup-parity.md` and `specs/0051-antigravity-cli-support.md`) were once able to silently share the same frontmatter `id` because the linter only checked a file's `id` against its own filename, never against every other spec file.

## How to read this PR?

Read in this order:

1. `specs/0098-spec-linter-cross-file-id-uniqueness.md` — the spec (already merged via spec-PR #655), for the requirements (R1-R11) this diff satisfies.
2. `scripts/lib/spec-linter.js` — the implementation. `lintFile()` now threads `id` and `isDelta` through every one of its five return points instead of computing `isDelta` locally and dropping both on return, so `run()`'s per-file loop can accumulate `{ file, id, isDelta }` per file without a second file read or a second YAML parse. After the loop, a new block groups the accumulated `id`s (skipping `isDelta` files and files whose `id` came back `undefined` because frontmatter parsing already failed and reported its own per-file error) and reports any group of 2+ files as a `[FAIL] Duplicate spec id ... across files:` block, naming every file, and increments the existing `totalErrors` counter so the existing `process.exit(1)` path is reused as-is.
3. `scripts/tests/test-spec-linter.sh` — the regression coverage, Cases 22-27 (added across the two commits on this branch — see below).

The non-obvious design decision: the manifest exclusion (`isExcludedSpecPath`) is applied once, before `lintFile()` is ever called in the existing per-file loop — nothing new was added for the cross-file pass to also respect it, because an excluded file simply never enters `fileResults` in the first place. Case 26/26b exercise this directly, including a negative control that proves the exclusion is actually doing the work and not just coincidentally not firing.

## How to test this PR?

Prerequisites: Node.js (repo's existing toolchain), no new dependencies.

1. Run the full spec-linter regression suite:
   ```
   bash scripts/tests/test-spec-linter.sh
   ```
   Expected: `Results: 28 passed, 0 failed` (verified locally on this branch).
2. Run the linter against the real `/specs/` tree to confirm no false positive on the current repository state:
   ```
   node scripts/lib/spec-linter.js specs
   ```
   Expected: `Linting passed!`, exit 0 (verified locally on this branch).
3. To see the new check fire, copy any existing spec file to a new filename under `specs/` without changing its frontmatter `id`, then re-run step 2 — expect a `[FAIL] Duplicate spec id "..." across files:` block naming both files and a non-zero exit.

## Detailed description (for agents)

This branch carries two commits, both against `scripts/lib/spec-linter.js` and `scripts/tests/test-spec-linter.sh`:

**Commit 1 (`9232784`)** — the implementation plus initial regression coverage:
- In `lintFile()`: hoists `const isDelta = basename.includes('.delta-');` earlier and adds `let id;`, so both are available on every return path, including the early ones (`_template.md`/`README.md`, filename-regex mismatch, frontmatter-parse failure, empty frontmatter). Assigns `id = fmIdStr` inside the existing `fm.id !== undefined` block — the only place the frontmatter `id` is normalized today — rather than re-deriving it. All five `lintFile()` return points now return `{ hasErrors, errors, id, isDelta }`.
- In `run()`: accumulates `fileResults.push({ file, id, isDelta })` per file inside the existing per-file loop, then — after that loop — builds a `Map` keyed by `id`, skipping `isDelta` files (R4) and `id === undefined` files (already reported per-file), and reports any group of 2+ colliding files (R1-R3), incrementing the existing `totalErrors` counter so R8 (non-zero exit) is satisfied via the pre-existing `if (totalErrors > 0) { ...; process.exit(1); }` block with no new exit path.
- Adds Cases 22-24 to `scripts/tests/test-spec-linter.sh`: Case 22 (R9, two original specs sharing an `id` fail), Case 23 (R10, a delta sharing its parent's `id` does not fail), Case 24 (R11, all-distinct ids pass).

**Commit 2 (`9183ad7`)** — additional regression coverage added by an independent `tester`-agent verification pass, closing three gaps the initial R9-R11 cases didn't reach:
- Case 25 (R2, R3) — a 3-way `id` collision, asserting by output inspection (not just exit code) that every one of the three colliding files is named, not only the first two encountered.
- Case 26 / 26b (R5, applied to the new cross-file check specifically, not just the pre-existing per-file loop) — a manifest-excluded spec file colliding with a real one is not reported as a duplicate (Case 26), with a negative control (Case 26b) that removes the manifest override and confirms the same fixture *does* report the collision without it — proving Case 26 passes because of the exclusion, not because the check is silently inert.
- Case 27 — a file with unparseable frontmatter must not leak a stale or fallback `id` into the cross-file comparison.

Per the commit message on `9183ad7`, each of these three cases was verified to fail against a deliberately reintroduced version of the bug it guards, before being kept.

**Verification performed on this branch**: `bash scripts/tests/test-spec-linter.sh` → `Results: 28 passed, 0 failed`; `node scripts/lib/spec-linter.js specs` → `Linting passed!`, exit 0. Both re-run and confirmed as part of composing this PR.

**Process context**: PLAN authored and cold-reviewed (verdict APPROVE, no findings) as comments on issue #606:
- Plan: https://github.com/crewrig/crewrig/issues/606#issuecomment-5062357661
- Plan review: https://github.com/crewrig/crewrig/issues/606#issuecomment-5062408596

Spec 0098 was merged to `main` via spec-PR #655 ahead of this implementation PR, per the Spec-PR workflow's ordering rule.

Closes #606
