### PR TITLE
📝 Record spec 0108's approved status (missed at spec-PR merge)

### DIFF
--- a/specs/0108-mempalace-runtime-version-guard.md
+++ b/specs/0108-mempalace-runtime-version-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0108"
 slug: mempalace-runtime-version-guard
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 623


### PR DESCRIPTION
Spec 0108 landed on `main` carrying `status: draft`, where `docs/spec-format.md` requires a merged spec-PR to carry `status: approved`. One frontmatter line, no other change.

Deliberately carries no closing keyword — issue #623 stays open to anchor the implementation of spec 0108.

## How to read this PR?

- One line in `specs/0108-mempalace-runtime-version-guard.md`: `status: draft` → `status: approved`. Nothing else — no body line, no `id`, no `slug`, no `interaction-mode` (already present), no `version`.

## How to test this PR?

```sh
task spec:lint          # -> "Linting passed!" (approved is a valid enum value)
git show --stat HEAD    # -> one file, +1/-1
```

## Detailed description (for agents)

**What went wrong.** `docs/spec-format.md` → *Lifecycle states* makes `approved` the status of a spec whose spec-PR has merged, and its *Recording a status transition* → *Merge mechanic* spells out the sequence: after the approval event is secured, and strictly **before** `gh pr merge --squash`, edit the frontmatter on the spec branch as a **new commit** (not an amend, because the branch squash-merges anyway and an amend would force a `--force-with-lease` push), push, and only then merge.

For spec 0108 the approval event *was* secured — the SPECS-stage content-approval gate ran through the `user-validate` skill on the `plannotator` backend and returned `{"decision":"approved"}` with exit 0 — but the frontmatter edit was skipped and PR #698 merged the spec as `draft`. The section's own assertion, *"a merged spec is never at once merged and still `draft`"*, was consequently false for 0108.

**Why a post-merge PR is the right remedy.** The same section states that no separate post-merge PR is *required* to record the approval — describing the happy path where the edit rode along in the spec-PR commit. It is silent on the corrective case. This PR uses the mechanism that section explicitly sanctions for every other transition: a post-merge, metadata-only edit touching `status` alone. `draft` → `approved` is a forward transition, so the prohibition on status regression (`approved` → `draft`) does not apply.

**How it surfaced.** As a non-blocking `spec`-class finding from the cold plan reviewer during the PLAN stage of #623 — it was reviewing the plan, noticed the spec it was reviewing against was still `draft` on `main`, and reported it rather than working around it.

**Wider drift, deliberately not addressed here.** A census of `main` shows this is not a one-off: **45 parent specs** currently sit at `status: draft` despite having merged, against 10 `approved` and 53 `implemented`. Delta specs are a separate matter — 30 of them are `draft` by an established convention that only the parent spec transitions — so the 45 are genuine. They include the lifecycle's own load-bearing contracts (`0003` spec-PR workflow, `0004` plan format, `0006` interaction modes, `0009` spec-linter), which are enforced daily while recorded as drafts. That backlog is out of scope for this one-line correction and is being raised as its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)