### PR TITLE
✨ Make harness-curator apply.py forge-agnostic (gh/glab/tea)

### DIFF
--- a/artifacts/library/skills/harness-curator/SKILL.md
+++ b/artifacts/library/skills/harness-curator/SKILL.md
@@ -11,12 +11,12 @@ description: "Harness feedback-loop curator. Activate on demand to read
   with dedup and per-run issue cap."
 type: skill
 license: Apache-2.0
-compatibility: Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.6.0,<3.7').
+compatibility: Requires bash, jq, a forge CLI (setup-labels.sh uses gh; --apply selects gh, glab, or tea per the target repository's forge), and the mempalace Python package (pipx install 'mempalace>=3.6.0,<3.7').
 metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.6.2"
+    version: "1.7.0"
 claude:
   allowed-tools:
     - Read
@@ -127,9 +127,10 @@ make sure it reads sensibly.
 Two paths, equivalent in outcome:
 
 - **Let the script do it**: `task harness-curate -- --apply`. The
-  script opens one issue per cluster via `gh issue create`, with all
-  three labels from the JSON (`harness-feedback`, `room:<x>`,
-  `severity:<y>`).
+  script opens one issue per cluster via the target forge's CLI
+  (`gh`, `glab`, or `tea`, selected from the cluster's canonical
+  repository host), with all three labels from the JSON
+  (`harness-feedback`, `room:<x>`, `severity:<y>`).
 - **Open them yourself**: iterate the JSON and run `gh issue create
   --repo <owner>/<repo> --title <title> --body <body> --label <...>`
   per cluster (the same argv `apply.py` builds), or the `glab`/`tea`

--- a/artifacts/library/skills/harness-curator/scripts/apply.py
+++ b/artifacts/library/skills/harness-curator/scripts/apply.py
@@ -2,9 +2,12 @@
 """harness_curate — Apply step.
 
 Reads the cluster JSON emitted by ``curate.py`` on stdin and either opens
-one GitHub issue per cluster via ``gh issue create`` (default) or, with
-``--dry-run-apply``, prints the resolved ``gh`` argv as one JSON line per
-cluster without running anything.
+one issue per cluster on whichever forge hosts that cluster's canonical
+repository — GitHub via ``gh``, GitLab via ``glab``, Gitea via ``tea``,
+selected from the target repository's host — or, with ``--dry-run-apply``,
+prints the resolved forge argv as one JSON line per cluster without running
+anything. The GitHub argv path is kept byte-for-byte identical to the
+original single-forge behavior (spec 0105 R7).
 
 The script is invoked by ``curate.sh`` through ``$MEMPALACE_PYTHON``
 rather than via shebang exec, so that any future ``from mempalace …``
@@ -19,15 +22,47 @@ import os
 import subprocess
 import sys
 from typing import Optional
+from urllib.parse import urlsplit
 
 
-def _build_cmd(cluster: dict) -> list[str]:
-    target = cluster["target_repo"]
-    # Defensive: a filer may set `canonical:` to a file URL
-    # (https://github.com/<o>/<r>/blob/<branch>/<path>) despite the
-    # schema requiring the bare repo form. Strip /blob/... or
-    # /tree/... so `gh --repo` receives a valid <owner>/<repo> slug.
-    # Schema contract: harness-report/SKILL.md → `canonical` field.
+def _detect_forge(url: str) -> str:
+    """Select the forge CLI family from a canonical repository URL's host.
+
+    `github.com` → ``"github"``; `gitlab.com`, a host whose name begins
+    ``gitlab.``, or a host present in the comma-separated
+    ``CREWRIG_GITLAB_HOSTS`` env var (default unset → empty; spec 0105 R9's
+    deterministic, default-unset self-hosted-GitLab allowlist) →
+    ``"gitlab"``; any other host → ``"gitea"``. Robust to a URL with or
+    without a scheme. Mirrors spec 0103 delta-01 R9 and spec 0105 R1.
+    """
+    # urlsplit only fills netloc when a scheme (or leading `//`) is present;
+    # prepend `//` for a bare `host/owner/repo` so the host parses reliably.
+    parsed = urlsplit(url.strip() if "://" in url else "//" + url.strip())
+    host = (parsed.hostname or "").lower()
+    if host == "github.com":
+        return "github"
+    if host == "gitlab.com" or host.startswith("gitlab."):
+        return "gitlab"
+    allow = {
+        h.strip().lower()
+        for h in os.environ.get("CREWRIG_GITLAB_HOSTS", "").split(",")
+        if h.strip()
+    }
+    if host in allow:
+        return "gitlab"
+    return "gitea"
+
+
+def _clean_target(target: str) -> str:
+    """Strip a `/blob/…` or `/tree/…` file-URL suffix to the repo root.
+
+    Defensive: a filer may set `canonical:` to a file URL
+    (`https://<host>/<o>/<r>/blob/<branch>/<path>`) despite the schema
+    requiring the bare repo form. Single-sources the issue-#63 normalization
+    previously duplicated in `_build_cmd` and `_repo_slug`, emitting the
+    unchanged warning on stderr. Idempotent: a clean URL passes through with
+    no warning. Schema contract: harness-report/SKILL.md → `canonical` field.
+    """
     for sep in ("/blob/", "/tree/"):
         if sep in target:
             print(
@@ -36,14 +71,64 @@ def _build_cmd(cluster: dict) -> list[str]:
                 "to the repo URL, not a file URL.",
                 file=sys.stderr,
             )
-            target = target.split(sep, 1)[0]
-            break
+            return target.split(sep, 1)[0]
+    return target
+
+
+def _repo_ref(forge: str, cleaned: str) -> str:
+    """Derive the repository reference the selected forge CLI accepts, from an
+    already-`_clean_target`-normalized canonical URL (spec 0105 R3):
+
+    - github: strip the `https://github.com/` prefix to the bare
+      `owner/repo` slug — kept VERBATIM so the `gh` argv stays byte-for-byte
+      identical to the original single-forge behavior (spec R7);
+    - gitlab: the full cleaned URL — `glab -R` accepts a full URL, covering
+      self-hosted hosts and nested subgroups;
+    - gitea: the last two path segments (`owner/repo`).
+    """
+    if forge == "github":
+        return cleaned.replace("https://github.com/", "")
+    if forge == "gitlab":
+        return cleaned
+    # gitea: owner/repo from the final two non-empty path segments.
+    parts = [p for p in cleaned.split("/") if p]
+    return "/".join(parts[-2:])
+
+
+def _build_cmd(cluster: dict) -> list[str]:
+    """Build the per-forge `issue create` argv for a cluster (spec R2, R4).
+
+    Dispatches on the target repository's host. The GitHub branch is
+    byte-for-byte identical to the original single-forge output (spec R7).
+    The `harness-feedback` label name is forge-independent (spec R4).
+    """
+    target = cluster["target_repo"]
+    cleaned = _clean_target(target)
+    forge = _detect_forge(target)
+    ref = _repo_ref(forge, cleaned)
     title = cluster["title"]
     body = cluster["body"]
     labels = cluster.get("labels", ["harness-feedback"])
+    if forge == "gitlab":
+        return [
+            "glab", "issue", "create",
+            "--repo", ref,
+            "--title", title,
+            "--description", body,
+            "--label", ",".join(labels),
+        ]
+    if forge == "gitea":
+        return [
+            "tea", "issues", "create",
+            "--repo", ref,
+            "--title", title,
+            "--description", body,
+            "--labels", ",".join(labels),
+        ]
+    # github (default): unchanged argv — same flag order, same warning path.
     cmd = [
         "gh", "issue", "create",
-        "--repo", target.replace("https://github.com/", ""),
+        "--repo", ref,
         "--title", title,
         "--body", body,
     ]
@@ -52,60 +137,109 @@ def _build_cmd(cluster: dict) -> list[str]:
     return cmd
 
 
-def _repo_slug(cluster: dict) -> str:
-    """Return the `<owner>/<repo>` slug for a cluster's target_repo, applying
-    the same /blob/ and /tree/ stripping as `_build_cmd` so the dedup query
-    matches the issue-create target exactly."""
-    target = cluster["target_repo"]
-    for sep in ("/blob/", "/tree/"):
-        if sep in target:
-            target = target.split(sep, 1)[0]
-            break
-    return target.replace("https://github.com/", "")
+def _dedup_list_cmd(forge: str, repo_ref: str, cluster_key: str) -> list[str]:
+    """Build the per-forge list/search argv for the dedup lookup (spec R5).
 
+    Each forge lists open `harness-feedback` issues matching the cluster-key
+    phrase; the skip decision itself is title-only and made by
+    `_match_existing`, so the forge-specific search need only narrow the set.
 
-def _existing_issue_url(repo: str, cluster_key: str) -> Optional[str]:
-    """Look up an open `harness-feedback` issue whose title matches the
-    cluster's canonical prefix `Friction cluster: <key> (`. Returns the
-    issue URL on match, None otherwise.
-
-    `gh search` / `gh issue list --search` is fuzzy, so we post-filter on
-    a startswith check. The trailing ` (` anchor is load-bearing — it
-    prevents substring collisions between sibling cluster keys (e.g.
-    `yq` vs `yq-merge`).
-
-    Race condition: two concurrent curator runs could both miss the
-    duplicate and both open an issue. V1 ignores this — the scheduler
-    runs serially on one machine and the reactive trigger is rare.
-    Fails open on `gh` errors: when in doubt, surface the friction.
+    - github: unchanged — `gh issue list … --search "… in:title" --json
+      title,url` (byte-identical to the original single-forge query);
+    - gitlab: `glab issue list … --search "…" --output json` (lists open by
+      default);
+    - gitea: `tea issues list … --keyword "…" --output json --fields
+      index,title,state,url`. The `--fields …,url` is REQUIRED — `tea
+      issues list --output json` uses tea's DEFAULT field set, which omits
+      `url`, so a URL-keyed skip would never fire on Gitea.
     """
-    prefix = f"Friction cluster: {cluster_key} ("
-    cmd = [
+    if forge == "gitlab":
+        return [
+            "glab", "issue", "list",
+            "--repo", repo_ref,
+            "--label", "harness-feedback",
+            "--search", f"Friction cluster: {cluster_key}",
+            "--output", "json",
+            "--per-page", "50",
+        ]
+    if forge == "gitea":
+        return [
+            "tea", "issues", "list",
+            "--repo", repo_ref,
+            "--labels", "harness-feedback",
+            "--state", "open",
+            "--keyword", f"Friction cluster: {cluster_key}",
+            "--fields", "index,title,state,url",
+            "--output", "json",
+            "--limit", "50",
+        ]
+    # github (default): unchanged query.
+    return [
         "gh", "issue", "list",
-        "--repo", repo,
+        "--repo", repo_ref,
         "--label", "harness-feedback",
         "--state", "open",
         "--search", f"Friction cluster: {cluster_key} in:title",
         "--json", "title,url",
         "--limit", "50",
     ]
+
+
+def _match_existing(items: list, cluster_key: str) -> Optional[str]:
+    """Pure title-prefix matcher (no I/O) for the dedup skip decision (R5).
+
+    Returns a truthy value for the first item whose title starts with
+    `Friction cluster: <key> (` — the matched issue's URL if any of
+    `url` / `web_url` / `html_url` is present (read defensively across the
+    forges' differing JSON shapes, for the caller's log line only), else the
+    matched **title** as a non-None placeholder so the caller's `if existing:`
+    still skips. The skip decision is therefore title-only and independent of
+    any forge-specific URL field (spec R5). Returns `None` only when no title
+    matches.
+
+    The trailing ` (` anchor is load-bearing — it prevents substring
+    collisions between sibling cluster keys (e.g. `yq` vs `yq-merge`).
+    """
+    prefix = f"Friction cluster: {cluster_key} ("
+    for item in items:
+        title = item.get("title", "")
+        if title.startswith(prefix):
+            return (
+                item.get("url")
+                or item.get("web_url")
+                or item.get("html_url")
+                or title
+            )
+    return None
+
+
+def _existing_issue_url(forge: str, repo_ref: str, cluster_key: str) -> Optional[str]:
+    """Look up an open `harness-feedback` issue on the selected forge whose
+    title matches the cluster's canonical prefix `Friction cluster: <key> (`.
+    Returns a truthy value on match (see `_match_existing`), None otherwise.
+
+    Race condition: two concurrent curator runs could both miss the duplicate
+    and both open an issue. V1 ignores this — the scheduler runs serially on
+    one machine and the reactive trigger is rare.
+
+    Fails open on ANY error — a tool error, a missing forge CLI binary, or
+    unparseable output all resolve to no-match so the cluster's issue is still
+    opened (spec R6): a duplicate is recoverable, a missed friction is not.
+    """
+    cmd = _dedup_list_cmd(forge, repo_ref, cluster_key)
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
         items = json.loads(result.stdout or "[]")
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        return _match_existing(items, cluster_key)
+    except Exception as e:  # noqa: BLE001 — spec R6 fail-open: any error → no-match
         # Fail open: log and let the cluster open. Duplicates are
         # recoverable; a missed friction is not.
         print(
-            f"  warn: dedup query failed on {repo} for '{cluster_key}': {e}; "
+            f"  warn: dedup query failed on {repo_ref} for '{cluster_key}': {e}; "
             "treating as no-match.",
             file=sys.stderr,
         )
         return None
-    for item in items:
-        title = item.get("title", "")
-        if title.startswith(prefix):
-            return item.get("url")
-    return None
 
 
 def _collect_drawer_ids(cluster: dict) -> tuple[list[str], int]:
@@ -155,7 +289,11 @@ def main() -> int:
             # the wire shape stays uniform across modes.
             dedup_match: Optional[str] = None
             if args.dedup:
-                dedup_match = _existing_issue_url(_repo_slug(c), c["cluster_key"])
+                target = c["target_repo"]
+                forge = _detect_forge(target)
+                dedup_match = _existing_issue_url(
+                    forge, _repo_ref(forge, _clean_target(target)), c["cluster_key"]
+                )
             print(json.dumps(_build_cmd(c)))
             # Issue #69: surface the drawers that would receive the
             # `opened_as` correlation stamp. Object shape (not array) so
@@ -194,7 +332,10 @@ def main() -> int:
         target = c["target_repo"]
         title = c["title"]
         if args.dedup:
-            existing = _existing_issue_url(_repo_slug(c), c["cluster_key"])
+            forge = _detect_forge(target)
+            existing = _existing_issue_url(
+                forge, _repo_ref(forge, _clean_target(target)), c["cluster_key"]
+            )
             if existing:
                 print(
                     f"--- Skipping duplicate cluster '{c['cluster_key']}' "

--- a/artifacts/library/skills/harness-curator/scripts/apply.py
+++ b/artifacts/library/skills/harness-curator/scripts/apply.py
@@ -359,7 +359,7 @@ def main() -> int:
             # narrows the clobber window against concurrent edits.
             # Partial failures are counted and logged but do NOT mark
             # the cluster failed — the issue is already opened on
-            # GitHub. The aggregate is surfaced in the final summary so
+            # the target forge. The aggregate is surfaced in the final summary so
             # the maintainer sees that some drawers remain unstamped.
             drawer_ids, missing = _collect_drawer_ids(c)
             if missing:

--- a/artifacts/library/skills/harness-curator/scripts/test.sh
+++ b/artifacts/library/skills/harness-curator/scripts/test.sh
@@ -655,6 +655,145 @@ if grep -q "stripping to repo root" "$NORM_TMP/err"; then
 fi
 echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
 
+# --- Spec 0105: forge-agnostic apply (offline --dry-run-apply + unit) -----
+# The apply step now files each cluster against whichever forge hosts its
+# canonical repo — GitHub via `gh`, GitLab via `glab`, Gitea via `tea` —
+# selected from the target host. Everything below is OFFLINE: --dry-run-apply
+# resolves and prints the create argv without ever exec'ing a forge binary,
+# and the unit block loads apply.py via importlib (no live forge, no network).
+# The GitHub argv/regression assertions above are the byte-identity R7 guard
+# and stay untouched; these only add the non-GitHub surfaces + the two
+# Finding-2 guards (PLAN v2 Step 8).
+
+# Multi-label variant of make_cluster_payload: the single-label helper above
+# cannot exercise label comma-joining, so this one carries the full
+# three-tuple ["harness-feedback","room:tool","severity:high"].
+make_forge_payload() {
+  local target="$1"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"forge-probe","cluster_size":1,"target_repo":"%s","title":"forge probe","body":"body","labels":["harness-feedback","room:tool","severity:high"],"frictions":[{"_drawer_id":"drw-forge-1"}]}],"skipped":[],"routing_failures":[]}' "$target"
+}
+
+# Emit the single create-argv JSON array line for a target. Optional $2 is a
+# value for CREWRIG_GITLAB_HOSTS, scoped to this one process only (proves the
+# spec 0105 R9 allowlist branch). The full dry-run output is captured first
+# (no early pipe close), then the lone `^[` argv line is extracted — one
+# cluster ⇒ exactly one argv line, so no SIGPIPE under pipefail.
+forge_argv() {
+  local target="$1" out
+  if [ -n "${2:-}" ]; then
+    out=$(make_forge_payload "$target" | CREWRIG_GITLAB_HOSTS="$2" python3 "$APPLY" --dry-run-apply)
+  else
+    out=$(make_forge_payload "$target" | python3 "$APPLY" --dry-run-apply)
+  fi
+  printf '%s\n' "$out" | grep '^\[' | head -n1
+}
+
+# Count occurrences of an exact token in a JSON argv array (0/1/…).
+argv_flag_count() { jq -c --arg f "$1" '[.[] | select(. == $f)] | length'; }
+
+# GitLab.com canonical → glab issue create; --description (not --body); --repo
+# is the FULL cleaned URL; exactly one --label carrying the comma-joined tuple.
+GL_ARGV=$(forge_argv "https://gitlab.com/gr/proj")
+[ -n "$GL_ARGV" ] || { echo "FAIL: gitlab.com produced no argv line" >&2; exit 1; }
+assert "gitlab.com argv head"            '["glab","issue","create"]' "$(echo "$GL_ARGV" | jq -c '.[0:3]')"
+assert "gitlab.com has --description"    "1" "$(echo "$GL_ARGV" | argv_flag_count '--description')"
+assert "gitlab.com has no --body"        "0" "$(echo "$GL_ARGV" | argv_flag_count '--body')"
+assert "gitlab.com --repo is full URL"   "https://gitlab.com/gr/proj" \
+  "$(echo "$GL_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "gitlab.com single --label flag"  "1" "$(echo "$GL_ARGV" | argv_flag_count '--label')"
+assert "gitlab.com has no --labels"      "0" "$(echo "$GL_ARGV" | argv_flag_count '--labels')"
+assert "gitlab.com --label comma-joined" "harness-feedback,room:tool,severity:high" \
+  "$(echo "$GL_ARGV" | jq -r '.[(index("--label"))+1]')"
+
+# A `gitlab.`-prefix host resolves to glab without any env var (spec R1 clause 2).
+GLPFX_ARGV=$(forge_argv "https://gitlab.example.com/gr/proj")
+assert "gitlab.-prefix host resolves to glab" '["glab","issue","create"]' \
+  "$(echo "$GLPFX_ARGV" | jq -c '.[0:3]')"
+
+# spec 0105 R9 allowlist — the key evidence pair. The SAME self-hosted host
+# resolves to glab WITH CREWRIG_GITLAB_HOSTS set, and to tea WITHOUT it.
+R9_ARGV=$(forge_argv "https://git.example.com/o/r" "git.example.com")
+assert "R9 CREWRIG_GITLAB_HOSTS host → glab" '["glab","issue","create"]' \
+  "$(echo "$R9_ARGV" | jq -c '.[0:3]')"
+assert "R9 glab --repo is full URL"          "https://git.example.com/o/r" \
+  "$(echo "$R9_ARGV" | jq -r '.[(index("--repo"))+1]')"
+R9_OFF_ARGV=$(forge_argv "https://git.example.com/o/r")
+assert "R9 same host without env → tea"      '["tea","issues","create"]' \
+  "$(echo "$R9_OFF_ARGV" | jq -c '.[0:3]')"
+
+# Plain self-hosted host → tea issues create; --description; --labels
+# comma-joined; --repo is the last two path segments (owner/repo).
+TEA_ARGV=$(forge_argv "https://git.acme.io/o/r")
+[ -n "$TEA_ARGV" ] || { echo "FAIL: gitea host produced no argv line" >&2; exit 1; }
+assert "gitea argv head"              '["tea","issues","create"]' "$(echo "$TEA_ARGV" | jq -c '.[0:3]')"
+assert "gitea has --description"      "1" "$(echo "$TEA_ARGV" | argv_flag_count '--description')"
+assert "gitea single --labels flag"   "1" "$(echo "$TEA_ARGV" | argv_flag_count '--labels')"
+assert "gitea --labels comma-joined"  "harness-feedback,room:tool,severity:high" \
+  "$(echo "$TEA_ARGV" | jq -r '.[(index("--labels"))+1]')"
+assert "gitea --repo is owner/repo"   "o/r" "$(echo "$TEA_ARGV" | jq -r '.[(index("--repo"))+1]')"
+
+# Finding-2 unit assertions — load apply.py as a module (importlib) and probe
+# the pure helpers directly. apply.py has no import-time side effects and its
+# `from mempalace.mcp_server import …` is function-local to main(), so a bare
+# import is safe offline. The snippet must set `OUT`; its str() is printed for
+# the bash `assert` to compare. A raising snippet writes nothing → the assert
+# mismatches → red (which is exactly how the "revert must fail" cases bite).
+apply_eval() {
+  APPLY_PATH="$APPLY" python3 -c '
+import importlib.util, os, sys
+_spec = importlib.util.spec_from_file_location("apply_mod", os.environ["APPLY_PATH"])
+_m = importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_m)
+_ns = {"m": _m}
+exec(sys.argv[1], _ns)
+sys.stdout.write(str(_ns["OUT"]))
+' "$1"
+}
+
+# PRIMARY Finding-2 guard (argv fix): the Gitea dedup list MUST carry
+# `--fields` immediately followed by `index,title,state,url`. `tea issues
+# list --output json` omits `url` from its DEFAULT field set, so dropping the
+# `,url` (or the flag) would make a URL-keyed skip never fire → revert = red.
+assert "gitea dedup --fields index,title,state,url" "True" \
+  "$(apply_eval 'c = m._dedup_list_cmd("gitea","o/r","k"); OUT = (c[c.index("--fields")+1] == "index,title,state,url")')"
+assert "gitea dedup --output json" "True" \
+  "$(apply_eval 'c = m._dedup_list_cmd("gitea","o/r","k"); OUT = (c[c.index("--output")+1] == "json")')"
+
+# GitLab dedup list uses --output json and --per-page (glab lists open by default).
+assert "gitlab dedup --output json" "True" \
+  "$(apply_eval 'c = m._dedup_list_cmd("gitlab","ref","k"); OUT = (c[c.index("--output")+1] == "json")')"
+assert "gitlab dedup has --per-page" "True" \
+  "$(apply_eval 'c = m._dedup_list_cmd("gitlab","ref","k"); OUT = ("--per-page" in c)')"
+
+# GitHub dedup list is UNCHANGED — `--json title,url` and the `in:title`
+# search qualifier (byte-identical to the original single-forge query).
+assert "github dedup --json title,url" "title,url" \
+  "$(apply_eval 'c = m._dedup_list_cmd("github","o/r","k"); OUT = c[c.index("--json")+1]')"
+assert "github dedup search uses in:title" "True" \
+  "$(apply_eval 'c = m._dedup_list_cmd("github","o/r","k"); OUT = any("in:title" in x for x in c)')"
+
+# PRIMARY Finding-2 guard (skip decoupling): _match_existing returns a truthy
+# value on a title match even when NO url/web_url/html_url field is present.
+# Reverting to a URL-keyed return (`item.get("url")`) yields None here → the
+# caller would never skip the duplicate on Gitea → revert = red.
+assert "match_existing truthy with no url field" "True" \
+  "$(apply_eval 'OUT = bool(m._match_existing([{"title":"Friction cluster: k (2 reports)"}], "k"))')"
+assert "match_existing returns html_url when present" "u" \
+  "$(apply_eval 'OUT = m._match_existing([{"title":"Friction cluster: k (2 reports)","html_url":"u"}], "k")')"
+assert "match_existing returns None on no title match" "None" \
+  "$(apply_eval 'OUT = m._match_existing([{"title":"unrelated"}], "k")')"
+# The trailing ` (` anchor is load-bearing: sibling key `k-merge` must NOT
+# match cluster_key `k`. Drop the anchor and this returns a truthy title → red.
+assert "match_existing anchor blocks k vs k-merge collision" "None" \
+  "$(apply_eval 'OUT = m._match_existing([{"title":"Friction cluster: k-merge (2 reports)"}], "k")')"
+
+# Fail-open (spec R6) — validates the deliberate `except Exception` broadening.
+# With `tea` absent (PATH scrubbed), subprocess.run raises FileNotFoundError,
+# which is NOT a CalledProcessError/JSONDecodeError. A narrow except tuple
+# would let it propagate and crash the apply loop; the broad except must
+# catch it and return None (no-match). Revert to a narrow tuple → red.
+assert "existing_issue_url fails open on missing forge binary" "True" \
+  "$(apply_eval 'import os; os.environ["PATH"]="/nonexistent"; OUT = (m._existing_issue_url("gitea","o/r","k") is None)' 2>/dev/null)"
+
 # --- Smoke test: setup-labels.sh bootstrap (offline, --dry-run only) -----
 # Offline assertions on the dry-run plan — never contacts GitHub. Mirrors
 # the norm.* sub-case shape used in the apply.py normalization block


