### PR TITLE
📝 Embed real substance in caller-built plannotator gate presentations

### DIFF
--- a/artifacts/library/skills/user-validate/SKILL.md
+++ b/artifacts/library/skills/user-validate/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.2.0"
+    version: "1.3.0"
 claude:
   allowed-tools:
     - Read
@@ -157,6 +157,67 @@ readability-critical color lives in the head:
     </main>
   </body>
 </html>
+```
+
+### Substance-embedding for caller-built presentations
+
+**Scope (spec 0104 R2).** This guidance applies **only** when you build a
+bespoke presentation of the artifact before handing it to the review viewer —
+for example because an active `pedagogy`, `translate`, or `illustration` option
+obliges a richer rendering than the raw file. It does **not** apply on the raw-
+passthrough path (see the *Raw passthrough* rule below): there the viewer's own
+renderer already displays the full artifact.
+
+**Why (spec 0104 R3/R4).** A caller-built presentation that only *describes* the
+change — a title, a one-line summary, and the prior reviewer's verdict — leaves
+the reviewing user unable to judge what is actually being decided. That is the
+summary-only merge-authorization outcome observed during a live gate:
+translation and professor-level pedagogy were active, yet the user never saw the
+modified content itself. "Professor" framing means *showing the work*, not
+narrating it.
+
+**Rules for a caller-built presentation:**
+
+- **Embed the real substance (spec 0104 R3).** When `pedagogy=professor` and/or
+  `translate=on`, the presentation SHALL embed the **concrete changed content
+  itself** — a rendered diff excerpt, or the added or changed prose verbatim —
+  not only a prose summary describing what changed.
+- **Show enough of a change set to judge it independently (spec 0104 R4).** For
+  a decision over a change set or diff — a merge-authorization gate, for
+  instance — show enough of the actual modified content for the reviewing user
+  to judge the change **independently**, rather than relying solely on a prior
+  REVIEW verdict.
+- **Translate the embedded substance, presentation-only (spec 0104 R5).** When
+  `translate=on`, translate the embedded substance itself within the
+  presentation, consistent with the `translate` boundary (see *Cross-cutting
+  options → `translate`*): the translation is presentation-only and the
+  repository artifact stays in English — never written back translated
+  (`AGENTS.md` → *Language*).
+- **Raw passthrough carries no obligation (spec 0104 R6).** When you pass the
+  raw artifact file directly to the review viewer without building a bespoke
+  presentation, the viewer already renders the full substance, so no separate
+  substance-embedding step is required.
+
+**Presentation-only (spec 0104 R7).** This obligation does **not** modify the
+invocation command, the dual-validation rule, the decision mapping, or the
+defined semantics of the `translate` / `pedagogy` / `illustration` cross-cutting
+options; it only clarifies how a caller-built presentation applies them.
+
+**Compliant vs thin example (spec 0104 R4).** A compliant merge-authorization
+presentation embeds the real change; a thin one summarizes it away:
+
+```text
+Compliant — embeds the substance:
+  Ask: "Authorize merge of PR #123?"
+  Change under decision (added prose, verbatim):
+    + The guidance SHALL direct showing enough of the actual modified
+    + content for the reviewing user to judge the change independently.
+  Prior REVIEW verdict: APPROVE — context, not a substitute for the diff.
+
+Thin — non-compliant:
+  Ask: "Authorize merge of PR #123?"
+  Summary: "Adds substance-embedding guidance; reviewer approved."
+  (no diff, no changed prose — the user cannot judge the change itself)
 ```
 
 ## Backend: `internal` (default floor)


### PR DESCRIPTION
This documentation-only change adds substance-embedding guidance to the `user-validate` skill so that a caller who builds a bespoke `plannotator` gate presentation embeds the artifact's real substance — a rendered diff excerpt or the added/changed prose verbatim — rather than a prose summary, whenever `pedagogy=professor` and/or `translate=on` are active. It closes the gap behind a live merge-authorization gate that summarized a change away, leaving the reviewing user unable to judge what was actually being decided.

Closes #670

## How to read this PR?

Single-file change — read it in this order:

1. `specs/0104-gate-presentation-substance.md` (already on `main`, not in this diff) for the WHAT: requirements R1–R7 and the three scenarios.
2. `artifacts/library/skills/user-validate/SKILL.md` — the only changed file (+62/−1). Jump to the new `### Substance-embedding for caller-built presentations` subsection, deliberately co-located immediately after the existing contrast-safety guidance in the `plannotator` backend section (R1).

