### PR TITLE
📝 Realize spec 0101 delta-01 — spec-PR merge gate discharge carve-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,9 @@ rule takes over.
 - The `main` branch is **protected**: no direct pushes allowed.
 - Every change must go through a **feature branch** merged into `main` via a Pull Request.
 - **NEVER merge a Pull Request (PR/MR)** without asking for the user's formal permission JUST BEFORE executing the merge.
+  - Narrow one-file spec-PR exception: [`docs/interaction-modes.md`](docs/interaction-modes.md) → *User-gate definition*.
 - The `import/gitlab` branch tracks the legacy GitLab project (`gitlab` remote) and serves as inspiration only.
-- Non-trivial tickets follow the **Spec-PR workflow** (see section below): a `spec/<NNNN>-<slug>` PR qualifies the WHAT and merges to `main` before the implementation branch is cut.
+- Non-trivial tickets follow the **Spec-PR workflow** (see below).
 
 ### On Claude Code CLI — solo-maintainer self-merge block
 

--- a/docs/interaction-modes.md
+++ b/docs/interaction-modes.md
@@ -47,6 +47,23 @@ agent posts ADRs, plan comments, or REVIEW iteration notices in a
 given mode is fixed by the lifecycle contract (ADR-0010), independent
 of mode.
 
+**Narrow discharge carve-out.** A SPECS-stage content-approval — the
+artifact-validation gate (realised through the `user-validate` skill) that
+validates a spec's content — of spec content that becomes a
+**one-file spec-PR** (per the Spec-PR workflow *one-file rule*: exactly one
+new file, no other edits) merging that content **unchanged** discharges the
+pre-merge merge-authorization gate for that spec-PR. The orchestrator SHALL
+NOT fire a second merge-authorization request for such a spec-PR, because
+the artifact merged to `main` is the identical, unchanged artifact the
+content-approval already approved. This discharge is deliberately narrow —
+it is not a general waiver of the gate. It does **not** apply in `AUTO`,
+where no SPECS-stage content-approval gate runs to discharge it, so the
+merge-authorization request there still fires and remains the sole approval
+event. And the merge-authorization gate stays mandatory and separate for
+every merge the carve-out does not cover — implementation-PRs, any
+delta-spec PR whose content changed after its own content-approval, and
+every non-spec-PR merge.
+
 ## Behavioral contract per (mode × stage) cell
 
 Each cell below names precisely the user gates the orchestrator SHALL
@@ -57,16 +74,25 @@ post hoc).
 
 | Stage \ Mode | FULL | INTERMEDIATE | MINIMAL | AUTO |
 |---|---|---|---|---|
-| **SPECS** | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | `AskUserQuestion` per interview turn during `spec-author`; merge-authorization gate before merging the spec-PR. | No interview gate (spec authored autonomously); merge-authorization gate before merging the spec-PR. |
+| **SPECS** | `AskUserQuestion` per interview turn during `spec-author`; the SPECS-stage content-approval of the spec content discharges the resulting one-file spec-PR's merge-authorization gate (see *User-gate definition*), so no second ask fires for it. | `AskUserQuestion` per interview turn during `spec-author`; the SPECS-stage content-approval of the spec content discharges the resulting one-file spec-PR's merge-authorization gate (see *User-gate definition*), so no second ask fires for it. | `AskUserQuestion` per interview turn during `spec-author`; the SPECS-stage content-approval of the spec content discharges the resulting one-file spec-PR's merge-authorization gate (see *User-gate definition*), so no second ask fires for it. | No interview gate (spec authored autonomously); merge-authorization gate before merging the spec-PR — no SPECS-stage content-approval runs to discharge it. |
 | **PLAN** | Validate the plan comment through the `user-validate` skill before DEV starts; second `architect` cold-review remains autonomous. | Validate the plan comment through the `user-validate` skill before DEV starts; second `architect` cold-review remains autonomous. | — (plan authored and cold-reviewed autonomously; DEV starts on APPROVE without user prompt). | — (plan authored and cold-reviewed autonomously). |
