### PR TITLE
📝 Add spec 0109 delta-01 — align requirement 5 with the carve-out it cites

### DIFF
--- a/specs/0109-spec-status-invariant-on-main.delta-01.md
+++ b/specs/0109-spec-status-invariant-on-main.delta-01.md
@@ -1,0 +1,96 @@
+---
+id: "0109"
+slug: spec-status-invariant-on-main
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 700
+version: 1.0.1
+---
+
+# 0109 — spec-status-invariant-on-main (delta-01)
+
+This delta makes spec 0109's Requirement 5 **consistent with the carve-out it
+cites**. As merged, R5 requires a status correction to change "`status` and
+nothing else — no body line, no `id`, no `slug`, no `interaction-mode`, no
+`version` — per the lifecycle-metadata carve-out in `docs/spec-format.md` →
+*Recording a status transition*". That carve-out says the opposite about one of
+those five fields: it states the edit "sets `interaction-mode` to the mode the
+spec was qualified under" when `interaction-mode` was omitted while the spec was
+`draft`.
+
+The contradiction is not academic. It makes R5 **unsatisfiable together with
+R1 and R4** for five of the specs R4 covers. `specs/0098`, `0100`, `0101`,
+`0102` and `0103` carry no `interaction-mode`, because the frontmatter schema
+(`docs/spec-format.md`, the frontmatter table) makes that field required only
+"from `approved` onward" and permits its omission while `draft`, where it
+defaults to `INTERMEDIATE`. Correcting those five to a non-`draft` status
+therefore *requires* adding the field — and every escape route is closed:
+
+- A status-only edit leaves those five failing the spec linter's own
+  frontmatter check (`'interaction-mode' MUST be present if status is not
+  'draft'`), so the corrected tree does not pass its own validation.
+- Leaving those five at `draft` violates R1 and R4, and makes the check R2
+  introduces fail on the very change that introduces it — contradicting R6.
+
+So the letter of R5 forbids the only conforming action. Each of the five
+spec-PRs, moreover, recorded the omission as deliberate and deferred to exactly
+this moment: PR #655 states "`interaction-mode` intentionally omitted (added at
+the `approved` transition per `docs/spec-format.md`)". That transition never
+happened, which is the defect this ticket exists to fix.
+
+This delta MODIFIES Requirement 5 only. Every other requirement of spec 0109 —
+Requirements 1 through 4 and 6 through 8 — is **UNCHANGED** and remains in
+force. No scenario changes: none of the five scenarios mentions the field list.
+No open question is introduced.
+
+The version bump is **PATCH** (`1.0.0` → `1.0.1`). Per `docs/spec-format.md` →
+*Delta-spec convention → Versioning*, `PATCH` covers a "clarification, wording
+fix". This delta constrains no previously unspecified case and invalidates no
+work: it aligns a field list with the document it already defers to, and the
+implementation authored against the parent spec already does the conforming
+thing.
+
+*Recorded for whoever reads this later:* this is the same authoring defect that
+issue #703 catalogues five times against spec 0108 — a requirement stating what
+is **forbidden** by enumeration, without checking the enumeration against the
+rule it references. #703's closing observation, that four instances in one spec
+point at the authoring habit rather than at that spec's luck, was written by the
+same author who then produced this sixth instance in the next spec they wrote.
+It is the strongest available argument for the checklist item #703 proposes.
+
+## ADDED
+
+(None. This delta modifies one requirement's field list; it adds no
+requirement, scenario, or out-of-scope item.)
+
+## MODIFIED
+
+1. **Requirement 5 is replaced** so that its field list matches the carve-out it
+   cites.
+
+   - Original R5:
+
+     > **R5.** A correction per requirement 4 SHALL be metadata-only: it changes
+     > `status` and nothing else — no body line, no `id`, no `slug`, no
+     > `interaction-mode`, no `version` — per the lifecycle-metadata carve-out
+     > in `docs/spec-format.md` → *Recording a status transition*.
+
+   - Replacement R5:
+
+     > **R5.** A correction per requirement 4 SHALL be metadata-only in the
+     > sense the lifecycle-metadata carve-out in `docs/spec-format.md` →
+     > *Recording a status transition* defines: it changes `status`, and it
+     > SHALL additionally set `interaction-mode` when — and only when — that
+     > field was absent because the spec was `draft`, setting it to the mode the
+     > spec was qualified under, since the frontmatter schema requires the field
+     > from `approved` onward. It SHALL touch nothing else: no body line, no
+     > `id`, no `slug`, no `version`. A diff that alters any normative content
+     > under cover of a status correction is a violation, exactly as that
+     > carve-out states.
+
+## REMOVED
+
+(None. This delta modifies Requirement 5 only; it removes no requirement,
+scenario, or out-of-scope item. Requirements 1 through 4 and 6 through 8 of
+spec 0109 remain in force unchanged.)

