### PR TITLE
📝 Name user-validate skill for artifact-validation gates in point-of-use docs

### DIFF
--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -301,7 +301,7 @@ tiers and their exact compositions:
 
 | Tier | DEV-stage team | Notes |
 |---|---|---|
-| `trivial` | No team — orchestrator handles the work inline in a single turn. | Bypasses `spec-author` per *Standard Team Templates → Step 0*. The `AskUserQuestion` and merge-authorization gates of the declared interaction mode still apply to inline work. |
+| `trivial` | No team — orchestrator handles the work inline in a single turn. | Bypasses `spec-author` per *Standard Team Templates → Step 0*. The artifact-validation gate(s) of the declared interaction mode — realised through the `user-validate` skill — and the distinct merge-authorization gate still apply to inline work. |
 | `small` | `developer` + `pr-logbook` + `pr-reviewer`. | No `architect` (the spec is its own architectural input). No `tester` unless the change carries a test surface; when added, slot `tester` between `developer` and `pr-logbook`. The *Security rule* still applies. |
 | `standard` | The matching Template (1 / 2 / 3) from *Standard Team Templates* above, unchanged. | Default tier when the frontmatter is silent. |
 | `large` | `architect`-led decomposition into one or more sub-specs **before** any `developer` spawn. | Each sub-spec is a separate ticket with its own SPECS-stage entry (a new spec file under `/specs/`, a new spec-PR, a new implementation-PR). The parent ticket coordinates; it does not implement. |

--- a/docs/interaction-modes.md
+++ b/docs/interaction-modes.md
@@ -8,18 +8,28 @@
 
 A **user gate** is defined narrowly as one of two actions:
 
-1. A call to `AskUserQuestion` (or the equivalent interactive prompt
-   exposed by the host CLI).
+1. An **artifact-validation gate** — presenting a spec, a plan, or a set
+   of REVIEW findings to the user for a validation decision — realised
+   through the `user-validate` skill. The skill dispatches to the
+   configured backend; the default-floor (`internal`) backend realizes the
+   gate as a call to `AskUserQuestion` (or the equivalent interactive
+   prompt exposed by the host CLI), while an opt-in backend such as
+   `plannotator` realizes it as a rich browser review. Agents invoke the
+   skill; they do NOT call `AskUserQuestion` directly to realise such a
+   gate.
 2. The pre-merge authorization request mandated by *Branching
    Strategy* — the explicit "may I merge?" question the agent MUST
-   ask JUST BEFORE every `gh pr merge` invocation.
+   ask JUST BEFORE every `gh pr merge` invocation. This is a distinct
+   action-authorization, NOT an artifact-validation gate, and is NOT
+   realised through the `user-validate` skill.
 
 Both gates **block** agent execution until the user responds. Nothing
 else does. **A prose question or status message directed at the user is
 NOT a gate, even when it ends with `?`. The host CLI's text-output
 guidance biases toward prose communication; that bias does NOT override
-this contract. Every INTERMEDIATE or FULL mode gate SHALL NOT be
-realised as a prose question — it MUST be an `AskUserQuestion` call.**
+this contract. Every INTERMEDIATE or FULL mode artifact-validation gate
+SHALL NOT be realised as a bare prose question — it MUST be realised
+through the `user-validate` skill.**
 
 The following outputs are explicitly **NOT** user gates and
 SHALL NOT pause the agent:
@@ -48,9 +58,9 @@ post hoc).
 | Stage \ Mode | FULL | INTERMEDIATE | MINIMAL | AUTO |
 |---|---|---|---|---|
 | **SPECS** | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | No interview gate (spec authored autonomously); merge-authorization gate before merging the spec-PR. |
-| **PLAN** | `AskUserQuestion` to validate the plan comment before DEV starts; second `architect` cold-review remains autonomous. | `AskUserQuestion` to validate the plan comment before DEV starts; second `architect` cold-review remains autonomous. | — (plan authored and cold-reviewed autonomously; DEV starts on APPROVE without user prompt). | — (plan authored and cold-reviewed autonomously). |
+| **PLAN** | Validate the plan comment through the `user-validate` skill before DEV starts; second `architect` cold-review remains autonomous. | Validate the plan comment through the `user-validate` skill before DEV starts; second `architect` cold-review remains autonomous. | — (plan authored and cold-reviewed autonomously; DEV starts on APPROVE without user prompt). | — (plan authored and cold-reviewed autonomously). |
 | **DEV** | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). |
