### PR TITLE
🐛 Charge a base-branch draft spec to the change that can fix it

### DIFF
--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -211,15 +211,32 @@ to use `status` for the one question it exists to answer — "merged and in
 force" or "proposed but never landed".
 
 The rule is enforced mechanically rather than by recall. The spec linter
-(`scripts/lib/spec-linter.js`, run as `task spec:lint` in CI) fails and names
-every non-delta spec that is **already present on the change's base branch**
-while carrying `status: draft`. Presence on the base branch is the
-discriminator, so a spec the change under test *introduces* is not flagged: it
-is legitimately `draft` until the *Merge mechanic* below flips it. Delta-specs
-are exempt too — what `status` a delta should carry is deliberately unsettled,
-per
+(`scripts/lib/spec-linter.js`, run as `task spec:lint` in CI) names every
+non-delta spec that is **already present on the change's base branch** while
+carrying `status: draft`. Presence on the base branch is the discriminator for
+being named, so a spec the change under test *introduces* is not named at all:
+it is legitimately `draft` until the *Merge mechanic* below flips it.
+Delta-specs are exempt too — what `status` a delta should carry is deliberately
+unsettled, per
 [`specs/0109-spec-status-invariant-on-main.md`](../specs/0109-spec-status-invariant-on-main.md)
 → *Out of scope*.
+
+**Which build the violation fails, and which it only warns.** Being named and
+being failed are two different things, decided by two different questions. A
+change that **modifies** a named spec is failed by it (`[FAIL]`), because it can
+record the correct status in the same edit. A change that does not — a pull
+request touching no spec at all, say — gets the same spec named as a
+**non-blocking** warning (`[WARN]`) and passes: a check a change has no power to
+satisfy must not block it. The build that does fail in that case is the base
+branch's own, where `HEAD` is the base and there is therefore no change to
+charge the violation to. So **a `[WARN]` met on a pull request is a statement
+about `main`, not about that pull request**: it is cleared by correcting the
+named spec's status on the base branch, and nothing in the change under test
+will make it go away. When the linter cannot determine which files the change
+modifies, it reports every named spec as blocking and says so — an
+indeterminate answer never becomes an exemption.
+[`specs/0109-spec-status-invariant-on-main.delta-02.md`](../specs/0109-spec-status-invariant-on-main.delta-02.md)
+is the contract.
 
 ### Recording a status transition
 

--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -163,6 +163,47 @@ function baseBranchPaths(baseRef, relPaths) {
     return new Set(result.stdout.split('\0').filter(Boolean));
 }
 
+// changedPaths(baseRef) — the repo-relative paths the change under test
+// modifies, as a Set, or `null` when that set cannot be derived. This is the
+// discriminator spec 0109 delta-02 adds on top of presence-on-base: a
+// base-branch violation fails the change that CAN cure it (R2 as replaced) and
+// is reported non-blocking to every change that cannot (R9).
+//
+// Derived from the repository at check time, never configured (R11, mirroring
+// what R3 already obliges for the set of files examined). Deliberately NOT a
+// second environment variable alongside BASE_REF: the value is measurable here,
+// and a second variable would have to be provisioned identically in two CI
+// engines that already drift on exactly this pair of jobs (issue #709).
+//
+// `git merge-base` then `git diff` against it, rather than a two-dot diff
+// against the base tip: against a base that has advanced, the two-dot form
+// reports base-only changes as this change's, which is MIS-attribution rather
+// than degraded attribution. There is no fallback to it for that reason — a
+// `null` here is an honest "unknown", which R11 answers by blocking.
+//
+// The diff compares the merge base to the WORK TREE (no second revision
+// argument), so committed, staged and unstaged edits all count. That matches
+// what the linter reads: it lints the work tree, so attribution must measure the
+// work tree too, or a status corrected but not yet committed would be attributed
+// to nobody.
+//
+// Empty is meaningful and distinct from `null`: an empty set means the tree
+// under test introduces nothing relative to the base — which is the state this
+// runs in on the base branch's own build, where `HEAD` IS the derived base — and
+// R10 answers it by blocking on every offender.
+function changedPaths(baseRef) {
+    const mergeBase = gitCapture(['merge-base', baseRef, 'HEAD']);
+    const mergeBaseSha = mergeBase.stdout.trim();
+    if (mergeBase.status !== 0 || mergeBaseSha === '') {
+        return null;
+    }
+    const diff = gitCapture(['diff', '--name-only', '-z', mergeBaseSha]);
+    if (diff.status !== 0) {
+        return null;
+    }
+    return new Set(diff.stdout.split('\0').filter(Boolean));
+}
+
 // resolveBaseContext(files) — decide whether the base-branch status check runs,
 // and if so against which paths. Three outcomes, deliberately distinct:
 //