### PR DESCRIPTION
Implements spec **0105** (+ delta **0105-01**) for ticket #671: the harness-curator's automated apply step now files each friction cluster on whichever forge hosts its canonical repository — GitHub via `gh`, GitLab via `glab`, Gitea via `tea` — instead of hardcoding GitHub.

Closes #671

## How to read this PR?

Two source files (harness-curator is **library-tier** → build outputs live in the gitignored `dist/library/`, so there are no committed built copies in this diff):

- `artifacts/library/skills/harness-curator/scripts/apply.py` — the change. Forge is selected from the canonical URL host by `_detect_forge` (`github.com`→`gh`; `gitlab.com` / `gitlab.`-prefix / a host in the default-unset `CREWRIG_GITLAB_HOSTS` allowlist→`glab`; any other host→`tea`). `_clean_target` single-sources the issue-#63 `/blob//tree/` strip; `_repo_ref` derives the reference each CLI accepts; `_build_cmd` / `_dedup_list_cmd` dispatch per forge; `_match_existing` decides the dedup skip on the **title prefix only** (spec R5), URL-field-independent.
- `artifacts/library/skills/harness-curator/scripts/test.sh` — +27 offline assertions.
- `SKILL.md` — version `1.6.2 → 1.7.0` + compatibility/prose.

