### PR TITLE
📝 Mark spec 0112 implemented

### DIFF
--- a/specs/0112-spec-id-reservation.md
+++ b/specs/0112-spec-id-reservation.md
@@ -1,7 +1,7 @@
 ---
 id: "0112"
 slug: spec-id-reservation
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 726


### PR DESCRIPTION
Records the lifecycle transition triggered by the merge of #734.

## How to read this PR?

One file, one field: `specs/0112-spec-id-reservation.md` frontmatter, `status: approved` → `status: implemented`. Nothing else in the diff.

`docs/spec-format.md` → *Lifecycle states* assigns `implemented` a single trigger — the implementation pull request for `related-issue` merging on `main` — which happened at `65c9b6f`. This is a metadata-only edit under the lifecycle-metadata carve-out: `status` changes and nothing else.

## How to test this PR?

```sh
git fetch crewrig docs/0112-implemented && git checkout docs/0112-implemented
node scripts/lib/spec-linter.js
```

Expected: `Linting passed!`.

## Detailed description (for agents)

**Modified:** `specs/0112-spec-id-reservation.md` — frontmatter `status`, `approved` → `implemented`. No body line, no `id`, no `slug`, no `interaction-mode`, no `version`.

The delta-spec `specs/0112-spec-id-reservation.delta-01.md` is deliberately left at `draft`. The spec-0109 base-branch invariant exempts delta-specs (R2), and 28 of the 39 delta-specs on `main` carry `draft` — the convention is unsettled and spec 0109 R2 leaves it to its own ticket. Changing it here would be a unilateral convention decision inside a status-transition PR.

Precedent: #723 (`docs/0111-implemented`), #717 (`docs/0110-implemented`) — a status transition ships as its own single-file pull request.