### PR TITLE
📝 Add delta-spec 0102-01 — relax R8 to permit docs/ extraction

### DIFF
--- a/specs/0102-solo-merge-classifier-workaround.delta-01.md
+++ b/specs/0102-solo-merge-classifier-workaround.delta-01.md
@@ -1,0 +1,162 @@
+---
+id: "0102"
+slug: solo-merge-classifier-workaround
+status: draft
+complexity: small
+related-issue: 636
+version: 1.1.0
+---
+
+# 0102 — solo-merge-classifier-workaround (delta-01)
+
+This delta relaxes the letter of Requirement 8 of spec 0102 to match its
+own rationale. The original R8 required the solo-merge guidance to *"live
+inline"* in `AGENTS.md` → *Branching Strategy* and forbade its relocation
+*"to a separate file"*. During DEV (issue #636), realizing the full
+Requirements 1–11 guidance inline pushed `AGENTS.md` over the hard
+22,000-byte ceiling enforced by `scripts/check-agents-size.sh` in CI — a
+pre-existing, project-wide constraint that R8 did not account for, because
+the SPECS stage does not simulate the byte cost of the eventual prose. The
+DEV team resolved this (with the user's explicit mid-implementation
+sign-off) by extracting the Requirements 1–11 detail into a dedicated
+`docs/solo-merge-classifier-workaround.md`, following the same established
+`AGENTS.md`-extraction convention the repository already uses throughout
+the file, while keeping the single operationally critical rule
+(retry-once, hand a hard block to the user, never delegate to a sibling)
+inline in `AGENTS.md` under the Claude-Code-labelled heading R8 already
+mandated.
+
+That implementation is in direct tension with R8's literal *"SHALL live
+inline … SHALL NOT be relocated to a separate file"* even though it
+satisfies R8's actual purpose: the CLI-labelling/recognizability
+guarantee, and the *"mirror an established `AGENTS.md` pattern"* instinct
+R8 already invoked (the `docs/agent-team-protocol.md` reference). This
+delta amends R8 so its letter matches its rationale, extending the
+"mirror an established pattern" instinct one level further — from the
+labelling convention to the extraction convention introduced by commit
+`c5eb2f4` (issue #500), which is the same convention the rest of
+`AGENTS.md` already follows.
+
+Grounded state (verified on branch `fix/636-solo-merge-classifier-workaround`):
+the post-extraction `AGENTS.md` is 21,870 bytes against the 22,000-byte
+`scripts/check-agents-size.sh` threshold; the fully-inline draft exceeded
+that budget (DEV-reported at ~23,874 bytes; the intermediate over-budget
+state was corrected before commit and is not itself in git history). The
+extracted file `docs/solo-merge-classifier-workaround.md` carries the full
+Requirements 1–11 detail; `AGENTS.md` → *Branching Strategy* retains a
+`### On Claude Code CLI — solo-maintainer self-merge block` section with an
+inline pointer to that file and the inline critical rule.
+
+Every other requirement of spec 0102 — Requirements 1–7 and 9–12 — is
+**UNCHANGED** and remains in force. In particular, the parent's *Out of
+scope* exclusion of a true CLI-conditional loading mechanism, and
+Requirements 9 and 12's Claude-Code-only / other-CLIs-unverified framing,
+are untouched and stay consistent with the amended R8: the extracted file
+loads identically for all four CLIs, gated only by the inline Claude-Code
+label plus the reader's own judgment to skip it — exactly as the original
+inline-only design would have been read by all four CLIs. No open
+questions are introduced by this delta.
+
+## ADDED
+
+1. **New scenario (happy path) — extraction with an inline pointer and the
+   inline critical rule conforms.** The following scenario SHALL be added to
+   spec 0102's `## Scenarios`, recording that the amended R8 treats the
+   extract-to-`docs/` layout as conformant:
+
+   ```text
+   **Scenario:** Extracted docs file with an inline pointer and inline
+   critical rule satisfies R8
+
+   Given the Requirements 1–7 and 9–11 detail is extracted into
+         docs/solo-merge-classifier-workaround.md to keep AGENTS.md under
+         the 22,000-byte scripts/check-agents-size.sh budget
+   And   AGENTS.md → Branching Strategy retains a Claude-Code-labelled
+         section carrying an inline pointer to that file and the inline
+         critical rule (re-attempt once, hand a hard block to the user,
+         never delegate to a sibling)
+   When  the amended R8 is evaluated against this layout
+   Then  the layout conforms, because the section names Claude Code, the
+         critical rule stays inline, and the extracted file loads
+         identically for all four CLIs
+   And   the separate-file extraction is not treated as an R8 violation
+   ```
+
+2. **New scenario (failure path) — extraction that drops the label or the
+   inline critical rule violates R8.** The following scenario SHALL be added
+   to spec 0102's `## Scenarios`, recording the boundary the amended R8 still
+   enforces:
+
+   ```text
+   **Scenario:** Extraction that drops the inline label or critical rule
+   violates R8
+
+   Given the full guidance is moved entirely into a docs/ file
+   And   AGENTS.md → Branching Strategy carries no Claude-Code-labelled
+         section, or omits the inline critical rule
+   When  the amended R8 is evaluated against this layout
+   Then  the layout violates R8, because the Claude-Code-labelled section
+         and the inline critical rule are both mandatory even when the
+         Requirements 1–11 detail is extracted
+   ```
+
+## MODIFIED
+
+1. **Requirement 8 is replaced.** The original R8 mandated a fully-inline
+   home for the guidance and forbade its relocation to a separate file. It
+   is replaced by an R8 that preserves the Claude-Code labelling and
+   recognizability guarantee unchanged, but permits the Requirements 1–11
+   detail to be extracted into a dedicated `docs/*.md` file — following the
+   established `AGENTS.md`-extraction convention (commit `c5eb2f4`,
+   issue #500) — provided a Claude-Code-labelled section, an inline pointer,
+   and the inline critical rule remain in `AGENTS.md`. The justification is
+   the hard `scripts/check-agents-size.sh` 22,000-byte CI budget, a
+   pre-existing project-wide constraint the original R8 did not account for.
+
+   - Original R8:
+
+     > The guidance of Requirements 1–7 SHALL be introduced under an
+     > explicit heading or lead sentence that names Claude Code as the CLI
+     > it applies to, so that an agent operating a different CLI can
+     > recognize the guidance does not apply to its session without reading
+     > the full passage. The guidance SHALL live inline in `AGENTS.md` →
+     > *Branching Strategy* as such a labelled Claude-Code section or
+     > callout, mirroring the established pattern in
+     > `docs/agent-team-protocol.md`, whose *On Claude Code CLI (single
+     > implicit session team)* and *On CLIs with no multi-agent coordination
+     > surface (e.g. Gemini CLI)* sections co-locate CLI-scoped guidance in
+     > one shared file, each headed by the CLI or CLIs it governs. The
+     > guidance SHALL NOT be relocated to a separate file, a new skill, or a
+     > memory space.
+
+   - Replacement R8:
+
+     > The guidance of Requirements 1–7 SHALL be introduced under an
+     > explicit heading or lead sentence that names Claude Code as the CLI
+     > it applies to, so that an agent operating a different CLI can
+     > recognize the guidance does not apply to its session without reading
+     > the full passage. `AGENTS.md` → *Branching Strategy* SHALL carry that
+     > labelled Claude-Code section, and the section SHALL retain inline the
+     > single operationally critical rule: re-attempt a classifier-denied
+     > `gh pr merge` once as the same agent, hand a persistent hard block to
+     > the user, and never delegate the denied merge to a sibling agent. The
+     > remaining detail of Requirements 1–7 and 9–11 MAY be extracted into a
+     > dedicated `docs/*.md` file that the labelled section links by an
+     > inline pointer, following the established `AGENTS.md`-extraction
+     > convention introduced by commit `c5eb2f4` (issue #500) — under which a
+     > short pointer plus a critical-rule excerpt stays inline in `AGENTS.md`
+     > while the full section body lives in a dedicated `docs/` file, as
+     > `docs/agent-team-protocol.md` and `docs/plan-review-protocol.md`
+     > already do. The extracted file, if any, SHALL load identically for all
+     > four CLIs; its Claude-Code labelling is a reader-facing recognizability
+     > label, not a loading condition. The guidance SHALL NOT be relocated to
+     > a new skill or a memory space, and SHALL NOT be placed behind a
+     > CLI-conditional loading mechanism that would deliver it to Claude Code
+     > only — no such mechanism exists in this repository (see this spec's
+     > *Out of scope*).
+
+## REMOVED
+
+(None. The delta modifies Requirement 8 and adds two scenarios; it removes
+no requirement, scenario, or out-of-scope item. Requirements 1–7 and 9–12
+of spec 0102 remain in force unchanged.)


### PR DESCRIPTION
Amends spec 0102's Requirement 8 to permit the `docs/`-extraction pattern DEV needed to fit `AGENTS.md` under its 22,000-byte CI budget, requested mid-implementation of `#636`. Adds `specs/0102-solo-merge-classifier-workaround.delta-01.md`, no implementation (the implementation itself is already drafted on the `fix/636-solo-merge-classifier-workaround` branch and follows in a separate PR).

## How to read this PR?

Single-file diff: `specs/0102-solo-merge-classifier-workaround.delta-01.md`. Read the intro prose for the WHY — realizing spec 0102's Requirements 1-11 fully inline in `AGENTS.md` → *Branching Strategy* pushed the file to ~23,874 bytes, over the hard 22,000-byte threshold `scripts/check-agents-size.sh` enforces in CI, a pre-existing constraint the original R8 didn't account for. Read `## MODIFIED` for the old→new R8 text (quoted verbatim, side by side) and `## ADDED` for the two new scenarios (a conformant extraction layout, and a layout that still violates the amended R8 by dropping the label or the critical rule). `## REMOVED` is empty — nothing is deleted, only R8 is replaced and two scenarios added.

## How to test this PR?

1. `npm install` at repo root (or in a scratch checkout) to get `markdownlint`/`js-yaml`/`semver` available.
2. `node scripts/lib/spec-linter.js specs/0102-solo-merge-classifier-workaround.delta-01.md` — expect `Linting passed!`.
3. Optionally `task spec:lint` to confirm the full `/specs/` tree still lints clean with the new delta file present.

## Detailed description (for agents)

- **Added:** `specs/0102-solo-merge-classifier-workaround.delta-01.md` — same `id: "0102"` and `slug` as the parent, `status: draft`, `complexity: small`, `related-issue: 636`, `version: 1.1.0` (MINOR — a broadening of R8, not a breaking change: any implementation that satisfied the old fully-inline R8 still satisfies the new one, so the MAJOR-bump "invalidates an in-flight implementation" test does not apply, per the `0026`-delta-01 vs. `0088`-delta-01 precedent comparison used to calibrate this).
- **Requirement 8, replaced:** the old text mandated the guidance "live inline" and forbade relocating it "to a separate file". The new text keeps the Claude-Code-labelled heading and the single operationally critical rule (retry-once-then-user, never delegate to a sibling) mandatorily inline in `AGENTS.md`, but explicitly permits extracting the remaining Requirements 1-7/9-11 detail into a dedicated `docs/*.md` file, following the established `AGENTS.md`-extraction convention already used throughout the file (commit `c5eb2f4`, issue #500). A true CLI-conditional loading mechanism remains forbidden — the extracted file still loads identically for all four CLIs, gated only by the inline label and the reader's own judgment.
- **Unchanged:** Requirements 1-7 and 9-12 of the parent spec remain in force exactly as merged. No open questions introduced.
- **Grounded in the actual implementation:** the delta cites the real, verified post-fix state (`AGENTS.md` at 21,870 bytes on branch `fix/636-solo-merge-classifier-workaround`, `docs/solo-merge-classifier-workaround.md` carrying the extracted detail) rather than a hypothetical shape.
- **Ordering:** this delta-spec PR merges before the implementation PR for `#636` is opened, per the Spec-PR workflow's ordering rule — the implementation PR (already drafted, not yet opened) will cite this delta as its authority for the R8 deviation.
- **Issue reference:** "Related `#636`" — `#636` is the shared logbook issue; only the implementation PR carries the closing keyword.

Related #636.