-| **REVIEW** | Non-blocking notification posted on the logbook issue at the start and end of every iteration (per the FULL-mode rule above), **plus** a bounded `AskUserQuestion` to triage the non-blocking findings of each pass (spec 0006 R10 / spec 0005 R10 FULL branch). That triage is the sole REVIEW-loop gate. | — (loop runs autonomously; iteration count visible via the `iter:N` PR label). | — (loop runs autonomously). | — (loop runs autonomously; halt at max-iteration guardrail pages the user per *Retroactive review loop*). |
+| **REVIEW** | Non-blocking notification posted on the logbook issue at the start and end of every iteration (per the FULL-mode rule above), **plus** a bounded triage of the non-blocking findings of each pass realised through the `user-validate` skill (spec 0006 R10 / spec 0005 R10 FULL branch). That triage is the sole REVIEW-loop gate. | — (loop runs autonomously; iteration count visible via the `iter:N` PR label). | — (loop runs autonomously). | — (loop runs autonomously; halt at max-iteration guardrail pages the user per *Retroactive review loop*). |
 
 Notes on the matrix:
 
@@ -59,10 +69,10 @@ Notes on the matrix:
   *Branching Strategy* is not waivable.
 - FULL-mode REVIEW notifications are non-blocking — posting them does
   not pause the loop. The one FULL-mode REVIEW gate is the bounded
-  non-blocking-finding triage `AskUserQuestion` (spec 0006 R10), under
-  which only FULL consults the user on optional findings; INTERMEDIATE,
-  MINIMAL, and AUTO fire no REVIEW gate. The per-iteration notifications
-  themselves are not gates.
+  non-blocking-finding triage realised through the `user-validate` skill
+  (spec 0006 R10), under which only FULL consults the user on optional
+  findings; INTERMEDIATE, MINIMAL, and AUTO fire no REVIEW gate. The
+  per-iteration notifications themselves are not gates.
 - The max-iteration guardrail (*Retroactive review loop*) pages the
   user in **every** mode, including AUTO. That paging is a gate by
   exception — the loop has halted and the user must decide whether

--- a/docs/plan-review-protocol.md
+++ b/docs/plan-review-protocol.md
@@ -37,3 +37,10 @@ list states the taxonomy, not the routing.
 **REQUEST CHANGES blocks DEV.** A plan-review verdict of `### Verdict:
 REQUEST CHANGES` SHALL block the DEV stage from starting until a
 revised plan is posted and re-reviewed cold.
+
+**Plan-validation gate.** In the modes that gate the PLAN stage (FULL
+and INTERMEDIATE per *Interaction modes → Behavioral contract per (mode
+× stage) cell*), the user gate that validates the plan comment before
+DEV starts is realised through the `user-validate` skill — not through a
+direct `AskUserQuestion` call. That keeps the user's configured
+validation backend (including `plannotator`) in effect.


### PR DESCRIPTION
Implements spec 0106 for the ticket #663 friction: the point-of-use lifecycle docs now name the `user-validate` skill as the artifact-validation gate mechanism instead of the raw `AskUserQuestion` primitive, so an orchestrator following the docs cannot silently bypass the user's configured backend (e.g. `plannotator`). Documentation-only prose across three files.

Closes #663.

## How to read this PR?

Three docs, smallest surface first:

1. `docs/agent-team-protocol.md` — one-line change to the trivial-tier row (R9).
2. `docs/plan-review-protocol.md` — one new **Plan-validation gate** note after *REQUEST CHANGES blocks DEV* (R8).
3. `docs/interaction-modes.md` — the substantive edits: *User-gate definition* action #1 now names `user-validate` and frames `AskUserQuestion` as the `internal`-backend realization (R1–R3); action #2 (the "may I merge?" gate) is clarified as a distinct, non-`user-validate` action-authorization (R4); the PLAN row (R5) and the FULL-mode REVIEW triage row + its note bullet (R6) now cite `user-validate`. The **SPECS row is deliberately unchanged** — `spec-author` interview turns are elicitation, not artifact validation (R7).

## How to test this PR?

```sh
task spec:lint      # 141 files, markdownlint + semantic — expect: Linting passed!
task lint-markdown  # expect: exit 0, no findings
```

Then read the *User-gate definition* section of `docs/interaction-modes.md` and confirm: an artifact-validation gate names `user-validate`; the merge gate stays distinct; no point-of-use cell names `AskUserQuestion` as the mechanism for validating a plan or REVIEW findings.

## Detailed description (for agents)

- **Modified:** `docs/interaction-modes.md`, `docs/plan-review-protocol.md`, `docs/agent-team-protocol.md` (prose only).
- **Untouched by design (spec 0106 `## Out of scope`):** `docs/cli-matrix.md` row 27b, `artifacts/core/rules/60-tools.md` `internal`-backend enumeration, `artifacts/library/skills/user-validate/SKILL.md`, `artifacts/core/skills/spec-author/SKILL.md`, the SPECS matrix row, and the merge-authorization request text.
- **No code / no build outputs / no version bump.** Targets are `docs/*.md`, not `artifacts/**`; `scripts/build-components.sh` is not involved and no skill/agent source (`metadata.provenance.version`) is modified. No `docs/cli-matrix.md` update is entailed (no matrix-governed path touched).
- **Lifecycle:** AUTO mode, `small` tier. Spec 0106 merged in #679. PLAN posted on #663. REVIEW is a cold `pr-reviewer` pass.