### PR TITLE
🐛 Resolve duplicate spec id 0104 on main (renumber forge-agnostic → 0105)

### DIFF
--- a/specs/0105-forge-agnostic-curator-apply.md
+++ b/specs/0105-forge-agnostic-curator-apply.md
@@ -1,5 +1,5 @@
 ---
-id: "0104"
+id: "0105"
 slug: forge-agnostic-curator-apply
 status: draft
 complexity: small


### PR DESCRIPTION
Fixes a broken `main`: two PRs (#673, #674) merged concurrently each claiming spec id `0104`, so `task spec:lint` fails on `main` and every PR. Renumbers the second-merged spec (`forge-agnostic-curator-apply`, issue #671) to `0105`, keeping the first-merged #673 spec at `0104`.

Closes #676.

## How to read this PR?

One rename + one frontmatter edit:
- `specs/0104-forge-agnostic-curator-apply.md` → `specs/0105-forge-agnostic-curator-apply.md` (git rename).
- Frontmatter `id: "0104"` → `id: "0105"`. Nothing else changes — `slug`, `status`, body, `related-issue: 671` are untouched.

## How to test this PR?

```sh
task spec:lint
```

Expected: exit 0, "Linting passed!" (139 files, no duplicate id). On `main` today this fails with `[FAIL] Duplicate spec id "0104" across files`.

## Detailed description (for agents)

- **Renamed + reid'd:** the second-merged colliding spec only. The first-merged spec (`specs/0104-gate-presentation-substance.md`, #673) keeps `0104` by merge-order priority.
- **No references updated:** a repo-wide grep found no in-repo reference to the old `0104-forge-agnostic-curator-apply` filename or to `id 0104` of this spec, and the body carries no self-reference to its id.
- **Immutability note:** spec-format freezes a merged spec's `id`. That rule yields here to the stronger invariant that ids are unique; leaving the duplicate would keep `main` and all PRs red.
- **Guard gap:** spec 0098's check is per-PR and blind to a concurrent PR's id. Tracked separately as a harness friction; not fixed in this PR (scope is unblocking `main`).