### PR TITLE
✨ Make a spec's recorded status tell the truth, and enforce it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,6 +285,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the base ref resolves (spec 0109)
 
       - uses: actions/setup-node@v4
         with:
@@ -297,7 +299,20 @@ jobs:
       - name: Install Task
         run: sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
+      # Runs before the corpus lint so a broken linter is diagnosed by its own
+      # suite rather than reported only as a corpus failure. This job is where
+      # the suite belongs: it provisions the npm-installed node_modules the
+      # suite needs, which the hermetic check-components job does not.
+      - name: Test spec linter regression
+        run: bash scripts/tests/test-spec-linter.sh
+
       - name: Lint specs
+        env:
+          # The base-branch `status: draft` check (spec 0109 R2) compares against
+          # the PR's *target* branch. On a push there is no PR context, so the
+          # empty value hands the linter back to its own default derivation
+          # (first `crewrig|origin` remote + /main).
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
         run: task spec:lint
 
   test-harness-curate:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,15 @@ jobs:
           # empty value hands the linter back to its own default derivation
           # (first `crewrig|origin` remote + /main).
           BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
+        # Read the log line, not the exit code, to tell an unresolvable-base
+        # wiring fault from a lint finding: the linter distinguishes them (exit 2
+        # vs 1), but Task collapses any non-zero status into its own 201, so only
+        # the `[ERROR]` line survives this wrapper. Kept behind `task` on purpose
+        # — `ci/ci-capabilities.yml` declares this command for both engines
+        # (check-ci-parity.sh enforces the agreement, and .gitlab-ci.yml is
+        # generated from it), and nothing here reads the exit code beyond
+        # pass/fail, so bypassing the wrapper would cost symmetry and buy no
+        # observable distinction.
         run: task spec:lint
 
   test-harness-curate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,10 +122,13 @@ lint-markdown:
 
 lint-specs:
   image: node:22
+  variables:
+    GIT_DEPTH: "0"
   before_script:
     - sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
   script:
     - "npm install"
+    - "bash scripts/tests/test-spec-linter.sh"
     - "task spec:lint"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -138,6 +138,9 @@ capabilities:
       - npm install -g markdownlint-cli
       - markdownlint "**/*.md" --ignore node_modules --ignore extension-skeleton --ignore communication --ignore 'extensions/**/commands/*.md'
 
+  # The spec linter's base-branch `status: draft` check (spec 0109 R2) resolves
+  # the change's base ref, so the job needs full source history — declared as
+  # `history-depth: full`, same as the two version-bump guards below.
   - id: lint-specs
     name: "Lint specification files"
     trigger:
@@ -149,8 +152,10 @@ capabilities:
     requires:
       runtime: node@22
       tools: [task]
+      history-depth: full
     command:
       - npm install
+      - bash scripts/tests/test-spec-linter.sh
       - task spec:lint
 
   - id: test-harness-curate

--- a/ci/test-wiring-exemptions.txt
+++ b/ci/test-wiring-exemptions.txt
@@ -17,5 +17,4 @@
 # the fact that the underlying bug is resolved.
 
 # --- Environment-dependent (cannot run in the hermetic check-components job) ---
-test-spec-linter.sh	requires the repo's npm-installed node_modules (markdownlint-cli via npx, plus js-yaml/semver) which the hermetic check-components job does not provision; spec-linter.js is exercised on real specs by the lint-specs job via `task spec:lint`.
 test-e2e-auth-scripts.sh	exercises scripts/e2e/auth-copilot.sh, which e2e_die's when ~/.copilot/instructions/ is absent — a `task setup:copilot` side-effect present on a developer host but not in a clean CI HOME; cannot pass in the hermetic check-components job. See follow-up note from #534 on whether the guidance path should print before that precondition.

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -200,6 +200,26 @@ table below is the contract.
 A `status` regression (e.g. `approved` → `draft`) is prohibited; if a
 spec must be re-opened, supersede it instead.
 
+### No spec on `main` is a draft
+
+A spec file present on `main`, other than a delta-spec, SHALL NOT carry
+`status: draft`. A spec reaches `main` only by its own merged spec-PR, which is
+the trigger the table above assigns to `approved`; `draft` on `main` therefore
+records a contradiction rather than a lagging value, and leaves a reader unable
+to use `status` for the one question it exists to answer — "merged and in
+force" or "proposed but never landed".
+
+The rule is enforced mechanically rather than by recall. The spec linter
+(`scripts/lib/spec-linter.js`, run as `task spec:lint` in CI) fails and names
+every non-delta spec that is **already present on the change's base branch**
+while carrying `status: draft`. Presence on the base branch is the
+discriminator, so a spec the change under test *introduces* is not flagged: it
+is legitimately `draft` until the *Merge mechanic* below flips it. Delta-specs
+are exempt too — what `status` a delta should carry is deliberately unsettled,
+per
+[`specs/0109-spec-status-invariant-on-main.md`](../specs/0109-spec-status-invariant-on-main.md)
+→ *Out of scope*.
+
 ### Recording a status transition
 
 The append-only rule (see *Delta-spec convention*) governs a spec's

--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -92,6 +92,134 @@ function isExcludedSpecPath(relPath, entries) {
     return best !== null && best.policy === 'excluded';
 }
 
