### PR TITLE
✨ Reject Bash 4+ constructs in governed scripts and port six suites

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,9 @@ jobs:
       - name: Test Gemini overlay enrollment regression (spec 0085)
         run: bash scripts/tests/test-check-gemini-overlay-enrollment.sh
 
+      - name: Test Bash 3.2 portability guard regression (spec 0111)
+        run: bash scripts/tests/test-check-bash32-portability.sh
+
   lint-markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scripting-conventions.yml
+++ b/.github/workflows/scripting-conventions.yml
@@ -54,3 +54,11 @@ jobs:
             exit 1
           fi
           echo "Rule 1 clean."
+
+      - name: Flag Bash 4+ constructs in governed scripts
+        # Rule 5 — unlike the two steps above, the matching lives in a script
+        # rather than inline here, so its declared set (ci/bash32-forbidden.txt)
+        # is one data file instead of a per-engine hand-copied regex, and a
+        # maintainer can run the same check locally.
+        # See docs/scripting-conventions.md, Rule 5.
+        run: bash scripts/check-bash32-portability.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,6 +107,7 @@ check-components:
     - "bash scripts/tests/test-setup-ensure-tier-built.sh"
     - "bash scripts/check-gemini-overlay-enrollment.sh"
     - "bash scripts/tests/test-check-gemini-overlay-enrollment.sh"
+    - "bash scripts/tests/test-check-bash32-portability.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'
@@ -207,6 +208,7 @@ grep-anti-patterns:
           exit 1
         fi
         echo "Rule 1 clean."
+    - "bash scripts/check-bash32-portability.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
       changes:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -334,6 +334,10 @@ tasks:
     desc: "Enforce a single authoritative version across an extension's manifests (local mirror of the CI guard, spec 0044)"
     cmd: bash {{.REPO_DIR}}/scripts/check-extension-manifest-version.sh
 
+  check-bash32-portability:
+    desc: "Reject Bash 4+ constructs in scripts/ and hooks/ (local mirror of the CI guard, spec 0111)"
+    cmd: bash {{.REPO_DIR}}/scripts/check-bash32-portability.sh
+
   skill:check:
     desc: "Verify built skill (+ optional agent) mirrors for one component across .claude/, .gemini/, .github/. Usage: task skill:check NAME=<skill-name>"
     silent: true

--- a/ci/bash32-forbidden.txt
+++ b/ci/bash32-forbidden.txt
@@ -1,0 +1,29 @@
+# bash32-forbidden.txt — the declared set of shell constructs forbidden in the
+# repository's governed scripts (spec 0111, requirement 2).
+#
+# This file is the one place both the enforcement and the documentation refer to:
+# scripts/check-bash32-portability.sh reads it to compose its match patterns, and
+# docs/scripting-conventions.md Rule 5 names the same tokens in prose.
+# scripts/tests/test-check-bash32-portability.sh asserts the two stay in sync, so
+# a construct added here without a matching Rule 5 entry fails CI.
+#
+# It lives under ci/ rather than scripts/ deliberately. The enforcement scans
+# scripts/ and hooks/; holding the literal tokens outside that tree is what lets
+# the guard match them without flagging its own declared set, and so without
+# needing a self-exemption at the very file that defines the rule.
+#
+# Format — one construct per line, <kind><TAB><token><TAB><reason>:
+#   kind=command       a builtin or command name, flagged when it stands in
+#                      command position on a line that is not itself a comment
+#   kind=declare-flag  an uppercase flag letter of declare/typeset/local/
+#                      readonly, flagged when the flag cluster contains it
+# Blank lines and lines whose first non-blank character is `#` are skipped;
+# a trailing carriage return is tolerated.
+#
+# The set is a floor, not a ceiling: every entry below has already been observed
+# to abort a governed script on the stock macOS shell. Growing it later is an
+# ordinary change to this file plus its Rule 5 entry.
+
+command	mapfile	Bash 4.0 builtin; fails `mapfile: command not found` on Bash 3.2.57 (stock macOS /bin/bash)
+command	readarray	Bash 4.0 builtin, synonym of mapfile; same failure on Bash 3.2.57
+declare-flag	A	Associative arrays are Bash 4.0; fails `-A: invalid option` on Bash 3.2.57

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -123,6 +123,7 @@ capabilities:
       - bash scripts/tests/test-setup-ensure-tier-built.sh
       - bash scripts/check-gemini-overlay-enrollment.sh
       - bash scripts/tests/test-check-gemini-overlay-enrollment.sh
+      - bash scripts/tests/test-check-bash32-portability.sh
 
   - id: lint-markdown
     name: "Lint Markdown files"
@@ -262,6 +263,7 @@ capabilities:
           exit 1
         fi
         echo "Rule 1 clean."
+      - bash scripts/check-bash32-portability.sh
 
   # security-mcp.yml gates on pull_request to [main] with a path filter on the
   # MCP/dependency manifests (.github/workflows/security-mcp.yml lines 3-11).

--- a/docs/scripting-conventions.md
+++ b/docs/scripting-conventions.md
@@ -208,6 +208,93 @@ A reviewer comparing "Scanned: 100" against an expected wing size of
 
 ---
 
+## Rule 5 — No Bash 4+ constructs in governed scripts
+
+Scripts under `scripts/` and `hooks/` must run on the Bash that ships with
+macOS — **3.2.57**, released in 2007 and still `/bin/bash` on a current
+machine. The constructs declared in
+[`ci/bash32-forbidden.txt`](../ci/bash32-forbidden.txt) are banned because that
+shell does not have them:
+
+| Construct | What Bash 3.2.57 does with it |
+| --- | --- |
+| `mapfile` | `mapfile: command not found` |
+| `readarray` (synonym of `mapfile`) | `readarray: command not found` |
+| `declare -A` (associative arrays) | `declare: -A: invalid option` |
+
+That data file is the authority and this table mirrors it;
+`scripts/tests/test-check-bash32-portability.sh` fails when the two drift apart.
+
+A fourth trap is not grep-detectable, so it is deliberately absent from the
+declared set — but it breaks a script just as thoroughly. Under `set -u`, Bash
+3.2 treats an **empty array** as an unset variable, so `"${arr[@]}"` aborts when
+`arr` is empty. Write `${arr[@]+"${arr[@]}"}` instead, or `${arr[*]:-}` where the
+expansion is interpolated into a message string. This bites accumulator arrays
+hardest, because an accumulator is empty on precisely the success path.
+
+### Why
+
+`mapfile` and `declare -A` had spread into six of the repository's own test
+suites. On a stock macOS shell each aborted partway through — and because a
+`set -u` abort can leave a zero exit status, three of them printed a passing
+count and exited **0** while silently never running their later cases:
+`test-e2e-report.sh` reported `10 passed / 0 failed` with cases 7 and 8 never
+executed at all. Across the six suites that shell ran 67 of the 117 verdicts a
+newer shell ran, and reported no error while doing it. A maintainer working on
+macOS was reading a false green. Issue #697, corrected under spec 0111.
+
+### Bad
+
+```bash
+set -uo pipefail
+
+mapfile -t dirs < <(find "$root" -type d | sort)   # aborts: no such builtin
+
+declare -A WANT=( [claude]=a [gemini]=b )          # aborts: -A invalid option
+want="${WANT[$cli]}"
+
+for d in "${dirs[@]}"; do :; done                  # aborts when dirs is empty
+```
+
+### Good
+
+```bash
+set -uo pipefail
+
+dirs=()
+while IFS= read -r line || [ -n "$line" ]; do dirs+=("$line"); done \
+  < <(find "$root" -type d | sort)
+
+case "$cli" in                                     # a case, not a lookup table
+  claude) want=a ;;
+  gemini) want=b ;;
+esac
+
+for d in ${dirs[@]+"${dirs[@]}"}; do :; done       # empty-safe expansion
+```
+
+Keep a `case` arm's value a verbatim literal rather than deriving it from the
+loop variable. An assertion that re-derives the convention it exists to pin
+asserts nothing.
+
+### Prose is not use
+
+The check separates a construct a script *uses* from one it merely *names*, so
+documenting the prohibition is never itself a violation. A construct counts as
+used only when it stands in command position — at line start, after a command
+separator (`;` `&` `|` `(` `)` `{` `}`), or after a shell keyword — on a line
+whose first non-blank character is not `#`. These are all fine:
+
+```bash
+# `while read` rather than `mapfile` for bash 3.2 compat (macOS default).
+collect_lines            # avoid mapfile here: it is a bash 4 builtin
+```
+
+As with every rule here, a script that deliberately requires a newer shell
+tags the line with `# acknowledged-exception: <reason>` and the check honours it.
+
+---
+
 ## Acknowledged exceptions
 
 If a real reason justifies breaking one of these rules (e.g. a third-party
@@ -236,6 +323,13 @@ discussed in the PR.
 
 `.github/workflows/scripting-conventions.yml` runs a small `grep` pass on
 `scripts/` and `hooks/` to flag new occurrences of the chained-test pattern
-and bare `except`. The check is intentionally lightweight; it does not try
-to be a full linter. False positives are handled with the
-`acknowledged-exception` tag.
+(Rule 3) and bare `except` (Rule 1), and invokes
+`scripts/check-bash32-portability.sh` for the forbidden Bash 4+ constructs
+(Rule 5). The same three run on GitLab, from the shared capability declaration
+in `ci/ci-capabilities.yml`. The Rule 5 check is a script rather than an inline
+`grep` block so a maintainer can run it locally — `task check-bash32-portability`
+— and so its declared set lives in one data file instead of being hand-copied
+per engine.
+
+All three are intentionally lightweight; they do not try to be a full linter.
+False positives are handled with the `acknowledged-exception` tag.

--- a/scripts/check-bash32-portability.sh
+++ b/scripts/check-bash32-portability.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# check-bash32-portability.sh — Reject Bash 4+ constructs in governed scripts.
+#
+# Per spec 0111 (Requirements 1-5, 10), continuous integration MUST fail a pull
+# request in which a governed script uses a shell construct that the Bash shipped
+# with macOS (3.2.57) does not understand. Such a script aborts on its first use
+# of the construct, and because the abort can leave a zero exit status it does not
+# announce itself: six of this repository's own test suites reported passing
+# counts on that shell while silently never running their later cases. This guard
+# catches the reintroduction before it reaches the canonical branch.
+#
+# The declared set (requirement 2) lives in ci/bash32-forbidden.txt, not here, so
+# that one file is the single authority this guard and docs/scripting-conventions.md
+# Rule 5 both refer to — and so that this script can match the literal tokens
+# without flagging its own source, which sits inside the tree it scans.
+#
+# Use versus mention (requirement 4). A construct counts as *used* only when it
+# stands in command position on a line that is not itself a comment. So a comment
+# documenting the prohibition — or explaining that a construct was deliberately
+# avoided — is not a violation. Concretely, a line is reported when:
+#   - its first non-blank character is not `#`; and
+#   - the token stands at line start, or after a command separator
+#     (`;` `&` `|` `(` `)` `{` `}`), or after a shell keyword (`if`, `while`,
+#     `until`, `then`, `do`, `else`, `elif`, `time`, `!`); and
+#   - the line does not carry the `acknowledged-exception:` marker (requirement
+#     10, the documented escape hatch for a script that deliberately requires a
+#     newer shell).
+# `declare`/`typeset`/`local`/`readonly` are matched when their flag cluster
+# contains a declared uppercase flag letter, so `-Ag` and `-rA` are caught while
+# `-a` is not.
+#
+# Like the CI grep pass it joins, this check is intentionally lightweight and
+# does not try to be a full linter: indirect use (`eval "…"`, a construct built
+# by string concatenation) is not detected, and a heredoc body or trailing
+# comment that happens to open with a declared token in command position is a
+# false positive answered by the escape-hatch marker.
+#
+# Scope (requirement 5): scripts/ and hooks/, the same tree the sibling
+# scripting-convention grep steps cover — the repository's own test scripts
+# included, on the same terms as the scripts it ships.
+#
+# Usage:
+#   bash scripts/check-bash32-portability.sh
+#
+# Override the repository root with CREWRIG_REPO_DIR (used by the self-test
+# against temporary fixtures), mirroring the sibling check-*.sh guards.
+#
+# Exits 0 when no governed script uses a declared construct, non-zero (naming
+# every offending file and line) otherwise.
+
+set -euo pipefail
+
+REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
+FORBIDDEN="$REPO_DIR/ci/bash32-forbidden.txt"
+
+if [ ! -f "$FORBIDDEN" ]; then
+  echo "Error: declared-set file not found: $FORBIDDEN" >&2
+  exit 2
+fi
+
+# --- Parse the declared set -------------------------------------------------
+# Accumulated into `|`-joined ERE alternation strings rather than arrays. That is
+# deliberate and not a style preference: Bash 3.2 treats an empty array as an
+# unset variable, so under `set -u` an accumulator array would abort this guard
+# on exactly the path where it has nothing to report — the clean path. That is
+# the failure class this script exists to catch, and it would be invisible to
+# both the grep rule below (not grep-detectable) and CI (which runs Bash 5).
+# `while read` rather than the Bash 4 line-reading builtin, for the same reason.
+CMD_ALT=""
+FLAG_ALT=""
+declared=0
+
+while IFS= read -r line || [ -n "$line" ]; do
+  line="${line%$'\r'}"                       # tolerate CRLF
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  kind="${line%%[[:space:]]*}"               # first whitespace field
+  rest="${line#"$kind"}"
+  rest="${rest#"${rest%%[![:space:]]*}"}"    # ltrim
+  token="${rest%%[[:space:]]*}"              # second whitespace field
+  if [ -z "$token" ]; then
+    echo "Error: $FORBIDDEN: entry of kind '$kind' declares no token." >&2
+    exit 2
+  fi
+  case "$kind" in
+    command)      CMD_ALT="${CMD_ALT:+$CMD_ALT|}$token" ;;
+    declare-flag) FLAG_ALT="${FLAG_ALT:+$FLAG_ALT|}$token" ;;
+    *)
+      echo "Error: $FORBIDDEN: unknown kind '$kind'" >&2
+      echo "       (expected 'command' or 'declare-flag')" >&2
+      exit 2
+      ;;
+  esac
+  declared=$((declared + 1))
+done < "$FORBIDDEN"
+
+if [ "$declared" -eq 0 ]; then
+  echo "Error: $FORBIDDEN declares no construct — the guard would pass vacuously." >&2
+  exit 2
+fi
+
+# --- Compose the match pattern ----------------------------------------------
+# Command-position anchor, shared by both patterns: line start (optionally
+# indented), a command separator, or a shell keyword. No `\b` and no `grep -P`,
+# so the behaviour is identical under BSD grep on macOS and GNU grep on CI.
+ANCHOR='(^[[:space:]]*|[;&|(){}][[:space:]]*|(^|[[:space:]])(if|while|until|then|do|else|elif|time|!)[[:space:]]+)'
+
+PATTERN=""
+if [ -n "$CMD_ALT" ]; then
+  PATTERN="${ANCHOR}(${CMD_ALT})([[:space:]]|\$)"
+fi
+if [ -n "$FLAG_ALT" ]; then
+  PATTERN="${PATTERN:+$PATTERN|}${ANCHOR}(declare|typeset|local|readonly)[[:space:]]+-[a-zA-Z]*(${FLAG_ALT})"
+fi
+
+# --- Scan the governed tree -------------------------------------------------
+SCAN_TARGETS=""
+for d in scripts hooks; do
+  if [ -d "$REPO_DIR/$d" ]; then
+    SCAN_TARGETS="${SCAN_TARGETS:+$SCAN_TARGETS }$d"
+  fi
+done
+
+if [ -z "$SCAN_TARGETS" ]; then
+  echo "Error: neither scripts/ nor hooks/ exists under $REPO_DIR — nothing to scan." >&2
+  exit 2
+fi
+
+# Surface the size of the input actually scanned (docs/scripting-conventions.md
+# Rule 4): a wedge that makes this guard see zero files must not read as a pass.
+scanned="$( (cd "$REPO_DIR" && find $SCAN_TARGETS -type f 2>/dev/null | wc -l) | tr -d '[:space:]' )"
+if [ "$scanned" -eq 0 ]; then
+  echo "Error: scanned 0 files under $SCAN_TARGETS in $REPO_DIR — refusing to pass vacuously." >&2
+  exit 2
+fi
+
+# Drop full-line comments (use versus mention, requirement 4), then lines
+# carrying the acknowledged-exception marker (requirement 10).
+HITS="$( (cd "$REPO_DIR" && grep -rnE "$PATTERN" $SCAN_TARGETS 2>/dev/null || true) \
+         | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' \
+         | grep -v 'acknowledged-exception:' || true )"
+
+if [ -n "$HITS" ]; then
+  hits_count="$(printf '%s\n' "$HITS" | wc -l | tr -d '[:space:]')"
+  echo "FAILED: $hits_count line(s) use a forbidden Bash 4+ construct:" >&2
+  echo "" >&2
+  printf '%s\n' "$HITS" >&2
+  echo "" >&2
+  echo "Each line above uses a construct declared forbidden in" >&2
+  echo "ci/bash32-forbidden.txt, because it aborts on the Bash 3.2 that ships" >&2
+  echo "with macOS. See docs/scripting-conventions.md, Rule 5, for the portable" >&2
+  echo "replacement of each. If a script deliberately requires a newer shell," >&2
+  echo "tag the line with '# acknowledged-exception: <reason>'." >&2
+  exit 1
+fi
+
+echo "OK: no forbidden Bash 4+ construct in $SCAN_TARGETS" \
+     "($declared declared construct(s), $scanned file(s) scanned)."

