### PR TITLE
📝 Add spec 0115 — a forge artifact has a single writer at a time

### DIFF
--- a/specs/0115-forge-artifact-single-writer.md
+++ b/specs/0115-forge-artifact-single-writer.md
@@ -1,7 +1,7 @@
 ---
 id: "0115"
 slug: forge-artifact-single-writer
-status: draft
+status: approved
 complexity: standard
 interaction-mode: AUTO
 related-issue: 735

--- a/specs/0115-forge-artifact-single-writer.md
+++ b/specs/0115-forge-artifact-single-writer.md
@@ -1,0 +1,253 @@
+---
+id: "0115"
+slug: forge-artifact-single-writer
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 735
+version: 1.0.0
+---
+
+# A forge artifact has a single writer at a time
+
+## Intent
+
+Two agents working the same ticket no longer overwrite each other's edits to
+a pull-request body, an issue body, or a comment without either of them
+noticing. Each such artifact has one agent answerable for its text at any
+instant; that answerability is knowable to anyone about to write, and changes
+hands only when it is handed over deliberately. An agent that tells the user
+or a teammate what an artifact currently says is reporting something it has
+just seen, not something it saw before another writer arrived. And when an
+overwrite happens anyway, the writer that caused it learns that it did,
+instead of reading a success report indistinguishable from a clean write.
+
+## Requirements
+
+1. This spec SHALL declare `complexity: standard` rather than `small`,
+   because realizing it amends `docs/agent-team-protocol.md` — an
+   established protocol document that `AGENTS.md` → *Agent Team Protocol*
+   refers every team to. `docs/agent-team-protocol.md` → *Standard Team
+   Templates → Template 2* mandates inserting `architect` as a DEV-stage
+   step whenever "the documentation change modifies an established
+   protocol, convention, or contract", and the `small`-tier composition in
+   *Team sizing by complexity* excludes `architect`, which would suppress
+   that mandatory review — the same reasoning recorded in
+   [`specs/0095-orchestrator-deliverable-edit-fence.md`](0095-orchestrator-deliverable-edit-fence.md)
+   requirement 1.
+2. The protocol document SHALL define *forge artifact*, for the purposes of
+   this rule, as the mutable text body of a pull request, of an issue, or of
+   a comment on either. The definition SHALL state that publishing a **new**
+   comment produces a new artifact whose writer is its author, so the
+   incremental-logbook practice of `AGENTS.md` → *Logbook Issues → Rule B*
+   is unaffected — only editing an already-published body or comment is
+   governed here.
+3. Every forge artifact a team writes SHALL have exactly one writer at any
+   instant. That writership SHALL be established when the artifact is
+   created and SHALL rest initially with the agent that created it.
+4. An agent about to write a forge artifact SHALL be able to determine that
+   artifact's current writer from a record that survives the writer's own
+   session and that is readable without an exchange with the current writer.
+   An agent that cannot determine the current writer SHALL treat itself as
+   not being that writer.
+5. An agent that is not a forge artifact's current writer SHALL NOT write
+   that artifact. When such an agent judges the artifact needs a change, it
+   SHALL either route the change through the current writer or SHALL first
+   receive writership per requirement 6.
+6. Writership SHALL change hands only through an explicit handover, recorded
+   where requirement 4's determination reads. Writership SHALL NOT transfer
+   by assumption, by the time elapsed since the current writer's last write,
+   by an idle notification, by the current writer's apparent inactivity, or
+   by a peer having finished a related task.
+7. An agent that asserts to the user or to a peer what a forge artifact
+   currently contains SHALL base that assertion on an observation of that
+   artifact that no later write has superseded, and SHALL carry with the
+   assertion the artifact's last-modification marker as the forge reported
+   it at that observation. An observation taken before another agent's write
+   SHALL NOT support an assertion made after it.
+8. An agent that writes a forge artifact SHALL determine whether the
+   artifact changed between that agent's own last observation of it and its
+   write, and SHALL NOT treat the forge's report of a successful write as
+   evidence that nothing was discarded. When the artifact did change in that
+   interval, the writer SHALL report on the ticket's logbook that its write
+   may have discarded another agent's content; a ticket SHALL NOT be left
+   carrying an unreported overwrite.
+9. Requirements 3 through 8 SHALL hold identically on every forge the
+   project's `AGENTS.md` → *Forge Access* policy admits, and SHALL NOT
+   depend on a capability only one of those forges offers. Where a forge
+   reports no last-modification marker for an artifact, requirements 3
+   through 6 SHALL still hold in full — writership is this spec's primary
+   protection and detection is its backstop, never the reverse.
+10. The obligation SHALL be carried by the contracts of the roles that
+    actually write forge artifacts — at minimum the `pr-logbook` skill
+    contract and the orchestrator guidance in `docs/agent-team-protocol.md`
+    → *Team Communication* — in addition to the protocol document itself, so
+    that an agent that has loaded only its own role contract still observes
+    the rule.
+11. The rule SHALL state explicitly that it is the forge-side counterpart to
+    the file-side fence of `docs/agent-team-protocol.md` → *Team
+    Communication* → Rule 5, and that worktree isolation affords a forge
+    artifact no protection whatever, because a forge artifact lives outside
+    every worktree.
+12. This spec SHALL NOT require a lock, a lease, a mutex, a compare-and-swap
+    write, or any change to a forge's own write path. What is qualified here
+    is a documented behavioural obligation, followed rather than
+    mechanically enforced — the same posture as
+    [`specs/0095-orchestrator-deliverable-edit-fence.md`](0095-orchestrator-deliverable-edit-fence.md)
+    requirement 6.
+
+## Scenarios
+
+**Scenario:** the creating agent stays the writer and a peer routes through it
+
+```text
+Given an agent has created a pull request and is therefore that pull
+      request's body's writer
+And   a peer agent on the same ticket has loaded only its own role contract
+And   that peer judges the body needs an additional change
+When  the peer determines the body's current writer
+Then  it finds the creating agent named as the writer
+And   it does not write the body itself
+And   it asks the creating agent to make the change
+```
+
+**Scenario:** writership is handed over explicitly before the new writer writes
+
+```text
+Given an agent is the writer of a pull-request body
+And   that agent hands writership to a peer and records the handover where a
+      writer determination reads
+When  the peer subsequently writes the body
+Then  the peer is the artifact's current writer at the moment of the write
+And   the previous writer does not write the body again without a handover
+      back
+```
+
+**Scenario:** a non-writer's write is a protocol violation
+
+```text
+Given an agent has created a pull request and is its body's writer
+And   a peer has published its own revision of that same body without having
+      received writership
+When  the ticket's conduct is audited
+Then  the peer's write is a violation of the single-writer rule
+And   the audit does not require the lost content to be recoverable to
+      establish the violation
+```
+
+**Scenario:** an assertion is not made from a superseded observation
+
+```text
+Given an agent observed a pull-request body and the forge reported a
+      last-modification marker for that observation
+And   another agent has since written that body
+When  the first agent is about to tell the user what the body contains
+Then  it does not assert the content of its earlier observation
+And   it observes the body again and asserts what it then sees, carrying the
+      last-modification marker of that new observation
+```
+
+**Scenario:** a lost update is reported instead of passing as a clean write
+
+```text
+Given an agent observed a forge artifact and recorded the last-modification
+      marker the forge reported
+And   another agent wrote that artifact afterwards
+When  the first agent writes the artifact and the forge reports the write
+      succeeded
+Then  the first agent determines that the artifact changed between its
+      observation and its write
+And   it reports on the ticket's logbook that its write may have discarded
+      another agent's content
+And   it does not report the write as clean on the strength of the forge's
+      success report
+```
+
+**Scenario:** an idle notification does not transfer writership
+
+```text
+Given a peer agent is the writer of a forge artifact
+And   the orchestrator receives an idle notification for that peer and no
+      handover has been recorded
+When  the orchestrator considers writing that artifact
+Then  it does not treat the idle notification as a handover
+And   it does not write the artifact
+```
+
+**Scenario:** an additional logbook comment stays unrestricted
+
+```text
+Given an agent is the writer of a logbook issue's body
+And   a peer agent needs to record an obstacle on that same logbook issue
+When  the peer publishes a new comment on the issue
+Then  the peer is not writing an artifact whose writer is the first agent
+And   the peer is the writer of the comment it has just created
+And   the incremental-logbook practice is unaffected
+```
+
+**Scenario:** the same obligations hold on a forge other than GitHub
+
+```text
+Given a ticket whose repository is hosted on a forge other than GitHub that
+      the project's Forge Access policy admits
+And   two agents on that ticket can both write one merge-request description
+When  the single-writer rule is applied to that description
+Then  the writership, handover, and assertion-freshness obligations hold
+      exactly as they do on GitHub
+And   no obligation depends on a capability only one forge offers
+```
+
+## Out of scope
+
+- Concurrent **file** edits by two agents sharing one worktree. That is a
+  distinct defect with a distinct mechanism — a working tree rather than a
+  forge — and it is tracked separately in issue #736. This spec governs only
+  the mutable text of an artifact that lives on a forge; nothing here
+  changes what worktree isolation does or does not guarantee for files.
+- Any lock, lease, mutex, compare-and-swap write, or other mechanical
+  enforcement of the single-writer rule, and any change to how a forge
+  command-line tool performs a write. Requirement 12 forecloses this
+  deliberately: the rule is meant to be followed, as Rule 5 is.
+- Mutable forge state that is not an artifact's text body — labels,
+  assignees, milestones, review-state transitions, merge state, reactions.
+  These are additive or state-machine fields whose concurrent writes do not
+  silently destroy authored prose, and folding them in would widen the rule
+  past the defect that motivates it.
+- Commits, branches, tags, and continuous-integration runs. They are not
+  forge artifacts under requirement 2's definition and are already governed
+  by the branching and worktree rules.
+- Binding a human collaborator who edits the same artifact outside the agent
+  protocol. A human's own edits are not governed by an agent-team rule;
+  requirement 8's detection still surfaces such a write to the agent that
+  writes after it.
+- Adopting a forge-native compare-and-swap affordance should one become
+  available on a forge the project admits. Requirement 9 forbids depending
+  on a single forge's capability; taking advantage of one where it exists is
+  a later ticket, not this one.
+- Any change to the existing text of `docs/agent-team-protocol.md` → *Team
+  Communication* Rules 1 through 5, or to *Worktree Isolation*, beyond the
+  minimal cross-reference that requirement 11 calls for.
+- Retroactive repair of the occurrence that motivated this spec — the body
+  of pull request #734, already reconciled by hand. This spec qualifies the
+  go-forward protocol, not a one-time cleanup.
+
+## Open questions
+
+None. Two points that the anchor issue left implicit were settled while
+drafting, and are recorded here so a reader can audit the choice rather than
+rediscover it.
+
+The first is where requirement 4's writer determination reads. The assumption
+taken is the ticket's logbook — the record `AGENTS.md` → *Logbook Issues →
+Rule A* already obliges every agent on the ticket to read and write, which
+makes it the only durable, session-independent surface the protocol already
+guarantees. The requirement therefore constrains the property (determinable
+without an exchange with the current writer) and leaves the exact rendering
+of the record to the PLAN stage.
+
+The second is how fresh requirement 7's observation must be. The assumption
+taken is that freshness is established at the moment of the assertion rather
+than by a bounded staleness window, because no evidence supports any
+particular window: in the occurrence that motivated this spec the read-back
+expired within roughly half a minute, so any window short enough to be safe
+would be indistinguishable from re-observing.


