### PR TITLE
📝 Mark spec 0109 implemented

### DIFF
--- a/specs/0109-spec-status-invariant-on-main.md
+++ b/specs/0109-spec-status-invariant-on-main.md
@@ -1,7 +1,7 @@
 ---
 id: "0109"
 slug: spec-status-invariant-on-main
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 700


### PR DESCRIPTION
Spec 0109's base-branch status check and its 44 corrections merged as `435b734` (PR #708), and anchor ticket #700 closed as completed, so `status: approved` no longer reflects the spec's state. One frontmatter line.

Closes #710

## How to read this PR?

- One line in `specs/0109-spec-status-invariant-on-main.md`: `status: approved` → `status: implemented`. Nothing else.
- **Check the diff is one hunk.** The body legitimately contains `status: draft` six times — in requirements 1 and 2 and in three scenarios, all describing what the new check must reject. A global replace would have rewritten normative content under cover of a metadata edit, which this spec's own requirement 5 forbids. The count is still 6 after the edit.

## How to test this PR?

```sh
npm install                              # a fresh worktree has no node_modules
task spec:lint                           # -> Linting passed!
git show --stat HEAD                     # -> one file, +1/-1
grep -c 'status: draft' specs/0109-spec-status-invariant-on-main.md   # -> 6, unchanged
```

Confirm the invariant the spec introduced actually holds on `main`:

```sh
for f in $(git ls-tree crewrig/main specs/ --name-only | grep '\.md$' \
           | grep -vE '_template|README|delta-'); do
  git show "crewrig/main:${f}" | sed -n 's/^status: *//p' | head -1
done | sort | uniq -c
```

No `draft` line appears. It was 44 before `435b734`.

## Detailed description (for agents)

Sanctioned post-merge transition per `docs/spec-format.md` → *Recording a status transition* → *Recording a post-merge transition*: `approved` → `implemented` is triggered by a genuinely later event — the implementation PR merging — that cannot be folded into the spec-PR, so it is recorded afterwards by a metadata-only frontmatter edit. The `draft` → `approved` transition rode inside the spec-PR's own commit, correctly, on its own branch before `gh pr merge`.

**`delta-01` keeps `status: approved`**, matching the treatment 0108's delta received. Whether delta-specs transition at all is the question spec 0109 deliberately left out of scope, with the measurement that motivates it: the corpus holds **30 `draft`, 5 `approved`, 2 `implemented`** deltas, so the "only the parent transitions" convention rests on one verified instance against seven counterexamples. Following the established treatment rather than inventing a third behaviour, and recording why.

**Incidental value, stated accurately.** This is the first pull request to run under the check PR #708 introduced. An earlier framing of mine claimed it would be "the first case policed by the new check" — that was wrong, and is corrected here: the check flags `draft` only, so it does not police an `approved` → `implemented` transition. What this PR does confirm is that the new check produces **no false positive on an ordinary one-line change**, which is a cheap end-to-end verification worth having on the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)