@@ -244,7 +285,7 @@ function resolveBaseContext(files) {
         process.exit(2);
     }
 
-    return { enforced: true, ref, basePaths, relPathByFile };
+    return { enforced: true, ref, basePaths, relPathByFile, changed: changedPaths(ref) };
 }
 
 function lintFile(filePath) {
@@ -479,7 +520,8 @@ function run() {
         }
     }
 
-    // Base-branch `status: draft` check (spec 0109 R1/R2). A non-delta spec
+    // Base-branch `status: draft` check (spec 0109 R1/R2, R2 as replaced by
+    // delta-02, plus delta-02 R9/R10/R11). A non-delta spec
     // already present on the base branch has by definition had its own spec-PR
     // merged, which is the trigger docs/spec-format.md assigns to `approved` —
     // so `draft` on it is a contradiction, not a lagging value. Delta-specs are
@@ -492,14 +534,49 @@ function run() {
             !isDelta && status === 'draft' && baseContext.basePaths.has(baseContext.relPathByFile.get(file))
         );
         if (offenders.length > 0) {
-            console.error(`\n[FAIL] Non-delta specs present on the base branch (${baseContext.ref}) carry 'status: draft':`);
-            for (const { file } of offenders) {
-                console.error(`  - ${file}`);
+            // Whose violation is it? (delta-02 R2/R9/R10/R11.) Identification
+            // above is unchanged; only the consequence is attributed. `null`
+            // means attribution is unavailable (R11) and an empty set means
+            // there is no change to attribute to (R10) — both make every
+            // offender blocking, so only a NON-EMPTY set can exempt one. That
+            // asymmetry is the whole safety property: no state of the
+            // repository turns the check green while the invariant is violated.
+            const changed = baseContext.changed;
+            const blockEveryOffender = changed === null || changed.size === 0;
+            const blocking = blockEveryOffender
+                ? offenders
+                : offenders.filter(({ file }) => changed.has(baseContext.relPathByFile.get(file)));
+            const bystanders = blockEveryOffender
+                ? []
+                : offenders.filter(({ file }) => !changed.has(baseContext.relPathByFile.get(file)));
+
+            if (changed === null) {
+                console.error(`\n[ERROR] Base-branch status check (spec 0109 R11): the set of files this`);
+                console.error(`        change modifies could not be derived from the repository, so every`);
+                console.error(`        spec below is reported as this change's to fix rather than exempt.`);
             }
-            console.error(`  A spec reaches the base branch only by its own merged spec-PR, which is`);
-            console.error(`  the trigger docs/spec-format.md assigns to 'approved'. Record the status`);
-            console.error(`  that reflects the spec's true state (metadata-only edit).`);
-            totalErrors++;
+
+            if (blocking.length > 0) {
+                console.error(`\n[FAIL] Non-delta specs present on the base branch (${baseContext.ref}) carry 'status: draft':`);
+                for (const { file } of blocking) {
+                    console.error(`  - ${file}`);
+                }
+                console.error(`  A spec reaches the base branch only by its own merged spec-PR, which is`);
+                console.error(`  the trigger docs/spec-format.md assigns to 'approved'. Record the status`);
+                console.error(`  that reflects the spec's true state (metadata-only edit).`);
+                totalErrors++;
+            }
+
+            if (bystanders.length > 0) {
+                console.error(`\n[WARN] Non-delta specs present on the base branch (${baseContext.ref}) carry 'status: draft':`);
+                for (const { file } of bystanders) {
+                    console.error(`  - ${file}`);
+                }
+                console.error(`  This change modifies none of them, so the violation lives on the base`);
+                console.error(`  branch rather than in this change and is not this change's to fix — it`);
+                console.error(`  does NOT fail this run. Correcting it is an edit to the named spec on the`);
+                console.error(`  base branch, whose own build fails on it (spec 0109 R1/R9/R10).`);
+            }
         }
     }
 

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -680,10 +680,12 @@ run_base_case "Case 34 — an uncanonicalizable linted path is named, not a stac
 # same way — `git symbolic-ref` rather than `git init -b`, so the fixture does
 # not depend on the host's init.defaultBranch.
 #
