### PR TITLE
📝 Add spec 0103 — MemPalace write-lock fallback

### DIFF
--- a/specs/0103-mempalace-write-lock-fallback.md
+++ b/specs/0103-mempalace-write-lock-fallback.md
@@ -1,0 +1,106 @@
+---
+id: "0103"
+slug: mempalace-write-lock-fallback
+status: draft
+complexity: small
+related-issue: 637
+version: 1.0.0
+---
+
+# MemPalace write-path fallback for friction tagging
+
+## Intent
+
+When an agent tags a friction and the memory-backed tagging path cannot
+record it — because a peer writer holds the write lock, or the memory
+service is unreachable — the friction-reporting protocol tells the agent
+exactly what to do so the signal is never silently lost. A future reader
+of the protocol finds its "fire-and-forget, costs nothing" promise
+qualified with the failure mode it can actually hit, and a concrete
+fallback that lands the friction in the same triage lane it would have
+reached through the normal path.
+
+## Requirements
+
+1. The friction-reporting protocol SHALL document an explicit fallback
+   for the case where a friction tag cannot be recorded because the
+   MemPalace write path is unavailable, covering both triggers: (a) a
+   peer-writer-lock hard error — MCP error `-32001`, "Peer MCP writer
+   active; this server is read-only for mutating tools" — returned by a
+   mutating tool, and (b) the MemPalace MCP server being unreachable or
+   disconnected entirely, in which case every MemPalace tool (not only
+   the mutating ones) is unavailable.
+2. The documented fallback SHALL be to file the friction directly as a
+   GitHub issue on the canonical repository, mirroring the manual
+   workaround already used for the GitHub issues #636 and #637.
+3. The directly-filed friction issue SHALL carry the `harness-feedback`
+   label, so the direct-filing path lands in the same triage lane as a
+   friction that reaches GitHub through the normal MemPalace-mediated
+   curator path.
+4. The operational fallback procedure SHALL live in
+   `artifacts/library/skills/harness-report/SKILL.md`, and
+   `artifacts/core/rules/60-tools.md` → *Friction Reporting* SHALL at
+   minimum acknowledge that the fire-and-forget tag has a documented
+   failure mode and point to that procedure — consistent with the
+   existing single-sourcing convention where `60-tools.md` states the
+   contract and `harness-report/SKILL.md` carries the procedure.
+5. The "fire-and-forget … costs nothing" framing of the tagging protocol
+   SHALL be qualified to name this failure mode explicitly, so a future
+   agent is not surprised when the "free" tag call fails.
+6. For trigger (a) — the transient peer-writer-lock error — the guidance
+   SHALL permit at most one immediate retry of the tag call before
+   directing the agent to the direct-filing fallback.
+7. The guidance SHALL NOT prescribe a retry-with-backoff loop against
+   MemPalace for either trigger; for trigger (b) — a disconnected server
+   — it SHALL direct the agent straight to the direct-filing fallback
+   with no retry.
+8. The directly-filed issue SHALL preserve the friction payload's
+   substance — at minimum the one-line title, the offender reference
+   (the `canonical` repository) when known, and the `evidence:` entries
+   — so it carries the same signal the MemPalace drawer would have
+   carried.
+
+## Scenarios
+
+**Scenario:** MemPalace available — nominal fire-and-forget tag
+
+Given the MemPalace MCP server is reachable and no peer writer holds the
+      write lock
+When  an agent tags a friction per the protocol
+Then  the single `mempalace_add_drawer` call succeeds and no fallback is
+      invoked
+
+**Scenario:** Peer-writer lock — one retry, then direct GitHub filing
+
+Given a peer MCP writer holds the write lock and `mempalace_add_drawer`
+      returns MCP error `-32001`
+When  the agent applies the documented fallback
+Then  it retries the tag at most once and, the lock still holding, files
+      the friction as a `harness-feedback`-labeled GitHub issue on the
+      canonical repository
+
+**Scenario:** MemPalace disconnected — direct GitHub filing, no retry
+
+Given the MemPalace MCP server is unreachable and all its tools are
+      unavailable
+When  the agent applies the documented fallback
+Then  it files the friction as a `harness-feedback`-labeled GitHub issue
+      on the canonical repository without attempting any retry against
+      MemPalace
+
+## Out of scope
+
+- The MemPalace server's own write-serialization or write-queuing
+  behavior (Option 1 in the GitHub issue #637). MemPalace is an external
+  MCP server dependency this repository integrates with, not a component
+  whose source lives here; this repository cannot fix it.
+- Any change to the MemPalace MCP protocol itself — for example altering
+  the `-32001` semantics or adding a server-side blocking-wait mode.
+- New tooling or automation to proactively detect a MemPalace lock or
+  disconnection (a health-check or probe mechanism). This spec qualifies
+  written guidance for agents, not a runtime detection mechanism.
+- Changes to the `harness-curator` clustering or issue-creation behavior.
+  The direct-filing fallback reuses the existing `harness-feedback` label
+  and the canonical-repository target; it does not alter the curator.
+
+## Open questions


### PR DESCRIPTION
Qualifies the WHAT for a documented fallback when a friction tag cannot reach MemPalace, requested by the friction report in `#637`. Adds `specs/0103-mempalace-write-lock-fallback.md`, no implementation.

## How to read this PR?

Single-file diff: `specs/0103-mempalace-write-lock-fallback.md`. Read `## Intent` for the WHAT — the friction-tagging protocol is specified as fire-and-forget "costs nothing," but a peer-writer-lock error or a full MemPalace MCP disconnection can silently swallow a tag with no documented recourse. Read `## Requirements` (8 SHALL statements): R1 names both triggers explicitly — (a) a peer-writer-lock `-32001` error on a mutating tool, and (b) the MemPalace MCP server being unreachable entirely (all tools gone, not just mutating ones). R2-R3 specify the single remedy for both: file the friction directly as a `harness-feedback`-labeled GitHub issue on the canonical repo — the same manual workaround already used live for tickets #636 and #637 themselves. R6-R7 draw the retry line precisely: one immediate retry permitted for the transient lock case only, no retry-with-backoff for either trigger, straight to direct filing for a disconnection (no live server to retry against).

## How to test this PR?

1. `npm install` at repo root (or in a scratch checkout) to get `markdownlint`/`js-yaml`/`semver` available.
2. `node scripts/lib/spec-linter.js specs/0103-mempalace-write-lock-fallback.md` — expect `Linting passed!`.
3. Optionally `task spec:lint` to confirm the full `/specs/` tree still lints clean with the new file present.

## Detailed description (for agents)

- **Added:** `specs/0103-mempalace-write-lock-fallback.md` — frontmatter `id: "0103"`, `slug: mempalace-write-lock-fallback`, `status: draft`, `complexity: small`, `related-issue: 637`, `version: 1.0.0`. `interaction-mode` intentionally omitted.
- **Scope:** amends `artifacts/library/skills/harness-report/SKILL.md` step 4 (the operational fallback procedure) and `artifacts/core/rules/60-tools.md` → *Friction Reporting* (a contract-level acknowledgement + pointer), following the existing single-sourcing convention between the two files. R8 requires the directly-filed issue to preserve the friction payload's substance (title, offender reference, evidence entries) so it carries the same signal a MemPalace drawer would have.
- **Explicitly excluded:** MemPalace's own write-serialization behavior (external MCP server dependency, not this repo's to fix — Option 1 of the originating issue); any change to the MemPalace MCP protocol; proactive lock/disconnection detection tooling; any change to `harness-curator`'s clustering/issue-creation behavior (the fallback reuses the existing `harness-feedback` label and canonical-repo target as-is).
- **Fresh live evidence incorporated:** this same processing session hit a full MemPalace MCP disconnection (`"36 deferred tools are no longer available (MCP server disconnected)"`) for an extended period — distinct from the originating issue's `-32001` peer-lock error, but resolved by the same direct-filing remedy. The spec explicitly covers both triggers rather than only the narrower one the issue reported.
- **Duplicate-check performed:** grepped for `-32001` / "Peer MCP writer" / "read-only for mutating" across `artifacts/` and `docs/` — no existing fallback guidance. Confirmed MemPalace is external (only integration docs and library imports in this repo, no server source) via `grep -rn "mempalace" artifacts/`.
- **Structural precedent cited:** spec 0080 R4 (`user-validate`'s `plannotator`-absent → degrade-to-`internal` fallback) is the closest existing analogy — an availability-degradation fallback with the same shape (external dependency unavailable → documented, non-error, alternate path).
- **Not touched:** `artifacts/library/skills/harness-report/SKILL.md`, `artifacts/core/rules/60-tools.md` themselves — implementation is a later PR (per the Spec-PR workflow's ordering rule; this spec-PR contains exactly one new file under `/specs/`).
- **Issue reference:** intentionally phrased as "Related `#637`" — `#637` is the shared logbook issue, so per the Spec-PR workflow's Independence rule only the implementation PR carries the closing keyword.

Related #637.