+// --- Base-branch status invariant (spec 0109) -------------------------------
+// The helpers below give the linter the one thing it previously lacked: a view
+// of the change's base branch. They exist to answer a single question — is this
+// spec file already present on the base branch? — because that is the
+// discriminator spec 0109 R2 names: a spec the change under test introduces is
+// legitimately `draft` until its own merge mechanic flips it, while a spec
+// already on the base branch carrying `draft` is the contradiction R1 forbids.
+
+// gitCapture(args) — run git, capturing both streams. Returns the exit status
+// and stdout; never throws and never leaks git's own stderr into the linter's
+// output, so callers can probe git freely (including outside a repository).
+function gitCapture(args) {
+    const result = spawnSync('git', args, { encoding: 'utf8' });
+    return {
+        status: result.status,
+        stdout: typeof result.stdout === 'string' ? result.stdout : '',
+    };
+}
+
+// resolveBaseRef() — the base ref to compare against, resolved exactly as
+// scripts/check-skill-versions.sh:24-33 does so the repository has one idiom
+// rather than two: `BASE_REF` when set, else the first remote matching
+// `crewrig|origin` (falling back to the first remote at all) with `/main`
+// appended. Verifies the ref, retrying once behind a shallow-clone `--depth=50`
+// fetch, and returns an `error` (never a silent fallback) if it still does not
+// resolve. The linter's positional arguments are spec targets, so `BASE_REF` is
+// the only override — that is the one difference from the shell sibling.
+function resolveBaseRef() {
+    let ref = process.env.BASE_REF;
+    if (!ref) {
+        const remotes = gitCapture(['remote']).stdout.split('\n').map((r) => r.trim()).filter(Boolean);
+        const preferred = remotes.find((r) => /crewrig|origin/.test(r)) || remotes[0];
+        if (!preferred) {
+            return { error: 'no git remote is configured, so no default base ref could be derived' };
+        }
+        ref = `${preferred}/main`;
+    }
+
+    if (gitCapture(['rev-parse', '--verify', ref]).status === 0) {
+        return { ref };
+    }
+
+    // Covers fresh CI clones, which are shallow by default.
+    const remote = ref.split('/')[0];
+    const branch = ref.slice(remote.length + 1);
+    if (branch) {
+        gitCapture(['fetch', '--depth=50', remote, branch]);
+        if (gitCapture(['rev-parse', '--verify', ref]).status === 0) {
+            return { ref };
+        }
+    }
+
+    return { error: `base ref '${ref}' does not resolve and \`git fetch\` did not recover it` };
+}
+
+// baseBranchPaths(baseRef, relPaths) — the subset of relPaths that exists on
+// baseRef, as a Set. One `git ls-tree` call with the linted paths as pathspecs:
+// git reports only the paths it finds, so the returned Set is the intersection
+// by construction. R3 is satisfied here — the set comes from the repository at
+// check time, never from a recorded list.
+function baseBranchPaths(baseRef, relPaths) {
+    if (relPaths.length === 0) {
+        return new Set();
+    }
+    const result = gitCapture(['ls-tree', '-r', '-z', '--name-only', baseRef, '--', ...relPaths]);
+    if (result.status !== 0) {
+        return null;
+    }
+    return new Set(result.stdout.split('\0').filter(Boolean));
+}
+
+// resolveBaseContext(files) — decide whether the base-branch status check runs,
+// and if so against which paths. Three outcomes, deliberately distinct:
+//
+//   1. Not inside a git work tree → SKIP, with a notice on stderr. Without a
+//      repository there is no "change under test" and so no base branch to be
+//      the discriminator; the check has no subject rather than a subject it
+//      failed to inspect. This is the tarball/temp-fixture case, never CI —
+//      every CI checkout is a git repository.
+//   2. Inside a repository, base ref resolves → ENFORCE.
+//   3. Inside a repository, base ref does NOT resolve → hard error, exit 2.
+//      Fail closed: a repository whose base cannot be resolved is a wiring
+//      fault (missing `fetch-depth: 0`, unfetched remote), and passing it as
+//      green would restore the "green does not mean checked" defect that spec
+//      0109 exists to remove. Exit 2 — not the linter's own exit 1 — marks it
+//      as an environment fault rather than a lint finding, matching
+//      check-skill-versions.sh.
+function resolveBaseContext(files) {
+    const toplevel = gitCapture(['rev-parse', '--show-toplevel']);
+    if (toplevel.status !== 0 || toplevel.stdout.trim() === '') {
+        console.error(
+            `[SKIP] Base-branch status check (spec 0109): not inside a git work tree, `
+            + `so the base branch of the change under test cannot be determined. `
+            + `Specs already on the base branch were NOT checked for 'status: draft'.`
+        );
+        return { enforced: false };
+    }
+    // Both sides are canonicalized before being compared: git reports the
+    // physical work-tree path, so a linted path reached through a symlink
+    // (a symlinked checkout, /tmp on macOS) would otherwise resolve "outside"
+    // the repository and be silently exempted from the check.
+    const repoRoot = fs.realpathSync(toplevel.stdout.trim());
+
+    const { ref, error } = resolveBaseRef();
+    if (error) {
+        console.error(`\n[ERROR] Base-branch status check (spec 0109) cannot run: ${error}.`);
+        console.error(`        Point it at a resolvable ref via the BASE_REF environment variable.`);
+        process.exit(2);
+    }
+
+    // Only paths inside the work tree can be compared against a tree-ish;
+    // anything outside it is not part of the change under test.
+    const relPathByFile = new Map();
+    for (const file of files) {
+        const rel = path.relative(repoRoot, fs.realpathSync(path.resolve(file))).split(path.sep).join('/');
+        if (rel === '' || rel.startsWith('../')) continue;
+        relPathByFile.set(file, rel);
+    }
+
+    const basePaths = baseBranchPaths(ref, Array.from(relPathByFile.values()));
+    if (basePaths === null) {
+        console.error(`\n[ERROR] Base-branch status check (spec 0109): 'git ls-tree ${ref}' failed.`);
+        process.exit(2);
+    }
+
+    return { enforced: true, ref, basePaths, relPathByFile };
+}
+
 function lintFile(filePath) {
     let hasErrors = false;
     const errors = [];
@@ -234,7 +362,7 @@ function lintFile(filePath) {
         }
     }
 
