### PR TITLE
📝 Add spec 0112 — atomic spec-id reservation at ticket pickup

### DIFF
--- a/specs/0112-spec-id-reservation.md
+++ b/specs/0112-spec-id-reservation.md
@@ -1,0 +1,143 @@
+---
+id: "0112"
+slug: spec-id-reservation
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 726
+version: 1.0.0
+---
+
+# Two tickets picked up at the same moment never receive the same spec id
+
+## Intent
+
+A session that picks up a ticket walks away with a spec id no other session can
+walk away with, decided at pickup time and before anything is written down. Two
+maintainers, two agents, two machines, or two command-line interfaces starting
+work at the same instant end up with two different ids. The failure this
+replaces is not a lint error but a misdirected one: today the collision is
+discovered by an unrelated third pull request, after both offending specs have
+already merged, and repairing it means renaming a file whose id is by then
+carried by an issue, a branch name, a pull-request title, and a logbook.
+
+## Requirements
+
+1. Two sessions allocating an id concurrently SHALL obtain distinct ids.
+   Exactly one session SHALL win any given id; there SHALL be no interval
+   during which both observe success, and the losing session SHALL be able to
+   retry without human intervention.
+2. The id SHALL be secured before the spec file is written and before the spec
+   branch is created, so that the branch name, the filename, and the
+   frontmatter `id` agree from the first commit.
+3. The set of unavailable ids SHALL be the union of the ids already present on
+   the reference branch and the ids secured by sessions whose spec has not yet
+   merged. Allocation SHALL read that union, never the merged ids alone.
+4. The mechanism SHALL operate identically on GitHub, GitLab, and Gitea, and
+   SHALL NOT require any credential beyond those the contributor already holds
+   for `git` and for the forge's own command-line tool, consistent with
+   `AGENTS.md` → *Forge Access*.
+5. An abandoned reservation SHALL be harmless. No expiry, no reclamation pass,
+   and no release protocol SHALL be required, and a gap in the numeric sequence
+   SHALL be an accepted outcome — `docs/spec-format.md` → *Naming convention*
+   already states that spec ids are never reused.
+6. `artifacts/core/skills/spec-author/SKILL.md` → *ID allocation* SHALL stop
+   prescribing an unsynchronised `max(existing) + 1` computation over the local
+   working tree, and SHALL instead consume an id obtained under requirement 1.
+   The corresponding agent source SHALL be updated in the same change.
+7. A check SHALL run in continuous integration on every pull request that adds
+   or renames a non-delta spec file, and SHALL fail when that spec's id was
+   never secured, or was secured for a different ticket. The check SHALL read
+   the authoritative record of secured ids rather than any local copy that may
+   lag behind it.
+8. `task spec:lint` SHALL remain executable offline and SHALL NOT acquire a
+   network dependency. The cross-file duplicate-id guard introduced by
+   `specs/0098-spec-linter-cross-file-id-uniqueness.md` SHALL remain in place
+   as a backstop and SHALL NOT be weakened by this change.
+9. When the author holds no write access to the reference repository — working
+   offline, or contributing from a forked repository — the author SHALL be able
+   to allocate an id locally and proceed, and the resulting spec SHALL carry an
+   explicit, machine-readable mark stating that its id is unsecured.
+10. The check of requirement 7 SHALL discriminate by pull-request origin: a
+    pull request opened from the reference repository SHALL fail when its id is
+    unsecured, whereas a pull request opened from a forked repository SHALL
+    report the condition without blocking. A maintainer SHALL secure the id
+    before merging such a pull request, and the mark of requirement 9 SHALL be
+    removed in the same act.
+11. Delta-specs SHALL be exempt. A delta-spec reuses its parent's id by
+    construction, secures nothing, and SHALL NOT be failed by the check of
+    requirement 7.
+12. The allocation tool SHALL be invocable directly by a human contributor with
+    no agent involved, and SHALL print the id it secured on success and the
+    reason on failure.
+13. Any continuous-integration capability added by this change SHALL be
+    declared in `ci/ci-capabilities.yml` so that the GitLab pipeline generated
+    from it stays in agreement, and any script added SHALL be reflected in
+    `docs/cli-matrix.md` per `AGENTS.md` → *CLI Matrix Maintenance*.
+
+## Scenarios
+
+**Happy path — concurrent pickup.**
+Given the reference branch carries specs `0001` through `0111` and no id beyond
+`0111` is secured, when two sessions pick up two different tickets within the
+same second and each requests an id, then one session receives `0112` and the
+other receives `0113`, neither session is left waiting on the other, and both
+proceed to write their spec file immediately.
+
+**Happy path — offline authoring.**
+Given a contributor with no network access, when that contributor authors a
+spec, then allocation succeeds locally, the spec carries the unsecured-id mark
+of requirement 9, and the contributor is told plainly that the id must be
+secured before the pull request can merge.
+
+**Failure path — unsecured id from the reference repository.**
+Given a pull request opened from a branch of the reference repository that adds
+`specs/0114-<slug>.md`, and given `0114` was never secured, when continuous
+integration runs, then the check of requirement 7 fails, and its message names
+the offending file, the unsecured id, and the command that secures one.
+
+**Failure path — id secured by another ticket.**
+Given `0114` was secured for issue #800, when a pull request for issue #801
+adds `specs/0114-<slug>.md`, then the check fails and its message names both
+the ticket holding the id and the ticket attempting to use it, so the collision
+is attributed to the right author before merge rather than after.
+
+**Failure path — fork contribution.**
+Given a pull request opened from a forked repository whose author cannot write
+to the reference repository, and given the spec carries the unsecured-id mark,
+when continuous integration runs, then the check reports the unsecured id
+without failing the pipeline, and the pull request remains mergeable only after
+a maintainer secures the id and the mark is removed.
+
+## Out of scope
+
+- Deriving the spec id from the issue number. Rejected: the forge already
+  allocates unique integers atomically, but adopting them breaks the compact,
+  contiguous, four-digit sequence that `0001`–`0111` establishes and that
+  branch names, filenames, and cross-references depend on.
+- A reservation registry tracked in the repository, such as a `specs/RESERVED.md`
+  file. Rejected: two pull requests each adding their own line both merge, which
+  reproduces exactly the race this spec exists to remove.
+- Replacing the numeric primary key with the slug so that nothing needs
+  allocating at all. Rejected: it dissolves the problem but requires migrating
+  111 specs, their branch names, and every cross-reference.
+- The concrete carrier of a reservation, its naming, and its visibility in the
+  forge interface. That is a PLAN-stage decision, bounded by requirements 1
+  through 5.
+- Retroactively securing ids `0001` through `0111`. Requirement 3 makes the
+  merged corpus authoritative on its own, so no back-fill is needed.
+- Securing delta-spec sequence numbers, issue numbers, or pull-request numbers.
+- Enabling the forge's "require branches to be up to date before merging"
+  setting. It is a detection aid, not an allocation mechanism, and it is
+  neither required nor precluded by this spec.
+
+## Open questions
+
+- [GROUNDING:] No spec on the reference branch carries any frontmatter field
+  denoting an unsecured id, and `docs/spec-format.md` → *Frontmatter schema*
+  defines no such field while stating that unknown fields SHOULD NOT be
+  introduced without amending that document first. Requirement 9 mandates the
+  mark. Responsibility: the implementation pull request for this spec SHALL
+  amend `docs/spec-format.md` to define the field as optional, and SHALL NOT
+  back-fill it into existing specs — the field is absent by default and carries
+  meaning only in the fallback case of requirement 9.