-# Case ORDER is load-bearing here: the three cases share one fixture and each
-# advances its work-tree state, from clean (35) to an unrelated edit (36) to an
-# edit of the offender itself (37). Reordering them silently changes what each
-# measures.
+# The three cases share this one fixture but do NOT depend on each other's
+# order: each one RESETS the work tree (`git checkout -- .`) and then applies
+# only the state it needs. An accumulating variant would pass just as green while
+# measuring something other than what the case names claim the moment anyone
+# inserts or reorders a case — an order-dependent test that silently changes
+# meaning is the same class of defect as the check being fixed here.
 # -------------------------------------------------------------------------
 GITFIX2="$TMP_ROOT/gitfix2"
 mkdir -p "$GITFIX2/specs" "$GITFIX2/docs"
@@ -711,6 +713,7 @@ printf '# Unrelated\n\nBody.\n' > "$GITFIX2/docs/unrelated.md"
 # empty-set branch and the base branch's build goes green while `main` violates
 # the invariant.
 # -------------------------------------------------------------------------
+git -C "$GITFIX2" checkout -q -- .
 run_base_case "Case 35 — no change relative to the base ref blocks on every offender (R10)" \
   "$GITFIX2" "specs" 1 "main" \
   "specs/0210-attributed.md" "[WARN]"
@@ -723,6 +726,7 @@ run_base_case "Case 35 — no change relative to the base ref blocks on every of
 # is present AND no `[FAIL]` block is — because exit 0 alone could not
 # distinguish "warned correctly" from "stopped checking".
 # -------------------------------------------------------------------------
+git -C "$GITFIX2" checkout -q -- .
 printf '# Unrelated\n\nBody, edited by the change under test.\n' > "$GITFIX2/docs/unrelated.md"
 run_base_case "Case 36 — an offender the change does not touch warns, and does not fail (R9)" \
   "$GITFIX2" "specs" 0 "main" \
@@ -735,6 +739,7 @@ run_base_case "Case 36 — an offender the change does not touch warns, and does
 # pins the replaced R2's discriminator: same offender, same base branch, and the
 # outcome turns only on whether the change touches the file.
 # -------------------------------------------------------------------------
+git -C "$GITFIX2" checkout -q -- .
 printf '\nEdited by the change under test.\n' >> "$GITFIX2/specs/0210-attributed.md"
 run_base_case "Case 37 — an offender the change does touch fails (R2 as replaced)" \
   "$GITFIX2" "specs" 1 "main" \

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -670,6 +670,117 @@ run_base_case "Case 34 — an uncanonicalizable linted path is named, not a stac
   "Cannot resolve linted path: specs/0205-dangling.md" "at resolveBaseContext"
 
 # -------------------------------------------------------------------------