Non-obvious decisions to note while reading:

- The guidance is **scoped** to the caller-built-presentation path and explicitly excludes the raw-passthrough path, where the viewer already renders the full artifact (R2, R6).
- The `translate` boundary is preserved: embedded substance is translated **presentation-only**, the repository artifact stays English (R5).
- The obligation is **presentation-only** — it does not touch the invocation command, dual-validation rule, decision mapping, or cross-cutting option semantics (R7).
- A `Compliant vs thin` example block anchors the abstract rule to a concrete merge-authorization presentation (R4).

## How to test this PR?

No runtime behavior changes; verification is by the standard CI suite plus a read of the rendered guidance.

Prerequisites: repo checked out on this branch, from the repo root (`task` runner + `markdownlint-cli` available).

```sh
# Version bump present on the modified skill source
task check-skill-versions

# Markdown lint (the changed skill is Markdown)
task lint-markdown

# Built outputs regenerate cleanly and match source — drift detection
task check-components

# Spec-format lint (spec 0104 already on main)
task spec:lint
```

Expected outcome: all four checks pass. Then open `artifacts/library/skills/user-validate/SKILL.md` and confirm the new subsection reads coherently against R1–R7 and that the `Compliant vs thin` example distinguishes an embedded-substance presentation from a summary-only one.

## Detailed description (for agents)

**Nature of change.** Documentation-only edit to a single library-tier skill source, `artifacts/library/skills/user-validate/SKILL.md` (+62/−1). No code, no CLI-integration surface, no schema change.

**What was added.** A new `### Substance-embedding for caller-built presentations` subsection inside the existing `plannotator` backend section, placed directly after the contrast-safety guidance it complements (satisfies R1 — co-location). Its structure maps one-to-one onto the spec requirements:

- **Scope** paragraph — restricts the guidance to the caller-built-presentation path and distinguishes it from raw passthrough (R2).
- **Why** paragraph — grounds the rule in the observed summary-only merge-authorization outcome from the reported gate (R3/R4 motivation).
- **Rules** list — four bullets: embed the concrete changed content when `pedagogy=professor` and/or `translate=on` (R3); show enough of a change set to judge it independently rather than trusting a prior REVIEW verdict (R4); translate embedded substance presentation-only with the repository artifact staying English (R5); raw passthrough carries no obligation (R6).
- **Presentation-only** paragraph — states the obligation does not modify the invocation command, dual-validation rule, decision mapping, or cross-cutting option semantics (R7).
- **Compliant vs thin example** — a `text` block contrasting an embedded-substance merge-authorization presentation against a summary-only one (R4 illustration).

**What was modified.** `metadata.provenance.version` bumped `1.2.0 → 1.3.0`. This is a **MINOR** bump under the project version-bump convention — the change is additive (a new subsection), introduces no breaking contract change, and the source already exists on `main`, so the bump-on-modification rule applies.

**Build outputs.** The `user-validate` skill is library-tier, so its compiled outputs land under `dist/library/…`, which is gitignored — nothing built is committed. `scripts/check-components.sh` verifies the outputs regenerate cleanly from the source; there is no built artifact to stage in this diff.

**CLI matrix.** `docs/cli-matrix.md` was consulted; no row changes. The change is guidance-only prose inside a skill body, symmetric across all four CLIs by construction (the skill source compiles identically for each), so there is no CLI-specific integration point to record.

**Verification / no separate tester.** This being a doc-only guidance change with no executable behavior, there is no unit under test; verification is CI: the `lint-markdown`, `check-skill-versions`, `check-components`, and spec-lint checks (Taskfile targets `lint-markdown`, `check-skill-versions`, `check-components`, `spec:lint`). No tester role was spawned.

**Scope discipline.** Implements spec 0104 (R1–R7) exactly. Everything the spec placed out of scope — the `plannotator` viewer itself, the `internal` backend, a numeric "how much" threshold, an automated enforcement linter, and any change to invocation/decision-mapping/option semantics — is untouched. This PR is a sibling of the spec-PR that landed spec 0104 on `main` (PR #673); that spec-PR deliberately carried no close-keyword, so this implementation PR is the one that closes the friction ticket.
