### PR TITLE
📝 Spec 0107 — auto-build setup components when staging tree is missing

### DIFF
--- a/specs/0107-auto-build-setup-components.md
+++ b/specs/0107-auto-build-setup-components.md
@@ -1,0 +1,104 @@
+---
+id: "0107"
+slug: auto-build-setup-components
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 618
+version: 1.0.0
+---
+
+# Auto-build setup components when the staging tree is missing
+
+## Intent
+
+Running any of the four interactive setup scripts for the first time on a
+fresh clone — before the component staging tree has ever been produced for
+the tool at hand — no longer leaves library, community, or organization
+skills and agents silently un-installed behind a one-line warning. The
+setup script produces what is missing for its own tool first, then installs
+every tier exactly as it already does today, so a first-time run delivers
+the same result as building manually beforehand — including validation-gate
+skills such as `user-validate` that the current gap silently drops.
+
+## Requirements
+
+1. Each of the four interactive setup scripts (`setup-gemini-interactive.sh`,
+   `setup-claude-interactive.sh`, `setup-copilot-interactive.sh`,
+   `setup-antigravity-interactive.sh`) SHALL check, before installing the
+   `library` tier to the user's home directory, whether the staging path its
+   own `install_tier_to_home` already reads for the `library` tier (
+   `dist/library/.gemini`, `dist/library/.claude`,
+   `dist/library/.github/skills`, `dist/library/.agents`, respectively)
+   exists.
+2. When that path is missing, the setup script SHALL build the missing
+   components for its own targeted tool automatically, with no interactive
+   confirmation prompt, before installing any tier.
+3. The triggered build SHALL be scoped to the script's own tool only, never
+   to the full four-tool build.
+4. When the triggered build exits non-zero (a missing prerequisite such as
+   `yq` or `jq`, or any other build-time error), the setup script SHALL
+   abort with a non-zero exit status and a message identifying the build
+   failure, instead of continuing to install a partially-populated or empty
+   staging tree.
+5. When the staging path already exists — a prior build already ran,
+   regardless of how long ago — the setup script SHALL NOT re-trigger a
+   build and SHALL proceed exactly as it does today.
+6. The detection condition, the automatic trigger, and the failure-abort
+   behavior SHALL be identical across all four interactive setup scripts —
+   a test exercising one script's behavior SHALL produce the same
+   observable outcome when run against any of the other three.
+
+## Scenarios
+
+**Scenario:** first run on a fresh clone builds automatically
+
+```text
+Given a fresh clone of the repository where dist/ does not exist and the
+      Gemini CLI target's required tools (yq, jq) are installed
+When  the user runs setup-gemini-interactive.sh
+Then  the script builds the Gemini-targeted components before the
+      "Installing library components" step, dist/library/.gemini/skills/
+      user-validate/ exists afterward, and the skill is installed to
+      ~/.gemini/skills/user-validate/ without the user having run
+      build-components.sh manually
+```
+
+**Scenario:** build failure aborts the setup instead of a partial install
+
+```text
+Given a fresh clone where dist/ does not exist and yq is not installed on
+      the machine
+When  the user runs setup-claude-interactive.sh
+Then  the triggered build fails, the setup script exits non-zero with a
+      message naming the build failure, and no skill or agent is copied to
+      ~/.claude/skills/ or ~/.claude/agents/
+```
+
+**Scenario:** an existing build is left untouched
+
+```text
+Given dist/library/.claude already exists from a prior manual or automatic
+      build
+When  the user runs setup-claude-interactive.sh again
+Then  the script does not re-trigger a build, prints no build-related
+      message, and installs the already-staged components exactly as it
+      does today
+```
+
+## Out of scope
+
+- Detecting or rebuilding a staging tree that exists but is stale relative
+  to `artifacts/` source changes, or partially built (some tiers present,
+  others missing) for the same tool — a possible follow-up ticket, not this
+  one.
+- Any change to `build-components.sh` itself (its `--target` flag, its tier
+  discovery, its output layout) beyond invoking it from the setup scripts.
+- Non-interactive or CI-only setup entry points — none exist today; only the
+  four `setup-*-interactive.sh` scripts are in scope.
+- Adding an opt-out flag (e.g. `--no-build`) to skip the automatic build —
+  not requested by the issue; the automatic, non-interruptive trigger is the
+  sole behavior specified.
+
+## Open questions
+

--- a/specs/0107-auto-build-setup-components.md
+++ b/specs/0107-auto-build-setup-components.md
@@ -101,4 +101,3 @@ Then  the script does not re-trigger a build, prints no build-related
   sole behavior specified.
 
 ## Open questions
-


### PR DESCRIPTION
Qualifies issue #618: interactive setup scripts silently warn and skip installing library/community/org skills and agents (including `user-validate`) when the `dist/` staging tree was never built, instead of building it automatically.

## How to read this PR?

Single new file: `specs/0107-auto-build-setup-components.md`. Read `## Intent` first, then `## Requirements` 1–6 (detection, silent tool-scoped trigger, abort-on-failure, no-rebuild-if-present, cross-script parity), then `## Scenarios` for the three observable behaviors, then `## Out of scope` for what is deliberately excluded (partial/stale per-tier builds, `build-components.sh` internals, non-interactive entry points, an opt-out flag).

## How to test this PR?

This PR ships qualification content only, no code. Verify: `specs/0107-auto-build-setup-components.md` frontmatter parses as YAML, the five mandatory headings (`## Intent`, `## Requirements`, `## Scenarios`, `## Out of scope`, `## Open questions`) are present in order, and `id`/`slug` match the filename.

## Detailed description (for agents)

Adds `specs/0107-auto-build-setup-components.md` (id `0107`, slug `auto-build-setup-components`, `complexity: small`, `interaction-mode: INTERMEDIATE`, `related-issue: 618`, `status: draft`). Authored via the `spec-author` skill's INTERMEDIATE interview: build-trigger mode (silent, tool-scoped `--target`), failure handling (abort with non-zero exit instead of degrading to today's warning), complexity tier (small), and scope boundary (excludes per-tier partial/stale build detection) were confirmed by the user. Grounding pass read `install_tier_to_home()` in all four `scripts/setup-*-interactive.sh` and confirmed the drafted requirements match the existing per-tier `dist/<tier>/.<cli>` staging-path shape — no `[GROUNDING:]` anomaly. No open questions remain.

Closes #618 is intentionally NOT included here — per the Spec-PR workflow, the logbook-issue closure happens at DEV-stage merge, not at spec-PR merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>