+# Cases 35-37 (delta-02 R13, covering R10, R9 and the R2 replacement) —
+# ATTRIBUTION. Identification is settled by the cases above; these pin who the
+# identified violation is charged to.
+#
+# A second git fixture, not $GITFIX: that one's work tree was mutated by cases
+# 30-31 (0200 corrected to `implemented`, 0202 added), and these cases need a
+# base-branch offender still carrying `draft` in the tree under test. Built the
+# same way — `git symbolic-ref` rather than `git init -b`, so the fixture does
+# not depend on the host's init.defaultBranch.
+#
+# Case ORDER is load-bearing here: the three cases share one fixture and each
+# advances its work-tree state, from clean (35) to an unrelated edit (36) to an
+# edit of the offender itself (37). Reordering them silently changes what each
+# measures.
+# -------------------------------------------------------------------------
+GITFIX2="$TMP_ROOT/gitfix2"
+mkdir -p "$GITFIX2/specs" "$GITFIX2/docs"
+cp "$ROOT_DIR/.markdownlintrc" "$GITFIX2/"
+ln -s "$ROOT_DIR/node_modules" "$GITFIX2/node_modules"
+render_spec "0210" "attributed" "draft" > "$GITFIX2/specs/0210-attributed.md"
+printf '# Unrelated\n\nBody.\n' > "$GITFIX2/docs/unrelated.md"
+(
+  cd "$GITFIX2" || exit 1
+  git init -q
+  git symbolic-ref HEAD refs/heads/main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+  git add specs docs
+  git commit -q -m "base branch content"
+)
+
+# -------------------------------------------------------------------------
+# Case 35 (delta-02 R10) — the tree under test modifies nothing relative to the
+# base ref, which is exactly the state the check runs in on the base branch's
+# own build (`HEAD` IS the derived base there). With no change to attribute the
+# violation to, every offender blocks. This is the case that keeps R1
+# mechanically enforced after R9 narrows the pull-request case: remove the
+# empty-set branch and the base branch's build goes green while `main` violates
+# the invariant.
+# -------------------------------------------------------------------------
+run_base_case "Case 35 — no change relative to the base ref blocks on every offender (R10)" \
+  "$GITFIX2" "specs" 1 "main" \
+  "specs/0210-attributed.md" "[WARN]"
+
+# -------------------------------------------------------------------------
+# Case 36 (delta-02 R9) — the change under test modifies an unrelated file, so
+# the offender is named as a NON-BLOCKING finding and the run passes. This is
+# the case the ticket exists for: the pull request that touches no spec is no
+# longer failed by a violation it cannot cure. Asserts both halves — the warning
+# is present AND no `[FAIL]` block is — because exit 0 alone could not
+# distinguish "warned correctly" from "stopped checking".
+# -------------------------------------------------------------------------
+printf '# Unrelated\n\nBody, edited by the change under test.\n' > "$GITFIX2/docs/unrelated.md"
+run_base_case "Case 36 — an offender the change does not touch warns, and does not fail (R9)" \
+  "$GITFIX2" "specs" 0 "main" \
+  "[WARN]" "[FAIL]"
+
+# -------------------------------------------------------------------------
+# Case 37 (delta-02 R2 as replaced) — the change under test modifies the
+# offending spec itself and leaves it `draft`. It can record the correct status
+# in the same edit, so it is the change that pays. Together with Case 36 this
+# pins the replaced R2's discriminator: same offender, same base branch, and the
+# outcome turns only on whether the change touches the file.
+# -------------------------------------------------------------------------
+printf '\nEdited by the change under test.\n' >> "$GITFIX2/specs/0210-attributed.md"
+run_base_case "Case 37 — an offender the change does touch fails (R2 as replaced)" \
+  "$GITFIX2" "specs" 1 "main" \
+  "specs/0210-attributed.md" "[WARN]"
+
+# -------------------------------------------------------------------------
+# Case 38 (delta-02 R11) — attribution that cannot be derived is not an
+# exemption. The base ref resolves (so this is NOT the Case 32 wiring fault, and
+# the exit is the linter's own 1 rather than 2), but it shares no history with
+# `HEAD`, so `git merge-base` fails and the modified-file set is unavailable.
+# Every offender blocks, and the cause is named on stderr rather than left as an
+# unexplained failure.
+#
+# An orphan branch is the cheapest reproduction of "resolves but has no common
+# ancestor"; `git checkout --orphan` keeps the index, so the same specs are
+# committed onto it and the offender is present on the base ref as required.
+# -------------------------------------------------------------------------
+GITFIX3="$TMP_ROOT/gitfix3"
+mkdir -p "$GITFIX3/specs"
+cp "$ROOT_DIR/.markdownlintrc" "$GITFIX3/"
+ln -s "$ROOT_DIR/node_modules" "$GITFIX3/node_modules"
+render_spec "0220" "unrelated-history" "draft" > "$GITFIX3/specs/0220-unrelated-history.md"
+(
+  cd "$GITFIX3" || exit 1
+  git init -q
+  git symbolic-ref HEAD refs/heads/main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+  git add specs
+  git commit -q -m "main content"
+  git checkout -q --orphan unrelated-base
+  # `git add specs`, never `git add -A`: the harness's own scaffolding sits in
+  # this directory untracked (.markdownlintrc, the node_modules symlink), and
+  # tracking it on the orphan branch makes the `checkout main` below DELETE it —
+  # markdownlint then dies on a missing config, which reads as a lint failure
+  # rather than as the fixture eating its own tooling.
+  git add specs
+  git commit -q -m "orphan base sharing no history with main"
+  git checkout -q main
+)
+run_base_case "Case 38 — attribution that cannot be derived blocks, and says so (R11)" \
+  "$GITFIX3" "specs" 1 "unrelated-base" \
+  "could not be derived" "[WARN]"
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
A non-delta spec carrying `status: draft` on the base branch failed **every** open pull request in the repository, including ones that touched no spec and had no way to go green. This charges the failure to the change that can actually record the correct status, and keeps it unconditional on the base branch's own build, where the invariant belongs.

