### PR TITLE
✨ Add contrast-safety guidance to user-validate plannotator backend

### DIFF
--- a/artifacts/library/skills/user-validate/SKILL.md
+++ b/artifacts/library/skills/user-validate/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.0"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read
@@ -109,6 +109,55 @@ missing; the `internal` backend is the guaranteed floor on every CLI.
    | exit `0` + `{"decision":"approved"}` | `approved` |
    | exit `0` + `{"decision":"annotated","feedback":"…"}` | `changes-requested`, carrying `feedback` to the upstream stage |
    | `{"decision":"dismissed"}`, OR non-zero exit, OR absent/malformed stdout | `rejected` — surface the situation, return to caller |
+
+### Contrast-safety for caller-built presentations
+
+**Scope (spec 0099 R2).** This guidance applies **only** when you build a
+bespoke HTML presentation of the artifact before handing it to the review
+viewer — for example because an active `pedagogy` or `illustration` option
+obliges a richer rendering than the raw file. It does **not** apply when you
+pass a raw Markdown or plain-text artifact file straight through (spec 0099
+R2/R8): on that passthrough path the viewer's own renderer owns readability,
+and you MUST NOT inject inline contrast styling.
+
+**Why (spec 0099 R3).** The review viewer renders the document body but does
+**not** reliably honor a `<head>`-scoped `<style>` block, and it may place the
+content on a **dark host surface**. Colors declared only in the head can
+therefore surface as unreadable low-contrast content — the black-text-on-black-
+background outcome observed during a live spec-approval gate.
+
+**Rules for a caller-built HTML presentation:**
+
+- **Inline every readability-critical declaration (spec 0099 R4).** Each color
+  and contrast declaration the presentation's readability depends on SHALL be
+  self-contained **inline** — on the content wrapper element **and** on the
+  document `<body>` element — never declared only inside a `<head>` `<style>`
+  block.
+- **Keep supplementary styling in the body (spec 0099 R5).** Any `<style>`
+  block used for non-critical, supplementary styling SHALL live inside
+  `<body>`, not in `<head>`.
+- **Declare a light color-scheme hint (spec 0099 R6).** The document SHALL
+  declare `<meta name="color-scheme" content="light only">` so the host does
+  not place light-assuming content on a dark surface.
+
+**Compliant example (spec 0099 R7).** Background and text colors are inline on
+both `<body>` and the content wrapper, the color-scheme hint is present, and no
+readability-critical color lives in the head:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta name="color-scheme" content="light only">
+  </head>
+  <body style="background:#ffffff; color:#111111;">
+    <main style="background:#ffffff; color:#111111; padding:1.5rem;">
+      <h1 style="color:#111111;">Approve this plan for DEV?</h1>
+      <p style="color:#111111;">…artifact content…</p>
+    </main>
+  </body>
+</html>
+```
 
 ## Backend: `internal` (default floor)
 


### PR DESCRIPTION
Teach the `user-validate` skill's `plannotator` backend how to keep a caller-built HTML presentation legible whatever theme the review viewer places behind it, closing the friction cluster in #608 where a spec-approval gate rendered black-text-on-black-background. This is the DEV-stage implementation of spec `0099-plannotator-gate-contrast` (merged via spec-PR #657); it adds one documentation subsection and bumps the skill version, with no behavioral or CLI-specific code change.

## How to read this PR?

Single-file diff — read `artifacts/library/skills/user-validate/SKILL.md`:

- **Frontmatter** — `metadata.provenance.version` bumps `1.1.0` → `1.2.0` (MINOR: additive guidance), per the Version Bump Convention.
- **New `### Contrast-safety for caller-built presentations` subsection** — inserted inside the existing `## Backend: plannotator` section, immediately after the exit-plus-stdout decision table, so it sits with the `plannotator annotate … --gate --json` invocation step it qualifies.

Non-obvious decisions worth noting while reading:

- The guidance is **scoped to caller-built HTML only** (spec 0099 R2). The raw-Markdown / plain-text passthrough path is explicitly exempted — there the viewer's own renderer owns readability, so injecting inline contrast styling would be wrong.
- The three rules trace one-to-one to spec requirements: inline every readability-critical color on both `<body>` and the content wrapper (R4), keep supplementary `<style>` in `<body>` not `<head>` (R5), and declare `<meta name="color-scheme" content="light only">` (R6). The rationale (R3) records the observed failure mode: the viewer does not reliably honor `<head>`-scoped `<style>` and may use a dark host surface.
- A single worked compliant example (R7) shows the end state rather than describing it abstractly.

