### PR TITLE
📝 Fold draft→approved status transition into the spec-PR commit

### DIFF
--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -192,7 +192,7 @@ table below is the contract.
 | `status` | Trigger | Authority | Accompanying artifact |
 |---|---|---|---|
 | `draft` | Spec file opened in the working branch | Spec author (human or `spec-author` skill) | Spec file in the worktree, no PR yet |
-| `approved` | Spec PR merged on `main` | Spec reviewer (per the interaction mode declared in frontmatter) | Merged spec PR + logbook comment recording the approval |
+| `approved` | Spec PR merged on `main` | Spec reviewer (per the interaction mode declared in frontmatter) | Merged spec PR — its own (squash) commit already carries `status: approved`, so no separate status-transition PR is opened — plus a logbook comment recording the approval |
 | `implemented` | Implementation PR for `related-issue` merged on `main` | Implementation team's `pr-logbook` | Merged implementation PR + logbook closure comment |
 | `archived` | Related issue closed without implementation (`won't fix`, duplicate, abandoned) | Ticket closer | Logbook comment explaining the archival |
 | `superseded` | A newer spec replaces this one (often through a `spec`-class loop that grows beyond a delta) | Author of the superseding spec | `superseded-by` field set; superseding spec exists with its own id |
@@ -207,17 +207,59 @@ The append-only rule (see *Delta-spec convention*) governs a spec's
 `## Scenarios`, `## Out of scope`, `## Open questions`) and the identifying
 frontmatter fields (`id`, `slug`). It does **not** freeze the
 lifecycle-tracking metadata: the `status` and `superseded-by` fields are
-*expected* to change after merge, since the table above defines transitions
-that occur once the spec PR, the implementation PR, or a superseding spec
-lands.
+*expected* to change, since the table above defines transitions the spec
+undergoes over its life.
 
-Such a transition SHALL be recorded by a **metadata-only edit** to the
-merged spec's frontmatter. The authority named in the table above changes
-the `status` field (and sets `superseded-by` when moving to `superseded`)
-and touches nothing else — no body line, no `id`, no `slug`, no `version`.
-A diff that alters any normative content under cover of a status bump is a
-violation. The `version` field stays immutable on the original after merge;
-the cumulative version lives on the highest-numbered delta (per
+Those transitions divide into two kinds, recorded differently. The first,
+`draft` → `approved`, is recorded **inside the spec-PR's own commit**, so the
+spec lands on `main` already carrying `status: approved`. Every **later**
+transition — `approved` → `implemented`, `→ superseded`, `→ archived` — is
+recorded **after** the spec has merged, by a metadata-only edit to the merged
+spec's frontmatter. The two cases are defined in turn below.
+
+**Recording the initial `draft` → `approved` transition (in the spec-PR).**
+The spec-PR merge **is** the approval event: the merge-authorization request
+that a maintainer grants just before a spec-PR merges is itself the decision
+that `status: approved` records. Because that gate fires in **every**
+interaction mode — `FULL`, `INTERMEDIATE`, `MINIMAL`, and `AUTO` alike — this
+rule applies independently of mode; no mode lacks a real approval event to
+record. The transition SHALL be recorded **only after** the spec-PR's
+merge-authorization approval has been granted; recording `status: approved`
+ahead of that gate is a violation, because a recorded `approved` status must
+reflect an approval decision that has actually been made, not one presumed
+before its authorization. The edit stays **metadata-only** in the sense the
+next paragraph defines: it sets `status` to `approved` and, when
+`interaction-mode` was omitted while the spec was `draft`, sets
+`interaction-mode` to the mode the spec was qualified under (the frontmatter
+schema requires it to be present once a spec is `approved`); it touches no
+body line, no `id`, no `slug`, and no `version`. Recorded this way, the merged
+spec-PR carries `status: approved` at the moment it lands on `main` — a merged
+spec is never at once merged and still `draft` — and **no** separate,
+post-merge, metadata-only pull request is required to record the approval.
+
+*Merge mechanic.* Strictly **after** the merge-authorization gate is granted
+and strictly **before** running `gh pr merge --squash`, on the spec-PR branch
+(`spec/<NNNN>-<slug>`) edit the spec's frontmatter (`status: draft` →
+`status: approved`, adding `interaction-mode` if it was omitted during
+`draft`), create a **new commit** — not `git commit --amend` — then `git push`
+and only then `gh pr merge --squash`. A new commit rather than an amend
+because the spec-PR squash-merges, so both routes collapse to the same single
+commit on `main` carrying `status: approved`; a new commit needs only a plain
+`git push`, whereas an amend would force `git push --force-with-lease` and
+risk clobbering a concurrent reviewer or CI push on the shared branch.
+
+**Recording a post-merge transition (every other transition).** Every
+transition other than `draft` → `approved` — `approved` → `implemented`,
+`→ superseded`, `→ archived` — is triggered by a genuinely later, separate
+event (an implementation PR merging, a superseding spec landing, a ticket
+closed without implementation) that cannot be folded into the spec-PR that
+introduces the spec, and so is recorded **after** merge by a **metadata-only
+edit** to the merged spec's frontmatter. The authority named in the table
+above changes the `status` field (and sets `superseded-by` when moving to
+`superseded`) and touches nothing else — no body line, no `id`, no `slug`, no
+`version`. A diff that alters any normative content under cover of a status
+bump is a violation. The `version` field stays immutable on the original after
+merge; the cumulative version lives on the highest-numbered delta (per
 *Versioning*).
 
 This carve-out admits lifecycle metadata. A second, equally narrow carve-out