### PR DESCRIPTION
Qualifies issue #726: a session that picks up a ticket must walk away with a spec id no other session can obtain, decided before anything is written. This is the SPECS-stage artifact only — one file, no implementation, and the allocation mechanism is deliberately left to PLAN.

## How to read this PR?

One file, `specs/0112-spec-id-reservation.md`, read top to bottom.

Three places carry the decisions that shaped it, and are where review effort pays off:

- **Requirements 1–5** are the property set the mechanism must satisfy. They are written to be mechanism-neutral on purpose: atomicity, forge-agnosticism, secure-before-write, union-of-merged-and-secured, and harmless abandonment. If any of these five is wrong, PLAN builds the wrong thing.
- **Requirements 9–10 and the fork scenario** are the non-obvious part. The reference repository is not the only place specs get authored; a contributor from a forked repository holds no write access to it by construction and cannot secure anything. Rather than assume that case away, the spec makes it a first-class path: allocate locally, carry a machine-readable unsecured mark, and let the CI check discriminate by pull-request origin. A maintainer secures the id before merge.
- **Out of scope** carries three rejections with their reasons attached — issue-number derivation, an in-repo registry, and dropping the numeric key for the slug. They are recorded so PLAN rejects them explicitly rather than rediscovering them.

The single `## Open questions` entry is a `[GROUNDING:]` finding from the pre-write grounding pass mandated by the `spec-author` skill. Its responsibility is already assigned in the bullet itself, so it does not block: the implementation PR amends `docs/spec-format.md` and back-fills nothing.

## How to test this PR?

