### PR TITLE
📝 Add spec 0099 — plannotator gate contrast-safety guidance

### DIFF
--- a/specs/0099-plannotator-gate-contrast.md
+++ b/specs/0099-plannotator-gate-contrast.md
@@ -1,0 +1,140 @@
+---
+id: "0099"
+slug: plannotator-gate-contrast
+status: draft
+complexity: small
+related-issue: 608
+version: 1.0.0
+---
+
+# Contrast-safety guidance for caller-built plannotator gate presentations
+
+## Intent
+
+When a CrewRig validation gate runs through the `plannotator` backend and
+the situation obliges the caller to construct a bespoke rich presentation
+of the artifact — rather than hand the review viewer a raw Markdown or
+plain-text file — the person performing the review must always see
+legible, sufficiently-contrasted content. Today the `user-validate` skill
+offers no guidance on keeping such a caller-built presentation readable
+across the review viewer's possible host themes, and that gap has already
+surfaced to a real user as black text on a black background during a live
+spec-approval gate. This spec closes the gap: the skill's
+`plannotator`-backend guidance states the contrast-safety expectations a
+caller-built presentation must meet so the reviewing user is never shown
+unreadable low-contrast content, whatever theme the viewer places behind
+it.
+
+## Requirements
+
+1. The `user-validate` skill SHALL carry contrast-safety guidance within
+   the existing `plannotator` backend section of
+   `artifacts/library/skills/user-validate/SKILL.md`, co-located with the
+   `plannotator annotate … --gate` invocation step that the guidance
+   qualifies.
+2. The guidance SHALL apply specifically to the case where a caller
+   constructs a bespoke HTML presentation of the artifact before invoking
+   the review viewer, and SHALL distinguish that case from passing a raw
+   Markdown or plain-text artifact file straight through.
+3. The guidance SHALL state the rationale for the requirement: the review
+   viewer renders the document body but does not reliably honor a
+   document-`<head>`-scoped `<style>` block, and may place the content on
+   a dark host surface — so colors declared only in the head can surface
+   as unreadable low-contrast content such as dark text on a dark
+   background.
+4. The guidance SHALL require that every color and contrast declaration on
+   which the presentation's readability depends be self-contained inline
+   on the content wrapper element and on the document `<body>` element,
+   rather than declared only inside a `<head>` `<style>` block.
+5. The guidance SHALL direct that any `<style>` block used for
+   supplementary, non-critical styling be placed inside `<body>` rather
+   than in `<head>`.
+6. The guidance SHALL direct the caller-built document to declare a light
+   color-scheme hint (`<meta name="color-scheme" content="light only">`)
+   so the host does not place light-assuming content on a dark surface.
+7. The guidance SHALL include at least one concrete example of a compliant
+   inline color/contrast declaration, so a caller can apply the
+   requirement without inferring the shape from prose alone.
+8. The guidance SHALL state that the contrast-safety requirement does NOT
+   apply when the caller passes a raw Markdown or plain-text artifact file
+   directly to the review viewer, because in that case the viewer's own
+   renderer is responsible for readability.
+
+## Scenarios
+
+**Scenario:** A caller follows the guidance and the review renders legibly
+
+```text
+Given the `plannotator`-backend guidance in the `user-validate` skill
+      states the contrast-safety requirement
+And   a caller must build a bespoke HTML presentation for a validation
+      gate because a `pedagogy` or `illustration` option is active
+When  the caller declares the presentation's background and text colors
+      inline on the `<body>` and content wrapper as the guidance directs
+Then  the reviewing user sees legible, sufficiently-contrasted content
+      regardless of the theme the review viewer places behind it
+```
+
+**Scenario:** A head-only stylesheet is recognized as non-compliant
+
+```text
+Given the guidance requires readability-critical color declarations to be
+      self-contained inline rather than only in a `<head>` `<style>` block
+When  a caller-built presentation declares its light background only inside
+      a `<head>` stylesheet
+Then  an agent or reviewer applying the guidance identifies the
+      presentation as non-compliant before it reaches the user, avoiding
+      the black-text-on-black-background outcome observed during the spec
+      0083 validation gate
+```
+
+**Scenario:** Raw Markdown passthrough carries no contrast obligation
+
+```text
+Given the guidance scopes the contrast-safety requirement to caller-built
+      HTML presentations only
+When  a caller passes a raw Markdown artifact file directly to the review
+      viewer without building a bespoke presentation
+Then  the caller is not required by the guidance to inject inline contrast
+      styling, and the viewer's own renderer remains responsible for
+      readability
+```
+
+## Out of scope
+
+- Any change to the `plannotator` tool itself — its review viewer, its
+  handling (dropping or overriding) of `<head>`-scoped stylesheets, or its
+  choice of host background. This spec designs caller guidance around the
+  viewer's behavior as a fixed constraint; it does not ask the viewer to
+  change.
+- The `internal` backend of `user-validate`. It realizes the gate through
+  `AskUserQuestion` (or the host CLI's structured-prompt equivalent) and
+  has no browser or HTML surface, so contrast-safety of caller-built HTML
+  does not apply to it.
+- Any change to the skill's invocation command, its dual-validation rule
+  (exit status plus gate JSON), its decision mapping, or the semantics of
+  the `translate` / `pedagogy` / `illustration` cross-cutting options. This
+  spec adds contrast-safety guidance only.
+- A programmatic or automated contrast checker — for example a linter that
+  measures a WCAG contrast ratio on caller-built HTML. This spec mandates
+  written guidance for the human or agent authoring the presentation, not
+  an automated enforcement mechanism.
+- Prescribing a specific numeric contrast ratio or an exact color palette.
+  The guidance mandates self-contained, contrast-safe declarations and an
+  illustrative example; it does not fix a particular ratio or a set of hex
+  values.
+- Duplicating the guidance into every skill that might request a validation
+  gate. Callers reach the review viewer through `user-validate`, which owns
+  the `plannotator` invocation, so the guidance is centralized there.
+- Code changes of any kind. This is a documentation-only edit to one
+  `SKILL.md`; the only mechanical obligation beyond the prose is the
+  `metadata.provenance.version` bump that the project's version-bump
+  convention already requires of any modified skill source.
+
+## Open questions
+
+None outstanding. The boundary decisions above — leaving the `plannotator`
+viewer unchanged, excluding the `internal` backend and the raw-passthrough
+case, and declining to mandate a numeric contrast ratio or an automated
+checker — were each resolved by explicit exclusion during authoring rather
+than left open.


### PR DESCRIPTION
Qualifies the WHAT for contrast-safety guidance in the `user-validate` skill's `plannotator` backend, requested by the friction report in `#608`. Adds `specs/0099-plannotator-gate-contrast.md`, no implementation.

## How to read this PR?

Single-file diff: `specs/0099-plannotator-gate-contrast.md`. Read `## Intent` for the WHAT (a caller-built HTML gate presentation rendered black-on-black during the spec 0083 SPECS gate because a `<head>`-scoped stylesheet was not honored by the `plannotator` review viewer), `## Requirements` (8 SHALL statements) for the testable contract, `## Scenarios` for the three Given/When/Then cases (compliant presentation, non-compliant head-only stylesheet caught, raw-Markdown passthrough carries no obligation), and `## Out of scope` for the deliberate exclusions — notably that this leaves the `plannotator` tool itself untouched and mandates no automated contrast checker or numeric ratio.

## How to test this PR?

1. `npm install` at repo root (or in a scratch checkout) to get `markdownlint`/`js-yaml`/`semver` available.
2. `node scripts/lib/spec-linter.js specs/0099-plannotator-gate-contrast.md` — expect `Linting passed!`.
3. Optionally `task spec:lint` to confirm the full `/specs/` tree still lints clean with the new file present.

## Detailed description (for agents)

- **Added:** `specs/0099-plannotator-gate-contrast.md` — frontmatter `id: "0099"`, `slug: plannotator-gate-contrast`, `status: draft`, `complexity: small`, `related-issue: 608`, `version: 1.0.0`. `interaction-mode` intentionally omitted (added at the `approved` transition per `docs/spec-format.md`).
- **Scope:** specifies contrast-safety guidance to be added to `artifacts/library/skills/user-validate/SKILL.md`'s existing `## Backend: plannotator (opt-in, rich review)` section — self-contained inline color/contrast declarations on the content wrapper and `<body>`, supplementary `<style>` inside `<body>` rather than `<head>`, a `<meta name="color-scheme" content="light only">` hint, and a concrete compliant example — scoped specifically to the case where a caller constructs a bespoke HTML presentation (as opposed to passing a raw Markdown/plain-text artifact through, which the `plannotator` viewer's own renderer already handles).
- **Explicitly excluded:** any change to the `plannotator` tool/viewer itself; the `internal` backend (no browser/HTML surface); the invocation command, dual-validation rule, decision mapping, or `translate`/`pedagogy`/`illustration` semantics; an automated/programmatic contrast checker; a prescribed numeric contrast ratio or color palette.
- **Not touched:** `artifacts/library/skills/user-validate/SKILL.md` itself — implementation is a later PR (per the Spec-PR workflow's ordering rule; this spec-PR contains exactly one new file under `/specs/` and nothing else).
- **Duplicate-check performed:** before authoring, and again after a SPECS-gate reviewer flagged "feels like this might already be handled," the repository was searched for any existing contrast/color-scheme guidance tied to the `plannotator` gate path (grep across `*.md` for `color-scheme`, `contrast-safe`, `black-on-black`, head-scoped styling; both merged PRs for spec 0083, #575 and #583). No prior coverage exists — the only `color-scheme`/`contrast` hits in the repository concern the general-purpose `frontend`/`designer` web-accessibility skills, unrelated to the `plannotator` gate viewer. This is a genuinely new gap, unlike the sibling ticket `#607` (confirmed duplicate of `#602`, closed without a spec).
- **Issue reference:** intentionally phrased as "Related `#608`" rather than a closing directive — `#608` is the ticket's shared logbook issue (auto-generated by the Harness Curator, functions as the logbook per `AGENTS.md` → Logbook Issues → Rule A), so per the Spec-PR workflow's Independence rule only the implementation PR carries the closing keyword for it, once PLAN/DEV/REVIEW complete.

Related #608.