### PR TITLE
📝 Add spec 0111 — Bash 3.2 portability guard for governed shell scripts

### DIFF
--- a/specs/0111-bash32-portability-guard.md
+++ b/specs/0111-bash32-portability-guard.md
@@ -1,0 +1,153 @@
+---
+id: "0111"
+slug: bash32-portability-guard
+status: approved
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 697
+version: 1.0.0
+---
+
+# A shell script that cannot run on a stock macOS shell does not reach `main`
+
+## Intent
+
+A contributor who reintroduces a shell construct that the Bash shipped with
+macOS does not understand is told so before the change lands, naming the
+offending lines, instead of the breakage surfacing later on a maintainer's
+machine as a script that aborts on its first line. And every test suite the
+repository ships runs to completion on that shell, so a maintainer working there
+gets an honest result rather than a green count produced by a newer shell they
+happen to have installed.
+
+## Requirements
+
+1. The project SHALL enforce a declared set of shell constructs as forbidden in
+   the governed scripts, and SHALL reject any change under test in which a
+   governed script uses one of them.
+2. The declared set of requirement 1 SHALL contain at least every construct that
+   has already caused a governed script to abort on the stock macOS shell —
+   `mapfile`, `readarray`, and associative-array declaration — and SHALL be
+   recorded in one place that both the enforcement and the documentation refer
+   to.
+3. A rejection per requirement 1 SHALL name every offending location, each by
+   file and line, rather than reporting only that a violation exists.
+4. The enforcement SHALL treat a construct that a governed script *uses*
+   differently from one it merely *names in prose*, so that a comment
+   documenting the prohibition — or explaining that a construct was deliberately
+   avoided — is not rejected.
+5. The governed scripts SHALL include the repository's own test scripts, on the
+   same terms as the scripts it ships.
+6. Every governed script present when this spec is realised SHALL satisfy
+   requirement 1 at that point, by being changed to avoid the forbidden
+   construct rather than by being exempted from the check.
+7. Each test suite changed under requirement 6 SHALL assert the same cases with
+   the same verdicts as before the change, so the correction alters what the
+   suite runs on and not what it checks.
+8. Each test suite changed under requirement 6 SHALL run to completion on the
+   stock macOS shell.
+9. The enforcement SHALL be exercised identically by every continuous
+   integration engine the project governs, so a change rejected by one is
+   rejected by all.
+10. The documented acknowledged-exception escape hatch SHALL remain available to
+    a script that deliberately requires a newer shell, and the enforcement SHALL
+    honour it.
+11. The rule SHALL be documented alongside the project's existing
+    scripting-convention rules, following their established structure.
+
+## Scenarios
+
+**Scenario:** a forbidden construct is reintroduced
+
+```text
+Given a governed script that uses none of the forbidden constructs
+When  a change under test adds a line that uses one of them
+Then  the change is rejected
+And   the rejection names that line's file and line number
+```
+
+**Scenario:** the repository as it stands is accepted
+
+```text
+Given the repository with requirement 6 satisfied
+When  the enforcement runs
+Then  no violation is reported
+```
+
+**Scenario:** prose mentioning a forbidden construct is accepted
+
+```text
+Given a governed script whose comment explains that a forbidden construct was
+      deliberately avoided
+When  the enforcement runs
+Then  that comment is not reported as a violation
+```
+
+**Scenario:** a deliberate requirement on a newer shell is accepted
+
+```text
+Given a governed script that uses a forbidden construct
+And   that line carries the documented acknowledged-exception marker
+When  the enforcement runs
+Then  that line is not reported as a violation
+```
+
+**Scenario:** a corrected suite behaves identically on both shells
+
+```text
+Given a test suite changed under requirement 6
+When  it is run on the stock macOS shell and on a newer shell
+Then  it runs to completion on both
+And   it reports the same set of case verdicts on both
+```
+
+**Scenario:** a test script is governed like any other
+
+```text
+Given a change under test that adds a forbidden construct to a test script
+When  the enforcement runs
+Then  the change is rejected on the same terms as for a shipped script
+```
+
+## Out of scope
+
+- **The test harnesses' interpreter resolution.** Several suites invoke their
+  subject as `bash "$SCRIPT"`, resolving `bash` from `PATH`, so a contributor
+  with a newer Bash ahead of `/bin/bash` still exercises the subject under that
+  newer shell. This spec makes the *scripts* portable and makes the enforcement
+  catch regressions; it does not pin the interpreter the harnesses use. That is a
+  distinct change with a blast radius across every suite, and the anchor issue
+  excludes it explicitly.
+- **A macOS leg on the CI matrix.** Considered and rejected in the anchor issue:
+  heavier and metered differently, and it would only cover scripts some test
+  actually exercises, whereas the enforcement here covers every governed script
+  whether tested or not. Recorded as the rejected alternative, not a later phase.
+- **Other portability classes.** GNU-versus-BSD divergence in the userland the
+  scripts call out to — `sed -i`, `date -d`, `readlink -f`, `grep -P` — is a real
+  and separate hazard with its own detection problem. Nothing here addresses it,
+  and requirement 2's declared set is deliberately about shell-builtin
+  availability rather than about external tools.
+- **Shell constructs newer than the forbidden set but not yet observed to
+  break.** Requirement 2 sets a floor, not a ceiling; growing the set later is an
+  ordinary change to it and needs no amendment here.
+- **Scripts outside the governed set.** Anything not under the directories the
+  existing scripting-convention enforcement already covers stays ungoverned by
+  this spec.
+- **Extending `ci/ci-capabilities.yml`'s vocabulary to express environment
+  variables.** A separate known defect (issue #709) with its own ticket;
+  requirement 9 needs no environment variable and must not wait on it.
+
+## Open questions
+
+None. The one question that could have been left open — whether the existing
+violations should be corrected or exempted — was settled before authoring, by
+measurement and then by the maintainer. Measured on `main` at `508f3f8`: 14
+occurrences across 6 files, all under `scripts/tests/`, none in a shipped script;
+12 are `mapfile -t X < <(…)` and 2 are associative-array declarations used as
+fixed lookup tables over literal keys, with no dynamic key access anywhere, so
+the correction is mechanical. Reproduced under `/bin/bash` 3.2.57: `mapfile:
+command not found` and `declare: -A: invalid option`. The maintainer chose
+correction over exemption on the grounds that exempting 14 lines would both leave
+six suites unrunnable on a stock macOS shell — the precise mechanism behind the
+false green the anchor issue reports — and normalise an escape hatch documented
+for scripts that will never run there.


### PR DESCRIPTION
Spec 0111 qualifies the SPECS stage of issue #697: nothing today can fail a change
that reintroduces a Bash 4+ construct into a governed script, because every CI
runner carries Bash 5.x and the test harnesses resolve `bash` from `PATH`. It
states what the guard must guarantee, and — because the repository already
violates the rule — that the existing violations are corrected rather than
exempted.

## How to read this PR?

One new file, no other edits (Spec-PR workflow *one-file rule*).

Read `specs/0111-bash32-portability-guard.md` top to bottom. Four parts carry
decisions a reviewer should weigh rather than skim:

- **Requirements 1 and 2 are deliberately shaped.** The natural phrasing — "any
  construct unavailable on the stock macOS shell" — reads well and cannot be
  satisfied to the letter, since any real check is a finite pattern. R1 therefore
  binds a *declared set* and R2 fixes its floor at the constructs already
  observed to abort a script. This applies the lesson issue #703 records against
  spec 0108, four of whose requirements are legible in intent but unsatisfiable
  as written, forcing every reviewer to reconstruct the intent.
- **Requirement 4 exists because of a live trap.** Seven files carry comments of
  the form "`while read` rather than `mapfile` for bash 3.2 compat" — eight lines
  in total. A naive pattern would reject precisely the comments that document the
  prohibition. R4 requires the check to distinguish use from mention.
- **Requirement 6 is the maintainer's scope decision, not a default.** The
  repository has 14 pre-existing violations. Exempting them was a real option and
  was rejected: it would leave six suites unrunnable on a stock macOS shell — the
  exact mechanism behind the false green the anchor issue reports — and normalise
  an escape hatch documented for scripts that will never run there.
- **`## Out of scope`** excludes the test harnesses' `PATH`-based interpreter
  resolution. That is the other half of the false local signal, and the anchor
  issue excludes it explicitly; this spec makes the scripts portable and the
  regressions detectable without pinning what the harnesses execute.

`## Open questions` records the measurement that settled the correct-versus-exempt
question, so a reviewer does not have to re-derive it.

## How to test this PR?

Prerequisites: a checkout of this branch; `task` available.

```sh
BASE_REF=crewrig/main task spec:lint
```

Expected: `Linting passed!` — markdownlint over 149 files plus semantic
validation (frontmatter schema, the five mandatory body sections in order, id and
slug matching the filename, and the spec-0109 invariant that no non-delta spec on
the base branch carries `status: draft`).

Nothing executable ships here: this PR is a specification only. The behaviour it
specifies is verified in the implementation PR, whose checks derive from the six
scenarios in `## Scenarios`.

To reproduce the measurement the spec cites, on a machine with stock Bash:

```sh
/bin/bash --version                      # expect 3.2.57 on macOS
/bin/bash -c 'mapfile -t X < <(echo a)'  # expect: mapfile: command not found
/bin/bash -c 'declare -A X=( [a]=1 )'    # expect: declare: -A: invalid option
```

## Detailed description (for agents)

**Added:** `specs/0111-bash32-portability-guard.md` — id `0111`, slug
`bash32-portability-guard`, `status: approved`, `complexity: standard`,
`interaction-mode: INTERMEDIATE`, `related-issue: 697`, `version: 1.0.0`.

`status: approved` is present in this PR's own commit per `docs/spec-format.md` →
*Lifecycle states*, which assigns `approved` the trigger "spec PR merged on
`main`" and states the spec-PR's own commit already carries it, so no separate
status-transition PR is opened for this step. The SPECS content-approval gate ran
through the `user-validate` skill on the `plannotator` backend and returned
`approved`.

**Requirements (11).** R1 binds a declared forbidden set and requires rejection
on use. R2 fixes the set's floor (`mapfile`, `readarray`, associative-array
declaration) and requires it recorded in one place both the enforcement and the
documentation depend on. R3 requires every offending location named by file and
line. R4 requires use to be distinguished from mention in prose. R5 brings the
repository's test scripts under governance on the same terms as shipped scripts.
R6 requires pre-existing violations corrected, not exempted. R7 requires each
corrected suite to assert the same cases with the same verdicts. R8 requires each
corrected suite to run to completion on the stock shell. R9 requires every
governed CI engine to exercise the check identically. R10 preserves the existing
acknowledged-exception hatch. R11 requires the rule documented alongside the
existing scripting-convention rules.

