### PR TITLE
📝 Mark spec 0111 implemented

### DIFF
--- a/specs/0111-bash32-portability-guard.md
+++ b/specs/0111-bash32-portability-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0111"
 slug: bash32-portability-guard
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 697


### PR DESCRIPTION
Spec 0111's implementation merged as `05f6728` (PR #720) and anchor ticket #697
closed as completed, so `status: approved` no longer reflects the spec's state.
One frontmatter line.

Closes #722

## How to read this PR?

- One line in `specs/0111-bash32-portability-guard.md`: `status: approved` →
  `status: implemented`. Nothing else.
- **Check the diff is one hunk.** Unlike spec 0110's transition (#717), whose body
  carried "exit status" twice, `status` appears exactly once in this spec — the
  frontmatter field. Measured: `grep -in status` over the file on `main` returns
  line 4 and nothing else. So there is no global-replace hazard here, but the diff
  is worth eyeballing anyway.

## How to test this PR?

```sh
BASE_REF=crewrig/main task spec:lint
```

Expected: `Linting passed!` — markdownlint plus semantic validation, including the
spec-0109 invariant that no non-delta spec on the base branch carries
`status: draft`. `implemented` is a valid enum value per `docs/spec-format.md` →
*Lifecycle states*.

## Detailed description (for agents)

**Modified:** `specs/0111-bash32-portability-guard.md`, frontmatter `status` field
only, `approved` → `implemented`.

This is the post-merge metadata-only transition prescribed by `docs/spec-format.md`
→ *Recording a status transition*, whose line 196 assigns `implemented` the trigger
"implementation PR for `related-issue` merged on `main`" and the authority
"implementation team's `pr-logbook`". It is deliberately a separate PR rather than
part of #720: the trigger cannot be satisfied until #720 has merged, so the flip is
not knowable at implementation time. Same shape as #711 for spec 0109 and #717 for
spec 0110.

**Evidence the trigger fired:**

- PR #720 merged to `main` at `05f6728` — 15 files, 1050 insertions, 47 deletions.
- Anchor issue #697 closed as `COMPLETED` by that merge.
- The guard and its declared set are present on `main`:
  `scripts/check-bash32-portability.sh`, `ci/bash32-forbidden.txt`.
- Seven cold REVIEW passes. The last returned APPROVE with an explicit
  recommendation to merge; of its two findings, one was corrected before merge and
  the other is tracked as #721.

**Not in this PR:** no code, no test, no documentation change. No delta-spec — the
spec's requirements are unchanged and were satisfiable as written; none of the seven
review passes reported a `spec`-class finding.
