### PR TITLE
📝 Mark spec 0110 implemented

### DIFF
--- a/specs/0110-transcript-hook-lock-bypass.md
+++ b/specs/0110-transcript-hook-lock-bypass.md
@@ -1,7 +1,7 @@
 ---
 id: "0110"
 slug: transcript-hook-lock-bypass
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 713


### PR DESCRIPTION
Spec 0110's implementation merged as `02b7639` (PR #715) and anchor ticket #713
closed as completed, so `status: approved` no longer reflects the spec's state.
One frontmatter line.

Closes #716

## How to read this PR?

- One line in `specs/0110-transcript-hook-lock-bypass.md`: `status: approved` →
  `status: implemented`. Nothing else.
- **Check the diff is one hunk.** The body legitimately contains the word
  "status" twice more — "exit status" in requirement 4 and in the third scenario,
  both describing the distinct exit code the hook must use. Neither is a
  frontmatter field, and a careless replace on `status` rather than on `status:`
  would rewrite normative content under cover of a metadata edit. Verified
  intact: lines 37 and 77 are unchanged.

## How to test this PR?

```sh
BASE_REF=crewrig/main task spec:lint
```

Expected: `Linting passed!` — markdownlint plus semantic validation, including
the spec-0109 invariant that no non-delta spec on the base branch carries
`status: draft`. `implemented` is a valid enum value per
`docs/spec-format.md` → *Lifecycle states*.

## Detailed description (for agents)

**Modified:** `specs/0110-transcript-hook-lock-bypass.md`, frontmatter `status`
field only, `approved` → `implemented`.

This is the post-merge metadata-only transition prescribed by
`docs/spec-format.md` → *Recording a status transition*, whose line 196 assigns
`implemented` the trigger "implementation PR for `related-issue` merged on
`main`" and the authority "implementation team's `pr-logbook`". It is deliberately
a separate PR rather than part of #715: the trigger cannot be satisfied until
#715 has merged, so the flip is not knowable at implementation time. Same shape
as #711 for spec 0109.

**Evidence the trigger fired:**

- PR #715 merged to `main` at `02b7639` — `hooks/mempalace-transcript.sh` (+132/-1),
  `scripts/tests/test-mempalace-transcript-hook.sh` (+666).
- Anchor issue #713 closed as `COMPLETED` by that merge.
- Three cold REVIEW passes, all APPROVE. iter:1 corrected the relief block's
  safety rationale (the write-ahead-log append is a real disk write, but sits
  outside `ChromaCollection._write_lock()`, so the palace lock never guarded it).
  iter:2 corrected a stale diff-stat in #715's body. iter:3 returned zero findings
  of any class, meeting the termination criterion with CI 12/12 green on the
  reviewed head `a214005`.

**Not in this PR:** no code, no test, no documentation change. No delta-spec — the
spec's requirements are unchanged and were satisfiable as written; all three
reviewers reported no `spec`-class finding.