-    return { hasErrors, errors, id, isDelta };
+    return { hasErrors, errors, id, isDelta, status: fm.status };
 }
 
 function run() {
@@ -253,6 +381,10 @@ function run() {
     
     const uniqueFiles = Array.from(new Set(filesToLint));
 
+    // Resolved before the (slow) markdownlint pass so a base-ref wiring fault
+    // surfaces immediately instead of after a full lint run.
+    const baseContext = resolveBaseContext(uniqueFiles);
+
     console.log(`Running markdownlint-cli on ${uniqueFiles.length} files...`);
     const lintResult = spawnSync('npx', ['markdownlint', ...uniqueFiles, '-c', '.markdownlintrc'], { stdio: 'inherit' });
     if (lintResult.status !== 0) {
@@ -268,8 +400,8 @@ function run() {
     const fileResults = [];
     for (const file of uniqueFiles) {
         if (isExcludedSpecPath(file, manifestEntries)) continue;
-        const { hasErrors, errors, id, isDelta } = lintFile(file);
-        fileResults.push({ file, id, isDelta });
+        const { hasErrors, errors, id, isDelta, status } = lintFile(file);
+        fileResults.push({ file, id, isDelta, status });
         if (hasErrors) {
             console.error(`\n[FAIL] ${file}`);
             for (const err of errors) {
@@ -300,6 +432,30 @@ function run() {
             for (const f of files) {
                 console.error(`  - ${f}`);
             }
+            totalErrors++;
+        }
+    }
+
+    // Base-branch `status: draft` check (spec 0109 R1/R2). A non-delta spec
+    // already present on the base branch has by definition had its own spec-PR
+    // merged, which is the trigger docs/spec-format.md assigns to `approved` —
+    // so `draft` on it is a contradiction, not a lagging value. Delta-specs are
+    // exempt (R2); their convention is deliberately left to its own ticket.
+    // The status read is the one in the tree under test, so the change that
+    // corrects a stale `draft` passes on the same run that introduces the
+    // check — which is what makes R6's single-change landing possible.
+    if (baseContext.enforced) {
+        const offenders = fileResults.filter(({ file, isDelta, status }) =>
+            !isDelta && status === 'draft' && baseContext.basePaths.has(baseContext.relPathByFile.get(file))
+        );
+        if (offenders.length > 0) {
+            console.error(`\n[FAIL] Non-delta specs present on the base branch (${baseContext.ref}) carry 'status: draft':`);
+            for (const { file } of offenders) {
+                console.error(`  - ${file}`);
+            }
+            console.error(`  A spec reaches the base branch only by its own merged spec-PR, which is`);
+            console.error(`  the trigger docs/spec-format.md assigns to 'approved'. Record the status`);
+            console.error(`  that reflects the spec's true state (metadata-only edit).`);
             totalErrors++;
         }
     }

--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -176,9 +176,21 @@ function baseBranchPaths(baseRef, relPaths) {
 //      Fail closed: a repository whose base cannot be resolved is a wiring
 //      fault (missing `fetch-depth: 0`, unfetched remote), and passing it as
 //      green would restore the "green does not mean checked" defect that spec
-//      0109 exists to remove. Exit 2 — not the linter's own exit 1 — marks it
-//      as an environment fault rather than a lint finding, matching
-//      check-skill-versions.sh.
+//      0109 exists to remove.
+//
+//      Exit 2 — not the linter's own exit 1 — marks it as an environment fault
+//      rather than a lint finding. Scope of that distinction, measured rather
+//      than assumed: it is observable only on DIRECT invocation
+//      (`node scripts/lib/spec-linter.js` → 2 for this fault, 1 for a lint
+//      finding), which is how the regression suite reads it (Case 32) and how a
+//      human debugging a base-ref fault reads it. Both CI engines invoke the
+//      linter through `task spec:lint`, and Task collapses ANY non-zero command
+//      status into its own 201 (measured on Task 3.50.0) — so downstream of the
+//      wrapper the two outcomes are indistinguishable by exit code, and the
+//      `[ERROR]` line below is what names the fault in the pipeline log. This is
+//      unlike check-skill-versions.sh, whose exit 2 does propagate because
+//      build.yml invokes it directly; that sibling is the model for the *code*,
+//      not evidence of a CI-observable property here.
 function resolveBaseContext(files) {
     const toplevel = gitCapture(['rev-parse', '--show-toplevel']);
     if (toplevel.status !== 0 || toplevel.stdout.trim() === '') {
@@ -206,7 +218,22 @@ function resolveBaseContext(files) {
     // anything outside it is not part of the change under test.
     const relPathByFile = new Map();
     for (const file of files) {
-        const rel = path.relative(repoRoot, fs.realpathSync(path.resolve(file))).split(path.sep).join('/');
+        let physical;
+        try {
+            physical = fs.realpathSync(path.resolve(file));
+        } catch (e) {
+            // A path that cannot be canonicalized (dangling symlink, symlink
+            // loop, unreadable parent directory) is also a path that cannot be
+            // read, so it is unlintable rather than merely unresolvable against
+            // the base. Report it here, naming the path, and exit on the
+            // linter's own exit 1: letting the canonicalization throw instead
+            // surfaces an uncaught stack trace, which is fail-closed but not a
+            // diagnostic — and the linter's job is to say what is wrong.
+            console.error(`\n[ERROR] Cannot resolve linted path: ${file}`);
+            console.error(`        ${e.message}`);
+            process.exit(1);
+        }
+        const rel = path.relative(repoRoot, physical).split(path.sep).join('/');
         if (rel === '' || rel.startsWith('../')) continue;
         relPathByFile.set(file, rel);
     }

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -509,7 +509,7 @@ mkdir -p "$GITFIX/specs"
 cp "$ROOT_DIR/.markdownlintrc" "$GITFIX/"
 ln -s "$ROOT_DIR/node_modules" "$GITFIX/node_modules"
 (
-  cd "$GITFIX"
+  cd "$GITFIX" || exit 1
   git init -q
   git symbolic-ref HEAD refs/heads/main
   git config user.email "test@example.com"
@@ -523,7 +523,7 @@ render_spec "0201" "on-base-delta" "draft" "standard" "" \
   "$(printf "## ADDED\n\n## MODIFIED\n\n## REMOVED")" \
   > "$GITFIX/specs/0201-on-base-delta.delta-01.md"
 (
-  cd "$GITFIX"
+  cd "$GITFIX" || exit 1
   git add specs
   git commit -q -m "base branch content"
   # A remote-tracking `origin/main` so the default base-ref derivation
@@ -637,6 +637,37 @@ ln -s "$ROOT_DIR/node_modules" "$SCENARIO33_ROOT/node_modules"
 render_spec "0203" "outside-any-repo" "draft" > "$SCENARIO33_ROOT/specs/0203-outside-any-repo.md"
 run_base_case "Case 33 — outside a git work tree the check skips and announces it" \
   "$SCENARIO33_ROOT" "specs" 0 "main" "Base-branch status check" "-"
+
+# -------------------------------------------------------------------------
+# Case 34 — a linted path that cannot be canonicalized (here: a dangling
+# symlink under specs/) is reported by name, not as an uncaught stack trace
+# from the base-branch check's `realpathSync`. The exit code alone cannot pin
+# this: an uncaught throw ALSO exits non-zero, so the regression is invisible
+# to an exit-code assertion. The two content assertions are what discriminate
+# — the offending path must be named in the linter's own voice, and the
+# stack-frame marker of the crash must be absent. Uses its own isolated root
+# so the dangling symlink cannot leak into the cases above.
+# -------------------------------------------------------------------------
+SCENARIO34_ROOT="$TMP_ROOT/scenario34"
+mkdir -p "$SCENARIO34_ROOT/specs"
+cp "$ROOT_DIR/.markdownlintrc" "$SCENARIO34_ROOT/"
+ln -s "$ROOT_DIR/node_modules" "$SCENARIO34_ROOT/node_modules"
+render_spec "0204" "beside-a-dangling-symlink" "draft" \
+  > "$SCENARIO34_ROOT/specs/0204-beside-a-dangling-symlink.md"
+ln -s "./no-such-target.md" "$SCENARIO34_ROOT/specs/0205-dangling.md"
+(
+  cd "$SCENARIO34_ROOT" || exit 1
+  git init -q
+  git symbolic-ref HEAD refs/heads/main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+  git add specs
+  git commit -q -m "content with a dangling symlink"
+)
+run_base_case "Case 34 — an uncanonicalizable linted path is named, not a stack trace" \
+  "$SCENARIO34_ROOT" "specs" 1 "main" \
+  "Cannot resolve linted path: specs/0205-dangling.md" "at resolveBaseContext"
 
 # -------------------------------------------------------------------------
 # Summary

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -496,6 +496,149 @@ else
 fi
 
 # -------------------------------------------------------------------------
+# Cases 28-33 (spec 0109) — the base-branch `status: draft` check. Unlike every
+# case above, these need a real repository with a real base branch, so they
+# build a throwaway one (mirroring new_repo() in
+# scripts/tests/test-check-skill-versions.sh:54-66) instead of reusing the flat
+# non-git fixtures in $TMP_ROOT. The branch name is pinned with
+# `git symbolic-ref` rather than `git init -b`, so the fixture does not depend
+# on the host's `init.defaultBranch`.
+# -------------------------------------------------------------------------
+GITFIX="$TMP_ROOT/gitfix"
+mkdir -p "$GITFIX/specs"
+cp "$ROOT_DIR/.markdownlintrc" "$GITFIX/"
+ln -s "$ROOT_DIR/node_modules" "$GITFIX/node_modules"
+(
+  cd "$GITFIX"
+  git init -q
+  git symbolic-ref HEAD refs/heads/main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+)
+
+# Base-branch content: one non-delta spec and one delta-spec, both `draft`.
+render_spec "0200" "on-base" "draft" > "$GITFIX/specs/0200-on-base.md"
+render_spec "0201" "on-base-delta" "draft" "standard" "" \
+  "$(printf "## ADDED\n\n## MODIFIED\n\n## REMOVED")" \
+  > "$GITFIX/specs/0201-on-base-delta.delta-01.md"
+(
+  cd "$GITFIX"
+  git add specs
+  git commit -q -m "base branch content"
+  # A remote-tracking `origin/main` so the default base-ref derivation
+  # (mirroring scripts/check-skill-versions.sh:24) has something to resolve.
+  git remote add origin "$GITFIX"
+  git fetch -q origin 2>/dev/null
+)
+
+# run_base_case <name> <workdir> <targets> <expected_exit> <base_ref|-> <must_contain|-> <must_not_contain|->
+# `-` for base_ref runs with BASE_REF explicitly *unset* (exercising the
+# default derivation) rather than inheriting an ambient value from the caller.
+run_base_case() {
+  local name="$1" workdir="$2" targets="$3" expected_exit="$4"
+  local base_ref="$5" must="$6" must_not="$7"
+
+  local actual_exit=0 output ok=true
+  if [ "$base_ref" = "-" ]; then
+    output=$( ( cd "$workdir" && env -u BASE_REF node "$LINTER_JS" $targets 2>&1 ) ) || actual_exit=$?
+  else
+    output=$( ( cd "$workdir" && BASE_REF="$base_ref" node "$LINTER_JS" $targets 2>&1 ) ) || actual_exit=$?
+  fi
+
+  if [ "$actual_exit" -ne "$expected_exit" ]; then
+    ok=false
+  fi
+  if [ "$must" != "-" ] && ! echo "$output" | grep -qF "$must"; then
+    ok=false
+  fi
+  if [ "$must_not" != "-" ] && echo "$output" | grep -qF "$must_not"; then
+    ok=false
+  fi
+
+  if [ "$ok" = true ]; then
+    echo "PASS  $name (exit $actual_exit)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $name (expected exit $expected_exit, got $actual_exit)"
+    echo "Output:"
+    echo "$output"
+    fail=$((fail + 1))
+  fi
+}
+
+# -------------------------------------------------------------------------
+# Case 28 (R2, Scenarios 1 and 3) — a non-delta spec present on the base
+# branch carrying `status: draft` is reported by name and fails; the
+# delta-spec sitting beside it, equally `draft` and equally on the base
+# branch, is NOT reported. One assertion covers both scenarios because the
+# exempt file and the flagged file are in the same invocation — an exit code
+# alone could not distinguish "flagged the right file" from "flagged both".
+#
+# This is the case R8 requires: delete the base-branch check from
+# spec-linter.js and this case goes red (exit 0, no offender named).
+# -------------------------------------------------------------------------
+run_base_case "Case 28 — draft non-delta spec on the base branch fails and is named" \
+  "$GITFIX" "specs" 1 "main" \
+  "specs/0200-on-base.md" "specs/0201-on-base-delta.delta-01.md"
+
+# -------------------------------------------------------------------------
+# Case 29 (R2) — same violation, but with BASE_REF unset so the base ref comes
+# from the default derivation (first remote matching crewrig|origin, plus
+# `/main`). Pins the path CI uses on a `push` event, where no BASE_REF is
+# supplied; without this the derivation could rot unnoticed behind the
+# explicit-BASE_REF cases.
+# -------------------------------------------------------------------------
+run_base_case "Case 29 — default base-ref derivation (origin/main) enforces the check" \
+  "$GITFIX" "specs" 1 "-" \
+  "specs/0200-on-base.md" "-"
+
+# -------------------------------------------------------------------------
+# Case 30 (R4, Scenario 4) — correcting the offending spec's status in the
+# tree under test clears the violation, even though the base branch still
+# carries `draft`. This is what lets the check and the corpus correction land
+# in a single change (R6): the status read is the tree's, not the base's.
+# -------------------------------------------------------------------------
+render_spec "0200" "on-base" "implemented" "standard" "interaction-mode: INTERMEDIATE" \
+  > "$GITFIX/specs/0200-on-base.md"
+run_base_case "Case 30 — correcting the status in the tree clears the violation" \
+  "$GITFIX" "specs" 0 "main" "-" "-"
+
+# -------------------------------------------------------------------------
+# Case 31 (R2, Scenario 2) — a spec introduced by the change under test
+# (absent from the base branch) is legitimately `draft` and is not flagged.
+# -------------------------------------------------------------------------
+render_spec "0202" "introduced-by-change" "draft" > "$GITFIX/specs/0202-introduced-by-change.md"
+run_base_case "Case 31 — a spec absent from the base branch may be draft" \
+  "$GITFIX" "specs" 0 "main" "-" "specs/0202-introduced-by-change.md"
+
+# -------------------------------------------------------------------------
+# Case 32 — inside a repository whose base ref cannot be resolved, the linter
+# fails closed with exit 2 (an environment fault, distinct from its own exit-1
+# lint findings) rather than passing unchecked. Pins the deliberate choice:
+# a resolvable repository with an unresolvable base is a wiring fault, and
+# reporting it green would restore the "green does not mean checked" defect
+# spec 0109 exists to remove.
+# -------------------------------------------------------------------------
+run_base_case "Case 32 — unresolvable base ref inside a repository fails closed (exit 2)" \
+  "$GITFIX" "specs" 2 "no-such-base" "BASE_REF" "-"
+
+# -------------------------------------------------------------------------
+# Case 33 — outside any git work tree there is no change under test and so no
+# base branch to be the discriminator: the check is skipped, and says so on
+# stderr. Pins the other half of the Case 32 decision — the skip is
+# deliberate and announced, never silent. Uses its own isolated root so the
+# non-conforming fixtures in $TMP_ROOT/specs cannot influence the exit code.
+# -------------------------------------------------------------------------
+SCENARIO33_ROOT="$TMP_ROOT/scenario33"
+mkdir -p "$SCENARIO33_ROOT/specs"
+cp "$ROOT_DIR/.markdownlintrc" "$SCENARIO33_ROOT/"
+ln -s "$ROOT_DIR/node_modules" "$SCENARIO33_ROOT/node_modules"
+render_spec "0203" "outside-any-repo" "draft" > "$SCENARIO33_ROOT/specs/0203-outside-any-repo.md"
+run_base_case "Case 33 — outside a git work tree the check skips and announces it" \
+  "$SCENARIO33_ROOT" "specs" 0 "main" "Base-branch status check" "-"
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""

--- a/specs/0003-spec-pr-workflow.md
+++ b/specs/0003-spec-pr-workflow.md
@@ -1,7 +1,7 @@
 ---
 id: "0003"
 slug: spec-pr-workflow
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 170

--- a/specs/0004-plan-format-and-review.md
+++ b/specs/0004-plan-format-and-review.md
@@ -1,7 +1,7 @@
 ---
 id: "0004"
 slug: plan-format-and-review
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 169

--- a/specs/0005-retroactive-routing-engine.md
+++ b/specs/0005-retroactive-routing-engine.md
@@ -1,7 +1,7 @@
 ---
 id: "0005"
 slug: retroactive-routing-engine
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 172

--- a/specs/0006-interaction-modes-and-sizing.md
+++ b/specs/0006-interaction-modes-and-sizing.md
@@ -1,7 +1,7 @@
 ---
 id: "0006"
 slug: interaction-modes-and-sizing
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 173

--- a/specs/0007-build-install-spec-author.md
+++ b/specs/0007-build-install-spec-author.md
@@ -1,7 +1,7 @@
 ---
 id: "0007"
 slug: build-install-spec-author
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 174

--- a/specs/0008-migration-of-in-flight-tickets.md
+++ b/specs/0008-migration-of-in-flight-tickets.md
@@ -1,7 +1,7 @@
 ---
 id: "0008"
 slug: migration-of-in-flight-tickets
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 175

--- a/specs/0009-spec-linter.md
+++ b/specs/0009-spec-linter.md
@@ -1,7 +1,7 @@
 ---
 id: "0009"
 slug: spec-linter
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 178

--- a/specs/0010-curator-rot-visibility.md
+++ b/specs/0010-curator-rot-visibility.md
@@ -1,7 +1,7 @@
 ---
 id: "0010"
 slug: curator-rot-visibility
-status: draft
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 203

--- a/specs/0011-agents-md-size-reduction.md
+++ b/specs/0011-agents-md-size-reduction.md
@@ -1,7 +1,7 @@
 ---
 id: "0011"
 slug: agents-md-size-reduction
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 219

--- a/specs/0012-core-framework-separation.md
+++ b/specs/0012-core-framework-separation.md
@@ -1,7 +1,7 @@
 ---
 id: "0012"
 slug: core-framework-separation
-status: draft
+status: implemented
 complexity: large
 interaction-mode: INTERMEDIATE
 related-issue: 224

--- a/specs/0013-layer-taxonomy-boundary-contract.md
+++ b/specs/0013-layer-taxonomy-boundary-contract.md
@@ -1,7 +1,7 @@
 ---
 id: "0013"
 slug: layer-taxonomy-boundary-contract
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 227

--- a/specs/0014-artifacts-directory-restructuring.md
+++ b/specs/0014-artifacts-directory-restructuring.md
@@ -1,7 +1,7 @@
 ---
 id: "0014"
 slug: artifacts-directory-restructuring
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 228

--- a/specs/0015-overlay-starter-templates.md
+++ b/specs/0015-overlay-starter-templates.md
@@ -1,7 +1,7 @@
 ---
 id: "0015"
 slug: overlay-starter-templates
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 229

--- a/specs/0016-sync-from-upstream.md
+++ b/specs/0016-sync-from-upstream.md
@@ -1,7 +1,7 @@
 ---
 id: "0016"
 slug: sync-from-upstream
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 230

--- a/specs/0017-adoption-guide.md
+++ b/specs/0017-adoption-guide.md
@@ -1,7 +1,7 @@
 ---
 id: "0017"
 slug: adoption-guide
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 231

--- a/specs/0018-assembly-verification.md
+++ b/specs/0018-assembly-verification.md
@@ -1,7 +1,7 @@
 ---
 id: "0018"
 slug: assembly-verification
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 232

--- a/specs/0020-overlay-carve-out.md
+++ b/specs/0020-overlay-carve-out.md
@@ -1,7 +1,7 @@
 ---
 id: "0020"
 slug: overlay-carve-out
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 264

--- a/specs/0021-adoption-ergonomics.md
+++ b/specs/0021-adoption-ergonomics.md
@@ -1,7 +1,7 @@
 ---
 id: "0021"
 slug: adoption-ergonomics
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 267

--- a/specs/0022-editorial-carve-out.md
+++ b/specs/0022-editorial-carve-out.md
@@ -1,7 +1,7 @@
 ---
 id: "0022"
 slug: editorial-carve-out
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 270

--- a/specs/0023-en-us-orthography-sweep.md
+++ b/specs/0023-en-us-orthography-sweep.md
@@ -1,7 +1,7 @@
 ---
 id: "0023"
 slug: en-us-orthography-sweep
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 273

--- a/specs/0024-extension-tiers.md
+++ b/specs/0024-extension-tiers.md
@@ -1,7 +1,7 @@
 ---
 id: "0024"
 slug: extension-tiers
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 276

--- a/specs/0025-harden-agent-team-protocol.md
+++ b/specs/0025-harden-agent-team-protocol.md
@@ -1,7 +1,7 @@
 ---
 id: "0025"
 slug: harden-agent-team-protocol
-status: draft
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 280

--- a/specs/0026-reconcile-rule4-modes.md
+++ b/specs/0026-reconcile-rule4-modes.md
@@ -1,7 +1,7 @@
 ---
 id: "0026"
 slug: reconcile-rule4-modes
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 281

--- a/specs/0027-docs-ia-and-publication-contract.md
+++ b/specs/0027-docs-ia-and-publication-contract.md
@@ -1,7 +1,7 @@
 ---
 id: "0027"
 slug: docs-ia-and-publication-contract
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 292

--- a/specs/0028-docs-section-overviews.md
+++ b/specs/0028-docs-section-overviews.md
@@ -1,7 +1,7 @@
 ---
 id: "0028"
 slug: docs-section-overviews
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 296

--- a/specs/0029-chroma-daemon-fd-limits.md
+++ b/specs/0029-chroma-daemon-fd-limits.md
@@ -1,7 +1,7 @@
 ---
 id: "0029"
 slug: chroma-daemon-fd-limits
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 300

--- a/specs/0030-feedback-routing-upstream-tiers.md
+++ b/specs/0030-feedback-routing-upstream-tiers.md
@@ -1,7 +1,7 @@
 ---
 id: "0030"
 slug: feedback-routing-upstream-tiers
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 304

--- a/specs/0031-core-paths-phantom-tolerance.md
+++ b/specs/0031-core-paths-phantom-tolerance.md
@@ -1,7 +1,7 @@
 ---
 id: "0031"
 slug: core-paths-phantom-tolerance
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 310

--- a/specs/0032-curator-blockscalar-suggestion.md
+++ b/specs/0032-curator-blockscalar-suggestion.md
@@ -1,7 +1,7 @@
 ---
 id: "0032"
 slug: curator-blockscalar-suggestion
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 312

--- a/specs/0085-gemini-overlay-enrollment-guard.md
+++ b/specs/0085-gemini-overlay-enrollment-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0085"
 slug: gemini-overlay-enrollment-guard
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 579

--- a/specs/0087-chroma-launcher-ulimit-floor.md
+++ b/specs/0087-chroma-launcher-ulimit-floor.md
@@ -1,7 +1,7 @@
 ---
 id: "0087"
 slug: chroma-launcher-ulimit-floor
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 587

--- a/specs/0089-merge-mcp-declarations.md
+++ b/specs/0089-merge-mcp-declarations.md
@@ -1,7 +1,7 @@
 ---
 id: "0089"
 slug: merge-mcp-declarations
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 616

--- a/specs/0090-forge-access-cli-only.md
+++ b/specs/0090-forge-access-cli-only.md
@@ -1,7 +1,7 @@
 ---
 id: "0090"
 slug: forge-access-cli-only
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 624

--- a/specs/0091-org-mcp-declaration.md
+++ b/specs/0091-org-mcp-declaration.md
@@ -1,7 +1,7 @@
 ---
 id: "0091"
 slug: org-mcp-declaration
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 631

--- a/specs/0093-worktree-subagent-cwd-guard.md
+++ b/specs/0093-worktree-subagent-cwd-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0093"
 slug: worktree-subagent-cwd-guard
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 599

--- a/specs/0094-spec-pr-shared-logbook-closing-keyword.md
+++ b/specs/0094-spec-pr-shared-logbook-closing-keyword.md
@@ -1,7 +1,7 @@
 ---
 id: "0094"
 slug: spec-pr-shared-logbook-closing-keyword
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 597

--- a/specs/0095-orchestrator-deliverable-edit-fence.md
+++ b/specs/0095-orchestrator-deliverable-edit-fence.md
@@ -1,7 +1,7 @@
 ---
 id: "0095"
 slug: orchestrator-deliverable-edit-fence
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 602

--- a/specs/0096-empty-teams-catalogue.md
+++ b/specs/0096-empty-teams-catalogue.md
@@ -1,7 +1,7 @@
 ---
 id: "0096"
 slug: empty-teams-catalogue
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 603

--- a/specs/0097-copilot-settings-workspace-scope.md
+++ b/specs/0097-copilot-settings-workspace-scope.md
@@ -1,7 +1,7 @@
 ---
 id: "0097"
 slug: copilot-settings-workspace-scope
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 605

--- a/specs/0098-spec-linter-cross-file-id-uniqueness.md
+++ b/specs/0098-spec-linter-cross-file-id-uniqueness.md
@@ -1,8 +1,9 @@
 ---
 id: "0098"
 slug: spec-linter-cross-file-id-uniqueness
-status: draft
+status: implemented
 complexity: small
+interaction-mode: INTERMEDIATE
 related-issue: 606
 version: 1.0.0
 ---

--- a/specs/0100-worktree-session-hygiene.md
+++ b/specs/0100-worktree-session-hygiene.md
@@ -1,8 +1,9 @@
 ---
 id: "0100"
 slug: worktree-session-hygiene
-status: draft
+status: implemented
 complexity: small
+interaction-mode: INTERMEDIATE
 related-issue: 609
 version: 1.0.0
 ---

--- a/specs/0101-spec-pr-inline-approval.md
+++ b/specs/0101-spec-pr-inline-approval.md
@@ -1,8 +1,9 @@
 ---
 id: "0101"
 slug: spec-pr-inline-approval
-status: draft
+status: implemented
 complexity: small
+interaction-mode: INTERMEDIATE
 related-issue: 610
 version: 1.0.0
 ---

--- a/specs/0102-solo-merge-classifier-workaround.md
+++ b/specs/0102-solo-merge-classifier-workaround.md
@@ -1,8 +1,9 @@
 ---
 id: "0102"
 slug: solo-merge-classifier-workaround
-status: draft
+status: implemented
 complexity: small
+interaction-mode: INTERMEDIATE
 related-issue: 636
 version: 1.0.0
 ---

--- a/specs/0103-mempalace-write-lock-fallback.md
+++ b/specs/0103-mempalace-write-lock-fallback.md
@@ -1,8 +1,9 @@
 ---
 id: "0103"
 slug: mempalace-write-lock-fallback
-status: draft
+status: implemented
 complexity: small
+interaction-mode: INTERMEDIATE
 related-issue: 637
 version: 1.0.0
 ---


### PR DESCRIPTION
`docs/spec-format.md` asserted that *"a merged spec is never at once merged and still `draft`"*. It was false for **44 of 109** non-delta specs on `main`, including the lifecycle's own contracts — enforced daily while recorded as drafts — so `status` could not answer the question it exists for. This corrects all 44 and adds the check that keeps the invariant true.

Implements spec 0109 and its delta-01.

Closes #700

## How to read this PR?

51 files, but only four things happen. Read in this order:

1. **`scripts/lib/spec-linter.js`** — the check. The linter had **no base-branch awareness at all**; even the spec-0098 duplicate-id guard compared only files within the tree under test. The load-bearing detail is the discriminator: base-branch *presence* selects which files are in scope, while the `status` read is the **working tree's**. That is the only reading under which the corrected tree passes while `main` still carries the drafts.
2. **`scripts/tests/test-spec-linter.sh`** — six new cases covering all five spec scenarios plus both environment branches.
3. **`docs/spec-format.md`** — the invariant stated as a findable rule, naming the linter as its enforcement.
4. **`specs/*.md` × 44** — `status: draft` → `implemented`. Five also gain `interaction-mode: INTERMEDIATE`; see below.

The CI files and `ci/test-wiring-exemptions.txt` are the fourth thing, explained under *scope judgement*.

## How to test this PR?

```sh
npm install                              # a fresh worktree has no node_modules; the suite needs it
task spec:lint                           # -> Linting passed!
bash scripts/tests/test-spec-linter.sh   # -> Results: 34 passed, 0 failed
```

**Prove the check actually catches a regression**, rather than trusting a green run:

```sh
sed -i '' 's/^status: implemented/status: draft/' specs/0009-spec-linter.md
task spec:lint
# -> [FAIL] Non-delta specs present on the base branch (crewrig/main) carry 'status: draft':
#    - specs/0009-spec-linter.md
git checkout -- specs/0009-spec-linter.md
```

**Prove requirement 8's removal-detector fires**, which is the assertion that matters most here:

```sh
# delete the offender block from spec-linter.js, then:
bash scripts/tests/test-spec-linter.sh    # -> Cases 28 and 29 go red
```

Both CI paths were simulated locally: `BASE_REF=crewrig/main` (pull-request path) and `BASE_REF=` (push path, falling back to the linter's own derivation).

## Detailed description (for agents)

**The one decision the spec left open, and why it became three outcomes rather than two.** "No base ref" is not a single situation. Outside a git work tree there is no change under test, so requirement 2's subject — *the base branch of the change under test* — does not exist: the check **skips with a notice naming what was not checked**, which is the temp-fixture case and cannot occur in CI. Inside a repository with the base resolvable, it enforces. Inside a repository with the base **unresolvable**, it exits **2** and fails closed: that means a wiring fault (missing `fetch-depth: 0`, an unfetched remote), and reporting it green is precisely the green-does-not-mean-checked defect this spec exists to remove. Exit 2 rather than the linter's own 1 marks an environment fault rather than a lint finding, matching `check-skill-versions.sh`. Both branches are pinned by tests and both go red under mutation.

Fail-closed has a consequence that had to be wired rather than hoped for: `lint-specs` now needs `fetch-depth: 0` and a PR-conditional `BASE_REF`. On `push` there is no PR context, `BASE_REF` is falsy, and the linter falls back to its own derivation — a test case pins that path.

**Base-ref resolution reuses `check-skill-versions.sh:24-33`** rather than inventing a second idiom: `BASE_REF` → first remote matching `crewrig|origin` (else the first remote) + `/main` → `rev-parse --verify` → `--depth=50` fetch retry → an error naming the override. One documented difference: the linter's positional arguments are spec targets, so `BASE_REF` is the only override.

**The corrections are mechanical, on evidence re-derived rather than inherited.** All 44 `related-issue`s are CLOSED/COMPLETED, and they were closed by 62 distinct linked pull requests, **62/62 MERGED**. No spec resolved to anything other than `implemented`, so none had to be forced to the majority — requirement 4's "the status that reflects its true state" was honoured rather than shortcut.

**Five of the 44 also gain `interaction-mode: INTERMEDIATE`.** They carried none, because the frontmatter schema requires that field only from `approved` onward and lets it default while `draft`. A status-only edit would leave them failing the linter's own frontmatter check, and leaving them at `draft` would violate requirements 1 and 4 and make the new check fail on the change that introduces it. Spec 0109's original requirement 5 forbade touching the field while citing a carve-out that *mandates* setting it — **delta-01 (#707) corrected that contradiction before this PR was opened**, so this diff conforms to the letter as well as the intent.

**Requirement 6 is why this is one change.** A check landing before the corrections would fail on `main` and on every subsequent PR; corrections landing without the check would leave the invariant free to decay again. Verified by running the new check against this tree with both halves in.

**One scope judgement, flagged for veto.** `scripts/tests/test-spec-linter.sh` was **exempted from CI**, so requirement 8's removal-detector would never have run: deleting the check would produce a green pipeline once the corpus was clean — the same green-does-not-mean-checked defect one level up. The suite is now wired into `lint-specs` and the exemption line deleted per that file's own hygiene rule. The exemption's stated blocker — no npm-installed `node_modules` — does not exist in `lint-specs`, which already runs `npm install`. Cost: 16 seconds. Reverting is three lines plus a `build-ci.sh` regeneration.

**Delta-specs are untouched** and remain 30 `draft` / 5 `approved` / 2 `implemented`. Spec 0109 deliberately leaves their status to its own ticket: the "only the parent transitions" convention rests on one verified instance against seven counterexamples, which is not a convention to codify.

**`docs/cli-matrix.md` is not updated**, deliberately: the diff touches none of the paths its maintenance rule enumerates. `build.yml` is not `claude.yml` or `gemini.yml`, and `build-ci.sh` itself is unmodified — only its generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)