--- a/scripts/check-bash32-portability.sh
+++ b/scripts/check-bash32-portability.sh
@@ -69,18 +69,46 @@ fi
 CMD_ALT=""
 FLAG_ALT=""
 declared=0
+TAB="$(printf '\t')"
 
 while IFS= read -r line || [ -n "$line" ]; do
   line="${line%$'\r'}"                       # tolerate CRLF
   [[ -z "$line" || "$line" == \#* ]] && continue
-  kind="${line%%[[:space:]]*}"               # first whitespace field
-  rest="${line#"$kind"}"
-  rest="${rest#"${rest%%[![:space:]]*}"}"    # ltrim
-  token="${rest%%[[:space:]]*}"              # second whitespace field
-  if [ -z "$token" ]; then
-    echo "Error: $FORBIDDEN: entry of kind '$kind' declares no token." >&2
+  # Split on TAB, which is what the format declares. Splitting on generic
+  # whitespace instead let a row with an empty token field slide its reason
+  # into the token's place — `command<TAB><TAB>some reason` parsed as
+  # token=`some`, and the guard then scanned for the wrong word and reported
+  # OK on a tree holding real violations. Same false green this script exists
+  # to eliminate, arriving through its own authority file.
+  case "$line" in
+    *"$TAB"*) : ;;
+    *)
+      echo "Error: $FORBIDDEN: entry '$line' has no tab-separated fields." >&2
+      echo "       (expected <kind><TAB><token><TAB><reason>)" >&2
+      exit 2
+      ;;
+  esac
+  kind="${line%%"$TAB"*}"                    # first tab field
+  rest="${line#*"$TAB"}"                     # everything past the first tab
+  token="${rest%%"$TAB"*}"                   # second tab field, verbatim
+  if [ -z "$kind" ] || [ -z "$token" ]; then
+    echo "Error: $FORBIDDEN: entry '$line' declares an empty kind or token." >&2
     exit 2
   fi
+  # A token is interpolated into an ERE below, so a regex metacharacter in it
+  # would build an invalid or wrongly-matching pattern. Reject it here rather
+  # than letting grep decide: the declared set is documented as a floor, not a
+  # ceiling, so a maintainer WILL add tokens, and nothing in the file warns
+  # that they are regex-interpolated.
+  case "$token" in
+    *[^A-Za-z0-9_-]*)
+      echo "Error: $FORBIDDEN: token '$token' contains a character that is not" >&2
+      echo "       a letter, digit, underscore or hyphen. Tokens are interpolated" >&2
+      echo "       into a regular expression; a metacharacter would silently" >&2
+      echo "       change or invalidate the pattern." >&2
+      exit 2
+      ;;
+  esac
   case "$kind" in
     command)      CMD_ALT="${CMD_ALT:+$CMD_ALT|}$token" ;;
     declare-flag) FLAG_ALT="${FLAG_ALT:+$FLAG_ALT|}$token" ;;
@@ -135,7 +163,34 @@ fi
 
 # Drop full-line comments (use versus mention, requirement 4), then lines
 # carrying the acknowledged-exception marker (requirement 10).
-HITS="$( (cd "$REPO_DIR" && grep -rnE "$PATTERN" $SCAN_TARGETS 2>/dev/null || true) \
+# grep's exit status is load-bearing and must not be swallowed. `|| true` on the
+# whole pipeline made exit 2 (invalid pattern) indistinguishable from exit 1 (no
+# match): the guard then found nothing, printed OK and exited 0 on a tree holding
+# real violations. Measured on a two-violation fixture, a declared token of `(`
+# produced `OK … (1 declared construct(s), 2 file(s) scanned)` at rc 0 while a
+# well-formed set on the same tree produced `FAILED: 2 line(s)` at rc 1.
+#
+# The token validation above should now make an invalid pattern unreachable, but
+# this stays as the second line of defence: a guard that cannot tell "nothing
+# found" from "could not look" has no business reporting OK. Anything above 1 is
+# grep failing, not grep finding nothing.
+RAW=""
+GREP_RC=0
+GREP_ERR="$(mktemp)"
+RAW="$( cd "$REPO_DIR" && grep -rnE "$PATTERN" $SCAN_TARGETS 2>"$GREP_ERR" )" || GREP_RC=$?
+GREP_MSG="$(cat "$GREP_ERR")"
+rm -f "$GREP_ERR"
+# stderr is captured to a separate file, never folded into stdout: a grep that
+# warns without failing (an unreadable file, a directory loop) would otherwise
+# have its warning counted as a match and reported as a violation.
+if [ "$GREP_RC" -gt 1 ]; then
+  echo "Error: the scan itself failed (grep exit $GREP_RC), so this run proves" >&2
+  echo "       nothing about the tree. Refusing to report a clean result." >&2
+  echo "       grep said: $GREP_MSG" >&2
+  exit 2
+fi
+
+HITS="$( printf '%s\n' "$RAW" \
          | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' \
          | grep -v 'acknowledged-exception:' || true )"
 

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -414,50 +414,19 @@ test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
       continue
     fi
     scanned=$((scanned + 1))
-    # Counted per occurrence, not per line. A line-level filter is wrong here
-    # and mutation-testing proved it: in
-    #   for p in "${pre_dirs[@]}" ${CREATED[@]+"${CREATED[@]}"}
-    # dropping every line that contains a guard hides the bare `pre_dirs`
-    # expansion behind the guarded `CREATED` one on the same line.
+    # Detection lives in `bare_expansions_in` — see its header for the model and
+    # for the three tally designs that preceded it, each of which shipped a false
+    # negative. Do not reimplement the decision here: it is probed directly by
+    # case i, and a copy of the logic at this call site would drift out from under
+    # those probes.
     #
-    # So compare counts — but PER ARRAY NAME, not per line. A bare expansion is
-    # `${name[@]}`, subscript closed immediately; a guard is `${name[@]+` or
-    # `${name[@]:-`. Comparing whole-line totals is unsound because the two
-    # guard spellings are asymmetric:
-    #
-    #   ${A[@]+"${A[@]}"}   1 bare + 1 guard  -> net zero
-    #   ${A[*]:-}           0 bare + 1 guard  -> one unit of spare credit
-    #
-    # Each `:-` guard on a line therefore grants credit that masks one genuinely
-    # bare expansion elsewhere on the same line. Reviewed and reproduced end to
-    # end: `note_fail "x=${ARGV_HTTP[*]:-} y=${ARGV_UNSET[@]}"` balanced the
-    # line tally while `ARGV_UNSET` was bare — case h green, guard green, suite
-    # rc 0 and "41 passed, 0 failed" on top of `ARGV_UNSET[@]: unbound variable`
-    # on stderr. That is exactly the #697 false green, walking past the only
-    # standing enforcement of R8. Four live code lines carry a `:-` guard
-    # (test-e2e-report.sh:141,161 and test-setup-org-mcp.sh:188,196), two of them
-    # `note_fail` message lines — the natural shape for a future edit to land on.
-    #
-    # Per name, a bare expansion can only be offset by a guard on that same
-    # array, so no credit crosses between names. The failure message names the
-    # offending array rather than only the line.
-    #
-    # `${#name[@]}` is deliberately not matched: the length form is safe on an
-    # empty array under `set -u` (verified on 3.2.57), and the leading `#`
-    # keeps it out of the `${name[` pattern.
-    #
-    # Full-line comments are dropped before counting, for the same reason the
+    # Full-line comments are dropped before scanning, for the same reason the
     # guard itself drops them (check-bash32-portability.sh, requirement 4): a
