### PR TITLE
🐛 Fix mempalace-transcript lock acquisition error

### DIFF
--- a/hooks/mempalace-transcript.sh
+++ b/hooks/mempalace-transcript.sh
@@ -228,6 +228,16 @@ except Exception as e:  # acknowledged-exception: broad except intentional — a
     print(f"DAEMON_UNREACHABLE: {_host}:{_port} — {e}", file=sys.stderr)
     sys.exit(4)
 
+import contextlib
+try:
+    import mempalace.palace
+    @contextlib.contextmanager
+    def _mock_mine_palace_lock(palace_path):
+        yield
+    mempalace.palace.mine_palace_lock = _mock_mine_palace_lock
+except ImportError:
+    pass
+
 try:
     from mempalace.mcp_server import tool_add_drawer
 except ImportError as e:


### PR DESCRIPTION
🐛 Fix systematic local file lock acquisition error in `hooks/mempalace-transcript.sh` when the HTTP server wrapper is running.

### Problem

When the MemPalace HTTP daemon (`mempalace-http-wrapper.py`) is running, it holds the SQLite database write lock exclusively.
Since `hooks/mempalace-transcript.sh` runs as a separate local shell-hook process, calling `tool_add_drawer` attempts to acquire `mine_palace_lock(palace_path)` in-process. This results in a systematic `ADD_FAILED: palace is held by PID` error and completely halts persistence.

### Solution

By monkey-patching `mempalace.palace.mine_palace_lock` to be a no-op context manager inside the Python script of the transcript hook, we bypass the unnecessary local on-disk lock check. 

This is perfectly safe and correct because:
1. `chromadb.PersistentClient` has already been successfully patched to route all operations via `HttpClient` (HTTP over port 8001).
2. The HTTP daemon itself maintains the exclusive file lock on disk and processes the HTTP requests safely.