Upstream context, if you want it — all comments on #608: `## PLAN — issue #608 (spec 0099)` and its cold-reviewed `## PLAN review — issue #608` (verdict APPROVE, zero findings).

## How to test this PR?

This is a documentation-only change to a skill body; there is no runtime behavior to exercise. Verify as follows:

1. **Inspect the diff** — `git show 07164f2` shows exactly one file changed: `1 file changed, 50 insertions(+), 1 deletion(-)`.
2. **Confirm the version bump landed with the content** (CI enforces this via `scripts/check-skill-versions.sh`):
   ```sh
   task check-skill-versions
   ```
   Expected: pass — the modified source carries a bumped `provenance.version` (`1.1.0` → `1.2.0`).
3. **Confirm the build produces no tracked diff.** `bash scripts/build-components.sh` was already run by the developer and produced **no tracked output diff** — this is a `library`-tier skill, which compiles to the git-ignored `dist/library/` tree, so no compiled artifact appears in the changeset. Re-running the build and then `git status` should show a clean working tree:
   ```sh
   bash scripts/build-components.sh && git status
   ```
   Expected: `nothing to commit, working tree clean`.

## Detailed description (for agents)

**Scope.** One file modified: `artifacts/library/skills/user-validate/SKILL.md`. No other file is touched.

**Change 1 — version bump (frontmatter).**
`metadata.provenance.version` changed from `1.1.0` to `1.2.0`. MINOR bump because the change is purely additive (a new guidance subsection); no existing contract field, backend, or decision-mapping semantics were altered.

**Change 2 — new subsection (body).**
Added `### Contrast-safety for caller-built presentations` inside the existing `## Backend: plannotator` section, placed after the exit-code/stdout decision-mapping table so it co-locates with the `plannotator annotate <file> --gate --json` invocation step it qualifies. The subsection contains:

- **Scope (spec 0099 R2/R8)** — applies only when the caller builds a bespoke HTML presentation (e.g. because an active `pedagogy` or `illustration` option obliges a richer rendering than the raw file). Explicitly does **not** apply to the raw-Markdown / plain-text passthrough path, and states that the caller MUST NOT inject inline contrast styling there.
- **Rationale (spec 0099 R3)** — records why: the review viewer renders the document body but does not reliably honor a `<head>`-scoped `<style>` block, and may place content on a dark host surface, producing the unreadable low-contrast outcome observed during a live spec-approval gate.
- **Three rules** — inline every readability-critical color/contrast declaration on both the content wrapper **and** `<body>`, never only in a `<head>` `<style>` (R4); keep any supplementary `<style>` inside `<body>`, not `<head>` (R5); declare `<meta name="color-scheme" content="light only">` (R6).
- **Compliant example (spec 0099 R7)** — one worked `<!doctype html>` snippet with background/text colors inline on both `<body>` and the content wrapper, the color-scheme hint present, and no readability-critical color in the head.

**Nature of the change.** Documentation-only, additive, and CLI-agnostic — it adds guidance prose to a `library`-tier skill source with no change to any CLI-specific integration point. The `library` tier compiles to the git-ignored `dist/library/` tree, so the regenerated build carries no tracked output diff.

**CLI-matrix consult (AGENTS.md → CLI Matrix Maintenance).** This PR touches `artifacts/**`, which is on the trigger surface, so `docs/cli-matrix.md` was consulted (rows 27 / 27b, `user-validate` / `plannotator`). **No-op** — those rows already document the two facts this change rests on (the `plannotator` viewer is browser-uniform across all four CLIs, and `user-validate` builds to the git-ignored `dist/library/` tree), so no row or cell edit is warranted; this guidance introduces no new integration point and no parity gap.

**Provenance.** Implements spec `specs/0099-plannotator-gate-contrast.md` (merged via spec-PR #657). PLAN authored and cold-reviewed on #608 (verdict APPROVE, zero findings) before DEV.

Closes #608.