### PR DESCRIPTION
This PR folds the initial `draft` → `approved` spec status transition into the spec-PR's own commit, so a merged spec lands on `main` already carrying `status: approved` instead of requiring a second, metadata-only follow-up PR. It rewrites the *Recording a status transition* section of `docs/spec-format.md` into two documented cases and updates the *Lifecycle states* table's `approved` row to match.

## How to read this PR?

A single file changed — `docs/spec-format.md` (one file, `54 insertions(+)`, `12 deletions(-)` per `git show 45506fb --stat`). Read the two hunks in order:

1. **The *Lifecycle states* table, `approved` row** (first hunk) — the one-line contract change. The "Accompanying artifact" cell now states that the merged spec-PR's own (squash) commit already carries `status: approved`, so no separate status-transition PR is opened. The Trigger and Authority cells are unchanged.
2. **The *Recording a status transition* section rewrite** (second hunk) — the section is split from one case into two: (a) the initial `draft` → `approved` transition, recorded inside the spec-PR's own commit; (b) every later transition (`approved` → `implemented`/`superseded`/`archived`), which stays a post-merge metadata-only edit.

Non-obvious decisions to note while reading:

- **Mode-invariance.** The `draft` → `approved` rule is stated to apply in all four interaction modes (`FULL`/`INTERMEDIATE`/`MINIMAL`/`AUTO`) because the merge-authorization gate fires in every mode — no mode lacks a real approval event to record.
- **Ordering guard.** The transition SHALL be recorded *only after* the merge-authorization approval is granted; recording `approved` ahead of that gate is defined as a violation.
- **New commit, not amend.** The documented merge mechanic creates a new commit rather than `git commit --amend`: under squash-merge both routes collapse to the same single commit on `main`, but a new commit needs only a plain `git push`, whereas an amend would force `git push --force-with-lease` and risk clobbering a concurrent push on the shared spec-PR branch.