-| **DEV** | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). |
+| **DEV** | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR whose content changed after its own content-approval; an unchanged one-file delta-spec PR is discharged per *User-gate definition*). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR whose content changed after its own content-approval; an unchanged one-file delta-spec PR is discharged per *User-gate definition*). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR whose content changed after its own content-approval; an unchanged one-file delta-spec PR is discharged per *User-gate definition*). | Merge-authorization gate before merging the implementation-PR (and before merging any delta-spec PR produced by the loop). |
 | **REVIEW** | Non-blocking notification posted on the logbook issue at the start and end of every iteration (per the FULL-mode rule above), **plus** a bounded triage of the non-blocking findings of each pass realised through the `user-validate` skill (spec 0006 R10 / spec 0005 R10 FULL branch). That triage is the sole REVIEW-loop gate. | — (loop runs autonomously; iteration count visible via the `iter:N` PR label). | — (loop runs autonomously). | — (loop runs autonomously; halt at max-iteration guardrail pages the user per *Retroactive review loop*). |
 
 Notes on the matrix:
 
-- The merge-authorization gate is **invariant across modes**: every
-  mode, including AUTO, MUST ask the user before any `gh pr merge`.
-  *Branching Strategy* is not waivable.
+- The merge-authorization gate is **mandatory and un-waived for every
+  merge the one-file spec-PR discharge does not cover**: in every mode,
+  including AUTO, the agent MUST ask the user before any `gh pr merge` of
+  an implementation-PR, a delta-spec PR whose content changed after its
+  own content-approval, or any other non-spec-PR — *Branching Strategy*
+  is not waivable for those merges. The sole exception is the narrow
+  discharge defined under *User-gate definition*: a one-file spec-PR's
+  merge-authorization request is discharged by a prior SPECS-stage
+  content-approval of the identical, unchanged spec content, so it is not
+  fired a second time. That discharge is not a general waiver of the gate,
+  and it does not apply in AUTO, where no content-approval runs to
+  discharge it.
 - FULL-mode REVIEW notifications are non-blocking — posting them does
   not pause the loop. The one FULL-mode REVIEW gate is the bounded
   non-blocking-finding triage realised through the `user-validate` skill

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -218,16 +218,23 @@ recorded **after** the spec has merged, by a metadata-only edit to the merged
 spec's frontmatter. The two cases are defined in turn below.
 
 **Recording the initial `draft` → `approved` transition (in the spec-PR).**
