### PR TITLE
📝 Mark spec 0099 implemented

### DIFF
--- a/specs/0099-plannotator-gate-contrast.md
+++ b/specs/0099-plannotator-gate-contrast.md
@@ -1,8 +1,9 @@
 ---
 id: "0099"
 slug: plannotator-gate-contrast
-status: draft
+status: implemented
 complexity: small
+interaction-mode: INTERMEDIATE
 related-issue: 608
 version: 1.0.0
 ---


### PR DESCRIPTION
## Purpose

Regularizes spec 0099 (`plannotator-gate-contrast`) lifecycle metadata, which was left at `status: draft` even though its implementation merged and anchor ticket #608 closed.

Closes #693

## How to read this PR?

- One frontmatter change in `specs/0099-plannotator-gate-contrast.md`: `status: draft` -> `status: implemented`, and a new `interaction-mode: INTERMEDIATE` line (the mode 0099 was qualified under, per the #608 logbook; omitted while `draft`, required from `approved` onward). No body, `id`, `slug`, or `version` touched.

## How to test this PR?

- `task spec:lint` -> `Linting passed!` (`implemented` and `INTERMEDIATE` are valid enums; frontmatter schema satisfied).
- `git show` -> a single frontmatter hunk.

## Detailed description (for agents)

- Sanctioned lifecycle-metadata carve-out (`docs/spec-format.md` -> *Recording a post-merge transition*): the append-only rule freezes normative content and `version`; only `status` and the previously-omitted `interaction-mode` change here.
- Evidence the impl landed: contrast-safety subsection live in `artifacts/library/skills/user-validate/SKILL.md`; spec-PR was #657 (`4b81ef4`); ticket #608 CLOSED/COMPLETED. Anomaly surfaced during #670 (the substance sibling of 0099).