### PR TITLE
✨ Add MemPalace write-lock fallback to harness-report tagging

### DIFF
--- a/artifacts/core/rules/60-tools.md
+++ b/artifacts/core/rules/60-tools.md
@@ -413,8 +413,11 @@ in each component's `provenance:` block.
 
 Tag a friction whenever a **recognition signal** fires (next section).
 Do not pause the user's task longer than the tag itself. The cost of
-one tag is negligible; the cost of an un-reported friction that bites
-the next agent is much higher.
+one tag is normally negligible — the one exception is when the MemPalace
+write path is unavailable (a peer holds the write lock, or the server is
+disconnected), a documented failure mode with a fallback in the
+`harness-report` procedure (see *How to tag* below); the cost of an
+un-reported friction that bites the next agent is much higher.
 
 If unsure whether something qualifies — tag it. Curation will discard
 noise; silent friction is the failure mode to avoid.
@@ -455,6 +458,15 @@ rather than re-implementing the protocol inline. This keeps the
 contract single-sourced and lets future improvements (richer
 `evidence:` format, new recognition signals, etc.) propagate without
 editing every skill body.
+
+The fire-and-forget tag has one **documented failure mode**: the
+MemPalace write path may be unavailable — a peer holds the write lock
+(MCP error `-32001`) or the server is disconnected — so the tag call
+cannot record the friction. The `harness-report` procedure carries the
+operational fallback for this case (file the friction directly as a
+`harness-feedback`-labeled GitHub issue on the canonical repository, so
+the signal still reaches the curator's triage lane). This file states
+the contract; the `SKILL.md` procedure carries the "how".
 
 ### Where to write
 

--- a/artifacts/core/rules/60-tools.md
+++ b/artifacts/core/rules/60-tools.md
@@ -464,9 +464,10 @@ MemPalace write path may be unavailable — a peer holds the write lock
 (MCP error `-32001`) or the server is disconnected — so the tag call
 cannot record the friction. The `harness-report` procedure carries the
 operational fallback for this case (file the friction directly as a
-`harness-feedback`-labeled GitHub issue on the canonical repository, so
-the signal still reaches the curator's triage lane). This file states
-the contract; the `SKILL.md` procedure carries the "how".
+`harness-feedback`-labeled issue on the offender's canonical repository,
+using the forge-appropriate CLI, so the signal still reaches the
+curator's triage lane). This file states the contract; the `SKILL.md`
+procedure carries the "how".
 
 ### Where to write
 

--- a/artifacts/library/skills/harness-report/SKILL.md
+++ b/artifacts/library/skills/harness-report/SKILL.md
@@ -156,7 +156,8 @@ suggestion: <optional fix idea>
 **Fallback — MemPalace write path unavailable.** The
 `mempalace_add_drawer` call above is the normal path, but it can fail
 in two ways. Both have the *same* remedy: file the friction directly as
-a GitHub issue so the signal is never silently lost.
+an issue on the offender's canonical repository so the signal is never
+silently lost.
 
 - **(a) A peer writer holds the write lock.** The mutating call returns
   MCP error `-32001` ("Peer MCP writer active; this server is read-only
@@ -168,10 +169,31 @@ a GitHub issue so the signal is never silently lost.
   unavailable. There is no live server to retry against: go **straight**
   to direct filing, with no retry.
 
-Direct-filing procedure — file the friction as a GitHub issue on the
-offender's canonical repository, carrying the same `harness-feedback`
-label the curator's normal path produces, so a directly-filed friction
-lands in the identical triage lane:
+**Choose the forge tool from the `canonical` URL host.** CrewRig is
+multi-forge (see `AGENTS.md` → *Forge Access*), so do **not** assume
+GitHub. Read the host of the offender's `canonical` repository URL and
+pick the matching CLI — this is guidance to apply by reading the URL,
+not a pattern to codify in a regex:
+
+- host is `github.com` → **`gh`**
+- host is `gitlab.com`, begins with `gitlab.`, or is a host the
+  environment is already configured to treat as a self-hosted GitLab
+  instance → **`glab`**
+- any other self-hosted host → assume a Gitea instance → **`tea`**
+
+When a host is genuinely ambiguous, prefer the tool whose authenticated
+login is already established for that host. When the offender cannot be
+identified and `canonical` is empty, default to the framework's own
+canonical repository and the forge that hosts it, mirroring the manual
+filing of issues #636 and #637.
+
+**Direct-filing procedure.** File the friction as an issue on the
+offender's canonical repository, carrying the `harness-feedback` label
+so a directly-filed friction lands in the identical triage lane the
+curator's normal path produces. The label name is **forge-independent** —
+the same `harness-feedback` on every forge; do **not** map it per-forge.
+Shown here with `gh`; `glab` and `tea` take the same shape with their own
+repo/label/body flag names (noted below the block):
 
 ```bash
 gh issue create \
@@ -191,11 +213,19 @@ EOF
 )"
 ```
 
-- `--repo <owner>/<repo>` is the offender's `canonical` repo with the
-  `https://github.com/` prefix stripped — the same transformation the
-  curator's apply step performs (see step 3's `canonical` note). When
-  the offender is unknown, default to the framework's own canonical
-  repository, mirroring the manual filing of issues #636 and #637.
+- **`gh`** (GitHub): as above — `--repo <owner>/<repo>` is the
+  `canonical` URL with the `https://github.com/` prefix stripped (the
+  same transformation the curator's apply step performs; see step 3's
+  `canonical` note), then `--label harness-feedback`, `--title`,
+  `--body`.
+- **`glab`** (GitLab): `glab issue create --repo <group>/<project>
+  --label harness-feedback --title "FRICTION: …" --description "…"` —
+  the repo path may be `group/project` or a deeper `group/subgroup/project`
+  namespace, and the body flag is `--description`, not `--body`.
+- **`tea`** (Gitea): `tea issue create --repo <owner>/<repo> --labels
+  harness-feedback --title "FRICTION: …" --description "…"` — note the
+  plural `--labels` and, as with `glab`, `--description` rather than
+  `--body`.
 - Preserve the payload's substance: the one-line title, the offender's
   `canonical` reference when known, and every `evidence:` entry carry
   the same signal the MemPalace drawer would have. The

--- a/artifacts/library/skills/harness-report/SKILL.md
+++ b/artifacts/library/skills/harness-report/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.2.2"
+    version: "1.3.0"
 claude:
   allowed-tools:
     - Read
@@ -47,8 +47,11 @@ short reminder list:
   and forced a workaround you had to explain explicitly to the user.
 
 If a signal fires, **tag the friction before resuming work**. Not
-"consider tagging". Not "when convenient". Tagging takes seconds and
-costs nothing; failing to tag loses the signal forever.
+"consider tagging". Not "when convenient". Tagging normally takes
+seconds and costs nothing — the one exception is when the MemPalace
+write path is unavailable (a peer holds the write lock, or the server
+is disconnected), a documented failure mode with a fallback in step 4
+below. Failing to tag loses the signal forever.
 
 ## Operating mode
 
@@ -149,6 +152,55 @@ suggestion: <optional fix idea>
 """
 )
 ```
+
+**Fallback — MemPalace write path unavailable.** The
+`mempalace_add_drawer` call above is the normal path, but it can fail
+in two ways. Both have the *same* remedy: file the friction directly as
+a GitHub issue so the signal is never silently lost.
+
+- **(a) A peer writer holds the write lock.** The mutating call returns
+  MCP error `-32001` ("Peer MCP writer active; this server is read-only
+  for mutating tools"). Retry the `mempalace_add_drawer` call **at most
+  once**. If it still returns `-32001`, fall back to direct filing. Do
+  **not** loop with backoff.
+- **(b) The MemPalace MCP server is unreachable.** It is disconnected
+  and *every* MemPalace tool — not only the mutating ones — is
+  unavailable. There is no live server to retry against: go **straight**
+  to direct filing, with no retry.
+
+Direct-filing procedure — file the friction as a GitHub issue on the
+offender's canonical repository, carrying the same `harness-feedback`
+label the curator's normal path produces, so a directly-filed friction
+lands in the identical triage lane:
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --label harness-feedback \
+  --title "FRICTION: <one-line title>" \
+  --body "$(cat <<'EOF'
+writer_agent: <you>
+subcategory: <optional anchor>
+canonical: <URL of offender, if known>
+severity: <low|med|high — default med>
+evidence:
+  - <commit_hash>:<path>:<line>
+  - <URL>
+suggestion: <optional fix idea>
+EOF
+)"
+```
+
+- `--repo <owner>/<repo>` is the offender's `canonical` repo with the
+  `https://github.com/` prefix stripped — the same transformation the
+  curator's apply step performs (see step 3's `canonical` note). When
+  the offender is unknown, default to the framework's own canonical
+  repository, mirroring the manual filing of issues #636 and #637.
+- Preserve the payload's substance: the one-line title, the offender's
+  `canonical` reference when known, and every `evidence:` entry carry
+  the same signal the MemPalace drawer would have. The
+  `harness-feedback` label is mandatory — it is exactly what routes the
+  friction into the curator's triage lane.
 
 ### 5. Resume
 


### PR DESCRIPTION
Qualifies the fire-and-forget friction-tagging protocol so its "costs nothing" promise names the one failure mode it can actually hit — the MemPalace write path being unavailable — and gives the agent a concrete, **forge-agnostic** fallback that never loses the signal. When the write path fails, the agent files the friction directly as a `harness-feedback`-labeled issue on the offender's canonical repository, using whichever CLI (`gh`/`glab`/`tea`) matches that repository's forge, so it still lands in the curator's triage lane.

## How to read this PR?

Documentation-only change across two source files, realized in **two commits** — read them in order, because the second one is a mid-flight correction the first one needed:

1. **`b598225`** — the original implementation: both failure triggers, the retry boundary, and the direct-filing procedure, but **hardcoded to GitHub** (`gh issue create` unconditionally).
2. **`24c368d`** — **forge-agnostic rework**, requested by the user while reviewing this PR's own merge-authorization gate: CrewRig is explicitly multi-forge (`AGENTS.md` → *Forge Access*: `gh`/GitHub, `glab`/GitLab, `tea`/Gitea), so hardcoding `gh` would silently lose the friction signal for any component whose `canonical` repo lives on GitLab or Gitea. This required amending the just-merged spec: **delta-spec `specs/0103-mempalace-write-lock-fallback.delta-01.md` (merged via PR #672, MAJOR bump `1.0.0`→`2.0.0`)** replaces Requirements 2/3 and adds R9 — the host-based forge-CLI selection rule this commit implements.

Read the two touched files in this order:

1. **`artifacts/library/skills/harness-report/SKILL.md`** — the load-bearing file. The **Fallback — MemPalace write path unavailable** subsection in step 4 (*Tag*) covers: the two triggers with the *same* remedy — (a) a peer writer holds the write lock (MCP error `-32001`), retry `mempalace_add_drawer` at most once then fall back; (b) the MCP server is disconnected, go straight to direct filing with no retry, neither loops with backoff — **and now a "Choose the forge tool from the `canonical` URL host" block**: `github.com` → `gh`; `gitlab.com`/`gitlab.*`/a configured self-hosted GitLab → `glab`; any other self-hosted host (assumed Gitea) → `tea`; ambiguous host → prefer the already-authenticated CLI; empty `canonical` → default to the framework's own repo/forge. The `gh`/`glab`/`tea` invocations are shown with their real, **verified-against-installed-CLI** flag differences (`glab`/`tea` use `-d/--description` not `--body`; `tea` uses plural `-L/--labels`). The `harness-feedback` label name does **not** vary by forge. Frontmatter `metadata.provenance.version` bumps `1.2.2` → `1.3.0` (unchanged by the second commit).
2. **`artifacts/core/rules/60-tools.md`** — the contract side. A contract-level acknowledgement of the documented failure mode plus a pointer to the SKILL.md procedure, and the "cost of one tag is negligible" framing qualified — both generalized in `24c368d` from "GitHub issue" to "an issue on the offender's canonical repository, using the forge-appropriate CLI." No procedure is restated here.

Non-obvious design decisions:
- **Single-sourcing split**: the operational "how" lives only in `harness-report/SKILL.md`; `60-tools.md` carries the contract and points at it (spec 0103 PLAN R4) — unaffected by the forge-agnostic rework.
- **No per-forge label mapping**: `harness-feedback` is one wire-protocol label name across every forge instance (delta R3) — deliberately not turned into a table.
- Issue #637 itself was filed by the manual GitHub workaround this PR's fallback formalizes — the change dogfoods its own remedy, now correctly generalized to whichever forge actually hosts the offending component.

## How to test this PR?

Prerequisites: this branch checked out (head `24c368d`), `bash` and `gh` available; `glab`/`tea` optional, for verifying their flag shapes.

1. **Version-bump gate (CI-equivalent):**
   ```bash
   bash scripts/check-skill-versions.sh
   ```
   Expected: passes. `harness-report/SKILL.md` bumps `1.2.2` → `1.3.0` (MINOR — additive procedure); the forge-agnostic rework in `24c368d` doesn't need a further bump — the PR hasn't merged yet, so this remains one shipped revision.

2. **Build components (mandatory when `artifacts/` is touched):**
   ```bash
   bash scripts/build-components.sh
   git status --porcelain
   ```
   Expected: no tracked output diff. `harness-report` is a **library-tier** skill (output → gitignored `dist/library/`); `60-tools.md` is a core *rules* file the build script doesn't process at all.

3. **Read-path check:** confirm the SKILL.md fallback subsection's forge-selection block reads coherently, the `gh`/`glab`/`tea` invocations carry `harness-feedback` (or `--label`/`--labels harness-feedback`) and a `FRICTION:` title, and the `60-tools.md` pointer resolves to it.

## Detailed description (for agents)

Net tracked change across both commits: **two source files** (`git diff --stat d5c8cbd..24c368d -- artifacts/`). No other file is touched by the implementation (the delta-spec doc itself landed separately via PR #672).

### `artifacts/library/skills/harness-report/SKILL.md`

- **Added** (step 4, *Tag*, commit `b598225`): a **Fallback — MemPalace write path unavailable** subsection covering triggers (a) peer-writer-lock `-32001` → retry once, no backoff, and (b) MCP disconnected → straight to fallback, no retry. Payload preserved (`writer_agent`, `subcategory`, `canonical`, `severity`, `evidence`, `suggestion`).
- **Reworked** (commit `24c368d`, per delta-spec 0103-01 R9): replaced the GitHub-only direct-filing block with a forge-selection block (host → `gh`/`glab`/`tea`) followed by per-forge invocation shapes with verified flag names. The `harness-feedback` label is stated explicitly as forge-independent (delta R3).
- **Modified** (*When to activate*, `b598225`): the "costs nothing" line names the write-path-unavailable exception.
- **Modified** (frontmatter, `b598225`): `metadata.provenance.version` `1.2.2` → `1.3.0`.

### `artifacts/core/rules/60-tools.md`

- **Modified** (*When to tag*, `b598225`): qualifies "cost of one tag is negligible" with the documented exception.
- **Added** (*How to tag*, `b598225`, wording generalized in `24c368d`): a contract-level acknowledgement pointing to the `harness-report` procedure, now saying "an issue on the offender's canonical repository, using the forge-appropriate CLI" rather than "a GitHub issue."

### Conventions accounted for

- **Version bump**: `harness-report/SKILL.md` `1.2.2` → `1.3.0` (MINOR). `60-tools.md` has no frontmatter/`provenance.version` and is absent from the affected-paths list → no bump. `scripts/check-skill-versions.sh`: passes.
- **Built components**: `bash scripts/build-components.sh` run — no tracked output diff (library-tier → gitignored `dist/library/`; rules files not processed by the build).
- **CLI matrix**: `docs/cli-matrix.md` consulted (diff touches `artifacts/**`) — no row/cell change. The forge-CLI selection (`gh`/`glab`/`tea`) is an orthogonal axis to `docs/cli-matrix.md`'s Claude/Gemini/Copilot/Antigravity parity tracking; it introduces no new CLI-specific (Claude-Code-vs-others) integration point.
- **Lifecycle**: spec `0103` merged via spec-PR #668; delta-spec `0103-01` merged via PR #672 (mid-flight correction, MAJOR bump, both requested by the user's own review of this PR's merge gate). PLAN posted on #637, cold-reviewed APPROVE, user-validated before DEV. REVIEW: `pr-reviewer` cold pass APPROVE at head `525e919`, then re-reviewed fresh at head `24c368d` after the forge-agnostic rework — APPROVE again, one non-blocking finding (this stale-body refresh) already addressed. Complexity tier `small`.

Closes #637.
