### PR TITLE
🐛 Record spec 0114's approved status on main

### DIFF
--- a/specs/0114-shared-worktree-agent-isolation.md
+++ b/specs/0114-shared-worktree-agent-isolation.md
@@ -1,7 +1,7 @@
 ---
 id: "0114"
 slug: shared-worktree-agent-isolation
-status: draft
+status: approved
 complexity: standard
 interaction-mode: AUTO
 related-issue: 736


### PR DESCRIPTION
Spec 0114 merged to `main` still carrying `status: draft`, breaking the invariant of `specs/0109-spec-status-invariant-on-main.md` and failing `lint-specs` on every open pull request in the repository. This PR flips that one frontmatter field to `approved`, recording an approval that was in fact granted before PR #759 merged.

Closes #763

## How to read this PR?

One file, one line. `specs/0114-shared-worktree-agent-isolation.md` frontmatter: `status: draft` → `status: approved`. Nothing else in the file is touched — no body line, no `id`, no `slug`, no `version`, and `interaction-mode: AUTO` was already present and stays.

The non-obvious part is not the diff, it is the provenance of the approval it records. `docs/spec-format.md` → *Recording the initial `draft` → `approved` transition* states that in `AUTO` mode there is no SPECS-stage content-approval gate, so the merge-authorization request **is** the approval event. The user granted that authorization for PR #759 before it merged. Per *Recording a status transition* → *Merge mechanic*, the flip should have shipped as a new commit on #759's own branch, pushed after the authorization and before `gh pr merge --squash`; that commit was simply never written. This PR writes it late, on `main`, rather than manufacturing a new decision.

## How to test this PR?

Prerequisite: a checkout of this branch.

```sh
git diff --stat main...HEAD
# expected: specs/0114-shared-worktree-agent-isolation.md | 2 +-
#           1 file changed, 1 insertion(+), 1 deletion(-)

task spec:lint
# expected: "Linting passed!"
```

Then confirm the repository-wide unblocking: the `lint-specs` check on any open pull request that was red before this lands should go green once it is merged and the branch is refreshed.

## Detailed description (for agents)

**Change.** Exactly one modified line in `specs/0114-shared-worktree-agent-isolation.md`:

```diff
-status: draft
+status: approved
```

**Why the fix lives here and not upstream.** The spec's authoring was correct. `docs/spec-format.md` names recording `approved` ahead of the approval event as its own violation, so the `spec-author` writing `draft` at authoring time — when no authorization had yet been granted — was right. The omission belongs to the merge step, which is the orchestrator's: the *Merge mechanic* commit between "authorization secured" and "`gh pr merge --squash`" was skipped. The remedy is to write that commit against `main` now.

**Why CI did not catch it before.** PR #759 was green on all twelve checks at merge time, `lint-specs` included. The invariant is evaluated against the tree, and a spec-PR whose spec is still `draft` on its own branch violates nothing until it lands. The failure is *created* by the merge, so it is first observable on `main` — which is where it appeared, four minutes later.

**Relationship to the blast-radius work.** `specs/0109-spec-status-invariant-on-main.delta-02.md` (merged at `863079f`) narrows the base-branch draft check so that a future occurrence fails the change able to fix it rather than every open pull request. That delta reduces the blast radius next time; it does not repair this instance. Both are needed.

**Scope discipline.** No body content, no other spec, no script, no doc. Deliberately no `version` bump: `docs/version-bump-convention.md` governs skill and agent sources under `artifacts/`, not spec frontmatter, and a status transition is not a revision of the spec's normative content.

**Verification performed.** `git diff` confirmed as one file, one insertion, one deletion. `task spec:lint` run locally on the branch: markdownlint-cli over 156 files plus semantic validation, `Linting passed!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
