### PR TITLE
📝 Mark spec 0107 implemented

### DIFF
--- a/specs/0107-auto-build-setup-components.md
+++ b/specs/0107-auto-build-setup-components.md
@@ -1,7 +1,7 @@
 ---
 id: "0107"
 slug: auto-build-setup-components
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 618


### PR DESCRIPTION
## Purpose

Regularizes spec 0107 (`auto-build-setup-components`) lifecycle metadata, which was left at `status: approved` even though its implementation merged and anchor ticket #618 closed as completed.

Closes #695

## How to read this PR?

- One frontmatter change in `specs/0107-auto-build-setup-components.md`: `status: approved` -> `status: implemented`. No body, `id`, `slug`, `interaction-mode`, or `version` touched — unlike #694, `interaction-mode` was already recorded, so nothing needed adding.

## How to test this PR?

- `task spec:lint` -> `Linting passed!` (143 files; `implemented` is a valid enum value and the frontmatter schema stays satisfied).
- `git show` -> a single one-line frontmatter hunk.

## Detailed description (for agents)

- Sanctioned lifecycle-metadata carve-out (`docs/spec-format.md` -> *Recording a post-merge transition*): the append-only rule freezes normative content and `version`; only `status` changes here.
- Evidence the implementation landed on `main`:
  - `scripts/lib/common.sh:447` — `ensure_tier_built()` (R1–R5: staging-path detection, tool-scoped build, non-zero abort on build failure, no-op when the path exists).
  - `scripts/setup-{gemini,claude,copilot,antigravity}-interactive.sh` — one `ensure_tier_built` call each, satisfying the four-way symmetry requirement R6.
  - `scripts/tests/test-setup-ensure-tier-built.sh` — dedicated regression suite, wired into `build.yml`, `ci-capabilities.yml` and `.gitlab-ci.yml`.
  - Implementation PR #691 merged 2026-07-25 (`8607d4c`); ticket #618 CLOSED/COMPLETED.
- Anomaly surfaced during an open-ticket inventory sweep on 2026-08-03: a spec-status audit across `main` found `0107` as the only `approved` spec whose implementation is already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)