**Scenarios (6).** Reintroduction rejected with the location named; the
repository as it stands accepted; a comment mentioning a forbidden construct
accepted; an acknowledged exception honoured; a corrected suite producing the
same verdicts on both shells; a test script governed on the same terms as a
shipped one.

**Out of scope (6 bullets).** Harness interpreter resolution; a macOS CI matrix
leg (the anchor issue's rejected alternative); other portability classes
(GNU-versus-BSD userland); constructs beyond the declared floor; scripts outside
the already-governed directories; and extending `ci/ci-capabilities.yml` to
express environment variables (issue #709 — R9 needs none and must not wait on
it).

**Measurement behind the spec**, taken on `main` at `508f3f8` and recorded in
`## Open questions`: 14 occurrences across `scripts/tests/test-e2e-runner.sh` (6),
`test-e2e-report.sh` (2), `test-e2e-runner-delegation.sh` (2),
`test-setup-org-mcp.sh` (2), `test-e2e-defaults-toml.sh` (1) and
`test-setup-ensure-tier-built.sh` (1). All six are CI-wired in
`.github/workflows/build.yml`, `.gitlab-ci.yml` and `ci/ci-capabilities.yml`. No
shipped script is affected. The two associative arrays are fixed lookup tables
over literal keys with no dynamic key access, so the correction is mechanical.

**Not in this PR:** no CI rule, no documentation section, no test correction.
Those land in the implementation PR for #697, after the PLAN stage — this ticket
is `complexity: standard`, so it runs a plan comment authored by an `architect`,
a cold second-`architect` review, and the INTERMEDIATE plan user gate before any
code. No closing keyword appears in this body: #697 must survive this merge as
the ticket's logbook anchor and be closed only by the implementation PR (Spec-PR
workflow *independence rule*).
