### PR TITLE
🏗️ Add ADR 0016 — shared MemPalace MCP HTTP server

### DIFF
--- a/docs/adr/0006-chromadb-http-server.md
+++ b/docs/adr/0006-chromadb-http-server.md
@@ -4,7 +4,26 @@
 
 ## Status
 
-Proposed — 2026-05-25. Scoped to issue #98.
+Implemented — decided 2026-05-25 (issue #98), delivered by PR #99, validated in
+production 2026-08-08 (issue #728).
+
+**Validation evidence.** The palace `.drift-*` directories record the corruption
+class this ADR targets. Counted on the authoring machine on 2026-08-08:
+
+| Period | Drift events |
+|---|---|
+| May 2026 | 2 |
+| June 2026 | 133 |
+| July 2026 | 130 |
+| Since 2026-07-21 | **0** |
+
+The last drift predates the start of the daemon then running. Eighteen days
+clean against roughly 130 per month before it. The corruption race this ADR set
+out to eliminate structurally is gone, not narrowed.
+
+[ADR 0016](0016-shared-mempalace-mcp-http-server.md) extends the same
+collapse-onto-one-daemon pattern to the MCP tier above this one, and depends on
+the guarantee recorded here.
 
 ## Context
 

--- a/docs/adr/0006-chromadb-http-server.md
+++ b/docs/adr/0006-chromadb-http-server.md
@@ -4,8 +4,13 @@
 
 ## Status
 
-Implemented — decided 2026-05-25 (issue #98), delivered by PR #99, validated in
-production 2026-08-08 (issue #728).
+Accepted — decided 2026-05-25 (issue #98), delivered by PR #99, owner-validated
+2026-08-08 (issue #728).
+
+An ADR records the standing of a *decision*, not the progress of its
+implementation — that is what a spec's `status` field tracks. `Accepted` is
+therefore the terminal status here even though the decision has shipped; the
+evidence below reports the outcome without inventing a status to carry it.
 
 **Validation evidence.** The palace `.drift-*` directories record the corruption
 class this ADR targets. Counted on the authoring machine on 2026-08-08:

--- a/docs/adr/0016-shared-mempalace-mcp-http-server.md
+++ b/docs/adr/0016-shared-mempalace-mcp-http-server.md
@@ -2,7 +2,8 @@
 
 <!-- crewrig-doc: section=architecture-adr nav_order=160 published=true title="ADR 0016 — Shared MemPalace MCP HTTP server" -->
 
-**Status:** Proposed — 2026-08-08 (issue #728)
+**Status:** Accepted — 2026-08-08 (issue #728; owner-validated 2026-08-08 after
+two rounds of review annotations)
 
 ## Framing
 

--- a/docs/adr/0016-shared-mempalace-mcp-http-server.md
+++ b/docs/adr/0016-shared-mempalace-mcp-http-server.md
@@ -1,0 +1,299 @@
+# ADR 0016 — Shared MemPalace MCP HTTP server
+
+<!-- crewrig-doc: section=architecture-adr nav_order=160 published=true title="ADR 0016 — Shared MemPalace MCP HTTP server" -->
+
+**Status:** Proposed — 2026-08-08 (issue #728)
+
+## Framing
+
+- **Goal.** Let every concurrent CLI session write to shared memory. Today the
+  first session to mutate takes the palace writer lease and holds it until its
+  process dies; every sibling session is refused for the rest of its life.
+- **Constraints.** Multi-CLI parity (`AGENTS.md` → *Multi-CLI parity*); the
+  corruption guarantee ADR-0006 established must not regress; the spec-0108
+  runtime version guard must keep a place to stand; no MemPalace source
+  modification.
+- **Non-goals.** Partitioning the palace by sphere (orthogonal — see *Open
+  questions*); changing the `-32001` semantics upstream; reworking the
+  ChromaDB tier, which ADR-0006 already settled.
+
+## Context
+
+### The observed failure
+
+Three concurrent Claude Code sessions, 2026-08-08. Every mutating MemPalace
+call from two of them returned MCP error `-32001` — *"Peer MCP writer active;
+this server is read-only for mutating tools"*. The Session-End protocol
+(`artifacts/core/rules/60-tools.md` → *Memory Activation Protocol*) mandates a
+handoff-drawer update and a diary entry; neither could land.
+
+The holder was identified directly:
+
+```text
+lsof ~/.mempalace/locks/mine_palace_e29dc40b24dad462.lock
+Python  4837  hoanicross  6u  REG  ...
+```
+
+The lock filename is keyed by `sha256(realpath(palace_path))[:16]`; recomputing
+it from `~/.mempalace/palace` produced the same key. The holder was **the most
+recently started session** — twenty minutes old, blocking two sessions that had
+been running for eight and ten hours. The lease goes to whoever mutates first,
+not to whoever arrived first.
+
+### The mechanism
+
+`mempalace/mcp_server.py` → `_acquire_mcp_writer_lock()`:
+
+- The lease **is** `mine_palace_lock(palace_path)` — an `fcntl.flock`, one per
+  palace.
+- It is acquired **lazily**, on the first mutating tool call, not at startup.
+- It is released **only at process exit** (`atexit`). Idleness releases nothing.
+- There is no backend conditional: the same lease is taken whether the ChromaDB
+  client is `PersistentClient` or `HttpClient`.
+
+It covers fourteen tools spanning two different stores — drawer writes that go
+through the ChromaDB daemon, and `kg_*` writes that go straight to
+`~/.mempalace/knowledge_graph.sqlite3`, a file outside the daemon's `--path`.
+
+### Two tiers of sharing; only one was addressed
+
+```text
+Tier 2 — MCP      : N CLI sessions        → N stdio MemPalace processes   ← contention
+Tier 1 — ChromaDB : N MemPalace processes → 1 `chroma run` daemon         ← ADR-0006
+```
+
+ADR-0006 applied the correct pattern — collapse N owners onto one daemon — one
+tier too low. The naming compounds it: the "http" in
+`scripts/lib/mempalace-http-wrapper.py` denotes the **ChromaDB client**, not the
+MCP transport.
+
+ADR-0006 is working, and measurably so. Palace `.drift-*` directories, which
+record the corruption class it targeted:
+
+| Period | Drift events |
+|---|---|
+| May 2026 | 2 |
+| June 2026 | 133 |
+| July 2026 | 130 |
+| Since 2026-07-21 | **0** |
+
+The last drift predates the current daemon's start. Eighteen days clean against
+roughly 130 per month before. This ADR extends that result upward; it does not
+revisit it.
+
+### The upstream remedy already exists
+
+`mempalace serve` (`cli.py` → `cmd_serve`) is described in its own docstring as
+*"a turnkey wrapper over `mempalace-mcp --transport http`"*. It is not a
+prototype:
+
+- `ThreadingHTTPServer` with `daemon_threads = True` — **one process, N
+  concurrent clients**.
+- Per-palace bearer token, auto-generated and stored `0600` at
+  `~/.mempalace/server/<sha256(palace)[:24]>/token`, stable across restarts. The
+  token is passed to the child through the environment, never through `argv`.
+- Optional TLS (`--tls-cert` / `--tls-key`), a `--read-only` mode, and an
+  unauthenticated `/healthz` liveness endpoint.
+- A token is *mandatory* on a non-loopback bind; on loopback it is optional, and
+  `cmd_serve` mints one anyway.
+
+The lease is designed for exactly this topology. From `mine_palace_lock`'s
+docstring:
+
+> Re-entrant … lets the threaded MCP HTTP transport write from a worker thread
+> while the long-lived writer-lease is held on another thread of the same
+> process.
+
+One process holds the lease; every client writes through it. The contention
+disappears by construction. **This is not an upstream defect to report** — it is
+a supported topology the framework has not adopted. It ships in the version the
+framework already pins (`>=3.6.0,<3.7`).
+
+### The framework already proved the client half
+
+Spec 0091 established that all four CLIs consume an HTTP-transport MCP server,
+with the translation to each native shape grounded empirically —
+`docs/cli-matrix.md` row 7h: *"stdio and http/sse reach all four CLIs
+(grounded)"*, mapping the neutral `url` to Claude's `--transport http`,
+Gemini's and Copilot's `{type,url,headers}`, and Antigravity's
+`{serverUrl,headers}`.
+
+Every piece exists. None has been pointed at MemPalace itself, which remains
+registered over stdio in all four surfaces.
+
+## Decision
+
+Adopt a **single supervised MemPalace MCP HTTP daemon** owning the palace writer
+lease, and register MemPalace over `--transport http` in all four CLI surfaces.
+
+### Topology
+
+```text
+`chroma run` ──────────────── sole PersistentClient + sole HNSW compactor  (ADR-0006)
+        ↑ 127.0.0.1:8001
+mempalace MCP HTTP daemon ── sole writer-lease holder                      (this ADR)
+        ↑ 127.0.0.1:<port>, bearer token
+Claude Code ×N ─┐
+Gemini CLI      ├─→ all clients, all sessions, concurrent
+Copilot CLI     │
+Antigravity CLI ┘
+```
+
+### The two tiers must compose
+
+The daemon **must be launched through `scripts/lib/mempalace-http-wrapper.py`**,
+not through a bare `mempalace serve`. The wrapper monkey-patches
+`chromadb.PersistentClient` before `mempalace` is imported and then calls
+`mempalace.mcp_server.main()`; a bare `mempalace serve` `execve`s the module
+directly and would resolve `PersistentClient` unpatched — re-introducing the
+second `PersistentClient` that ADR-0006 exists to prevent, and bypassing the
+spec-0108 launch-time version guard that lives in the same wrapper.
+
+This is the central implementation constraint of this ADR: **collapsing tier 2
+must not un-collapse tier 1.**
+
+### Fail loud, never silent
+
+ADR-0006's contract is carried over verbatim to the new tier. If the MCP daemon
+is unreachable, the CLI's MCP registration must fail visibly — never fall back
+to spawning a stdio MemPalace process, which would silently restore the
+contention this ADR removes and mask the outage.
+
+### Daemon lifecycle
+
+Supervised per OS, mirroring the ChromaDB daemon: a launchd user agent on macOS
+with `KeepAlive=true`, a systemd user unit on Linux with `Restart=always`.
+
+`MEMPALACE_MCP_IDLE_HOURS` (default 8 h) terminates the server after an idle
+period — a guard designed for per-session stdio servers, where stale processes
+accumulate. On a supervised shared daemon it is either counter-productive
+(a restart cycles the lease for no reason) or harmless (the supervisor restarts
+it immediately). The derived spec sets it deliberately rather than inheriting
+the default.
+
+## Alternatives considered
+
+### A. Status quo — retry once, then fall back (spec 0103)
+
+- **Pro:** already specified and implemented; zero new moving parts.
+- **Con:** it is a *loss-mitigation* protocol, not a fix. Its fallback is
+  "file the friction as an issue" — which covers friction tagging only, and has
+  no counterpart for the Session-End memory flush that this ADR's motivating
+  incident actually lost.
+- **Verdict:** retained as the degraded-path safety net, not as the answer.
+
+### B. `MEMPALACE_MCP_ALLOW_PEER_WRITER=1`
+
+- **Pro:** one environment variable; instant.
+- **Con:** disables the guard for *all* fourteen mutating tools, including the
+  `kg_*` writes to `knowledge_graph.sqlite3`, which sit outside the ChromaDB
+  daemon's protection. It removes the symptom and the diagnostic at once: the
+  day the lease matters, nothing reports it.
+- **Verdict:** rejected as a durable setting; acceptable only as a one-off
+  operator escape hatch.
+
+### C. Ask upstream to make the lease backend-conditional
+
+- **Pro:** would shrink the lease to the stores that still need it.
+- **Con:** the shared HTTP server already solves the problem completely, in the
+  pinned version. Asking upstream to change a mechanism whose supported
+  alternative we have not adopted is asking them to work around our
+  configuration.
+- **Verdict:** rejected. Should the derived specs uncover a real gap in the
+  HTTP topology, this reopens on evidence.
+
+### D. One palace per sphere
+
+- **Pro:** the lease is keyed per palace, so sessions on different projects
+  would stop contending. It would also serve the sphere-tightness rule in the
+  operator's own organization rules, which a single palace mixing client,
+  employer, and personal wings does not.
+- **Con:** does not help two sessions on the *same* project — the exact case
+  observed. It is a data-partitioning decision with migration consequences,
+  independent of transport.
+- **Verdict:** orthogonal and worth its own ADR; not a substitute for this one.
+
+### E. Bare `mempalace serve`, no wrapper
+
+- **Pro:** the shortest path — one supervised command.
+- **Con:** breaks ADR-0006 and the spec-0108 guard, as set out in *The two tiers
+  must compose*.
+- **Verdict:** rejected.
+
+## Consequences
+
+### Positive
+
+- Writer contention is eliminated by construction: one lease, one holder, all
+  sessions writing through it. `-32001` between sibling sessions becomes
+  unreachable in the nominal path.
+- N MemPalace processes collapse to one — less resident memory, fewer ChromaDB
+  connection pools, one log instead of N interleaved.
+- The spec-0108 version guard gets a single, authoritative enforcement point
+  instead of one per session.
+- Symmetric across all four CLIs by construction: the registration is a client
+  concern, and spec 0091 already ships the per-CLI translation.
+- Consistent with ADR-0006 — the same pattern, the same fail-loud contract, one
+  tier up.
+
+### Negative / trade-offs
+
+- **A second SPOF.** Memory dies for every session at once instead of for one.
+  Mitigated by the supervisor and by fail-loud detection, exactly as ADR-0006
+  mitigated the first.
+- **A second loopback port**, plus a bearer token to provision and to keep out
+  of `argv` and out of committed config.
+- **Version-guard semantics shift.** Today each session serves the MemPalace
+  version its own interpreter resolves; afterwards every session is served by
+  the daemon's version. A session started after an upgrade keeps talking to the
+  pre-upgrade daemon until it is restarted. The derived spec must state how the
+  daemon is cycled on upgrade, and `scripts/doctor-mempalace.sh` must report the
+  daemon's served version rather than four per-CLI registrations.
+- **Startup ordering grows a step:** ChromaDB daemon → MCP daemon → CLI session.
+
+### Blast radius
+
+In scope for the derived specs:
+
+- Supervisor units for the MCP daemon under `config/`, alongside the ChromaDB
+  units.
+- The four `setup-*-interactive.sh`, switching the `mempalace` registration from
+  stdio to `--transport http` with its token, using the spec-0091 translation.
+- `scripts/doctor-mempalace.sh` — report the daemon rather than per-session
+  registrations.
+- `docs/cli-matrix.md` rows 7c and 7d, and the MemPalace entries they describe.
+- Taskfile entries for daemon lifecycle, mirroring the ChromaDB ones.
+
+Out of scope: the palace-partitioning question (D), the ChromaDB tier, and any
+MemPalace source change.
+
+## Derived spec plan
+
+1. **Daemon and supervisor** — launch through the wrapper, supervisor units for
+   both OSes, health check, deliberate `MEMPALACE_MCP_IDLE_HOURS`, fail-loud
+   probe. Must land first; everything else depends on it.
+2. **Four-CLI registration** — stdio → HTTP in every setup script, token
+   provisioning, no committed secret. Symmetric by the parity rule.
+3. **Migration and diagnostics** — detect and replace a pre-existing stdio
+   registration, cycle the daemon on MemPalace upgrade, extend
+   `doctor-mempalace.sh`.
+4. **Documentation** — `docs/cli-matrix.md`, the ADR-0006 cross-reference, and
+   the runbook.
+
+## Open questions
+
+- **ADR-0006 is still `Proposed`** while running in production for eighteen days
+  with the validation table above. This ADR builds directly on it; a dependency
+  on an unaccepted decision is a weak foundation. Promoting it to `Accepted`
+  with that evidence is a prerequisite of coherence, not a separate errand.
+- **Does the wrapper forward `argv` to `mcp_server.main()`?** The handoff calls
+  `main()` with no explicit arguments, so it reads `sys.argv`. Passing
+  `--transport http --host … --port …` through the wrapper is expected to work
+  but must be verified in DEV before spec 1 commits to the launch line.
+- **Token on a loopback bind** — mint one anyway (defence in depth, matching
+  `cmd_serve`'s own behaviour) or rely on the loopback boundary?
+- **What becomes of spec 0103?** Its `-32001` fallback stops describing the
+  expected case. Keep it as the degraded-path net, or restate its trigger?
+- **Is a per-session read-only client worth it?** `MEMPALACE_MCP_READ_ONLY`
+  would let a session declare itself a reader; probably unnecessary once one
+  writer serves everyone, but it is the natural place to ask.

--- a/docs/adr/0016-shared-mempalace-mcp-http-server.md
+++ b/docs/adr/0016-shared-mempalace-mcp-http-server.md
@@ -11,11 +11,16 @@
   process dies; every sibling session is refused for the rest of its life.
 - **Constraints.** Multi-CLI parity (`AGENTS.md` → *Multi-CLI parity*); the
   corruption guarantee ADR-0006 established must not regress; the spec-0108
-  runtime version guard must keep a place to stand; no MemPalace source
-  modification.
+  runtime version guard must keep a place to stand; **transcript persistence
+  must not regress** — spec 0110 made it survive a held lock and that outcome is
+  a floor, not a bargaining chip; no MemPalace source modification.
 - **Non-goals.** Partitioning the palace by sphere (orthogonal — see *Open
   questions*); changing the `-32001` semantics upstream; reworking the
-  ChromaDB tier, which ADR-0006 already settled.
+  ChromaDB tier, which ADR-0006 already settled. **Deciding** the transcript
+  hook's write path is explicitly deferred to a derived spec: this ADR scopes
+  the question and states the constraints it must satisfy, but the answer
+  depends on a latency measurement and on an upstream policy that is still
+  moving.
 
 ## Context
 
@@ -55,6 +60,51 @@ It covers fourteen tools spanning two different stores — drawer writes that go
 through the ChromaDB daemon, and `kg_*` writes that go straight to
 `~/.mempalace/knowledge_graph.sqlite3`, a file outside the daemon's `--path`.
 
+### The palace has three families of writers
+
+The MCP servers are the loudest contender for the lease, but not the only one.
+A decision about "who writes to the palace" that counts only MCP is incomplete:
+
+1. **MCP servers** — one per CLI session. The subject of this ADR.
+2. **The transcript hook** — `hooks/mempalace-transcript.sh`, fired on every
+   session lifecycle event on all four CLIs. It writes **outside MCP**, from a
+   short-lived subprocess, using the MemPalace Python library directly.
+3. **The CLI and maintenance paths** — `mine`, `sync`, repair, and the harness
+   curator's bundled batch reader.
+
+Family 2 already collides with the lease, and spec 0110 already resolved that
+collision — by the same reasoning this ADR generalises.
+
+### Spec 0110 is the precedent, one path wide
+
+`specs/0110-transcript-hook-lock-bypass.md` (status `implemented`, issue #713,
+PR #715) states the problem in its Intent: a peer holding the lock is *"the
+ordinary condition as soon as more than one agent or background task runs
+against the same palace, and today the condition under which every transcript is
+silently lost."*
+
+Its remedy is a **lock relief**, and its guard rails are the interesting part:
+
+- R2 — the relief takes effect **only after** the hook has established that the
+  remote memory service is reachable. The ordering is normative: a write whose
+  remote routing is not established keeps the lock's protection.
+- R6 — the relief is confined to the hook's own interpreter. It rebinds an
+  in-memory symbol (`mine_palace_lock` → a recording stand-in); it never
+  releases or removes a lock another process holds.
+- R3/R4 — if the relief is not actually in force on the path the entry takes,
+  the hook declines to write and reports a dedicated exit status
+  (`5 LOCK_BYPASS_INEFFECTIVE`), distinguishable from every other failure.
+
+The principle spec 0110 established is precisely this ADR's: **once the store
+sits behind a single reachable service, a per-process local lock is no longer
+what protects it.** Spec 0110 applied that to one write path, defensively and
+under proof of reachability. This ADR applies it to the topology, so the
+condition becomes structurally true rather than locally worked around.
+
+That framing also corrects a claim this ADR must not overstate: collapsing the
+MCP tier does **not**, on its own, make the palace single-writer. The transcript
+hook keeps writing directly. See *Consequences* and *Open questions*.
+
 ### Two tiers of sharing; only one was addressed
 
 ```text
@@ -67,7 +117,9 @@ tier too low. The naming compounds it: the "http" in
 `scripts/lib/mempalace-http-wrapper.py` denotes the **ChromaDB client**, not the
 MCP transport.
 
-ADR-0006 is working, and measurably so. Palace `.drift-*` directories, which
+ADR-0006 is working, and measurably so — which is why this PR also promotes it
+from `Proposed` to `Implemented`, evidence included, rather than leaving this
+decision to rest on an unrecorded one. Palace `.drift-*` directories, which
 record the corruption class it targeted:
 
 | Period | Drift events |
@@ -224,9 +276,12 @@ the default.
 
 ### Positive
 
-- Writer contention is eliminated by construction: one lease, one holder, all
-  sessions writing through it. `-32001` between sibling sessions becomes
-  unreachable in the nominal path.
+- Writer contention **between CLI sessions** is eliminated by construction: one
+  lease, one holder, every session writing through it. `-32001` between sibling
+  sessions becomes unreachable in the nominal path. Scope stated precisely: this
+  is the MCP family (writer family 1). The transcript hook still writes directly
+  under its spec-0110 relief, so "one writer for the whole palace" is **not** a
+  claim this ADR makes — see *Open questions*.
 - N MemPalace processes collapse to one — less resident memory, fewer ChromaDB
   connection pools, one log instead of N interleaved.
 - The spec-0108 version guard gets a single, authoritative enforcement point
@@ -263,6 +318,9 @@ In scope for the derived specs:
   registrations.
 - `docs/cli-matrix.md` rows 7c and 7d, and the MemPalace entries they describe.
 - Taskfile entries for daemon lifecycle, mirroring the ChromaDB ones.
+- Conditionally, and only if the first open question resolves that way:
+  `hooks/mempalace-transcript.sh` and the four `hooks/*-transcript-hooks.json`
+  manifests — plus a revisit of spec 0110, whose relief would become dead code.
 
 Out of scope: the palace-partitioning question (D), the ChromaDB tier, and any
 MemPalace source change.
@@ -277,15 +335,42 @@ MemPalace source change.
 3. **Migration and diagnostics** — detect and replace a pre-existing stdio
    registration, cycle the daemon on MemPalace upgrade, extend
    `doctor-mempalace.sh`.
-4. **Documentation** — `docs/cli-matrix.md`, the ADR-0006 cross-reference, and
+4. **Transcript-hook write path** — resolve the first open question below: keep
+   the spec-0110 direct write with its relief, or route the hook through the
+   daemon. Depends on spec 1 and on re-checking MemPalace's write-routing
+   policy; must preserve spec 0110's guard rails either way. Deliberately last:
+   it is the only step that can regress a path which currently works.
+5. **Documentation** — `docs/cli-matrix.md`, the ADR-0006 cross-reference, and
    the runbook.
 
 ## Open questions
 
-- **ADR-0006 is still `Proposed`** while running in production for eighteen days
-  with the validation table above. This ADR builds directly on it; a dependency
-  on an unaccepted decision is a weak foundation. Promoting it to `Accepted`
-  with that evidence is a prerequisite of coherence, not a separate errand.
+- **Where do the transcript hook's writes go once the daemon exists?** Two
+  shapes, and this ADR deliberately does not pick one:
+  - **(a) Unchanged** — the hook keeps writing directly under its spec-0110
+    relief. Cheapest; leaves the palace multi-writer and keeps a bypass alive
+    whose precondition (a reachable remote service) the new topology makes
+    permanently true, which is either reassuring or a smell.
+  - **(b) Routed through the MCP daemon** — the hook stops writing directly, the
+    relief becomes dead code, and the palace becomes genuinely single-writer.
+    Costs the hook an HTTP round trip per lifecycle event, on a path deliberately
+    built to be non-blocking (spec 0073 R3/R4 already soft-skip on an unreachable
+    daemon, and the hook caps itself at five seconds so a lock cannot stall the
+    calling CLI). Whether an MCP call fits inside that budget is unverified.
+  Whichever is chosen, spec 0110's guard rails are the floor: a write must not
+  proceed on an unproven path, and an ineffective relief must stay
+  distinguishable in the exit status.
+- **Should the framework adopt MemPalace's write-routing policy instead of
+  deciding this itself?** `config.py` (`resolve_write_routing`) already exposes
+  per-caller policies — `MEMPALACE_HOOK_WRITE_ROUTING` and
+  `MEMPALACE_CLI_WRITE_ROUTING`, plus a global `MEMPALACE_WRITE_ROUTING`, with a
+  documented precedence chain and `direct` as the default. Its own docstring says
+  the foundation *"does not change current hook or CLI behavior"* and that
+  *"policy-aware consumers are introduced by follow-up PRs"*. Upstream is
+  building the mechanism this question needs. Aligning with it — rather than
+  inventing a crewrig-side routing switch that will collide with it — looks
+  right, but the policy vocabulary is not yet stable enough to depend on. The
+  derived specs should re-check it at implementation time.
 - **Does the wrapper forward `argv` to `mcp_server.main()`?** The handoff calls
   `main()` with no explicit arguments, so it reads `sys.argv`. Passing
   `--transport http --host … --port …` through the wrapper is expected to work

--- a/docs/adr/0016-shared-mempalace-mcp-http-server.md
+++ b/docs/adr/0016-shared-mempalace-mcp-http-server.md
@@ -118,7 +118,7 @@ tier too low. The naming compounds it: the "http" in
 MCP transport.
 
 ADR-0006 is working, and measurably so — which is why this PR also promotes it
-from `Proposed` to `Implemented`, evidence included, rather than leaving this
+from `Proposed` to `Accepted`, evidence included, rather than leaving this
 decision to rest on an unrecorded one. Palace `.drift-*` directories, which
 record the corruption class it targeted:
 
@@ -222,6 +222,25 @@ accumulate. On a supervised shared daemon it is either counter-productive
 (a restart cycles the lease for no reason) or harmless (the supervisor restarts
 it immediately). The derived spec sets it deliberately rather than inheriting
 the default.
+
+### Prefer upstream write routing over a framework-side switch
+
+Where a write path must be steered — the transcript hook being the open case —
+the framework SHALL use MemPalace's own routing policy rather than invent a
+crewrig-side equivalent. `config.py` (`resolve_write_routing`) already exposes
+per-caller policies (`MEMPALACE_HOOK_WRITE_ROUTING`,
+`MEMPALACE_CLI_WRITE_ROUTING`, plus a global `MEMPALACE_WRITE_ROUTING`) with a
+documented precedence chain and `direct` as the default. Two sibling mechanisms
+steering the same writes would eventually disagree, and the framework's would
+lose.
+
+Feasibility caveat, stated rather than hidden: the upstream docstring says the
+foundation *"does not change current hook or CLI behavior"* and that
+*"policy-aware consumers are introduced by follow-up PRs"*. The mechanism exists;
+its consumers do not yet. The derived specs re-check its state at implementation
+time and fall back to a framework-side steer **only** if upstream still cannot
+carry the case — recording that as an explicit, time-stamped deviation, not as a
+default.
 
 ## Alternatives considered
 
@@ -337,40 +356,53 @@ MemPalace source change.
    `doctor-mempalace.sh`.
 4. **Transcript-hook write path** — resolve the first open question below: keep
    the spec-0110 direct write with its relief, or route the hook through the
-   daemon. Depends on spec 1 and on re-checking MemPalace's write-routing
-   policy; must preserve spec 0110's guard rails either way. Deliberately last:
-   it is the only step that can regress a path which currently works.
+   daemon. Steered through upstream write routing per *Prefer upstream write
+   routing*; must preserve spec 0110's guard rails either way. Deliberately
+   late: it is the only step that can regress a path which currently works.
+
+   **Latency measurement — mandatory, blocking.** This spec SHALL NOT choose a
+   shape on judgement. It SHALL measure, against the real palace with the daemon
+   from step 1 running, the wall-clock cost of one hook-equivalent write through
+   the MCP daemon versus the current direct path, at each of the four lifecycle
+   events, on a palace of production size — the authoring palace held 24 481
+   drawers when this ADR was written, and a measurement on an empty palace
+   proves nothing. The comparison SHALL be reported in the spec, not merely
+   asserted, and SHALL state the p95 rather than a single sample.
+
+   The pass criterion is the hook's own five-second self-cap: a routed write
+   whose p95 does not fit **well** inside that budget — leaving room for a
+   loaded machine, not just an idle one — disqualifies shape (b), and the ADR's
+   open question resolves to (a) on evidence rather than on preference.
+
+   This measurement cannot be taken today: the daemon does not exist yet, and
+   measuring against a scratch palace would answer a different question. That is
+   why it is a requirement on this step rather than a figure in this ADR.
 5. **Documentation** — `docs/cli-matrix.md`, the ADR-0006 cross-reference, and
    the runbook.
 
 ## Open questions
 
 - **Where do the transcript hook's writes go once the daemon exists?** Two
-  shapes, and this ADR deliberately does not pick one:
+  shapes. This ADR does not pick one, and states the criterion that decides it:
+  **which topology is correct**, not which is cheaper to build. Implementation
+  cost is not a discriminant here — a one-off cost cannot outweigh a permanent
+  structural property.
   - **(a) Unchanged** — the hook keeps writing directly under its spec-0110
-    relief. Cheapest; leaves the palace multi-writer and keeps a bypass alive
-    whose precondition (a reachable remote service) the new topology makes
-    permanently true, which is either reassuring or a smell.
+    relief. The palace stays multi-writer, and a bypass stays alive whose
+    precondition (a reachable remote service) the new topology makes permanently
+    true. A bypass whose guard can no longer fail is either redundant or
+    load-bearing in a way nobody has stated; both readings deserve an answer
+    before it is kept.
   - **(b) Routed through the MCP daemon** — the hook stops writing directly, the
-    relief becomes dead code, and the palace becomes genuinely single-writer.
-    Costs the hook an HTTP round trip per lifecycle event, on a path deliberately
-    built to be non-blocking (spec 0073 R3/R4 already soft-skip on an unreachable
-    daemon, and the hook caps itself at five seconds so a lock cannot stall the
-    calling CLI). Whether an MCP call fits inside that budget is unverified.
-  Whichever is chosen, spec 0110's guard rails are the floor: a write must not
-  proceed on an unproven path, and an ineffective relief must stay
-  distinguishable in the exit status.
-- **Should the framework adopt MemPalace's write-routing policy instead of
-  deciding this itself?** `config.py` (`resolve_write_routing`) already exposes
-  per-caller policies — `MEMPALACE_HOOK_WRITE_ROUTING` and
-  `MEMPALACE_CLI_WRITE_ROUTING`, plus a global `MEMPALACE_WRITE_ROUTING`, with a
-  documented precedence chain and `direct` as the default. Its own docstring says
-  the foundation *"does not change current hook or CLI behavior"* and that
-  *"policy-aware consumers are introduced by follow-up PRs"*. Upstream is
-  building the mechanism this question needs. Aligning with it — rather than
-  inventing a crewrig-side routing switch that will collide with it — looks
-  right, but the policy vocabulary is not yet stable enough to depend on. The
-  derived specs should re-check it at implementation time.
+    relief becomes dead code, and the palace becomes genuinely single-writer:
+    one lease, one holder, no exceptions to reason about. It costs the hook an
+    HTTP round trip per lifecycle event on a path deliberately built to be
+    non-blocking — spec 0073 R3/R4 soft-skip on an unreachable daemon, and the
+    hook caps itself at five seconds so a lock cannot stall the calling CLI.
+  The deciding input is therefore a **measurement, not a preference** — see the
+  latency requirement in *Derived spec plan* step 4. Whichever shape wins, spec
+  0110's guard rails are the floor: a write must not proceed on an unproven
+  path, and an ineffective relief must stay distinguishable in the exit status.
 - **Does the wrapper forward `argv` to `mcp_server.main()`?** The handoff calls
   `main()` with no explicit arguments, so it reads `sys.argv`. Passing
   `--transport http --host … --port …` through the wrapper is expected to work

--- a/docs/index.json
+++ b/docs/index.json
@@ -201,6 +201,11 @@
           "title": "ADR 0015 — Forge access CLI-only; no framework forge MCP",
           "path": "docs/adr/0015-forge-access-cli-only.md",
           "nav_order": 150
+        },
+        {
+          "title": "ADR 0016 — Shared MemPalace MCP HTTP server",
+          "path": "docs/adr/0016-shared-mempalace-mcp-http-server.md",
+          "nav_order": 160
         }
       ]
     }


### PR DESCRIPTION
Records the decision to collapse the N per-session MemPalace MCP processes onto a single supervised HTTP daemon, so one writer lease serves every concurrent CLI session instead of locking out all but the first to mutate. Decision only — implementation lands in the four derived specs listed at the end of the ADR.

## How to read this PR?

One new file plus a regenerated manifest. Read the ADR in order; the sections build on each other.

- `docs/adr/0016-shared-mempalace-mcp-http-server.md` — the whole change.
  - **Context** first. It establishes three things a reviewer needs before the decision makes sense: the observed `-32001` incident with the lease holder identified by `lsof`, the two-tier diagram showing that ADR-0006 solved the lower tier only, and the discovery that `mempalace serve` already implements the upper one in the version the framework pins.
  - **Decision → "The two tiers must compose"** is the non-obvious part, and the one most likely to be got wrong at implementation time. Launching a bare `mempalace serve` would `execve` the module with `chromadb.PersistentClient` unpatched, re-creating the second `PersistentClient` that ADR-0006 exists to prevent and skipping the spec-0108 version guard. The daemon must be launched *through* `scripts/lib/mempalace-http-wrapper.py`.
  - **Alternatives** — five, all rejected with reasons. C (ask upstream to make the lease backend-conditional) is the one worth scrutinising: it was the author's own first recommendation, reversed once `mempalace serve` was found.
  - **Open questions** — five, all genuinely open. The first (ADR-0006 is still `Proposed` after eighteen days of validated production use) is a dependency issue this ADR inherits rather than creates.
- `docs/index.json` — regenerated by `scripts/build-docs-index.sh`; the five added lines are the new page's manifest entry.

The ADR carries a measurement table (palace `.drift-*` events per month) supporting ADR-0006's effectiveness. It is evidence for the foundation this decision builds on, not a claim about this change.

## How to test this PR?

Documentation only — no runtime behaviour changes. Two guards must pass:

```sh
# 1. Markdown lint (repo config: .markdownlintrc)
npx --yes markdownlint-cli docs/adr/0016-shared-mempalace-mcp-http-server.md
# expected: no output, exit 0

# 2. Docs manifest drift guard
bash scripts/build-docs-index.sh --check
# expected: "OK: docs/index.json is up to date (32 published pages)."
```

To reproduce the incident the ADR documents, on a machine with two or more concurrent CLI sessions sharing one palace:

```sh
# Identify the palace lock key and its holder
python3 -c "import hashlib,os;p=os.path.realpath(os.path.expanduser('~/.mempalace/palace'));print(hashlib.sha256(os.path.normcase(p).encode()).hexdigest()[:16])"
lsof ~/.mempalace/locks/mine_palace_<key>.lock
```

The reported PID is the MemPalace process holding the lease; every other session's mutating MCP call returns `-32001` until that process exits.

## Detailed description (for agents)

### Added

`docs/adr/0016-shared-mempalace-mcp-http-server.md`, status `Proposed`, `nav_order=160`, following the section layout of ADR-0015 (Framing / Context / Decision / Alternatives considered / Consequences / Derived spec plan / Open questions).

**Framing.** Goal: let concurrent CLI sessions all write to shared memory. Constraints: multi-CLI parity, no regression of ADR-0006's corruption guarantee, the spec-0108 version guard keeps an enforcement point, no MemPalace source modification. Non-goals: palace partitioning, upstream `-32001` semantics, the ChromaDB tier.

**Context.** Four subsections:

1. The 2026-08-08 incident — three concurrent Claude Code sessions, two refused every mutating call. Holder identified by `lsof` on `~/.mempalace/locks/mine_palace_e29dc40b24dad462.lock`, the filename key recomputed from `sha256(realpath(palace))[:16]` and matched. The holder was the *most recently started* session: the lease goes to whoever mutates first, not whoever arrived first.
2. The mechanism, cited to `mempalace/mcp_server.py` → `_acquire_mcp_writer_lock()` — the lease is `mine_palace_lock`, acquired lazily at the first mutating call, released only at `atexit`, with no backend conditional. It spans fourteen tools across two stores: drawer writes through the ChromaDB daemon, and `kg_*` writes direct to `~/.mempalace/knowledge_graph.sqlite3`, a file outside the daemon's `--path`.
3. The two-tier diagram, plus the `.drift-*` measurement table (May 2 / June 133 / July 130 / zero since 2026-07-21) showing ADR-0006 works, and the observation that the wrapper's name misleads — its "http" denotes the ChromaDB client, not the MCP transport.
4. The upstream remedy: `mempalace serve` (`cli.py` → `cmd_serve`), a `ThreadingHTTPServer` with `daemon_threads = True`, per-palace bearer token stored `0600` at `~/.mempalace/server/<sha256(palace)[:24]>/token` and passed by environment never `argv`, optional TLS, `--read-only`, unauthenticated `/healthz`. Token mandatory on non-loopback binds only. Quotes `mine_palace_lock`'s own docstring, which describes the re-entrant threaded-HTTP case explicitly — the lease is *designed* for this topology. Closes with spec 0091 / cli-matrix row 7h: all four CLIs already consume HTTP-transport MCP servers, grounded empirically.

**Decision.** A single supervised MemPalace MCP HTTP daemon owning the lease; all four surfaces registering over `--transport http`. Three sub-parts: the topology diagram; **the two tiers must compose** (launch through the wrapper, never bare `mempalace serve` — the central implementation constraint); ADR-0006's fail-loud contract carried over verbatim (unreachable daemon fails visibly, never falls back to stdio). Lifecycle mirrors the ChromaDB daemon (launchd `KeepAlive` / systemd `Restart=always`), with `MEMPALACE_MCP_IDLE_HOURS` set deliberately rather than inherited — its 8 h default targets stale per-session stdio servers, a hazard a supervised shared daemon does not have.

**Alternatives considered.** A status quo / spec 0103 fallback (retained as degraded-path net, not the answer); B `MEMPALACE_MCP_ALLOW_PEER_WRITER=1` (rejected as durable setting — disables the guard for the `kg_*` writes too, which sit outside the ChromaDB daemon's protection); C upstream backend-conditional lease (rejected — asks upstream to work around a supported topology we have not adopted); D one palace per sphere (orthogonal, own ADR — does not help two sessions on the same project, the case observed); E bare `mempalace serve` (rejected — breaks ADR-0006 and spec 0108).

**Consequences.** Positive: contention eliminated by construction; N processes collapse to one; single version-guard enforcement point; symmetric across four CLIs by construction; consistent with ADR-0006. Negative: a second SPOF (mitigated as ADR-0006 mitigated the first); a second loopback port plus token provisioning; **version-guard semantics shift** — sessions are served by the daemon's MemPalace version rather than their own interpreter's, so the derived spec must state how the daemon is cycled on upgrade and `doctor-mempalace.sh` must report the daemon rather than four registrations; startup ordering grows a step.

**Blast radius.** In scope for derived specs: supervisor units under `config/`, the four `setup-*-interactive.sh` registrations, `scripts/doctor-mempalace.sh`, `docs/cli-matrix.md` rows 7c/7d, Taskfile lifecycle entries. Out of scope: palace partitioning, the ChromaDB tier, any MemPalace source change.

**Derived spec plan.** Four specs, ordered: (1) daemon and supervisor — must land first; (2) four-CLI registration; (3) migration and diagnostics; (4) documentation.

**Open questions.** Five: ADR-0006 still `Proposed` while validated in production (a coherence prerequisite, since this ADR builds on it); whether the wrapper forwards `argv` to `mcp_server.main()` — expected to work since the handoff calls `main()` with no arguments so it reads `sys.argv`, but unverified and must be confirmed in DEV before spec 1 commits to a launch line; token on loopback binds; the fate of spec 0103; whether a per-session `MEMPALACE_MCP_READ_ONLY` client is worth it.

### Modified

`docs/index.json` — regenerated via `bash scripts/build-docs-index.sh`. Five added lines: the manifest entry for the new page (32 published pages total). No other entry changed.

### Not done, deliberately

No implementation, no script changes, no `docs/cli-matrix.md` edit. The matrix rows this decision affects (7c, 7d) change when the registration actually changes, in derived spec 2 — editing them now would describe a topology that is not yet deployed.

No closing keyword on issue #728: the issue tracks adoption of the topology, of which this ADR is the decision step only. It stays open until the derived specs land.
