### PR TITLE
📝 Add spec 0108 delta-01 — make requirement 2 literally satisfiable

### DIFF
--- a/specs/0108-mempalace-runtime-version-guard.delta-01.md
+++ b/specs/0108-mempalace-runtime-version-guard.delta-01.md
@@ -1,0 +1,93 @@
+---
+id: "0108"
+slug: mempalace-runtime-version-guard
+status: approved
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 623
+version: 1.0.1
+---
+
+# 0108 — mempalace-runtime-version-guard (delta-01)
+
+This delta makes spec 0108's Requirement 2 **literally satisfiable**. As
+merged, R2 forbids taking the version "from a package-manager inventory",
+but every source available inside the serving process arguably falls under
+that phrase: `importlib.metadata.version()` resolves the `*.dist-info`
+directory that pip and pipx themselves write, and the only alternative —
+MemPalace's own `__version__` literal — is a hand-maintained value that can
+disagree with what was installed. Read strictly, R2 admits no compliant
+source at all.
+
+The requirement's *intent* is legible and is not in doubt: do not query an
+installer's bookkeeping out of process (`pipx list`, `uv tool list`), do not
+trust a `mempalace` executable resolved from `PATH`, and do not reuse a value
+recorded at setup time. The #623 incident is precisely what that intent
+guards against — `pipx list` reported 3.3.5 while the interpreter that
+actually served resolved elsewhere, so an installer's own inventory was the
+one source that could not detect the drift.
+
+What the requirement fails to say is what *is* permitted. The evidence that
+this is a real defect rather than pedantry: **two independent cold reviewers,
+reviewing two successive plan revisions, each had to infer the permitted
+source and each recorded that inference in their verdict** rather than
+reading it from the spec. An inference two reviewers had to make separately
+is a clause the spec is missing.
+
+This delta MODIFIES Requirement 2 only. Every other requirement of spec 0108
+— Requirements 1 and 3 through 12 — is **UNCHANGED** and remains in force. No
+scenario changes: the seven scenarios in the parent spec are all silent on
+*how* the version is obtained, so none is affected. No open question is
+introduced.
+
+The version bump is **PATCH** (`1.0.0` → `1.0.1`). Per `docs/spec-format.md`
+→ *Delta-spec convention → Versioning*, `PATCH` covers a "clarification,
+wording fix, scenario added without changing any existing requirement". This
+delta removes an ambiguity without constraining any previously unspecified
+case and without invalidating any work: both plan revisions authored against
+the parent spec already honour the clarified reading, so nothing planned or
+built needs to change because of it.
+
+## ADDED
+
+(None. This delta modifies one requirement's wording; it adds no
+requirement, scenario, or out-of-scope item.)
+
+## MODIFIED
+
+1. **Requirement 2 is replaced** so that it states the permitted source
+   rather than only the forbidden ones.
+
+   - Original R2:
+
+     > **R2.** The version determined per requirement 1 SHALL be the version
+     > resolvable from the interpreter that will actually serve the session,
+     > and SHALL be determined inside the very process that goes on to serve,
+     > before that process begins serving. It SHALL NOT be taken from a
+     > package-manager inventory, from a version reported by a `mempalace`
+     > executable found on the operator's search path, or from a version
+     > recorded when the framework was last set up.
+
+   - Replacement R2:
+
+     > **R2.** The version determined per requirement 1 SHALL be the version
+     > resolvable from the interpreter that will actually serve the session,
+     > and SHALL be determined inside the very process that goes on to serve,
+     > before that process begins serving. It SHALL be obtained through that
+     > interpreter's **own in-process resolution** — the same machinery an
+     > `import` in that process would use — so that the value reflects what
+     > that interpreter will actually load. It SHALL NOT be obtained by
+     > querying a package manager's inventory **out of process**, by invoking
+     > a `mempalace` executable resolved from the operator's search path, or
+     > by reusing a version recorded when the framework was last set up. That
+     > an in-process resolution reads metadata a package manager originally
+     > wrote does not place it under this prohibition: the prohibition
+     > targets *asking an installer what it believes it installed*, which is
+     > the class of source that cannot detect the resolution drift this spec
+     > exists to catch.
+
+## REMOVED
+
+(None. This delta modifies Requirement 2 only; it removes no requirement,
+scenario, or out-of-scope item. Requirements 1 and 3 through 12 of spec 0108
+remain in force unchanged.)


