### PR TITLE
📝 Add spec 0112 delta-01 — org-corpus scope for spec-id reservation

### DIFF
--- a/specs/0112-spec-id-reservation.delta-01.md
+++ b/specs/0112-spec-id-reservation.delta-01.md
@@ -1,0 +1,119 @@
+---
+id: "0112"
+slug: spec-id-reservation
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 726
+version: 1.1.0
+---
+
+# 0112 — spec-id-reservation (delta-01)
+
+Spec 0112 qualified reservation for the upstream `/specs/` corpus and said
+nothing about `specs/org/`, the org-owned overlay in which an adopting
+organization authors its own specifications. That silence is the gap this delta
+closes, and it was surfaced by the user at the PLAN validation gate.
+
+The gap matters because org specs are subject to the identical race: two
+contributors in the same organization, authoring in parallel, will pick the same
+org id for exactly the reason spec 0112 documents for upstream ids. But the fix
+cannot be a copy of the upstream one. `specs/0071-org-specs-lint-exclusion.md`
+establishes that upstream tooling does **not** validate `specs/org/`, precisely
+so that an adopting organization may choose its own numbering convention; the
+`ORG-0001` form appears in that spec only as an illustrative example, never as a
+mandated pattern. Upstream therefore cannot know the shape of an org id, and any
+requirement that assumes one would reopen the layer boundary spec 0071 drew.
+
+The resolution separates two capabilities that spec 0112 conflated: *securing a
+given identifier*, which needs no knowledge of the identifier's form, and
+*computing the next free identifier*, which does. The first is made generic and
+serves both corpora; the second stays upstream-only.
+
+## ADDED
+
+1. **R14.** The reservation mechanism SHALL expose the securing of a
+   caller-supplied identifier, treating that identifier as an **opaque string**
+   and asserting nothing about its shape, length, or numeric content. The
+   atomicity guarantee of requirement 1 SHALL apply to it identically.
+
+2. **R15.** An identifier belonging to a specification under `specs/org/` SHALL
+   be securable through requirement 14, and org reservations SHALL occupy a
+   reservation namespace **disjoint** from the one holding upstream
+   reservations, so that no org identifier can collide with an upstream
+   identifier and no read of one corpus can return a reservation belonging to
+   the other.
+
+3. **R16.** Computation of the next free identifier SHALL remain confined to the
+   upstream corpus. The mechanism SHALL NOT attempt to derive, infer, or
+   validate the next org identifier, because the org numbering convention is
+   deliberately unknown to upstream per
+   `specs/0071-org-specs-lint-exclusion.md`. An organization selects its own org
+   identifier and secures it through requirement 14.
+
+4. **Scenario — an org identifier is secured.**
+   Given an organization whose specs under `specs/org/` use an identifier form
+   upstream has never seen, when a contributor secures one of those identifiers,
+   then the reservation succeeds, a concurrent attempt on the same identifier is
+   refused, and no upstream identifier is affected.
+
+5. **Scenario — two corpora, one numeric suffix.**
+   Given an upstream identifier and an org identifier whose numeric portions
+   coincide, when both are secured, then both succeed, and a read of the
+   upstream allocated set does not report the org reservation.
+
+6. **Out of scope — computing an org identifier.** Offering an organization the
+   next free identifier for its own corpus, in any form, including a
+   configurable numbering pattern supplied by the adopter. Rejected because it
+   would oblige upstream to know a convention spec 0071 deliberately excluded it
+   from knowing, and would add an adopter-supplied pattern as a new failure
+   surface.
+
+## MODIFIED
+
+1. **Requirement 3 is replaced** to name the corpus it governs, which was
+   unambiguous only while `specs/org/` was out of view.
+
+   - Original R3:
+
+     > **R3.** The set of unavailable ids SHALL be the union of the ids already
+     > present on the reference branch and the ids secured by sessions whose
+     > spec has not yet merged. Allocation SHALL read that union, never the
+     > merged ids alone.
+
+   - Replacement R3:
+
+     > **R3.** For the **upstream** corpus, the set of unavailable ids SHALL be
+     > the union of the upstream ids already present on the reference branch and
+     > the upstream ids secured by sessions whose spec has not yet merged.
+     > Allocation SHALL read that union, never the merged ids alone. Org
+     > reservations SHALL NOT appear in that union, per requirement 15.
+
+2. **Requirement 7 is replaced** so the continuous-integration check does not
+   extend upstream enforcement over org-owned content.
+
+   - Original R7:
+
+     > **R7.** A check SHALL run in continuous integration on every pull request
+     > that adds or renames a non-delta spec file, and SHALL fail when that
+     > spec's id was never secured, or was secured for a different ticket. The
+     > check SHALL read the authoritative record of secured ids rather than any
+     > local copy that may lag behind it.
+
+   - Replacement R7:
+
+     > **R7.** A check SHALL run in continuous integration on every pull request
+     > that adds or renames a non-delta spec file **outside `specs/org/`**, and
+     > SHALL fail when that spec's id was never secured, or was secured for a
+     > different ticket. The check SHALL read the authoritative record of
+     > secured ids rather than any local copy that may lag behind it. A
+     > specification under `specs/org/` SHALL NOT fail this check, consistent
+     > with the exclusion `specs/0071-org-specs-lint-exclusion.md` establishes
+     > for upstream validation of org-owned content.
+
+## REMOVED
+
+(None. This delta adds three requirements, two scenarios and one out-of-scope
+item, and replaces two requirements. Requirements 1, 2, 4 through 6, and 8
+through 13 of spec 0112 stand unchanged, as do all five of its original
+scenarios and the remainder of its out-of-scope list.)


