### PR TITLE
📝 Mark spec 0108 implemented

### DIFF
--- a/specs/0108-mempalace-runtime-version-guard.md
+++ b/specs/0108-mempalace-runtime-version-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0108"
 slug: mempalace-runtime-version-guard
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 623


### PR DESCRIPTION
Spec 0108's runtime version guard merged as `13f4994` (PR #702) and anchor ticket #623 closed as completed, so `status: approved` no longer reflects the spec's state. One frontmatter line.

Closes #704

## How to read this PR?

- One line in `specs/0108-mempalace-runtime-version-guard.md`: `status: approved` → `status: implemented`. Nothing else — no body line, no `id`, no `slug`, no `interaction-mode`, no `version`.
- `specs/0108-mempalace-runtime-version-guard.delta-01.md` is deliberately **not** touched; see below.

## How to test this PR?

```sh
task spec:lint          # -> "Linting passed!" (implemented is a valid enum value)
git show --stat HEAD    # -> one file, +1/-1
```

Evidence the implementation is really live, rather than merely merged:

```sh
bash scripts/doctor-mempalace.sh    # exits 1 on the reporting machine, naming the real divergence
bash scripts/tests/test-mempalace-pin.sh           # 36 / 0
bash scripts/tests/test-mempalace-runtime-guard.sh # 85 / 0
bash scripts/tests/test-mempalace-doctor.sh        # 72 / 0
```

## Detailed description (for agents)

Sanctioned post-merge transition per `docs/spec-format.md` → *Recording a status transition* → *Recording a post-merge transition*: `approved` → `implemented` is triggered by a genuinely later event (the implementation PR merging) that cannot be folded into the spec-PR, so it is recorded after the fact by a metadata-only frontmatter edit. `draft` → `approved` is the only transition that rides inside the spec-PR's own commit, and that one was recorded correctly for this spec on its own branch before `gh pr merge`.

**`delta-01` keeps `status: approved`, deliberately.** The convention — verified against spec 0069 during ticket #570 — transitions only the parent spec, leaving each `delta-NN` where it stands. `docs/spec-format.md` does not currently state that rule, and whether it should is one of the open questions on **#700**, which tracks the wider status drift on `main` (45 parent specs at `draft` despite having merged, plus 30 draft deltas that this convention would explain). Following the established practice here rather than inventing a third behaviour mid-ticket.

**Implementation evidence:** `scripts/lib/mempalace_pin.py` and `scripts/doctor-mempalace.sh` present on `main`; the two-phase guard live in `scripts/lib/mempalace-http-wrapper.py`; 193 assertions across three suites green on both the default interpreter and one carrying a real MemPalace 3.6.0; the diagnostic reproduces the spec's *divergent installs* scenario live on the reporting machine, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)