--- a/specs/0109-spec-status-invariant-on-main.delta-01.md
+++ b/specs/0109-spec-status-invariant-on-main.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0109"
 slug: spec-status-invariant-on-main
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 700


### PR DESCRIPTION
Spec 0109's requirement 5 forbids a status correction from touching `interaction-mode`, citing a carve-out in `docs/spec-format.md` that says the opposite about that exact field. The contradiction makes R5 unsatisfiable together with R1 and R4 for five of the 44 specs R4 covers.

Deliberately carries no closing keyword — issue #700 stays open to anchor the implementation.

## How to read this PR?

One new file. `## ADDED` and `## REMOVED` are empty by design; the substance is one replaced requirement in `## MODIFIED`, and the preamble explains why the original is not merely awkward but *unsatisfiable*.

## How to test this PR?

```sh
task spec:lint          # -> "Linting passed!"
git show --stat HEAD    # -> exactly one added file
```

Verify the contradiction is real rather than stylistic:

```sh
# The schema makes interaction-mode required only from `approved` onward
grep -n 'interaction-mode' docs/spec-format.md | head -1

# The carve-out R5 cites explicitly SETS that field on this transition
sed -n '236,252p' docs/spec-format.md

# The five specs that have no interaction-mode to preserve
for s in 0098 0100 0101 0102 0103; do
  f=$(git ls-tree crewrig/main specs/ --name-only | grep "^specs/${s}-" | grep -v delta)
  printf '%s: [%s]\n' "$(basename "$f")" \
    "$(git show "crewrig/main:${f}" | sed -n 's/^interaction-mode: //p')"
done
```

The last command prints five empty brackets. A status-only correction on those files then fails the linter's own frontmatter check — `'interaction-mode' MUST be present if status is not 'draft'`.

## Detailed description (for agents)

**Why every escape route is closed.** A status-only edit leaves those five specs failing the spec linter's own frontmatter validation, so the corrected tree does not pass its own check. Leaving them at `draft` violates R1 and R4, and makes the check R2 introduces fail on the very change that introduces it — contradicting R6, which requires the check and the corrections to land together. So the letter of R5 forbids the only conforming action.

**The five omissions were deliberate and deferred to exactly this moment.** Each of the five spec-PRs says so; PR #655 states *"`interaction-mode` intentionally omitted (added at the `approved` transition per `docs/spec-format.md`)"*. That transition never happened — which is the defect issue #700 exists to fix. Adding the field now makes an already-effective default explicit, at precisely the point the schema says it must become explicit.

**Scope.** MODIFIED: R5 only. Requirements 1–4 and 6–8 unchanged and in force. No scenario affected — none mentions the field list. No open question introduced.

**Version — `PATCH` (`1.0.0` → `1.0.1`).** A wording fix aligning a field list with the document it already defers to. It constrains no previously unspecified case and invalidates nothing: the implementation authored against the parent spec already does the conforming thing, which is how the contradiction surfaced.

**How it surfaced, and the pattern it belongs to.** Reported as a `spec`-class finding by the DEV pass, which implemented the schema-conformant version and flagged it rather than implementing around it silently. This is the same authoring defect that issue **#703** catalogues five times against spec 0108 — a requirement stating what is **forbidden** by enumeration, without checking the enumeration against the rule it references. Recorded plainly in the delta body: #703's own closing observation, that four instances in one spec point at the authoring habit rather than at that spec's luck, was written by the same author who then produced this sixth instance in the next spec they wrote. That is the strongest argument available for the `spec-author` checklist item #703 proposes.

Authored in `AUTO` mode: no SPECS-stage content gate runs, so per `docs/interaction-modes.md` the merge-authorization request is the sole approval event, and `status` stays `draft` until it has been secured — per the *Merge mechanic*, recording `approved` ahead of the approval event is itself a violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)