### PR DESCRIPTION
Qualifies the scope spec 0112 left unstated: whether spec-id reservation governs the org-owned overlay `specs/org/` as well as the upstream corpus. One file, SPECS-stage artifact only, no implementation.

## How to read this PR?

One file, `specs/0112-spec-id-reservation.delta-01.md`, read top to bottom. It is a delta, so it carries `## ADDED` / `## MODIFIED` / `## REMOVED` rather than the five sections of an originating spec — spec 0112 is merged and immutable.

Two places carry the reasoning:

- **The preamble** explains why this is a `class: spec` finding rather than `class: arch`. Spec 0112 says "spec ids" throughout and never names a corpus. An unqualified scope routes to SPECS; a design defect would have routed to PLAN.
- **`## ADDED` R14–R16** carry the resolution. Spec 0112 conflated two capabilities: *securing a given identifier*, which needs no knowledge of the identifier's form, and *computing the next free identifier*, which does. The first becomes generic over an opaque string and serves both corpora; the second stays upstream-only.

The constraint driving all of it: **upstream cannot know the shape of an org id.** `specs/0071-org-specs-lint-exclusion.md` makes the linter ignore `specs/org/` so an adopting organization can pick its own numbering. The `ORG-0001` form appears there only inside illustrative scenarios; `specs/org/README.md` documents no convention, and `grep -rn 'ORG-[0-9]'` finds it in exactly two places, both of them spec 0071's scenarios and its test fixture. Any requirement presupposing a form would reopen that layer boundary.

## How to test this PR?

```sh
git fetch crewrig spec/0112-spec-id-reservation-delta-01
git checkout spec/0112-spec-id-reservation-delta-01
node scripts/lib/spec-linter.js
```

Expected: `Linting passed!` — frontmatter shape, delta filename convention, and the base-branch status invariant all clean.

Verify the premise the delta rests on, that no org id convention exists upstream:

```sh
grep -rn 'ORG-[0-9]' --include='*.md' --include='*.js' --include='*.sh' . | grep -v node_modules
grep -in 'ORG-' specs/org/README.md
```

Expected: matches only in `specs/0071-org-specs-lint-exclusion.md` and `scripts/tests/test-spec-linter.sh`, and no match at all in `specs/org/README.md`.

## Detailed description (for agents)

**Added:** `specs/0112-spec-id-reservation.delta-01.md` — id `0112`, slug `spec-id-reservation`, status `draft`, complexity `standard`, interaction-mode `INTERMEDIATE`, related-issue `726`, version `1.1.0` (MINOR: additive). Per `docs/spec-format.md` → *Versioning*, the cumulative version is read from the highest-numbered delta; spec 0112's own `version` stays `1.0.0` and is not edited.

**`## ADDED`** — three requirements, two scenarios, one out-of-scope item:

- **R14** — securing a caller-supplied identifier, treated as an opaque string, with requirement 1's atomicity guarantee applying identically.
- **R15** — org identifiers securable through R14, in a namespace disjoint from upstream reservations, so no org id can collide with an upstream id and no read of one corpus returns the other's reservations.
- **R16** — next-free-identifier computation confined to the upstream corpus; the mechanism does not derive, infer, or validate an org identifier.
- **Scenarios** — an org identifier of a form upstream has never seen is secured, and a concurrent attempt on it is refused; and two identifiers whose numeric portions coincide, one per corpus, are both secured without the upstream allocated set reporting the org one.
- **Out of scope** — offering an organization the next free identifier for its own corpus in any form, including a configurable numbering pattern supplied by the adopter. Rejected because it would oblige upstream to know a convention spec 0071 deliberately excluded it from knowing, and would add an adopter-supplied pattern as a new failure surface.

**`## MODIFIED`** — two requirements replaced, each quoted in full before and after:

- **R3** now names the upstream corpus explicitly. Its original wording was unambiguous only while `specs/org/` was out of view; it now states that org reservations do not appear in the upstream union.
- **R7** now excludes `specs/org/` from the blocking continuous-integration check. Its original wording covered every non-delta spec file without restriction, which would have extended upstream enforcement over org-owned content — a direct contradiction of spec 0071.

**`## REMOVED`** — none. Requirements 1, 2, 4–6 and 8–13 stand unchanged, as do all five original scenarios and the remainder of the out-of-scope list.

**Provenance.** Raised by the user at the PLAN validation gate for issue #726, where the plan was returned `changes-requested`. Scope decision taken by the user in INTERMEDIATE mode; SPECS content-approval ran through the `user-validate` skill on the `plannotator` backend and returned `approved`.

**Ordering.** This delta merges before the plan is revised. The plan (currently at v7, cold-review APPROVE) will be revised to carry R14–R16, re-submitted to independent review, and re-presented for user validation before DEV starts. Issue #726 stays open as the logbook anchor.