One fitting irony, worth a sentence: this ticket (#610) is itself an instance of the overhead it eliminates. Specs 0099, 0100, and 0101 — all processed in this same session — still show the old two-PR-shaped world: each merged spec-PR left its spec at `status: draft` with no follow-up transition PR ever opened in practice (the separate-PR step was already being informally skipped), and this PR is what makes that skip *correct by rule* going forward instead of a silent deviation.

## How to test this PR?

This is a process-documentation change — no code, no build artifact, no CLI-facing surface. Verify the contract holds:

1. **Scope is one file.** `git show 45506fb --stat` → exactly `docs/spec-format.md`, `1 file changed, 54 insertions(+), 12 deletions(-)`.
2. **Markdown lint is clean.** `task lint-markdown` (runs `markdownlint` over `**/*.md`) — expected: pass.
3. **No version bump required.** `task check-skill-versions` — expected: pass. `docs/spec-format.md` is a process doc, not a `artifacts/core/skills/*/SKILL.md` or `artifacts/core/agents/*/AGENT.md` source, so the rule in `AGENTS.md` → *Version Bump Convention* does not apply.
4. **No CLI-matrix update required.** `docs/spec-format.md` is not on the trigger-path list in `AGENTS.md` → *CLI Matrix Maintenance*, so `docs/cli-matrix.md` is untouched by design.
5. **Read the two cases end-to-end** in the rendered `docs/spec-format.md` and confirm they partition every status transition without overlap: `draft` → `approved` recorded in-PR; every other transition recorded post-merge.

## Detailed description (for agents)

Single commit `45506fb` — `📝 Fold draft→approved status transition into the spec-PR commit`. One file touched: `docs/spec-format.md`.

**Change 1 — *Lifecycle states* table, `approved` row.**
The "Accompanying artifact" cell was expanded from "Merged spec PR + logbook comment recording the approval" to state that the merged spec-PR's own (squash) commit already carries `status: approved`, so no separate status-transition PR is opened, plus the logbook comment recording the approval. The Trigger cell ("Spec PR merged on `main`") and Authority cell ("Spec reviewer per the interaction mode declared in frontmatter") are unchanged.

**Change 2 — *Recording a status transition* section, rewritten from one case into two.**

- The opening paragraph now frames transitions as two kinds recorded differently, replacing the prior single "metadata-only edit to the merged spec" framing.
- **New subsection — *Recording the initial `draft` → `approved` transition (in the spec-PR)*.** States that the spec-PR merge *is* the approval event; that the rule applies mode-independently across `FULL`/`INTERMEDIATE`/`MINIMAL`/`AUTO`; that the transition SHALL be recorded only after the merge-authorization approval is granted; that the edit stays metadata-only (sets `status` to `approved`, and sets `interaction-mode` when it was omitted during `draft` since the schema requires it once `approved`, touching no body line, no `id`, `slug`, or `version`); and concludes that no separate post-merge metadata-only PR is required.
- **New sub-paragraph — *Merge mechanic*.** Documents the exact sequence: strictly after the gate and strictly before `gh pr merge --squash`, on the `spec/<NNNN>-<slug>` branch edit the frontmatter (`status: draft` → `status: approved`, adding `interaction-mode` if omitted), create a **new commit** (not `--amend`), `git push`, then `gh pr merge --squash`. The rationale is given inline: squash collapses both routes to one commit on `main`, and a new commit avoids the `--force-with-lease` a shared-branch amend would demand.
- **New subsection — *Recording a post-merge transition (every other transition)*.** Preserves the prior metadata-only-edit rule for `approved` → `implemented`/`superseded`/`archived`: the named authority changes only `status` (and `superseded-by` when moving to `superseded`), touches no normative content, keeps `version` immutable on the original, and locates the cumulative version on the highest-numbered delta.

**Process obligations checked (none triggered):**

- Version bump — N/A; `docs/spec-format.md` is not a skill/agent source (`AGENTS.md` → *Version Bump Convention*).
- CLI matrix — N/A; path not on the trigger list (`AGENTS.md` → *CLI Matrix Maintenance*).
- Build components — N/A; nothing under `artifacts/` was touched.

Spec: `specs/0101-spec-pr-inline-approval.md`, merged via spec-PR #661. PLAN posted on #610, cold-reviewed APPROVE with zero findings, then user-validated before DEV started. Complexity tier `small` — review team is `pr-reviewer` only.

Closes #610.