### PR DESCRIPTION
Delta-spec for issue #623. Spec 0108's requirement 2 forbids taking the MemPalace version "from a package-manager inventory" but names no permitted source, and no in-process source escapes that phrase — so as merged, R2 cannot be satisfied literally.

Deliberately carries no closing keyword — issue #623 stays open to anchor the implementation.

## How to read this PR?

One new file, `specs/0108-mempalace-runtime-version-guard.delta-01.md`. Read the prose preamble for the defect and the evidence, then `## MODIFIED` for the replacement text. `## ADDED` and `## REMOVED` are both empty by design — this delta changes one requirement's wording and nothing else.

The replacement adds two things to R2 and removes nothing: a positive statement of the permitted source (the serving interpreter's own in-process resolution — the machinery an `import` in that process would use), and an explicit carve-out saying that reading metadata a package manager originally wrote does not fall under the prohibition, because the prohibition targets *asking an installer what it believes it installed*.

## How to test this PR?

```sh
task spec:lint          # -> "Linting passed!" (145 files; delta headings ADDED/MODIFIED/REMOVED present and in order)
git show --stat HEAD    # -> exactly one added file
```

Verify the defect is real, not stylistic — every in-process source falls under the prohibition as written:

```sh
# importlib.metadata resolves the *.dist-info that pip/pipx write
~/.local/pipx/venvs/mempalace/bin/python -c \
  "import importlib.metadata as m; print(m.version('mempalace'))"

# and the only alternative is a hand-maintained literal
~/.local/pipx/venvs/mempalace/bin/python -c \
  "import mempalace.version as v, inspect; print([l for l in inspect.getsource(v).splitlines() if '__version__' in l][0])"
```

## Detailed description (for agents)

**Why this is a spec defect and not an implementation question.** The requirement's intent is legible — do not query `pipx list` or `uv tool list` out of process, do not trust a `mempalace` executable resolved from `PATH`, do not reuse a value recorded at setup. The #623 incident is precisely what that intent guards against: `pipx list` reported 3.3.5 while the interpreter that actually served resolved elsewhere, so the installer's own inventory was the single source structurally incapable of detecting the drift. What R2 omits is what *is* permitted, and the omission has a measured cost: **two independent cold reviewers, on two successive plan revisions, each had to infer the permitted source and record that inference in their verdict**. An inference two reviewers had to make separately is a missing clause, not a reading failure.

**Scope.** MODIFIED: R2 only. Requirements 1 and 3–12 are unchanged and remain in force. No scenario is affected — all seven scenarios in the parent are silent on *how* the version is obtained. No open question is introduced.

**Version — `PATCH` (`1.0.0` → `1.0.1`), and the reasoning is contestable.** `docs/spec-format.md` → *Delta-spec convention → Versioning* reserves `PATCH` for a "clarification, wording fix, scenario added without changing any existing requirement", and this delta does change an existing requirement's text. The judgement is that it removes an ambiguity without constraining any previously unspecified case and without invalidating any work — both plan revisions authored against the parent already honour the clarified reading, so nothing planned or built changes because of it. `MINOR` is reserved for an additive normative change and `MAJOR` for one that invalidates an in-flight implementation; neither applies. Recorded explicitly because a future audit may read the rule differently.

**Status handling, and a convention tension worth flagging.** `status: approved` was set on the branch in a separate commit *before* the merge, per `docs/spec-format.md` → *Recording a status transition* → *Merge mechanic*. That is deliberate: PR #698 merged the parent spec as `draft` by skipping exactly this step, and PR #699 had to correct it after the fact.

Note that prevailing practice differs — **30 of 36 delta-specs on `main` currently sit at `draft`** — so this PR is consistent with the *document* and inconsistent with the *corpus*. Whether delta-specs are meant to be exempt from the lifecycle table is one of the open questions in #700, which tracks the broader status drift (45 parent specs at `draft` despite having merged). Following the written rule here rather than the majority practice, and recording the divergence so a reader does not mistake it for an oversight.

SPECS gate approved through the `user-validate` skill (`plannotator` backend, `translate=on`, `pedagogy=professor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)