### PR TITLE
📝 Transition spec 0106 to implemented

### DIFF
--- a/specs/0106-gate-docs-name-user-validate.md
+++ b/specs/0106-gate-docs-name-user-validate.md
@@ -1,7 +1,7 @@
 ---
 id: "0106"
 slug: gate-docs-name-user-validate
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 663


### PR DESCRIPTION
Metadata-only lifecycle transition: `specs/0106-gate-docs-name-user-validate.md` `status: approved` → `implemented`, triggered by the merge of implementation PR #682 (issue #663) per `docs/spec-format.md` → *Recording a status transition*.

## How to read this PR?

One-line frontmatter change (`status`). No body, `id`, `slug`, or `version` change.

## How to test this PR?

`task spec:lint` → expect "Linting passed!".

## Detailed description (for agents)

Closes out the SPECS-stage lifecycle for spec 0106: the spec was folded to `approved` at spec-PR #679's merge and its implementation (#682) is now merged, so the recorded status advances to `implemented`. Anchored to the closed ticket #663; no closing keyword (the ticket is already closed).