Regression guards: the **GitHub argv is byte-for-byte identical** (spec R7); `opened_as` write-back (#69), the #63 warning, and the run summary are untouched (spec R8); the dedup lookup **fails open on any error**, including a missing `glab`/`tea` binary (spec R6).

## How to test this PR?

```bash
bash artifacts/library/skills/harness-curator/scripts/test.sh   # 161 PASS / 0 FAIL
bash scripts/build-components.sh                                 # clean; library-tier → nothing staged
```

The suite is offline. Per-forge argv, the `CREWRIG_GITLAB_HOSTS` R9 pair, the Gitea `--fields …,url` fix, the title-only matcher, and fail-open-on-missing-binary are all bite-verified (reverting each fix turns its guard red).

## Detailed description (for agents)

- **Spec renumber:** authored as 0104, renumbered to **0105** by PR #677 after a concurrent duplicate-id collision (#673 merged a different 0104). Delta **0105-01** (PR #681) blesses the deterministic `CREWRIG_GITLAB_HOSTS` allowlist as R1 clause 3's realization (R9), resolving a PLAN-review `class: spec` tie.
- **Deliberate deviation (spec-R6-justified):** `_existing_issue_url` broadens its fail-open catch from `(CalledProcessError, JSONDecodeError)` to `except Exception`, so a missing `glab`/`tea` binary (`FileNotFoundError`) resolves to no-match instead of crashing the apply loop mid-run — the exact new failure mode this ticket introduces. GitHub path unaffected; a dedicated test bites this.
- **CLI-matrix — no-op (consulted).** The change is on the **forge axis** (GitHub/GitLab/Gitea) inside a bundled Python script that `build-components.sh` deploys byte-identically to all four CLIs; it is orthogonal to the **CLI axis** (Claude/Gemini/Copilot/Antigravity). No CLI-specific integration point changes → no `docs/cli-matrix.md` row change.
- **Out of scope (own follow-up):** `setup-labels.sh` and `schedule-curator.sh` remain GitHub-only; `curate.py` and the auto-fix mode (#42) are untouched.