```sh
git fetch crewrig spec/0112-spec-id-reservation
git checkout spec/0112-spec-id-reservation
node scripts/lib/spec-linter.js
```

Expected: `Linting passed!`. The linter checks frontmatter shape, the five mandatory body sections in order, filename/slug/id agreement, and the cross-file duplicate-id guard from spec 0098.

To confirm the id itself is free on a freshly-fetched reference branch:

```sh
git fetch crewrig main
git ls-tree --name-only crewrig/main specs/ | grep -E '^specs/[0-9]{4}-' | grep -v delta | cut -c7-10 | sort | tail -3
gh pr list --state open --json number,title,headRefName
```

Expected: the highest merged id is `0111`, and no other open pull request adds a spec file. That manual check is precisely what this spec exists to remove.

## Detailed description (for agents)

**Added:** `specs/0112-spec-id-reservation.md` — id `0112`, slug `spec-id-reservation`, status `draft`, complexity `standard`, interaction-mode `INTERMEDIATE`, related-issue `726`, version `1.0.0`. Nothing else is added, modified, or removed; the one-file rule of the spec-PR workflow is respected.

**Problem qualified.** `artifacts/core/skills/spec-author/SKILL.md` → *ID allocation* prescribes listing `/specs/*.md`, parsing the `<NNNN>` prefixes, and taking `max(existing) + 1`, with a write-time retry that inspects only the local working tree. That retry cannot observe an id claimed by an open-but-unmerged sibling spec-PR, by another worktree, by another machine, or by another CLI. The spec-0098 cross-file duplicate-id guard in `scripts/lib/spec-linter.js` operates on a single merge-ref tree, so two parallel spec-PRs each see only their own new id plus the reference branch's, both pass, and both merge. Live occurrence on 2026-07-24: PR #673 merged `0104` at 14:46:02Z, PR #674 merged `0104` at 14:46:39Z; the next ticket's spec-PR inherited the duplicate and failed `lint-specs`; #677 renumbered the second spec to `0105`.

**Requirements, by intent.**

- 1–3 define atomic allocation and its authoritative input set — the union of merged ids and secured-but-unmerged ids, never the merged corpus alone.
- 4 binds the mechanism to `git` plus the forge's own CLI, with no additional credential, consistent with `AGENTS.md` → *Forge Access* and with the forge-agnosticism precedent of spec 0105.
- 5 removes any need for expiry, reclamation, or release, leaning on the existing rule in `docs/spec-format.md` → *Naming convention* that ids are never reused.
- 6 retires the unsynchronised computation from the `spec-author` skill and its agent source.
- 7–8 place enforcement in CI, where network access already exists, and explicitly protect `task spec:lint` from acquiring a network dependency. The spec-0098 guard is retained as a backstop.
- 9–10 define the no-write-access fallback and the origin-discriminating check.
- 11 exempts delta-specs, which reuse their parent id and secure nothing.
- 12 keeps the tool usable by a human with no agent involved.
- 13 carries the repository's own parity obligations: `ci/ci-capabilities.yml` declaration so the generated GitLab pipeline stays in agreement, and `docs/cli-matrix.md` for any script added.

**Scenarios.** Five, two happy-path and three failure-path: concurrent pickup yielding distinct ids; offline authoring; unsecured id on a reference-repository pull request; id secured by a different ticket; fork contribution reported without blocking.

**Grounding pass (skill R16).** In scope via conditions b, c and d — the spec qualifies a verification tool whose acceptance is file-level. Inspected: `docs/spec-format.md` → *Frontmatter schema*, a real instance (`specs/0111-bash32-portability-guard.md`), the `lint-specs` job in `.github/workflows/build.yml`, and the `lint-specs` entry in `ci/ci-capabilities.yml`. Three findings shaped the text: the job already runs `fetch-depth: 0` and compares against the target branch through `BASE_REF` (the spec-0109 precedent), the capability is declared for both engines with the GitLab pipeline generated from it (hence requirement 13), and no frontmatter field exists for an unsecured id (hence the `[GROUNDING:]` open question, with the amend-and-do-not-back-fill responsibility assigned in the bullet).

**Interaction mode.** INTERMEDIATE. Four interview questions were put to the user: mechanism-versus-properties scope, enforcement level, no-write-access fallback, and complexity tier. The SPECS content-approval gate ran through the `user-validate` skill on the `plannotator` backend and returned `approved`.

**Lifecycle position.** Per ADR-0010 and `docs/spec-pr-workflow.md`, this spec-PR merges to `main` before any implementation branch for issue #726 is opened. Issue #726 stays open as the logbook anchor; it is not closed by this merge.