-    # comment that *names* an expansion is prose, not use. Without this the
-    # scan contradicts the very doctrine this change establishes. Four of the
-    # six suites document their own guarding convention in exactly that form —
-    # e.g. "`${A[*]:-}` rather than `${A[*]}` because bash 3.2 …" — and they
-    # satisfied the count comparison only because each names the guarded form
-    # alongside the bare one, which balances the tally by phrasing coincidence.
-    # Rewording such a comment to cite only the bare form would have turned this
-    # case red with nothing wrong in the suite.
-    #
-    # No -P and no \b, so BSD grep (macOS) and GNU grep (CI) agree.
+    # comment that *names* an expansion is prose, not use. Without this the scan
+    # contradicts the very doctrine this change establishes. Four of the six
+    # suites document their own guarding convention in exactly that form — e.g.
+    # "`${A[*]:-}` rather than `${A[*]}` because bash 3.2 …" — so a scan that
+    # counted them would fail on the suites' own documentation.
     while IFS= read -r ln || [ -n "$ln" ]; do
       [ -n "$ln" ] || continue
       hit="$(bare_expansions_in "$ln")"

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -318,6 +318,95 @@ bad() { echo "FAIL  $1"; fail=$((fail + 1)); }
 }
 
 # ---------------------------------------------------------------------------
