### PR TITLE
📝 Mark spec 0112 approved

### DIFF
--- a/specs/0112-spec-id-reservation.md
+++ b/specs/0112-spec-id-reservation.md
@@ -1,7 +1,7 @@
 ---
 id: "0112"
 slug: spec-id-reservation
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 726


### PR DESCRIPTION
Restores `lint-specs` on `main`. Spec 0112's spec-PR (#727) merged without the accompanying `draft` → `approved` transition, so `main` has carried a non-delta spec with `status: draft` since 36c543d.

## How to read this PR?

One file, one field. `specs/0112-spec-id-reservation.md` frontmatter: `status: draft` → `status: approved`. Nothing else in the diff.

The rule being satisfied is `specs/0109-spec-status-invariant-on-main.md` R1/R2: a non-delta spec reaches the base branch only by its own merged spec-PR, which is exactly the trigger `docs/spec-format.md` → *Lifecycle states* assigns to `approved`. `draft` on the base branch is therefore a contradiction, not a lagging value.

This is a metadata-only edit under the lifecycle-metadata carve-out in `docs/spec-format.md` → *Recording a status transition*. The carve-out's conditional clause — set `interaction-mode` when it was omitted while `draft` — does not apply, because 0112 already carried `interaction-mode: INTERMEDIATE` explicitly.

## How to test this PR?

```sh
git fetch crewrig docs/0112-approved && git checkout docs/0112-approved
node scripts/lib/spec-linter.js
```

Expected: `Linting passed!`.

On `main` at 8be2a5c the same command fails with:

```
[FAIL] Non-delta specs present on the base branch (crewrig/main) carry 'status: draft':
  - specs/0112-spec-id-reservation.md
```

Confirm the breakage is repository-wide rather than local to this branch:

```sh
gh run list --workflow=build.yml --branch main --limit 2
```

Expected: `failure` on both 36c543d (the 0112 spec-PR merge) and 8be2a5c (the next merge, which inherited it).

## Detailed description (for agents)

**Modified:** `specs/0112-spec-id-reservation.md` — frontmatter `status`, `draft` → `approved`. No body line, no `id`, no `slug`, no `interaction-mode`, no `version`.

**Root cause.** The SPECS stage for issue #726 merged spec-PR #727 and moved directly to PLAN without performing the status transition the merge triggers. The omission is invisible on the spec-PR itself — that branch's linter run passes, because the invariant is evaluated against the *base* branch, where the spec does not yet exist. It only fails once the spec is on `main`, which is after the merge, and it then fails for everyone: `lint-specs` runs on `push` to `main` and on every pull request, and a pull request inherits the broken base through its merge-ref.

**Blast radius while unfixed.** Every open pull request targeting `main` fails `lint-specs` for a reason unrelated to its own content — the same misdirected-failure shape that issue #726 itself exists to eliminate for spec ids.

**Detection.** Surfaced while linting an unrelated delta-spec in a fresh worktree cut from `crewrig/main`; the failure named 0112 rather than the file being authored.

**Precedent followed:** #723 (`docs/0111-implemented`) — a status transition ships as its own single-file pull request rather than riding along with substantive content.