### PR TITLE
📝 Mark spec 0113 implemented

### DIFF
--- a/specs/0113-shared-mempalace-mcp-daemon.md
+++ b/specs/0113-shared-mempalace-mcp-daemon.md
@@ -1,7 +1,7 @@
 ---
 id: "0113"
 slug: shared-mempalace-mcp-daemon
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 739


### PR DESCRIPTION
Records that the shared MemPalace MCP HTTP daemon shipped. Metadata-only transition, one field, one file.

## How to read this PR?

`specs/0113-shared-mempalace-mcp-daemon.md` — `status: approved` → `implemented`. Nothing else changes; the spec's normative content is immutable once merged.

`delta-01` deliberately stays `approved`: it is the cumulative record for the parent, and the format does not transition a delta separately.

## How to test this PR?

```sh
task spec:lint     # expected: "Linting passed!"
```

The spec-0109 invariant is what makes this transition mandatory rather than bookkeeping: a spec's recorded status must tell the truth on `main`.

## Detailed description (for agents)

The implementation merged as f29db15 (#742) after three specialist reviews found sixteen blocking defects — two HIGH security findings (a whitespace-only token that defeated the fail-closed guard; the bearer token written into client configs at 0644 by downgrading a 0600 file), a rollback that destroyed Claude's registration outright, and a headline assertion that stayed green while a session kept its own memory server.

Remaining ADR 0016 work is tracked separately: derived spec 3 (recovery beyond repetition), derived spec 4 (the transcript hook's write path, gated on a latency measurement that only became possible now this has shipped), and derived spec 5 (runbook and README).

Refs #739