-The spec-PR merge **is** the approval event: the merge-authorization request
-that a maintainer grants just before a spec-PR merges is itself the decision
-that `status: approved` records. Because that gate fires in **every**
-interaction mode — `FULL`, `INTERMEDIATE`, `MINIMAL`, and `AUTO` alike — this
-rule applies independently of mode; no mode lacks a real approval event to
-record. The transition SHALL be recorded **only after** the spec-PR's
-merge-authorization approval has been granted; recording `status: approved`
-ahead of that gate is a violation, because a recorded `approved` status must
-reflect an approval decision that has actually been made, not one presumed
-before its authorization. The edit stays **metadata-only** in the sense the
+Every interaction mode has a real approval event whose grant the recorded
+`status: approved` reflects, but **which** user gate constitutes that event
+is mode-dependent. In `FULL`, `INTERMEDIATE`, and `MINIMAL` the approval
+event is the **SPECS-stage content-approval gate**; because the approved
+spec content becomes a one-file spec-PR that merges unchanged, that same
+content-approval discharges the spec-PR's merge-authorization request, which
+is therefore not fired a second time (see
+[`interaction-modes.md`](interaction-modes.md) → *User-gate definition*). In
+`AUTO`, where no SPECS-stage content-approval gate runs, the approval event
+is the **merge-authorization request**, which still fires and remains the
+sole approval event. The rule is thus mode-independent in effect — no mode
+lacks a real approval decision to record — while the gate that constitutes
+that decision differs by mode. The transition SHALL be recorded **only
+after** that approval event has been secured; recording `status: approved`
+ahead of it is a violation, because a recorded `approved` status must reflect
+an approval decision that has actually been made, not one presumed before it.
+The edit stays **metadata-only** in the sense the
 next paragraph defines: it sets `status` to `approved` and, when
 `interaction-mode` was omitted while the spec was `draft`, sets
 `interaction-mode` to the mode the spec was qualified under (the frontmatter
@@ -237,7 +244,7 @@ spec-PR carries `status: approved` at the moment it lands on `main` — a merged
 spec is never at once merged and still `draft` — and **no** separate,
 post-merge, metadata-only pull request is required to record the approval.
 
-*Merge mechanic.* Strictly **after** the merge-authorization gate is granted
+*Merge mechanic.* Strictly **after** the approval event has been secured
 and strictly **before** running `gh pr merge --squash`, on the spec-PR branch
 (`spec/<NNNN>-<slug>`) edit the spec's frontmatter (`status: draft` →
 `status: approved`, adding `interaction-mode` if it was omitted during


### PR DESCRIPTION
This PR realizes spec 0101 delta-01 (merged via #678) across the three implementation docs, adding a narrow carve-out whereby a one-file spec-PR's merge-authorization gate is discharged by the prior SPECS-stage content-approval of the identical, unchanged spec content. The change is docs-only and keeps the merge-authorization gate mandatory and separate for every merge the carve-out does not cover.

Closes #662

## How to read this PR?

Read the three files in this order — the normative rule lands first, its consumers follow:

1. **`docs/interaction-modes.md`** — the home of the carve-out. Start with the new *Narrow discharge carve-out* paragraph in *User-gate definition* (delta R9): it defines the rule and its boundaries. Then read the reconciled matrix — the SPECS-row cells, the DEV-row cells, and the rewritten "invariant across modes" note (R10/R11/R12). The whole point is that these three surfaces now agree with the carve-out instead of asserting an unqualified invariant.
2. **`docs/spec-format.md`** — *Recording the initial `draft` → `approved` transition* is rewritten so the approval event is mode-dependent (revised R4/R5): the content-approval gate in `FULL`/`INTERMEDIATE`/`MINIMAL`, the merge-authorization request in `AUTO`. The invariant that `approved` is never recorded ahead of a real approval is preserved (R14); the *Merge mechanic* sub-paragraph gets a one-line coherence touch.
3. **`AGENTS.md`** — one pointer-only sub-bullet under the unconditional "NEVER merge" bullet (R13), naming `docs/interaction-modes.md` as the home of the exception. Read it alongside the paired one-line reclaim on the Spec-PR summary bullet.

Two non-obvious decisions worth flagging:

- **The framing is deliberately narrow.** The discharge applies *only* to a one-file spec-PR whose approved content merges unchanged. It is not a general gate waiver, it does not apply in `AUTO` (no content-approval runs there to discharge anything), and the merge-authorization gate stays mandatory and separate for implementation-PRs, changed delta-spec PRs, and every non-spec-PR merge. The prose says this explicitly in all three surfaces so no reader can generalize it.
- **The `AGENTS.md` byte reclaim is intentional and paired in the same diff.** `AGENTS.md` is guarded by `scripts/check-agents-size.sh` at a 22,000-byte ceiling. Adding the pointer sub-bullet was offset in the same commit by tightening the (now-redundant) Spec-PR summary bullet, landing the file at 21,879 bytes.

## How to test this PR?

Prerequisites: `node` and `npx` on `PATH` (the repo's standard toolchain). From the worktree root:

```sh
npx markdownlint-cli AGENTS.md docs/interaction-modes.md docs/spec-format.md
bash scripts/check-agents-size.sh
node scripts/lib/spec-linter.js
```

Expected outcomes (all observed on HEAD `5eae69e`):

- `markdownlint-cli` — exits `0`, no output.
- `check-agents-size.sh` — prints `OK: AGENTS.md is    21879 bytes (threshold: 22000 bytes)` and exits `0`.
- `spec-linter.js` — prints `Linting passed!` and exits `0`.

Then read the three surfaces of the carve-out for mutual consistency: the *Narrow discharge carve-out* paragraph in `docs/interaction-modes.md`, the SPECS/DEV matrix cells + the "mandatory and un-waived" note below the matrix, and the mode-dependent approval-event paragraph in `docs/spec-format.md` should all state the same boundary — discharge for an unchanged one-file spec-PR only, gate still fires in `AUTO` and for every uncovered merge.

## Detailed description (for agents)

This is the implementation-PR (DEV stage) for ticket #662. The SPECS-stage artifact — the delta spec file `specs/0101-spec-pr-inline-approval.delta-01.md` — already merged to `main` via the spec-PR #678 and is **not** part of this changeset. This PR realizes that delta's requirements (R4/R5 revised, R9–R14) in the implementation docs. Diff scope per `git show 5eae69e --stat`: 3 files, 51 insertions, 17 deletions.

### `docs/interaction-modes.md`

- **New *Narrow discharge carve-out* paragraph (R9)** added to the *User-gate definition* section, immediately after the "invariant across modes" paragraph on ADR/plan/REVIEW-notice posting. It defines the rule: a SPECS-stage content-approval (the artifact-validation gate realised through the `user-validate` skill) of spec content that becomes a one-file spec-PR (per the Spec-PR workflow *one-file rule*) merging that content unchanged discharges the pre-merge merge-authorization gate for that spec-PR — the orchestrator SHALL NOT fire a second merge-authorization request. The paragraph states the three boundaries explicitly: not a general waiver; does not apply in `AUTO` (no content-approval runs to discharge it); gate stays mandatory and separate for implementation-PRs, changed delta-spec PRs, and every non-spec-PR merge.
- **SPECS matrix row reconciled (R10/R11/R12).** The `FULL`/`INTERMEDIATE`/`MINIMAL` cells now state that the SPECS-stage content-approval discharges the resulting one-file spec-PR's merge-authorization gate (so no second ask fires). The `AUTO` cell keeps firing the merge-authorization gate and now makes explicit that no SPECS-stage content-approval runs there to discharge it.
- **DEV matrix row reconciled.** The `FULL`/`INTERMEDIATE`/`MINIMAL` cells now qualify the delta-spec clause: the gate fires before merging any delta-spec PR *whose content changed after its own content-approval*, while an unchanged one-file delta-spec PR is discharged per *User-gate definition*. The `AUTO` DEV cell is unchanged (still fires before every merge produced by the loop).
- **"Invariant across modes" note rewritten.** The former blanket "the merge-authorization gate is invariant across modes … *Branching Strategy* is not waivable" note is replaced by "mandatory and un-waived for every merge the one-file spec-PR discharge does not cover", spelling out the covered merges (implementation-PRs, changed delta-spec PRs, non-spec-PRs) and naming the narrow discharge as the sole exception that does not apply in `AUTO`.

### `docs/spec-format.md`

- **Mode-dependent approval event (revised R4/R5, R14).** The *Recording the initial `draft` → `approved` transition* paragraph previously asserted "the spec-PR merge **is** the approval event" and that the merge-authorization gate "fires in **every** interaction mode". It is rewritten so that every mode still has a real approval event, but *which* gate constitutes it is mode-dependent: the SPECS-stage content-approval gate in `FULL`/`INTERMEDIATE`/`MINIMAL` (which then discharges the unchanged one-file spec-PR's merge-authorization request, cross-referencing `interaction-modes.md` → *User-gate definition*), and the merge-authorization request in `AUTO`. The rewrite preserves the invariant (R14) that `status: approved` SHALL be recorded only after the approval event is secured — never ahead of it.
- **Coherence touch to *Merge mechanic*.** The sub-paragraph opener "Strictly **after** the merge-authorization gate is granted" becomes "Strictly **after** the approval event has been secured", so the mechanic reads correctly under both the content-approval and merge-authorization approval events.

### `AGENTS.md`

- **Pointer-only sub-bullet (R13).** A single sub-bullet is added under the unconditional "**NEVER merge** a Pull Request … without asking for the user's formal permission" bullet in *Branching Strategy*: "Narrow one-file spec-PR exception: `docs/interaction-modes.md` → *User-gate definition*." This follows the spec 0094 pointer-only precedent — `AGENTS.md` names the exception and delegates the normative detail to the doc, rather than restating it.
- **Paired byte reclaim.** In the same diff, the Spec-PR summary bullet was tightened from "Non-trivial tickets follow the **Spec-PR workflow** (see section below): a `spec/<NNNN>-<slug>` PR qualifies the WHAT and merges to `main` before the implementation branch is cut." to "Non-trivial tickets follow the **Spec-PR workflow** (see below)." The removed detail is already stated in full in the dedicated *Spec-PR workflow* section. This offsets the added sub-bullet and keeps `AGENTS.md` under the 22,000-byte `check-agents-size.sh` ceiling — final size 21,879 bytes.

### Concurrency / rebase note

The branch was rebased onto `main` after PR #682 (spec 0106) landed concurrently. #682 renamed gate #1 to the "artifact-validation gate realised through the `user-validate` skill". The matrix conflict was resolved by combining rows — SPECS + DEV cells belong to this ticket, PLAN + REVIEW cells to #682 — and the carve-out wording was aligned to #682's terminology (the *Narrow discharge carve-out* paragraph and the spec-format cross-reference both name the SPECS-stage content-approval as that artifact-validation gate). HEAD `5eae69e` is a single commit ahead of `crewrig/main`.

### Blast radius

Docs-only. No `artifacts/**` sources and no build outputs are touched, so no `provenance.version` bump applies. None of the touched paths (`AGENTS.md`, `docs/interaction-modes.md`, `docs/spec-format.md`) are on the `docs/cli-matrix.md` trigger list in *CLI Matrix Maintenance*, so no CLI-matrix update is required. The delta spec file itself merged via #678 and is not in this PR.