### PR DESCRIPTION
Qualifies the WHAT for ticket #735: a forge artifact — the mutable text body of a pull request, an issue, or a comment on either — has exactly one writer at any instant, and a lost update on it is reported rather than passing as a clean write. Ticket: #735.

## How to read this PR?

One file, no other change: `specs/0115-forge-artifact-single-writer.md`.

Read it in this order:

1. `## Intent` — the four properties the spec commits to, in one breath.
2. `## Requirements` 3 through 8 — the behavioural core. R3–R6 are the writership half (one writer, knowable before a write, non-writers do not write, handover is explicit). R7–R8 are the detection half (an assertion rests on an observation no later write has superseded; a lost update is surfaced instead of hidden behind the forge's success report).
3. `## Requirements` 9 — the forge-independence clause, and the reason the two halves are not symmetric: writership is the primary protection, detection is the backstop, never the reverse.
4. `## Out of scope` — the first bullet is the boundary against issue #736.

Two non-obvious decisions worth pausing on:

- **R1 declares `complexity: standard` and says why.** Realizing this spec amends `docs/agent-team-protocol.md`, which fires the *Template 2* clause that inserts `architect` as a DEV-stage step; the `small` tier's composition excludes `architect` and would suppress that review. Same reasoning as `specs/0095` R1.
- **R2 carves out new comments.** Publishing a *new* comment creates a new artifact owned by its author, so `AGENTS.md` → *Logbook Issues → Rule B* (comment incrementally, as it happens) is untouched. Without that clause the rule would read as "one agent may comment on a logbook issue", which would break the incremental-logbook practice outright.

## How to test this PR?

```sh
node scripts/lib/spec-linter.js specs/0115-forge-artifact-single-writer.md
node scripts/lib/spec-linter.js specs/
```

Both exit `0` and print `Linting passed!` (markdownlint plus the semantic validation: frontmatter schema, the five mandatory level-2 headings in order, cross-file id uniqueness).

Conformance to `docs/spec-format.md` is checkable by reading:

- Frontmatter carries every required field; `id` is `"0115"`, secured on the reference repository through `scripts/reserve-spec-id.sh --issue 735` (exit `0`, `refs/spec-ids/0115`), so no `unsecured-id` mark is present.
- The filename slug and the frontmatter `slug` match, and both match the branch name.
- `## Scenarios` carries eight scenarios in Given/When/Then form — three happy-path, five failure-path.
- Every requirement except R1 (a frontmatter assertion, checkable by inspection) traces to at least one scenario.

## Detailed description (for agents)

**Added:** `specs/0115-forge-artifact-single-writer.md`. Nothing else — the one-file spec-PR rule of `docs/spec-pr-workflow.md`.

**What the spec commits to.** Twelve requirements over four groups.

- *Definition (R2).* Bounds the term `forge artifact` to the mutable text body of a pull request, an issue, or a comment on either, and excludes the creation of a new comment from the rule's reach.
- *Writership (R3–R6).* One writer per artifact at any instant, established at creation and resting initially with the creating agent (R3). Determinable before a write, from a record that survives the writer's own session and is readable without an exchange with that writer; undeterminable means "I am not the writer" (R4). A non-writer does not write, and routes its change through the writer or receives writership first (R5). Writership moves only through an explicit recorded handover — never by elapsed time, by an idle notification, by apparent inactivity, or by a peer having finished something related (R6).
- *Detection (R7–R8).* An assertion about an artifact's content rests on an observation no later write has superseded, and carries the last-modification marker the forge reported at that observation (R7). A writer determines whether the artifact changed between its own last observation and its write, does not read the forge's success report as evidence that nothing was discarded, and reports a possible overwrite on the ticket's logbook when it did change (R8).
- *Shape of the delivery (R1, R9–R12).* Forge independence, with an explicit asymmetry: where a forge reports no last-modification marker, R3–R6 still hold in full (R9). The obligation is carried by the role contracts that actually write forge artifacts — at minimum the `pr-logbook` skill contract and the orchestrator guidance in *Team Communication* — so an agent that has loaded only its own contract still observes it (R10). The rule names itself the forge-side counterpart to the file-side fence of *Team Communication* → Rule 5 and states that worktree isolation protects a forge artifact not at all, because a forge artifact lives outside every worktree (R11). No lock, lease, mutex, or compare-and-swap write is required, and no forge write path changes — a followed behavioural rule, the posture of `specs/0095` R6 (R12).

**Scope boundary against issue #736.** Issue #736 covers concurrent *file* edits by two agents sharing one worktree — a different mechanism (a working tree) on a different surface. The first `## Out of scope` bullet names it explicitly so the two specs cannot overlap, and states that nothing here changes what worktree isolation guarantees for files.

**Forge-agnostic phrasing.** Following the pattern established by `specs/0104` and `specs/0105`, the requirements are stated against "every forge the project's `AGENTS.md` → *Forge Access* policy admits" rather than against GitHub. R9 forbids depending on a capability only one forge offers, and one scenario exercises a non-GitHub forge directly. Adopting a forge-native compare-and-swap affordance, should one appear, is deferred to a later ticket in `## Out of scope`.

**Grounding performed before writing** (`spec-author` skill → *Pre-write grounding*): `docs/agent-team-protocol.md` → *Team Communication* Rule 5 and *Worktree Isolation* were read to confirm the file-side precedent this spec mirrors, and `artifacts/core/skills/pr-logbook/SKILL.md` was read to confirm the role named in R10 exists and is the one that composes PR bodies and logbook entries. Every surface the requirements target exists on `main`; no anomaly surfaced, so no `[GROUNDING:]` bullet is emitted (conforming-case silence).

**Open questions: none.** Authored in `AUTO` mode, so `## Open questions` records the two assumptions taken instead of leaving them for a `spec`-class REVIEW iteration: (a) R4's writer record is the ticket's logbook, since `AGENTS.md` → *Logbook Issues → Rule A* already makes it the one durable, session-independent surface every agent on the ticket reads and writes — the requirement constrains the property and leaves the rendering to PLAN; (b) R7's freshness is established at the moment of the assertion rather than by a bounded staleness window, because the occurrence that motivated the spec saw a read-back expire within roughly half a minute, so any safe window would be indistinguishable from re-observing.

**Lifecycle position.** SPECS stage for #735, `interaction-mode: AUTO`. This spec-PR merges before any implementation branch for #735 opens, per `docs/spec-pr-workflow.md` → *Ordering rule*. The implementation surface it points at is documentation plus role contracts: `docs/agent-team-protocol.md` and at least the `pr-logbook` skill source — which is what makes the tier `standard` (`artifacts/**` is touched, so the DEV PR must also consult `docs/cli-matrix.md` and bump `metadata.provenance.version`).