+# Case h — Every array expansion in the suites corrected under R6 stays guarded.
+#
+# This is the standing half of scenario 5. The two-shell evidence run proves the
+# corrected suites report identical verdicts today; nothing re-proves it
+# tomorrow, because CI runs Bash 5 where the defect is invisible. What CAN be
+# re-proved cheaply is the invariant the correction established: in these six
+# suites, no array is expanded without a guard.
+#
+# Why that invariant is the right proxy. Under `set -u` Bash 3.2 aborts on an
+# empty-array expansion where Bash 5 does not. The abort is not reliably visible
+# either: these suites run `set -uo pipefail` WITHOUT `-e`, so when the
+# expansion sits in a command substitution or subshell only that child dies —
+# the suite continues and can exit 0 with cases silently skipped. So neither a
+# zero exit status nor a clean-looking summary is evidence the suite ran
+# everything, which is exactly how the false green in issue #697 was produced.
+# A guarded expansion cannot abort, so guarding every one of them removes the
+# class rather than the symptom.
+#
+# This case also settles a judgement call recorded on the ticket: expansions on
+# arrays that provably cannot be empty were guarded too. Uniform guarding is
+# only worth its noise if something checks it — this is that something, and it
+# is why the uniform choice is an invariant rather than cargo cult.
+# ---------------------------------------------------------------------------
+{
+  # The suites corrected under R6. Scoped deliberately: other suites under
+  # scripts/tests/ carry unguarded expansions and are outside spec 0111, whose
+  # R8 constrains only the suites changed under R6.
+  corrected_suites='test-e2e-runner test-e2e-report test-e2e-runner-delegation
+test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
+
+  # Accumulate into a string, never an array: an empty accumulator array is the
+  # very abort this case exists to keep out of the corrected suites, and this
+  # file is itself governed.
+  unguarded=''
+  scanned=0
+  for suite in $corrected_suites; do
+    suite_path="$REPO_ROOT/scripts/tests/$suite.sh"
+    if [ ! -f "$suite_path" ]; then
+      bad "case-h: corrected suite not found: scripts/tests/$suite.sh"
+      continue
+    fi
+    scanned=$((scanned + 1))
+    # Counted per occurrence, not per line. A line-level filter is wrong here
+    # and mutation-testing proved it: in
+    #   for p in "${pre_dirs[@]}" ${CREATED[@]+"${CREATED[@]}"}
+    # dropping every line that contains a guard hides the bare `pre_dirs`
+    # expansion behind the guarded `CREATED` one on the same line.
+    #
+    # So compare counts. A bare expansion is `${name[@]}` — subscript closed
+    # immediately. A guard is `${name[@]+` or `${name[@]:-`. A complete guard
+    # `${A[@]+"${A[@]}"}` contributes one of each, so a healthy line has
+    # bare <= guards; any bare expansion without its guard tips the balance.
+    #
+    # `${#name[@]}` is deliberately not matched: the length form is safe on an
+    # empty array under `set -u` (verified on 3.2.57), and the leading `#`
+    # keeps it out of the `${name[` pattern.
+    #
+    # No -P and no \b, so BSD grep (macOS) and GNU grep (CI) agree.
+    while IFS= read -r ln || [ -n "$ln" ]; do
+      [ -n "$ln" ] || continue
+      n_bare=$(printf '%s\n' "$ln" \
+        | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]\}' | wc -l | tr -d ' ')
+      n_guard=$(printf '%s\n' "$ln" \
+        | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\](\+|:-)' | wc -l | tr -d ' ')
+      if [ "$n_bare" -gt "$n_guard" ]; then
+        unguarded="$unguarded  $suite.sh: $ln
+"
+      fi
+    done <<PORTABILITY_SCAN
+$(grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$suite_path" || true)
+PORTABILITY_SCAN
+  done
+
+  # Fail closed: scanning nothing must not read as success (Rule 4).
+  if [ "$scanned" -ne 6 ]; then
+    bad "case-h: expected 6 corrected suites, scanned $scanned"
+  else
+    ok "case-h: all 6 suites corrected under R6 are present and scanned"
+  fi
+
+  if [ -z "$unguarded" ]; then
+    ok "case-h: no unguarded array expansion remains in the corrected suites (R8)"
+  else
+    bad "case-h: unguarded array expansion(s) survive in the corrected suites:
+$unguarded"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -366,10 +366,27 @@ test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
     # dropping every line that contains a guard hides the bare `pre_dirs`
     # expansion behind the guarded `CREATED` one on the same line.
     #
-    # So compare counts. A bare expansion is `${name[@]}` — subscript closed
-    # immediately. A guard is `${name[@]+` or `${name[@]:-`. A complete guard
-    # `${A[@]+"${A[@]}"}` contributes one of each, so a healthy line has
-    # bare <= guards; any bare expansion without its guard tips the balance.
+    # So compare counts — but PER ARRAY NAME, not per line. A bare expansion is
+    # `${name[@]}`, subscript closed immediately; a guard is `${name[@]+` or
+    # `${name[@]:-`. Comparing whole-line totals is unsound because the two
+    # guard spellings are asymmetric:
+    #
+    #   ${A[@]+"${A[@]}"}   1 bare + 1 guard  -> net zero
+    #   ${A[*]:-}           0 bare + 1 guard  -> one unit of spare credit
+    #
+    # Each `:-` guard on a line therefore grants credit that masks one genuinely
+    # bare expansion elsewhere on the same line. Reviewed and reproduced end to
+    # end: `note_fail "x=${ARGV_HTTP[*]:-} y=${ARGV_UNSET[@]}"` balanced the
+    # line tally while `ARGV_UNSET` was bare — case h green, guard green, suite
+    # rc 0 and "41 passed, 0 failed" on top of `ARGV_UNSET[@]: unbound variable`
+    # on stderr. That is exactly the #697 false green, walking past the only
+    # standing enforcement of R8. Four live code lines carry a `:-` guard
+    # (test-e2e-report.sh:141,161 and test-setup-org-mcp.sh:188,196), two of them
+    # `note_fail` message lines — the natural shape for a future edit to land on.
+    #
+    # Per name, a bare expansion can only be offset by a guard on that same
+    # array, so no credit crosses between names. The failure message names the
+    # offending array rather than only the line.
     #
     # `${#name[@]}` is deliberately not matched: the length form is safe on an
     # empty array under `set -u` (verified on 3.2.57), and the leading `#`
@@ -389,14 +406,20 @@ test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
     # No -P and no \b, so BSD grep (macOS) and GNU grep (CI) agree.
     while IFS= read -r ln || [ -n "$ln" ]; do
       [ -n "$ln" ] || continue
-      n_bare=$(printf '%s\n' "$ln" \
-        | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]\}' | wc -l | tr -d ' ')
-      n_guard=$(printf '%s\n' "$ln" \
-        | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\](\+|:-)' | wc -l | tr -d ' ')
-      if [ "$n_bare" -gt "$n_guard" ]; then
-        unguarded="$unguarded  $suite.sh: $ln
+      # Array names appearing on this line, deduplicated. `tr -d` rather than a
+      # sed capture: BSD sed reads `\{` as an interval and errors out.
+      names=$(printf '%s\n' "$ln" \
+        | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[' | tr -d '${[' | sort -u)
+      for nm in $names; do
+        n_bare=$(printf '%s\n' "$ln" \
+          | grep -oE '\$\{'"$nm"'\[[@*]\]\}' | wc -l | tr -d ' ')
+        n_guard=$(printf '%s\n' "$ln" \
+          | grep -oE '\$\{'"$nm"'\[[@*]\](\+|:-)' | wc -l | tr -d ' ')
+        if [ "$n_bare" -gt "$n_guard" ]; then
+          unguarded="$unguarded  $suite.sh [$nm]: $ln
 "
-      fi
+        fi
+      done
     done <<PORTABILITY_SCAN
 $(grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$suite_path" \
    | grep -vE '^[0-9]+:[[:space:]]*#' || true)

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -376,6 +376,65 @@ bare_expansions_in() {
   else
     bad "case-g: expected exit 2 for an unknown kind, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
   fi
+
+  # The three shapes below all produced `OK` and exit 0 on a tree holding real
+  # violations before iteration 6 — the guard's own authority file delivering the
+  # false green the guard exists to eliminate. Each is asserted against a tree
+  # that genuinely violates, so a regression cannot pass by finding nothing.
+  printf '%s\n' '#!/bin/bash' 'mapfile -t x < f' > "$repo/scripts/offender.sh"
+  printf '%s\n' '#!/bin/bash' 'declare -A m=( [a]=1 )' > "$repo/scripts/offender2.sh"
+
+  # A token carrying a regex metacharacter. Tokens are interpolated into an ERE,
+  # so `(` built an invalid pattern; grep exited 2 and the old pipeline discarded
+  # it, making "could not look" indistinguishable from "found nothing".
+  printf '%s\t%s\t%s\n' 'command' '(' 'a token with a metacharacter' \
+    > "$repo/ci/bash32-forbidden.txt"
+  run_check "$repo"
+  if [ "$CHECK_EXIT" -eq 2 ]; then
+    ok "case-g: a token with a regex metacharacter exits 2, never OK"
+  else
+    bad "case-g: metacharacter token gave $CHECK_EXIT, expected 2 (stdout: $CHECK_STDOUT)"
+  fi
+
+  # An empty token field. Splitting on generic whitespace slid the reason into the
+  # token's place, so the guard scanned for the first word of the prose.
+  printf '%s\t%s\t%s\n' 'command' '' 'a reason that used to slide into the token' \
+    > "$repo/ci/bash32-forbidden.txt"
+  run_check "$repo"
+  if [ "$CHECK_EXIT" -eq 2 ]; then
+    ok "case-g: an empty token field exits 2 rather than adopting the reason"
+  else
+    bad "case-g: empty token gave $CHECK_EXIT, expected 2 (stdout: $CHECK_STDOUT)"
+  fi
+
+  # A row with no tab at all: the format is tab-separated, and a space-separated
+  # row is a malformed authority rather than something to interpret generously.
+  printf '%s\n' 'command mapfile a space separated row' \
+    > "$repo/ci/bash32-forbidden.txt"
+  run_check "$repo"
+  if [ "$CHECK_EXIT" -eq 2 ]; then
+    ok "case-g: a row with no tab-separated fields exits 2"
+  else
+    bad "case-g: tabless row gave $CHECK_EXIT, expected 2 (stdout: $CHECK_STDOUT)"
+  fi
+
+  # Non-regression on the two tolerated shapes, so the stricter parsing above did
+  # not buy its correctness by rejecting valid input.
+  printf 'command\tmapfile\ttolerated CRLF\r\n' > "$repo/ci/bash32-forbidden.txt"
+  run_check "$repo"
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    ok "case-g: a CRLF-terminated row is still accepted and still detects"
+  else
+    bad "case-g: CRLF row gave $CHECK_EXIT, expected 1 (stderr: $CHECK_STDERR)"
+  fi
+
+  printf 'command\tmapfile\tno trailing newline' > "$repo/ci/bash32-forbidden.txt"
+  run_check "$repo"
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    ok "case-g: a final row without a trailing newline is still read"
+  else
+    bad "case-g: unterminated row gave $CHECK_EXIT, expected 1 (stderr: $CHECK_STDERR)"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -25,10 +25,17 @@
 #      gate covers.
 #   g. A declared set with no usable entry fails closed rather than passing
 #      vacuously (docs/scripting-conventions.md Rule 4).
+#   h. No array expansion in the six suites corrected under R6 is unguarded —
+#      the standing half of scenario 5 (R8). See `bare_expansions_in`.
+#   i. That detector is itself probed on 13 fixtures in both directions, so a
+#      future narrowing of it fails here rather than silently going quiet.
 #
 # Scenario 5 — a corrected suite reports the same verdicts on both shells — is
-# not scriptable here: it needs two different Bash binaries. It is discharged by
-# the recorded two-shell evidence run on issue #697.
+# only partly scriptable here: comparing two shells needs two Bash binaries, and
+# that half is discharged by the recorded two-shell evidence run on issue #697.
+# The half that CAN be re-proved every run is case h's invariant: a guarded
+# expansion cannot abort under `set -u`, so guarding all of them removes the
+# class the two-shell run merely samples.
 #
 # Fixtures are written with `printf '%s\n' 'line' 'line'`, never a heredoc, and
 # that is load-bearing rather than stylistic. This file lives under the tree the
@@ -482,6 +489,7 @@ $unguarded"
     'safe	a default with a literal is safe	s="${D[*]:-(none)}"' \
     'bare	bare masked by :- on ANOTHER name	s="${C[*]:-} ${D[@]}"' \
     'bare	bare masked by :- on the SAME name	s="${D[*]:-} ${D[@]}"' \
+    'bare	bare masked by :- on SAME name AND subscript	s="${D[@]:-} ${D[@]}"' \
     'bare	prefix names do not bleed	s="${D[*]:-}" t="${DE[@]}"' \
     'safe	length form is safe	if [ ${#D[@]} -eq 0 ]; then' \
     'safe	slice form is safe	echo "${D[@]:1}"' \
@@ -507,10 +515,10 @@ $unguarded"
 $i_rows
 DETECTOR_PROBE
 
-  if [ "$i_total" -ne 12 ]; then
-    bad "case-i: expected 12 detector probes, ran $i_total"
+  if [ "$i_total" -ne 13 ]; then
+    bad "case-i: expected 13 detector probes, ran $i_total"
   elif [ "$i_fail" -eq 0 ]; then
-    ok "case-i: the bare-expansion detector is correct on all 12 probes, both directions"
+    ok "case-i: the bare-expansion detector is correct on all 13 probes, both directions"
   fi
 }
 

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# test-check-bash32-portability.sh — Regression tests for
+# check-bash32-portability.sh (spec 0111).
+#
+# check-bash32-portability.sh is the CI guard that fails when a governed script
+# under scripts/ or hooks/ uses a shell construct the Bash shipped with macOS
+# (3.2.57) does not have. This is the parity sibling mandated by the repo
+# convention "every check-*.sh has a test-*.sh" (spec 0076 R6).
+#
+# Cases, one per spec 0111 scenario:
+#   a. A reintroduced forbidden construct is rejected, naming file and line
+#      (scenario 1, R1/R3).
+#   b. The repository as it stands is accepted (scenario 2, R6). This case is
+#      also what catches the guard flagging its own source or its own declared
+#      set — both live inside or beside the tree it scans.
+#   c. A comment naming a forbidden construct is accepted (scenario 3, R4), as
+#      is `declare -a`, which is not `declare -A`.
+#   d. A line carrying the acknowledged-exception marker is accepted
+#      (scenario 4, R10).
+#   e. A forbidden construct in a *test* script is rejected on the same terms as
+#      in a shipped script (scenario 6, R5).
+#   f. Every token in ci/bash32-forbidden.txt is named in Rule 5 of
+#      docs/scripting-conventions.md (R2's "one place both the enforcement and
+#      the documentation refer to"). This is the doc-to-data link that no other
+#      gate covers.
+#   g. A declared set with no usable entry fails closed rather than passing
+#      vacuously (docs/scripting-conventions.md Rule 4).
+#
+# Scenario 5 — a corrected suite reports the same verdicts on both shells — is
+# not scriptable here: it needs two different Bash binaries. It is discharged by
+# the recorded two-shell evidence run on issue #697.
+#
+# Fixtures are written with `printf '%s\n' 'line' 'line'`, never a heredoc, and
+# that is load-bearing rather than stylistic. This file lives under the tree the
+# guard scans, and the guard flags a declared token in command position; in a
+# heredoc body a fixture line would start with the token and be reported, turning
+# case b red on the very change that introduces the gate. In the printf form
+# every token sits immediately after a quote, so it is never in command position.
+# Self-exempting this file with the acknowledged-exception marker is not the
+# fallback: R5 governs test scripts "on the same terms", and R6 requires
+# correction rather than exemption.
+#
+# Usage:
+#   bash scripts/tests/test-check-bash32-portability.sh
+
+# -e intentionally omitted: pass/fail counters drive the harness; adding -e
+# would abort on the expected non-zero exits from the script under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-bash32-portability.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DECLARED_SET="$REPO_ROOT/ci/bash32-forbidden.txt"
+CONVENTIONS_DOC="$REPO_ROOT/docs/scripting-conventions.md"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+if [ ! -f "$DECLARED_SET" ]; then
+  echo "FATAL: cannot find $DECLARED_SET" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# mk_fixture <dir> — scaffold a fixture repo carrying the real declared set, so
+# the cases below exercise the shipped construct list rather than a stand-in.
+mk_fixture() {
+  mkdir -p "$1/ci" "$1/scripts/tests"
+  cp "$DECLARED_SET" "$1/ci/bash32-forbidden.txt"
+}
+
+# run_check <dir> — run the guard with CREWRIG_REPO_DIR set, capturing stdout,
+# stderr and exit code into CHECK_EXIT / CHECK_STDOUT / CHECK_STDERR.
+run_check() {
+  local repo="$1" out_file err_file
+  out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
+  err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
+  CHECK_EXIT=0
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  CHECK_STDOUT="$(cat "$out_file")"
+  CHECK_STDERR="$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+}
+
+# ok <message> / bad <message> — verdict recorders.
+ok() { echo "PASS  $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL  $1"; fail=$((fail + 1)); }
+
+# ---------------------------------------------------------------------------
+# Case a — A reintroduced forbidden construct is rejected, by file and line.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'set -uo pipefail' \
+    'dirs=()' \
+    'mapfile -t dirs < <(find . -type d)' \
+    > "$repo/scripts/offender.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    ok "case-a: a reintroduced forbidden construct fails the check (exit 1)"
+  else
+    bad "case-a: expected exit 1, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+
+  # R3: the rejection names the offending location by file AND line, not merely
+  # that a violation exists. The construct sits on line 4 of the fixture.
+  if echo "$CHECK_STDERR" | grep -qF "scripts/offender.sh:4:"; then
+    ok "case-a: the rejection names the offender by file and line (R3)"
+  else
+    bad "case-a: stderr did not name scripts/offender.sh:4 (stderr: $CHECK_STDERR)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case b — The repository as it stands is accepted (R6), and the guard does not
+#          flag its own source or its own declared set.
+# ---------------------------------------------------------------------------
+{
+  run_check "$REPO_ROOT"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    ok "case-b: the repository as it stands passes the check (exit 0)"
+  else
+    bad "case-b: expected exit 0, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+
+  if echo "$CHECK_STDOUT" | grep -qF "no forbidden Bash 4+ construct"; then
+    ok "case-b: OK line emitted on stdout"
+  else
+    bad "case-b: missing OK line (stdout: $CHECK_STDOUT)"
+  fi
+
+  # Rule 4: the OK line must surface how much input it actually saw, so a wedge
+  # that makes the guard scan nothing cannot read as a pass.
+  if echo "$CHECK_STDOUT" | grep -qE 'file\(s\) scanned'; then
+    ok "case-b: the OK line surfaces the number of files scanned (Rule 4)"
+  else
+    bad "case-b: OK line does not report its input size (stdout: $CHECK_STDOUT)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case c — Prose naming a forbidden construct is accepted (R4).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\n' \
+    '#!/bin/bash' \
+    '# `while read` rather than `mapfile` for bash 3.2 compat (macOS default).' \
+    '  # an indented full-line comment naming readarray is prose too' \
+    'collect_lines  # avoid mapfile here: it is a bash 4 builtin' \
+    'declare -a IDX=()' \
+    > "$repo/scripts/prose.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    ok "case-c: comments naming a forbidden construct are not violations (R4)"
+  else
+    bad "case-c: expected exit 0, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case d — The acknowledged-exception marker is honoured (R10).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'mapfile -t k < f  # acknowledged-exception: this tool ships its own bash 5' \
+    > "$repo/scripts/hatch.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    ok "case-d: an acknowledged-exception line is accepted (R10)"
+  else
+    bad "case-d: expected exit 0, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+
+  # The hatch must be line-scoped, not file-scoped: a second, untagged use in
+  # the same file still fails.
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'mapfile -t k < f  # acknowledged-exception: this tool ships its own bash 5' \
+    'mapfile -t j < g' \
+    > "$repo/scripts/hatch.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ] && echo "$CHECK_STDERR" | grep -qF "scripts/hatch.sh:3:"; then
+    ok "case-d: the hatch is line-scoped — an untagged use in the same file still fails"
+  else
+    bad "case-d: expected exit 1 naming line 3, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case e — A test script is governed on the same terms (R5, scenario 6).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'declare -A M=( [k]=v )' \
+    > "$repo/scripts/tests/test-offender.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    ok "case-e: a forbidden construct in a test script fails the check (R5)"
+  else
+    bad "case-e: expected exit 1, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF "scripts/tests/test-offender.sh:2:"; then
+    ok "case-e: the rejection names the test script by file and line"
+  else
+    bad "case-e: stderr did not name scripts/tests/test-offender.sh:2 (stderr: $CHECK_STDERR)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case f — Declared set and Rule 5 stay in sync (R2).
+# ---------------------------------------------------------------------------
+{
+  # The Rule 5 section only, so a token named under some other rule does not
+  # satisfy the requirement by accident.
+  rule5="$(awk '/^## Rule 5 /{f=1; next} f && /^## /{exit} f' "$CONVENTIONS_DOC")"
+
+  if [ -n "$rule5" ]; then
+    ok "case-f: docs/scripting-conventions.md carries a Rule 5 section (R11)"
+  else
+    bad "case-f: no '## Rule 5 ' section found in $CONVENTIONS_DOC (R11)"
+  fi
+
+  # Walk the declared set with `while read` — no array, so this loop cannot
+  # abort on an empty accumulator under bash 3.2 `set -u`.
+  missing=""
+  checked=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    kind="${line%%[[:space:]]*}"
+    rest="${line#"$kind"}"
+    rest="${rest#"${rest%%[![:space:]]*}"}"
+    token="${rest%%[[:space:]]*}"
+    [ -n "$token" ] || continue
+    # A bare flag letter would match almost any prose, so a declare-flag entry
+    # is required to appear in its usable form.
+    needle="$token"
+    if [ "$kind" = "declare-flag" ]; then
+      needle="declare -$token"
+    fi
+    checked=$((checked + 1))
+    if ! printf '%s\n' "$rule5" | grep -qF -- "$needle"; then
+      missing="${missing:+$missing, }$needle"
+    fi
+  done < "$DECLARED_SET"
+
+  if [ "$checked" -eq 0 ]; then
+    bad "case-f: parsed 0 entries from $DECLARED_SET — the sync case would pass vacuously"
+  elif [ -z "$missing" ]; then
+    ok "case-f: all $checked declared construct(s) are named in Rule 5 (R2)"
+  else
+    bad "case-f: declared construct(s) missing from Rule 5 (R2): $missing"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case g — An empty declared set fails closed, not vacuously open (Rule 4).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\n' '# every line here is a comment, so no construct is declared' \
+    > "$repo/ci/bash32-forbidden.txt"
+  printf '%s\n' '#!/bin/bash' 'mapfile -t x < f' > "$repo/scripts/offender.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 2 ]; then
+    ok "case-g: an empty declared set exits 2 rather than passing vacuously"
+  else
+    bad "case-g: expected exit 2, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+
+  # An unrecognised kind is a malformed authority, not something to skip.
+  printf '%s\n' 'bogus-kind	mapfile	a kind the guard does not know' \
+    > "$repo/ci/bash32-forbidden.txt"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 2 ]; then
+    ok "case-g: an unknown declared-set kind exits 2"
+  else
+    bad "case-g: expected exit 2 for an unknown kind, got $CHECK_EXIT (stderr: $CHECK_STDERR)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+echo "Results: $pass/$total passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -96,6 +96,60 @@ run_check() {
 ok() { echo "PASS  $1"; pass=$((pass + 1)); }
 bad() { echo "FAIL  $1"; fail=$((fail + 1)); }
 
+# bare_expansions_in <line> — echo the `name[subscript]` of every array expansion
+# on the line that would abort under `set -u` when the array is empty, or nothing
+# when the line is safe. Used by case h against the corrected suites, and probed
+# directly by case i.
+#
+# It works by CONSUMPTION, not by tallying, and that distinction is the whole
+# history of this function. Three successive tally designs each left a hole:
+#
+#   1. Per line, guarded-vs-bare counts: a guard anywhere on the line hid a bare
+#      expansion elsewhere on it.
+#   2. Per line with comment lines dropped: fixed a false positive, not the tally.
+#   3. Per array name: narrowed *who* could spend the slack without removing it.
+#
+# The slack is a property of the guard SPELLING. `${A[@]+"${A[@]}"}` contains one
+# closed `${A[@]}` and is worth one; `${A[*]:-}` contains no closed form and is
+# worth zero — so on `"${A[*]:-} ${A[@]}"` any tally balances while `A` is bare.
+# That shape reproduces the very false green this ticket exists to remove:
+# `A=(); s="${A[*]:-}"; out=$(printf '%s' "${A[@]}")` prints
+# `A[@]: unbound variable` to stderr and still exits 0.
+#
+# So: count the closed forms `${name[@]}` / `${name[*]}`, then subtract only the
+# ones a complete canonical guard `${name[@]+"${name[@]}"}` accounts for. Anything
+# left is genuinely bare. `${name[*]:-…}` contributes no closed form, so it needs
+# no special case. Matching is done with `grep -oF` on literals built per name, so
+# there is no regex to escape and no BSD-versus-GNU divergence to reason about.
+#
+# Deliberately not matched, all verified safe on an empty array under `set -u` on
+# 3.2.57: `${#name[@]}` (length), `${name[@]:1}` (slice), `${!name[@]}` (keys).
+bare_expansions_in() {
+  _bx_line="$1"
+  _bx_out=''
+  # Array names on the line, deduplicated. `tr -d` rather than a sed capture:
+  # BSD sed reads `\{` as an interval and errors "braces not balanced".
+  _bx_names=$(printf '%s\n' "$_bx_line" \
+    | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[' | tr -d '${[' | sort -u)
+  for _bx_nm in $_bx_names; do
+    for _bx_sub in '@' '*'; do
+      # Braced interpolation (`${var}[`) rather than `$var[`: the latter is a
+      # literal string being built for `grep -oF`, but shellcheck reads it as an
+      # array expansion and raises SC1087 at error level.
+      _bx_closed=$(printf '%s\n' "$_bx_line" \
+        | grep -oF "\${${_bx_nm}[${_bx_sub}]}" | wc -l | tr -d ' ')
+      _bx_wrapped=$(printf '%s\n' "$_bx_line" \
+        | grep -oF "\${${_bx_nm}[${_bx_sub}]+\"\${${_bx_nm}[${_bx_sub}]}\"}" \
+        | wc -l | tr -d ' ')
+      if [ "$_bx_closed" -gt "$_bx_wrapped" ]; then
+        _bx_out="${_bx_out}${_bx_nm}[${_bx_sub}] "
+      fi
+    done
+  done
+  # Trailing space trimmed without a bashism, so the caller can test -n cleanly.
+  printf '%s' "$_bx_out" | sed -e 's/[[:space:]]*$//'
+}
+
 # ---------------------------------------------------------------------------
 # Case a — A reintroduced forbidden construct is rejected, by file and line.
 # ---------------------------------------------------------------------------
@@ -406,20 +460,11 @@ test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
     # No -P and no \b, so BSD grep (macOS) and GNU grep (CI) agree.
     while IFS= read -r ln || [ -n "$ln" ]; do
       [ -n "$ln" ] || continue
-      # Array names appearing on this line, deduplicated. `tr -d` rather than a
-      # sed capture: BSD sed reads `\{` as an interval and errors out.
-      names=$(printf '%s\n' "$ln" \
-        | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[' | tr -d '${[' | sort -u)
-      for nm in $names; do
-        n_bare=$(printf '%s\n' "$ln" \
-          | grep -oE '\$\{'"$nm"'\[[@*]\]\}' | wc -l | tr -d ' ')
-        n_guard=$(printf '%s\n' "$ln" \
-          | grep -oE '\$\{'"$nm"'\[[@*]\](\+|:-)' | wc -l | tr -d ' ')
-        if [ "$n_bare" -gt "$n_guard" ]; then
-          unguarded="$unguarded  $suite.sh [$nm]: $ln
+      hit="$(bare_expansions_in "$ln")"
+      if [ -n "$hit" ]; then
+        unguarded="$unguarded  $suite.sh [$hit]: $ln
 "
-        fi
-      done
+      fi
     done <<PORTABILITY_SCAN
 $(grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$suite_path" \
    | grep -vE '^[0-9]+:[[:space:]]*#' || true)
@@ -438,6 +483,65 @@ PORTABILITY_SCAN
   else
     bad "case-h: unguarded array expansion(s) survive in the corrected suites:
 $unguarded"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case i — The detector case h relies on is itself probed, both directions.
+#
+# Case h is only as good as `bare_expansions_in`, and that function has been
+# found defective three times: once by the author's own mutation test and twice
+# by cold review, each time by a reviewer hand-building a line the current design
+# missed. Every one of those was a false NEGATIVE — the detector reporting clean
+# while a bare expansion sat there — which is the same failure mode as the defect
+# this whole change removes.
+#
+# So the shapes that broke it are fixtures now. A fourth narrowing of the detector
+# that reopens any of these holes fails here, in CI, instead of waiting for a
+# fourth reviewer to think of the line again.
+# ---------------------------------------------------------------------------
+{
+  # Each row: <expect> <TAB> <description> <TAB> <line>. `expect` is `bare` when
+  # the detector must report something, `safe` when it must report nothing.
+  # Written with printf, never a heredoc, for the reason recorded in the header.
+  i_rows=$(printf '%s\n' \
+    'safe	a complete canonical guard is safe	for p in ${D[@]+"${D[@]}"}; do' \
+    'safe	two canonical guards on one line	for p in ${D[@]+"${D[@]}"} ${C[@]+"${C[@]}"}; do' \
+    'bare	bare expansion alone	printf "%s" "${D[@]}"' \
+    'bare	bare behind a guard on another name	for p in "${D[@]}" ${C[@]+"${C[@]}"}; do' \
+    'safe	a default-valued guard is safe	s="${D[*]:-}"' \
+    'safe	a default with a literal is safe	s="${D[*]:-(none)}"' \
+    'bare	bare masked by :- on ANOTHER name	s="${C[*]:-} ${D[@]}"' \
+    'bare	bare masked by :- on the SAME name	s="${D[*]:-} ${D[@]}"' \
+    'bare	prefix names do not bleed	s="${D[*]:-}" t="${DE[@]}"' \
+    'safe	length form is safe	if [ ${#D[@]} -eq 0 ]; then' \
+    'safe	slice form is safe	echo "${D[@]:1}"' \
+    'safe	key form is safe	echo "${!D[@]}"')
+
+  i_fail=0
+  i_total=0
+  while IFS= read -r row || [ -n "$row" ]; do
+    [ -n "$row" ] || continue
+    expect=$(printf '%s' "$row" | cut -f1)
+    what=$(printf '%s' "$row" | cut -f2)
+    line=$(printf '%s' "$row" | cut -f3-)
+    got="$(bare_expansions_in "$line")"
+    i_total=$((i_total + 1))
+    if [ "$expect" = bare ] && [ -z "$got" ]; then
+      bad "case-i: detector missed a bare expansion — $what: $line"
+      i_fail=$((i_fail + 1))
+    elif [ "$expect" = safe ] && [ -n "$got" ]; then
+      bad "case-i: detector flagged a safe line [$got] — $what: $line"
+      i_fail=$((i_fail + 1))
+    fi
+  done <<DETECTOR_PROBE
+$i_rows
+DETECTOR_PROBE
+
+  if [ "$i_total" -ne 12 ]; then
+    bad "case-i: expected 12 detector probes, ran $i_total"
+  elif [ "$i_fail" -eq 0 ]; then
+    ok "case-i: the bare-expansion detector is correct on all 12 probes, both directions"
   fi
 }
 

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -375,6 +375,17 @@ test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
     # empty array under `set -u` (verified on 3.2.57), and the leading `#`
     # keeps it out of the `${name[` pattern.
     #
+    # Full-line comments are dropped before counting, for the same reason the
+    # guard itself drops them (check-bash32-portability.sh, requirement 4): a
+    # comment that *names* an expansion is prose, not use. Without this the
+    # scan contradicts the very doctrine this change establishes. Four of the
+    # six suites document their own guarding convention in exactly that form —
+    # e.g. "`${A[*]:-}` rather than `${A[*]}` because bash 3.2 …" — and they
+    # satisfied the count comparison only because each names the guarded form
+    # alongside the bare one, which balances the tally by phrasing coincidence.
+    # Rewording such a comment to cite only the bare form would have turned this
+    # case red with nothing wrong in the suite.
+    #
     # No -P and no \b, so BSD grep (macOS) and GNU grep (CI) agree.
     while IFS= read -r ln || [ -n "$ln" ]; do
       [ -n "$ln" ] || continue
@@ -387,7 +398,8 @@ test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built'
 "
       fi
     done <<PORTABILITY_SCAN
-$(grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$suite_path" || true)
+$(grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$suite_path" \
+   | grep -vE '^[0-9]+:[[:space:]]*#' || true)
 PORTABILITY_SCAN
   done
 

--- a/scripts/tests/test-e2e-defaults-toml.sh
+++ b/scripts/tests/test-e2e-defaults-toml.sh
@@ -56,7 +56,9 @@ done
 # --- Case 3: each [cli.*] has required fields ---------------------------
 REQUIRED=(image command command_args env_keys mounts)
 for cli in claude gemini copilot; do
-  for k in "${REQUIRED[@]}"; do
+  # `${A[@]+…}` per docs/scripting-conventions.md Rule 5: bash 3.2 (stock macOS)
+  # treats an empty array as an unset variable and aborts on it under `set -u`.
+  for k in ${REQUIRED[@]+"${REQUIRED[@]}"}; do
     if jq -e --arg c "$cli" --arg k "$k" '.cli[$c] | has($k)' <<< "$JSON" >/dev/null; then
       note_pass "[cli.$cli].$k present"
     else
@@ -76,12 +78,19 @@ for cli in claude gemini copilot; do
 done
 
 # --- Case 5: known image tags ------------------------------------------
-declare -A WANT_IMG=( [claude]="crewrig/e2e-claude:latest"
-                      [gemini]="crewrig/e2e-gemini:latest"
-                      [copilot]="crewrig/e2e-copilot:latest" )
+# A `case` rather than an associative-array lookup table: bash 3.2 (stock
+# macOS) has no associative arrays, per docs/scripting-conventions.md Rule 5.
+# The three tags stay verbatim literals on purpose — deriving them as
+# "crewrig/e2e-$cli:latest" would couple this assertion to the very naming
+# convention it exists to pin, so it would assert nothing.
 for cli in claude gemini copilot; do
   got="$(jq -r --arg c "$cli" '.cli[$c].image' <<< "$JSON")"
-  want="${WANT_IMG[$cli]}"
+  case "$cli" in
+    claude)  want="crewrig/e2e-claude:latest" ;;
+    gemini)  want="crewrig/e2e-gemini:latest" ;;
+    copilot) want="crewrig/e2e-copilot:latest" ;;
+    *)       want="(no expected image declared for $cli)" ;;
+  esac
   if [[ "$got" == "$want" ]]; then
     note_pass "[cli.$cli].image == $want"
   else

--- a/scripts/tests/test-e2e-report.sh
+++ b/scripts/tests/test-e2e-report.sh
@@ -128,11 +128,17 @@ TAP version 13
 ok 1 - claude/01-layered-context
 EOF
 bash "$REPORT_SH" --tap-dir "$tap7_dir" --output-dir "$out7_dir" --dry-run >/dev/null 2>"$TMP/c7.err"
-mapfile -t md_files7 < <(find "$out7_dir" -maxdepth 1 -name '*.md' 2>/dev/null)
+# `while read` rather than `mapfile` for bash 3.2 compat (macOS default), and
+# `${A[*]:-}` rather than `${A[*]}` because bash 3.2 treats an empty array as an
+# unset variable under `set -u` — the case-8 message below already used that
+# idiom. Both per docs/scripting-conventions.md Rule 5.
+md_files7=()
+while IFS= read -r line || [ -n "$line" ]; do md_files7+=("$line"); done \
+  < <(find "$out7_dir" -maxdepth 1 -name '*.md' 2>/dev/null)
 if [[ ${#md_files7[@]} -eq 0 ]]; then
   note_pass "--dry-run writes no markdown file"
 else
-  note_fail "--dry-run writes no markdown file" "found: ${md_files7[*]}"
+  note_fail "--dry-run writes no markdown file" "found: ${md_files7[*]:-}"
 fi
 
 # --- Case 8: without --dry-run, parity-*.md is created -------------------
@@ -146,7 +152,9 @@ ok 1 - claude/01-layered-context
 EOF
 bash "$REPORT_SH" --tap-dir "$tap8_dir" --output-dir "$out8_dir" >/dev/null 2>"$TMP/c8.err"
 rc8=$?
-mapfile -t md_files8 < <(find "$out8_dir" -maxdepth 1 -name 'parity-*.md' 2>/dev/null)
+md_files8=()
+while IFS= read -r line || [ -n "$line" ]; do md_files8+=("$line"); done \
+  < <(find "$out8_dir" -maxdepth 1 -name 'parity-*.md' 2>/dev/null)
 if [[ $rc8 -eq 0 && ${#md_files8[@]} -ge 1 ]]; then
   note_pass "non-dry-run creates parity-*.md"
 else

--- a/scripts/tests/test-e2e-runner-delegation.sh
+++ b/scripts/tests/test-e2e-runner-delegation.sh
@@ -27,20 +27,30 @@ RUN_SH="${REPO_DIR}/tests/e2e/run.sh"
 REPORTS="${REPO_DIR}/tests/e2e/reports"
 
 # Track every dir created by this test so we leave no debris behind.
-mapfile -t pre_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+#
+# Two bash 3.2 (stock macOS) accommodations run throughout this file, both per
+# docs/scripting-conventions.md Rule 5:
+#   - `while read` rather than `mapfile`, which is a bash 4 builtin;
+#   - every array expansion written `${A[@]+"${A[@]}"}`, because bash 3.2 treats
+#     an empty array as an unset variable and aborts on it under `set -u`.
+pre_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do pre_dirs+=("$line"); done \
+  < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 CREATED=()
 cleanup() {
-  for d in "${CREATED[@]}"; do
+  for d in ${CREATED[@]+"${CREATED[@]}"}; do
     [[ -n "$d" && -d "$d" ]] && rm -rf -- "$d"
   done
 }
 trap cleanup EXIT
 
 collect_new_dirs() {
-  mapfile -t now_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
-  for d in "${now_dirs[@]}"; do
+  now_dirs=()
+  while IFS= read -r line || [ -n "$line" ]; do now_dirs+=("$line"); done \
+    < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+  for d in ${now_dirs[@]+"${now_dirs[@]}"}; do
     known=0
-    for p in "${pre_dirs[@]}"  "${CREATED[@]}"; do
+    for p in ${pre_dirs[@]+"${pre_dirs[@]}"} ${CREATED[@]+"${CREATED[@]}"}; do
       [[ "$d" == "$p" ]] && { known=1; break; }
     done
     [[ $known -eq 0 ]] && CREATED+=("$d")

--- a/scripts/tests/test-e2e-runner.sh
+++ b/scripts/tests/test-e2e-runner.sh
@@ -39,7 +39,15 @@ REPORTS="$E2E_REPORTS_ROOT"
 ERR_DIR="$E2E_REPORTS_ROOT"
 
 # Snapshot of existing report dirs (we only inspect new entries).
-mapfile -t pre_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+#
+# Two bash 3.2 (stock macOS) accommodations run throughout this file, both per
+# docs/scripting-conventions.md Rule 5:
+#   - `while read` rather than `mapfile`, which is a bash 4 builtin;
+#   - every array expansion written `${A[@]+"${A[@]}"}`, because bash 3.2 treats
+#     an empty array as an unset variable and aborts on it under `set -u`.
+pre_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do pre_dirs+=("$line"); done \
+  < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
 # Track every dir we create so we can clean up after ourselves. The temp root
 # itself is swept unconditionally on EXIT — that is the authoritative
@@ -47,7 +55,7 @@ mapfile -t pre_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/n
 # original idiom.
 CREATED=()
 cleanup() {
-  for d in "${CREATED[@]}"; do
+  for d in ${CREATED[@]+"${CREATED[@]}"}; do
     [[ -n "$d" && -d "$d" ]] && rm -rf -- "$d"
   done
   [[ -n "${E2E_REPORTS_ROOT:-}" && -d "$E2E_REPORTS_ROOT" ]] && rm -rf -- "$E2E_REPORTS_ROOT"
@@ -71,11 +79,13 @@ else
 fi
 
 # Identify the new report dir produced by case 1.
-mapfile -t post1_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+post1_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do post1_dirs+=("$line"); done \
+  < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 NEW_DIR=""
-for d in "${post1_dirs[@]}"; do
+for d in ${post1_dirs[@]+"${post1_dirs[@]}"}; do
   found=0
-  for p in "${pre_dirs[@]}"; do
+  for p in ${pre_dirs[@]+"${pre_dirs[@]}"}; do
     [[ "$d" == "$p" ]] && { found=1; break; }
   done
   if [[ $found -eq 0 ]]; then NEW_DIR="$d"; CREATED+=("$d"); break; fi
@@ -112,7 +122,9 @@ fi
 [[ -n "$NEW_DIR" && -d "$NEW_DIR" ]] && rm -rf -- "$NEW_DIR"
 N=3
 TMP_REPORTS_ROOT="$REPORTS"
-mapfile -t pre_keep_dirs < <(find "$TMP_REPORTS_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+pre_keep_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do pre_keep_dirs+=("$line"); done \
+  < <(find "$TMP_REPORTS_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 # Create N+5 fakes with old, lexicographically-low names so they appear "older".
 FAKES=()
 for i in $(seq 1 $((N + 5))); do
@@ -129,19 +141,21 @@ rc5=$?
 [[ $rc5 -eq 0 ]] || note_fail "dry-run --keep N exit 0" "rc=$rc5"
 
 # Identify the new run dir from this invocation.
-mapfile -t post5_dirs < <(find "$TMP_REPORTS_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+post5_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do post5_dirs+=("$line"); done \
+  < <(find "$TMP_REPORTS_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 NEW_DIR2=""
-for d in "${post5_dirs[@]}"; do
+for d in ${post5_dirs[@]+"${post5_dirs[@]}"}; do
   is_fake=0
-  for f in "${FAKES[@]}"; do [[ "$d" == "$f" ]] && { is_fake=1; break; }; done
+  for f in ${FAKES[@]+"${FAKES[@]}"}; do [[ "$d" == "$f" ]] && { is_fake=1; break; }; done
   is_old=0
-  for p in "${pre_keep_dirs[@]}"; do [[ "$d" == "$p" ]] && { is_old=1; break; }; done
+  for p in ${pre_keep_dirs[@]+"${pre_keep_dirs[@]}"}; do [[ "$d" == "$p" ]] && { is_old=1; break; }; done
   if [[ $is_fake -eq 0 && $is_old -eq 0 ]]; then NEW_DIR2="$d"; CREATED+=("$d"); break; fi
 done
 
 # Surviving fakes after prune:
 surviving_fakes=0
-for f in "${FAKES[@]}"; do [[ -d "$f" ]] && surviving_fakes=$((surviving_fakes + 1)); done
+for f in ${FAKES[@]+"${FAKES[@]}"}; do [[ -d "$f" ]] && surviving_fakes=$((surviving_fakes + 1)); done
 
 # The new dir is the "newest" lexicographically (real ISO timestamp >
 # 00000000T000000Z). The N kept slots all get taken by newer entries first,
@@ -172,10 +186,12 @@ fi
 rm -f "$err6_file"
 
 # Cleanup any new dir that case 6 happened to create before failing.
-mapfile -t post6_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
-for d in "${post6_dirs[@]}"; do
+post6_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do post6_dirs+=("$line"); done \
+  < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+for d in ${post6_dirs[@]+"${post6_dirs[@]}"}; do
   known=0
-  for c in "${CREATED[@]}" "${pre_dirs[@]}"; do [[ "$d" == "$c" ]] && { known=1; break; }; done
+  for c in ${CREATED[@]+"${CREATED[@]}"} ${pre_dirs[@]+"${pre_dirs[@]}"}; do [[ "$d" == "$c" ]] && { known=1; break; }; done
   if [[ $known -eq 0 ]]; then CREATED+=("$d"); fi
 done
 
@@ -212,10 +228,12 @@ if [[ $rc9 -eq 0 ]] && grep -q '^1\.\.11$' <<< "$out9"; then
 else
   note_fail "default scenario set → 1..11" "rc=$rc9 stdout=$(echo "$out9" | tr '\n' '|')"
 fi
-mapfile -t post9_dirs < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
-for d in "${post9_dirs[@]}"; do
+post9_dirs=()
+while IFS= read -r line || [ -n "$line" ]; do post9_dirs+=("$line"); done \
+  < <(find "$REPORTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+for d in ${post9_dirs[@]+"${post9_dirs[@]}"}; do
   known=0
-  for c in "${CREATED[@]}" "${pre_dirs[@]}"; do [[ "$d" == "$c" ]] && { known=1; break; }; done
+  for c in ${CREATED[@]+"${CREATED[@]}"} ${pre_dirs[@]+"${pre_dirs[@]}"}; do [[ "$d" == "$c" ]] && { known=1; break; }; done
   if [[ $known -eq 0 ]]; then CREATED+=("$d"); fi
 done
 

--- a/scripts/tests/test-setup-ensure-tier-built.sh
+++ b/scripts/tests/test-setup-ensure-tier-built.sh
@@ -171,15 +171,20 @@ extract_install_fn_staging_pattern() {
   printf '%s\n' "$line" | sed -E 's/^local staging="(.*)"$/\1/'
 }
 
-declare -A EXPECTED_TOOLS=(
-  [setup-gemini-interactive.sh]=gemini
-  [setup-claude-interactive.sh]=claude
-  [setup-copilot-interactive.sh]=copilot
-  [setup-antigravity-interactive.sh]=antigravity
-)
-
 for s in setup-gemini-interactive.sh setup-claude-interactive.sh \
          setup-copilot-interactive.sh setup-antigravity-interactive.sh; do
+  # A `case` rather than an associative-array lookup table: bash 3.2 (stock
+  # macOS) has no associative arrays, per docs/scripting-conventions.md Rule 5.
+  # The four tool names stay verbatim literals on purpose — deriving them from
+  # "$s" would couple this assertion to the very naming convention it exists to
+  # pin, so it would assert nothing.
+  case "$s" in
+    setup-gemini-interactive.sh)      expected_tool=gemini ;;
+    setup-claude-interactive.sh)      expected_tool=claude ;;
+    setup-copilot-interactive.sh)     expected_tool=copilot ;;
+    setup-antigravity-interactive.sh) expected_tool=antigravity ;;
+    *)                                expected_tool="(no expected build_target declared for $s)" ;;
+  esac
   path="$SETUP_DIR/$s"
   if [ ! -f "$path" ]; then
     bad "$s: script not found at $path"
@@ -200,9 +205,9 @@ for s in setup-gemini-interactive.sh setup-claude-interactive.sh \
     continue
   fi
 
-  [ "$ensure_tool" = "${EXPECTED_TOOLS[$s]}" ] \
-    && ok "$s: ensure_tier_built build_target is '${EXPECTED_TOOLS[$s]}'" \
-    || bad "$s: ensure_tier_built build_target was '$ensure_tool', expected '${EXPECTED_TOOLS[$s]}'"
+  [ "$ensure_tool" = "$expected_tool" ] \
+    && ok "$s: ensure_tier_built build_target is '$expected_tool'" \
+    || bad "$s: ensure_tier_built build_target was '$ensure_tool', expected '$expected_tool'"
 
   # Substitute the literal '$tier' token in the install function's pattern
   # with the literal tier argument the script actually passes to its

--- a/scripts/tests/test-setup-org-mcp.sh
+++ b/scripts/tests/test-setup-org-mcp.sh
@@ -177,14 +177,23 @@ apply_org_mcp_servers "{}" "$CFG2" "$PRE" "$BK" >/dev/null 2>&1
 # ---------------------------------------------------------------------------
 echo "4. org_mcp_to_claude_argv — pure argv translation (Claude R13 equivalent)"
 # ---------------------------------------------------------------------------
-mapfile -t ARGV_STDIO < <(org_mcp_to_claude_argv github "$ORG_STDIO")
-STDIO_STR="${ARGV_STDIO[*]}"
+# `while read` rather than `mapfile` for bash 3.2 compat (macOS default), and
+# `${A[*]:-}` rather than `${A[*]}` because bash 3.2 treats an empty array as an
+# unset variable under `set -u`. Both per docs/scripting-conventions.md Rule 5;
+# an empty argv joins to the empty string either way, so the assertions below
+# see exactly the value they saw before.
+ARGV_STDIO=()
+while IFS= read -r line || [ -n "$line" ]; do ARGV_STDIO+=("$line"); done \
+  < <(org_mcp_to_claude_argv github "$ORG_STDIO")
+STDIO_STR="${ARGV_STDIO[*]:-}"
 [[ "$STDIO_STR" == *"--scope user"* ]] && ok "stdio argv: --scope user" || bad "stdio argv missing --scope user ($STDIO_STR)"
 [[ "$STDIO_STR" == *"-e GITHUB_HOST=github.example"* ]] && ok "stdio argv: -e KEY=VALUE" || bad "stdio argv missing -e env ($STDIO_STR)"
 [[ "$STDIO_STR" == *"github -- gh-mcp --stdio"* ]] && ok "stdio argv: <name> -- <command> <args>" || bad "stdio argv command tail wrong ($STDIO_STR)"
 
-mapfile -t ARGV_HTTP < <(org_mcp_to_claude_argv atlassian "$ORG_HTTP")
-HTTP_STR="${ARGV_HTTP[*]}"
+ARGV_HTTP=()
+while IFS= read -r line || [ -n "$line" ]; do ARGV_HTTP+=("$line"); done \
+  < <(org_mcp_to_claude_argv atlassian "$ORG_HTTP")
+HTTP_STR="${ARGV_HTTP[*]:-}"
 [[ "$HTTP_STR" == *"--transport http"* ]] && ok "http argv: --transport http" || bad "http argv missing --transport http ($HTTP_STR)"
 [[ "$HTTP_STR" == *"atlassian https://mcp.atlassian.example/mcp"* ]] && ok "http argv: <name> <url>" || bad "http argv name/url wrong ($HTTP_STR)"
 [[ "$HTTP_STR" == *"--header Authorization: Bearer"* ]] && ok "http argv: --header \"K: V\"" || bad "http argv missing --header ($HTTP_STR)"


### PR DESCRIPTION
Six of this repository's own test suites used `mapfile` or `declare -A`, and on the
Bash 3.2.57 that ships with macOS they did not merely break — three of them printed a
passing count and exited `0` with their later cases silently never executed, so a
maintainer working there was reading a false green. This ports all six off those
constructs and adds `scripts/check-bash32-portability.sh`, wired into both CI engines,
which rejects a reintroduction by file and line before it reaches `main`.

Implements `specs/0111-bash32-portability-guard.md` (spec-PR #718, merged as
`795fc35`). Closes #697.

## How to read this PR?

15 files, `1050` insertions / `47` deletions
(`git diff --numstat crewrig/main...HEAD`, excluding the spec already on `main`).
Four commits, each one requirement group, readable in order:

| Commit | Scope |
| --- | --- |
| `ff868e3` | Port the six suites off Bash 4 constructs (R6, R7, R8) |
| `d23dba9` | The guard, the declared set, Rule 5, the `task` entry (R1–R5, R10, R11) |
| `8c473f7` | Both CI engines plus the self-test (R9) |
| `8577458` | Case h — make scenario 5's invariant standing rather than one-shot |

### The defect is sharper than the issue states

The issue describes a missing CI guard. The measured defect is that the affected
suites did not *fail* on a stock macOS shell; they reported success with cases
skipped. Two mechanisms compose:

1. These suites run `set -uo pipefail` **without `-e`**, because pass/fail counters
   drive their harness.
2. Bash 3.2 treats an empty array as an unset variable, so `"${arr[@]}"` aborts under
   `set -u` where Bash 5 does not.

When such an expansion sits in a command substitution or a subshell, only the child
dies. The suite continues and exits `0`:

```console
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ /bin/bash -c 'set -uo pipefail; a=(); out=$(printf "%s\n" "${a[@]}"); echo done'; echo "rc=$?"
/bin/bash: a[@]: unbound variable
done
rc=0
```

Under Bash 5.3.15 the same line prints `done` with no error at all — which is why CI
could never see this. Pre-change on `/bin/bash` the six suites ran **67** of the
**117** verdicts a newer shell ran; `test-e2e-report.sh` printed
`# 10 passed / 0 failed / 0 skipped` with cases 7 and 8 never executed
([evidence table](https://github.com/crewrig/crewrig/issues/697#issuecomment-5192706742)).
That is why the fix is larger than adding a `grep` rule, and it is recorded in Rule 5's
`### Why` (`docs/scripting-conventions.md:235`).

### The load-bearing design decisions

**The declared set lives outside the scanned tree** — `ci/bash32-forbidden.txt`, not
under `scripts/`. Not stylistic. The guard scans `scripts/` and `hooks/`, and a script
holding `(mapfile|readarray)` in a pattern assignment puts the token immediately after
`(`, which is a command-position anchor, so it would flag its own source. The
alternatives were self-exemption — weakening R5 and R6 at the very file that defines
them — or obfuscating the tokens. Rationale in the data file's own header and at
`scripts/check-bash32-portability.sh:12-15`.

**Use versus mention** (R4) is command-position anchoring plus dropping full-line
comments (`scripts/check-bash32-portability.sh:105` for the anchor,
`:138-140` for the two filters). The acceptance bar is measured, not asserted: against
the pre-change tree the guard rejects **14** real uses and accepts all **8** lines that
name a forbidden construct virtuously, spread across 7 files. Five of those 8 are
comments of the form ``# `while read` rather than `mapfile` for bash 3.2 compat``, left
behind by earlier hand-portability work in the sibling guards; the other three are prose
in `sync-from-upstream.sh` and `lib/common.sh`.

**The guard carries no array at all**, accumulating hits into a `|`-joined string
(`scripts/check-bash32-portability.sh:61-68`). The plan review's finding 2 was that a
guard modelled on the three sibling guards in this repo — `check-core-paths.sh`,
`check-test-wiring.sh`, `check-ci-parity.sh`, all `set -euo pipefail` plus an
accumulator array — would abort on `/bin/bash` **on the clean path**, where the
accumulator is empty, while CI stayed green. That is the ticket's own failure mode
reproduced inside the fix:

```console
$ /bin/bash -c 'set -euo pipefail; violations=(); printf "%s\n" "${violations[@]}"'; echo "rc=$?"
/bin/bash: violations[@]: unbound variable
rc=1
```

**Fixtures use `printf`, never heredocs**
(`scripts/tests/test-check-bash32-portability.sh:33-41`). The test file lives inside
the tree the guard scans; in a heredoc body a fixture line would open with the token in
command position and be reported, turning case b red on the very change that introduces
the gate. In the `printf '%s\n' 'mapfile …'` form every token sits immediately after a
quote.

**Both `declare -A` ports keep their literals verbatim** rather than deriving them from
the loop variable (`test-e2e-defaults-toml.sh` case 5,
`test-setup-ensure-tier-built.sh`). An assertion that re-derives the naming convention
it exists to pin asserts nothing — that is R7's requirement that the correction change
what the suite runs on and not what it checks.

### Two judgement calls worth a reviewer's agreement

**Uniform guarding of expansions that provably cannot be empty.** Every array
expansion in the six suites was rewritten `${A[@]+"${A[@]}"}`, including ones whose
array is never empty on any exercised path. That is justified *because* commit
`8577458` added case h, which checks the invariant
(`scripts/tests/test-check-bash32-portability.sh:320-407`). Uniform guarding is only
worth its noise if something verifies it; without that link it is cargo cult.

**A `*)` catch-all on both `case` ports**, yielding a failing sentinel string
(`"(no expected image declared for $cli)"`,
`"(no expected build_target declared for $s)"`). An associative-array read of a missing
key returns empty; a `case` with no matching arm leaves the variable holding the
previous iteration's value, which would assert the wrong thing silently if the loop
list grew. Changes no current verdict.

### One honest limitation

R8's two-shell evidence is a **recorded manual run**, not a standing gate — CI runs
Bash 5 on Linux, where the defect is invisible. What is standing is the `grep` rule
plus case h's invariant: no array expansion in the six corrected suites is unguarded,
so the abort class is removed rather than the symptom. The plan recorded a `bash:3.2`
container leg as the follow-up if that proves too thin.

## How to test this PR?

Prerequisites: macOS with `/bin/bash` 3.2.57 for the portability half; Docker only for
the cross-`grep` check.

**1. The guard passes on this tree, and says how much it saw.**

```console
$ bash scripts/check-bash32-portability.sh; echo "rc=$?"
OK: no forbidden Bash 4+ construct in scripts hooks (3 declared construct(s), 136 file(s) scanned).
rc=0
```

Also reachable as `task check-bash32-portability`.

**2. The self-test passes on the stock macOS shell** — 9 cases, 22 verdicts:

```console
$ /bin/bash scripts/tests/test-check-bash32-portability.sh | tail -3

Results: 22/22 passed
```

**3. The guard rejects the pre-change tree by file and line.** Scan `main`'s
`scripts/`+`hooks/` with this branch's guard:

```console
$ T=$(mktemp -d) && git archive main scripts hooks | tar -x -C "$T" \
    && mkdir -p "$T/ci" && cp ci/bash32-forbidden.txt "$T/ci/" \
    && CREWRIG_REPO_DIR="$T" bash scripts/check-bash32-portability.sh 2>&1 | head -2
FAILED: 14 line(s) use a forbidden Bash 4+ construct:

```

14 lines across 6 files, all under `scripts/tests/` — 12 `mapfile`, 2 `declare -A`.

**4. Both `grep` implementations agree, byte for byte.** The GitLab job image runs GNU
grep, macOS runs BSD grep, and the pattern uses no `-P` and no `\b` for that reason:

```console
$ /usr/bin/grep --version | head -1
grep (BSD grep, GNU compatible) 2.6.0-FreeBSD
$ PATH=/usr/bin:/bin CREWRIG_REPO_DIR="$T" /bin/bash scripts/check-bash32-portability.sh 2>&1 \
    | grep -cE '^scripts/'
14
$ docker run --rm -v "$T:/repo:ro" -v "$PWD/scripts/check-bash32-portability.sh:/g.sh:ro" \
    debian:stable-slim sh -c 'grep --version | head -1;
      CREWRIG_REPO_DIR=/repo bash /g.sh 2>&1 | grep -cE "^scripts/"'
grep (GNU grep) 3.11
14
```

`diff` of the two hit lists: identical, 14 lines. (`ugrep` 7.5.0 on `PATH` locally also
reports 14.)

**5. The six corrected suites run to completion on `/bin/bash`** — 117 verdicts,
`rc=0` each, where the pre-change suites managed 67:

```console
$ for s in test-e2e-runner test-e2e-report test-e2e-runner-delegation \
           test-setup-org-mcp test-e2e-defaults-toml test-setup-ensure-tier-built; do
    /bin/bash "scripts/tests/$s.sh" >/dev/null 2>&1; echo "$s rc=$?"
  done
test-e2e-runner rc=0
test-e2e-report rc=0
test-e2e-runner-delegation rc=0
test-setup-org-mcp rc=0
test-e2e-defaults-toml rc=0
test-setup-ensure-tier-built rc=0
```

Per-suite counts on `/bin/bash` 3.2.57: `11 + 12 + 8 + 41 + 29 + 16 = 117`.

**6. Failure mode — case h catches a reintroduced bare expansion.** The interesting
mutation is one sharing a line with a guarded expansion, which a line-level filter
would miss. Against a scratch copy of `HEAD`, rewrite
`test-e2e-runner-delegation.sh:53` back to
`for p in "${pre_dirs[@]}" ${CREATED[@]+"${CREATED[@]}"}`:

```console
$ /bin/bash scripts/tests/test-check-bash32-portability.sh | tail -5
FAIL  case-h: unguarded array expansion(s) survive in the corrected suites:
  test-e2e-runner-delegation.sh: 53:    for p in "${pre_dirs[@]}" ${CREATED[@]+"${CREATED[@]}"}; do

Results: 21/22 passed
```

**7. The CI wiring is consistent and the surfaces it touches are undisturbed:**

```console
$ bash scripts/check-ci-parity.sh
OK: reference, GitHub Actions, GitLab agree on the portable capability set; every pipeline job is traceable.
$ bash scripts/build-ci.sh --check
OK: .gitlab-ci.yml matches the CI capability reference.
$ bash scripts/check-test-wiring.sh
OK: all test scripts are wired (61) or exempted with a reason (1); the exemption allowlist is honest.
$ bash scripts/build-docs-index.sh --check
OK: docs/index.json is up to date (31 published pages).
$ bash scripts/check-skill-versions.sh
OK: no existing skill/agent sources modified vs crewrig/main.
```

## Known, deliberately not fixed before merge

Iteration 7 raised one finding recommended as fix-forward rather than blocking,
and it is recorded here rather than left implicit:

**Case f re-implements the declared-set parser** that `192884c` corrected in the
guard, still splitting on generic whitespace. No false green is reachable through
it — token validation forbids whitespace inside a token, and a malformed row
already turns cases a, b, d and g red — so its cost is one misleading extra
message inside an already-failing scenario, plus a duplicated parser of ambiguous
authority. It is a follow-up ticket, not a blocker: touching test code after an
APPROVE would legitimately reopen the review, and seven iterations have already
been spent, six of them on the verification machinery rather than on the port.

The line anchors cited in this body were accurate when written and have shifted
with later commits; treat the surrounding quoted text as the reference, not the
numbers.

## Detailed description (for agents)

### Added — `ci/bash32-forbidden.txt` (29 lines)

The declared set of R2, and the one place the enforcement and the documentation both
refer to. Format is one construct per line, `<kind><TAB><token><TAB><reason>`, with two
kinds:

- `command` — a builtin flagged when it stands in command position on a non-comment
  line. Two entries: `mapfile`, `readarray`.
- `declare-flag` — an uppercase flag letter flagged when it appears in the flag cluster
  of `declare`/`typeset`/`local`/`readonly`. One entry: `A`.

Blank lines and `#` lines are skipped; a trailing `\r` is tolerated. The set is a
floor, not a ceiling (spec 0111 *Out of scope*): every entry has already been observed
to abort a governed script on 3.2.57. Growing it is an edit here plus a Rule 5 entry —
case f fails if the two drift.

**Why under `ci/` and not `scripts/`:** see *The load-bearing design decisions* above.
Moving this file into the scanned tree reintroduces the self-flagging problem; do not.

### Added — `scripts/check-bash32-portability.sh` (212 lines, mode `100755`)

`set -euo pipefail`, `CREWRIG_REPO_DIR` override for the self-test's fixtures (mirrors
the sibling `check-*.sh` guards). Four stages:

1. **Parse the declared set** (`:61-99`) into two `|`-joined ERE alternation strings,
   `CMD_ALT` and `FLAG_ALT`. `while read`, no array — see finding 2 above. An entry with
   no token, an unknown `kind`, a missing file, or a set that declares nothing all exit
   **2**.
2. **Compose the pattern** (`:101-113`). One shared `ANCHOR` for command position: line
   start optionally indented, a command separator `; & | ( ) { }`, or a shell keyword
   (`if while until then do else elif time !`). No `\b`, no `grep -P` — BSD and GNU grep
   must agree. The `declare-flag` arm matches `-[a-zA-Z]*A`, so `-Ag` and `-rA` are
   caught and `-a` is not.
3. **Fail closed on an empty input** (`:115-134`). Scan targets are `scripts` and
   `hooks` when present; `find … | wc -l` is surfaced on the OK line, and scanning zero
   files exits **2** rather than reading as a pass (Rule 4). This is the check that
   caught a bad cross-`grep` measurement during DEV — Docker Desktop does not share
   `/tmp` on macOS, so the mount was empty and GNU grep "found" 0 violations
   ([logbook](https://github.com/crewrig/crewrig/issues/697#issuecomment-5192706742)).
4. **Scan and report** (`:136-157`). `grep -rnE` then two filters: drop
   `file:line:<spaces>#` (full-line comments, R4), then drop `acknowledged-exception:`
   (R10, line-scoped not file-scoped). Non-empty result → count, every offending
   `file:line:text`, the pointer to Rule 5, exit **1**.

Exit codes are meaningful: `0` clean, `1` violations, `2` the guard itself cannot
trust its inputs.

Deliberately not detected, and documented as such at `:32-36`: indirect use (`eval`,
string concatenation), and a heredoc body or trailing comment that opens with a
declared token in command position — a false positive answered by the escape hatch.

### Added — `scripts/tests/test-check-bash32-portability.sh` (590 lines, mode `100755`)

The parity sibling mandated by the repo convention *every `check-*.sh` has a
`test-*.sh`* (spec 0076 R6). 9 cases / 22 verdicts, one per spec 0111 scenario plus three
structural ones:

| Case | What it pins | Requirement |
| --- | --- | --- |
| a | Reintroduction rejected, named by file **and** line | R1, R3 |
| b | This repository passes; the guard flags neither its own source nor its declared set | R6 |
| c | A comment naming a construct is not a violation; `declare -a` is not `declare -A` | R4 |
| d | The `acknowledged-exception:` marker is honoured, and is line-scoped | R10 |
| e | A construct in a *test* script is rejected on the same terms | R5 |
| f | Every declared token is named in Rule 5 — the doc-to-data link no other gate covers | R2, R11 |
| g | An empty or malformed declared set exits 2, not vacuously 0 | Rule 4 |
| h | No array expansion in the six corrected suites is unguarded | R8 |

**Case h is the standing half of scenario 5** and the piece a future agent is most
likely to misread, so its rationale is inline at `:320-343`. It compares bare-expansion
count against guard count **per occurrence, not per line**. That is the fix for a real
failure: the first version filtered per line, and in

```bash
for p in "${pre_dirs[@]}" ${CREATED[@]+"${CREATED[@]}"}
```

dropping every line containing a guard hid the bare `pre_dirs` expansion behind the
guarded `CREATED` one on the same line.

Detection works by **consumption, not by tallying** — that distinction is the whole
history of this function, and three tally designs were rejected before it. Count the
closed forms `${name[@]}` / `${name[*]}`, then subtract only those a complete canonical
guard `${name[@]+"${name[@]}"}` accounts for; anything left is genuinely bare. Tallying
cannot work, because the two guard spellings are asymmetric: the canonical guard contains
one closed form and is worth one, while `${name[*]:-}` contains none and is worth zero. So
on `"${A[*]:-} ${A[@]}"` any tally balances while `A` is bare — and that shape reproduces
this ticket's own false green. `case i` probes the detector directly on 13 fixtures in both
directions, so a future narrowing that reopens any historical hole fails in CI rather than
waiting for another reviewer to think of the line.

`${#name[@]}` is deliberately **not** matched — the length form is safe on an empty
array under `set -u`, verified on 3.2.57 (`len=0`, `rc=0`), and the leading `#` keeps
it out of the pattern.

Case h is scoped to the six suites corrected under R6, listed as a whitespace-separated
string (`:348-349`). That scope is deliberate: 13 other suites under `scripts/tests/`
carry 28 unguarded expansion lines and are outside spec 0111, whose R8 constrains only
the suites changed under R6. See the logbook entry on #697 for that finding.

### Modified — `docs/scripting-conventions.md` (+97 / −3)

New `## Rule 5 — No Bash 4+ constructs in governed scripts` at `:211`, following the
established Rule structure (`### Why` / `### Bad` / `### Good`), plus a
`### Prose is not use` subsection stating the use-versus-mention contract in prose.

Two content notes for a future editor:

- The construct table mirrors `ci/bash32-forbidden.txt`, which is the authority. Case f
  fails if a token is added to the data file without a Rule 5 entry.
- The **empty-array trap is documented but absent from the declared set**, on purpose
  (`:228`). It is not grep-detectable — `"${arr[@]}"` is legitimate on Bash 4+ and
  indistinguishable from the unsafe use by pattern alone — so Rule 5 teaches the
  `${arr[@]+"${arr[@]}"}` idiom in prose while case h enforces it structurally on the
  six suites. Adding it to the data file would produce a guard that flags every array
  expansion in the repository.

The `## CI grep check` closing section was rewritten to name all three checks and to
say why Rule 5 is a script rather than an inline `grep` block.

### Modified — CI wiring (R9: rejected by one engine ⇒ rejected by all)

`ci/ci-capabilities.yml` is the shared reference; `.gitlab-ci.yml` is generated from it
by `scripts/build-ci.sh` and was never hand-edited. Two capabilities gain an entry:

- `grep-anti-patterns` → `bash scripts/check-bash32-portability.sh` (the guard itself)
- `check-components` → `bash scripts/tests/test-check-bash32-portability.sh` (its
  regression suite)

Mirrored to `.github/workflows/scripting-conventions.yml` and
`.github/workflows/build.yml`. `scripts/check-ci-parity.sh` and
`scripts/build-ci.sh --check` both pass, which is what makes "identically exercised by
every engine" checkable rather than asserted. `Taskfile.yml` gains
`check-bash32-portability` as the local mirror.

No environment variable is needed, so R9 does not wait on the `ci-capabilities.yml`
vocabulary gap tracked in #709.

### Modified — the six ported suites (R6, R7, R8)

Two mechanical transformations, each carrying a comment that cites Rule 5:

**`mapfile -t A < <(cmd)` → `while read` accumulation.** 12 sites.

```bash
A=()
while IFS= read -r line || [ -n "$line" ]; do A+=("$line"); done < <(cmd)
```

The `|| [ -n "$line" ]` tail keeps a final unterminated line. Process substitution is
Bash 3.2-clean; only the builtin was not.

**`declare -A` lookup table → `case`.** 2 sites,
`test-e2e-defaults-toml.sh` (image tags) and `test-setup-ensure-tier-built.sh`
(`build_target` names). Both keep verbatim literals and both gained a `*)` sentinel arm
— see *Two judgement calls* above.

**Every array expansion guarded.** `"${A[@]}"` → `${A[@]+"${A[@]}"}` in list context,
`"${A[*]}"` → `"${A[*]:-}"` where the expansion is interpolated into a message string.
An empty argv joins to the empty string either way, so the assertions see exactly the
value they saw before.

R7 was discharged by diffing each suite's post-change Bash 5 output against its
pre-change Bash 5 output — byte-identical for all six — and R8 by running each on both
shells
([evidence](https://github.com/crewrig/crewrig/issues/697#issuecomment-5192706742)).

### Not in this PR, on purpose

- **`specs/0111-*.md` stays `status: approved`.** The flip to `implemented` is a
  separate metadata-only PR after merge, following #711 and #717.
- **Nothing under `artifacts/`** is touched, so `scripts/build-components.sh` owes no
  regenerated output and no skill or agent version bump applies
  (`check-skill-versions.sh` confirms).
- **No CLI-matrix trigger surface fires** — the changed paths are `ci/`, `scripts/`,
  `docs/`, the two workflows already listed, and `Taskfile.yml` without a CLI-prefixed
  entry.
- **The harnesses' interpreter resolution** stays as it was: several suites invoke their
  subject as `bash "$SCRIPT"` from `PATH`. Spec 0111 excludes it explicitly; this PR
  makes the scripts portable, it does not pin the interpreter.
- **13 other suites' 28 unguarded expansion lines** are recorded on #697 and left
  alone. R8 governs only the suites corrected under R6.


