### PR TITLE
🔧 Record spec 0107 status: draft -> approved

### DIFF
--- a/specs/0107-auto-build-setup-components.md
+++ b/specs/0107-auto-build-setup-components.md
@@ -1,7 +1,7 @@
 ---
 id: "0107"
 slug: auto-build-setup-components
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 618


### PR DESCRIPTION
Corrective, metadata-only follow-up to spec-PR #689 (issue #618). The content-approval gate for spec 0107 was secured via the interactive interview before merge, but the pre-merge `status: draft` → `status: approved` frontmatter commit mandated by `docs/spec-format.md` → *Lifecycle states → Recording a status transition → Merge mechanic* was skipped, so the spec landed on `main` still carrying `status: draft`.

## How to read this PR?

Single-line frontmatter change in `specs/0107-auto-build-setup-components.md`: `status: draft` → `status: approved`. No other field, no body-line change — a metadata-only edit per the same document's *Recording a post-merge transition* allowance.

## How to test this PR?

`grep '^status:' specs/0107-auto-build-setup-components.md` should print `status: approved`. Diff should touch exactly one line.

## Detailed description (for agents)

Logged as an obstacle on issue #618 (comment before this PR was opened). No normative content, complexity, interaction-mode, or version field changes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>