Implements `specs/0109-spec-status-invariant-on-main.delta-02.md` (R2 as replaced, R9–R13). Closes #732.

## How to read this PR?

Three files. Read them in this order — the second is where the behaviour is, the first is why it is shaped that way.

1. **`specs/0109-spec-status-invariant-on-main.delta-02.md`** — already on `main` (PR #758), not in this diff, but read its preamble first if you have not. Two of the three fixes the originating friction report proposed were **already in force** and are deliberately not rebuilt here: the atomic `draft` → `approved` transition (PR #664, two weeks before the incident) and the detection itself, which failed the `main` build four minutes after the offending merge. What was missing is *attribution*.
2. **`scripts/lib/spec-linter.js`** — one new helper (`changedPaths`) and one rewritten block. Identification of an offender is untouched; only the consequence is partitioned. The comment above `changedPaths` carries the two decisions worth arguing with: no second environment variable, and no two-dot-diff fallback.
3. **`scripts/tests/test-spec-linter.sh`** — cases 35–38, on two new git fixtures. Cases 35–37 share `$GITFIX2` and **their order is load-bearing**: each advances that fixture's work-tree state, from clean, to an unrelated edit, to an edit of the offender itself. Reordering them silently changes what each measures, which is why the comment says so.

Three non-obvious points:

- **The asymmetry is the safety property.** `changed === null` (attribution unavailable) and `changed.size === 0` (nothing to attribute to) both make **every** offender blocking. Only a non-empty set can exempt one. So no state of the repository — shallow clone, unrelated histories, detached checkout — turns the check green while the invariant is violated.
- **`size === 0` is how the base branch keeps failing.** On a `push` to `main`, `HEAD` *is* the derived base, so the merge base is `HEAD` and the diff against a clean tree is empty. Requirement 10 is not a special case bolted on for CI; it falls out of the same measurement.
- **The diff has no second revision argument on purpose.** It compares the merge base to the *work tree*, so committed, staged and unstaged edits all count — matching what the linter reads. A status corrected but not yet committed would otherwise be attributed to nobody.

## How to test this PR?

```sh
# The suite needs node_modules resolvable from the worktree root it computes.
# A fresh worktree has none, and 25 of 39 cases then fail on
# `npx markdownlint: could not determine executable to run`.
ln -s /path/to/main/checkout/node_modules node_modules   # or: npm install

bash scripts/tests/test-spec-linter.sh        # expect: 39 passed, 0 failed
BASE_REF=crewrig/main node scripts/lib/spec-linter.js    # whole corpus
npx markdownlint docs/spec-format.md -c .markdownlintrc
```

**The live negative control, which is the test that matters.** At the time of writing, `specs/0114-shared-worktree-agent-isolation.md` is on `main` carrying `status: draft` (landed by `a0291d2`, PR #759) — a second, independent occurrence of this ticket's incident, 24 hours after the first. So the fix can be exercised against production data rather than a fixture:

```sh
# This branch's linter — same corpus, same base:
BASE_REF=crewrig/main node scripts/lib/spec-linter.js
#   [WARN] … specs/0114-shared-worktree-agent-isolation.md … does NOT fail this run
#   Linting passed!

# main's linter — same corpus, same base:
git show crewrig/main:scripts/lib/spec-linter.js > scripts/lib/.control.js
BASE_REF=crewrig/main node scripts/lib/.control.js specs
#   [FAIL] … specs/0114-shared-worktree-agent-isolation.md
#   Linting failed: 1 files contain errors.
rm scripts/lib/.control.js
```

Run the control from **inside** the worktree, not `/tmp` — `js-yaml` resolves relative to the script's own path, and a copy in `/tmp` dies on `MODULE_NOT_FOUND` before it reaches the check.

**Falsification.** Each new case was verified to fail when the behaviour it covers is removed, rather than asserted to:

| Mutation | Requirement removed | Case that goes red |
|---|---|---|
| `blockEveryOffender = true` | R9 — the bystander partition | 36 |
| `blockEveryOffender = changed === null` | R10 — an empty set stops blocking | 35 (and 28, 29 with it) |
| `changed \|\| new Set(['__none__'])`, `[ERROR]` suppressed | R11 — unavailable attribution exempts | 38 |

**Known limit, stated rather than glossed:** Case 37 does *not* fail if the implementation reverts to unconditional blocking — under that behaviour it still passes. It falsifies "never fail"; Case 36 falsifies "always fail". Neither alone pins the replaced R2's discriminator; the pair does.

## Detailed description (for agents)

### `scripts/lib/spec-linter.js`

**Added `changedPaths(baseRef)`**, beside the existing `baseBranchPaths()`. Runs `git merge-base <baseRef> HEAD`, then `git diff --name-only -z <merge-base>` with no second revision, and returns a `Set` of repo-relative paths — or `null` if either command fails or the merge base comes back empty.

Two rejected alternatives are recorded at the call site because both are reasonable and both are wrong here:

- *A second environment variable* (`SPEC_STATUS_SCOPE=strict|attributed`) wired per CI event. Rejected: it would have to be provisioned identically in two engines that already drift on exactly this pair of jobs (#709), and it would restate a fact the linter can measure.
- *A two-dot `git diff <baseRef>` fallback when `merge-base` fails.* Rejected: against a base that has advanced it reports base-only changes as the change under test's — mis-attribution, which is worse than an honest `null` that R11 handles by blocking.

**`resolveBaseContext()`** now returns `changed: changedPaths(ref)` alongside `basePaths` and `relPathByFile`, so the offender block reads one context object instead of re-probing git. It is called only on the enforced path, so the not-in-a-git-work-tree skip (Case 33) never touches git.

**The offender block** keeps its identification filter verbatim and partitions the result: `blocking` when `changed` contains the path, `bystanders` otherwise, with `blockEveryOffender = changed === null || changed.size === 0` collapsing both degenerate states onto "everything blocks". `[FAIL]` keeps its exact previous wording and still increments `totalErrors`; `[WARN]` is new, names the files and the base ref, states the violation is on the base branch and not this change's to fix, points at where it *is* fixed, and does not touch `totalErrors`. On the `null` path an `[ERROR]` line naming R11 precedes the `[FAIL]` block so the failure is explained rather than mysterious.

### `scripts/tests/test-spec-linter.sh`

**`$GITFIX2`** — one non-delta spec at `draft` plus one unrelated tracked file, committed on `main`, no remote (these cases pass `BASE_REF` explicitly). Cases 35 → 37 walk its work tree: clean (R10, exit 1), unrelated edit (R9, exit 0 with `[WARN]` and asserting no `[FAIL]`), edit of the offender (replaced R2, exit 1). Cases 36 and 37 both assert on *presence and absence* of a marker, because an exit code alone cannot distinguish "warned correctly" from "stopped checking".

**`$GITFIX3`** — an orphan branch as the base ref, the cheapest reproduction of "resolves but shares no ancestor", so `git merge-base` genuinely fails (R11, exit 1, stderr naming the cause). The orphan commit stages `specs` explicitly and **not** `git add -A`: adding everything tracks the harness's own untracked scaffolding, and the `checkout main` that follows then *deletes* `.markdownlintrc`, so markdownlint dies on a missing config and the case fails for a reason that has nothing to do with the check. The comment in the file says this, because the symptom is thoroughly misleading.

### `docs/spec-format.md`

Requirement 12. In *Lifecycle states → No spec on `main` is a draft*, the enforcement paragraph is reworded from "fails and names" to "names" (naming and failing are now separate decisions), and a new paragraph states which build fails, which only warns, and — the point of the requirement — that **a `[WARN]` met on a pull request is a statement about `main`, not about that pull request**, cleared by editing the named spec on the base branch and by nothing in the change under test.

### Not triggered, checked rather than assumed

- **CLI matrix:** none of the three paths is a trigger surface under `AGENTS.md` → *CLI Matrix Maintenance*. No `docs/cli-matrix.md` edit is due.
- **CI wiring:** unchanged in both engines. Attribution reads the `BASE_REF` the check already reads; no new variable, no new parity surface.
- **Version bump:** `metadata.provenance.version` lives on skill and agent sources; none is touched. The spec-side bump (`2.0.0`) shipped in #758.
- **Build outputs / core-paths manifest:** nothing under `artifacts/`, no core-layer path added, removed or reclassified.
