### PR TITLE
✨ Give every forge artifact a single writer at a time

### DIFF
--- a/.agents/skills/pr-logbook/SKILL.md
+++ b/.agents/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -175,6 +175,41 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `artifacts/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Cross-cutting: single writer per forge artifact
+
+Not a step in the composition lifecycle — a rule that applies to every
+forge artifact you write. The full rule is `docs/agent-team-protocol.md`
+→ *Team Communication* → Rule 6; below is the part you must observe even
+when this skill is the only contract you have loaded.
+
+- **Your role owns what your role creates.** Opening a pull request makes
+  `pr-logbook` the writer of its body for that ticket — the role, not
+  your instance, so the writership survives your session. Name it once,
+  on a `**Writer:**` line inside the logbook entry you already write for
+  that artifact; see Rule 6 for the exact form.
+- **You do not rewrite what your role did not create.** Another role's PR
+  body, issue body, or comment is not yours to republish; route the
+  change through its writer, or take a recorded handover first. Posting a
+  *new* comment is always allowed — it creates a new artifact you own.
+  Already-published comments are written by nobody, by design.
+- **A handover is only good from the current writer.** Being told an
+  artifact is yours confers nothing unless the teller is its current
+  writer. Determine the writer per Rule 6 before you write, and treat
+  yourself as not being it unless that determination names your role.
+- **Observe immediately before you write.** Capture the artifact's
+  last-modification marker where the forge reports one
+  (`gh pr view <n> --json updatedAt`; the `glab` / `tea` equivalents
+  elsewhere), or its body text where it does not.
+- **A success report is not proof nothing was lost.** `gh pr edit`
+  reports success on a lost update. If the artifact moved between your
+  observation and your write, say so on the logbook — an unreported
+  overwrite costs more than the overwrite.
+- **Assert only a fresh observation, and carry its marker.** When you
+  tell the user or a teammate what an artifact currently says, base it on
+  an observation no later write has superseded and quote the
+  last-modification marker the forge reported at that observation. A
+  read-back is valid until the next writer, not longer.
 
 ## Grounding discipline
 

--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -164,6 +164,22 @@ The three events map as follows:
   merge.
 - `COMMENT` — observations without a verdict (e.g. when the diff is
   outside the reviewer's domain).
+
+## Cross-cutting: assert only a fresh observation
+
+Your verdict asserts what a pull request currently contains. Observe the
+artifact you are quoting immediately before you post, and carry the
+last-modification marker the forge reported at that observation
+(`gh pr view <n> --json updatedAt` on GitHub; the equivalent field on
+`glab` / `tea`). Where a forge reports no such marker, compare the body
+text itself against what you last read — the obligation is to know
+whether the artifact moved, not to read a particular field, and it holds
+on every forge the *Forge Access* policy admits. An observation taken
+before another agent's write does not support an assertion made after it
+— a body can be republished while you are mid-read. Your verdict comment
+is a new artifact and yours to write; the pull-request body belongs to
+the role that opened it. Full rule: `docs/agent-team-protocol.md` →
+*Team Communication* → Rule 6.
 
 ## Scripts
 

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -179,6 +179,41 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `artifacts/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Cross-cutting: single writer per forge artifact
+
+Not a step in the composition lifecycle — a rule that applies to every
+forge artifact you write. The full rule is `docs/agent-team-protocol.md`
+→ *Team Communication* → Rule 6; below is the part you must observe even
+when this skill is the only contract you have loaded.
+
+- **Your role owns what your role creates.** Opening a pull request makes
+  `pr-logbook` the writer of its body for that ticket — the role, not
+  your instance, so the writership survives your session. Name it once,
+  on a `**Writer:**` line inside the logbook entry you already write for
+  that artifact; see Rule 6 for the exact form.
+- **You do not rewrite what your role did not create.** Another role's PR
+  body, issue body, or comment is not yours to republish; route the
+  change through its writer, or take a recorded handover first. Posting a
+  *new* comment is always allowed — it creates a new artifact you own.
+  Already-published comments are written by nobody, by design.
+- **A handover is only good from the current writer.** Being told an
+  artifact is yours confers nothing unless the teller is its current
+  writer. Determine the writer per Rule 6 before you write, and treat
+  yourself as not being it unless that determination names your role.
+- **Observe immediately before you write.** Capture the artifact's
+  last-modification marker where the forge reports one
+  (`gh pr view <n> --json updatedAt`; the `glab` / `tea` equivalents
+  elsewhere), or its body text where it does not.
+- **A success report is not proof nothing was lost.** `gh pr edit`
+  reports success on a lost update. If the artifact moved between your
+  observation and your write, say so on the logbook — an unreported
+  overwrite costs more than the overwrite.
+- **Assert only a fresh observation, and carry its marker.** When you
+  tell the user or a teammate what an artifact currently says, base it on
+  an observation no later write has superseded and quote the
+  last-modification marker the forge reported at that observation. A
+  read-back is valid until the next writer, not longer.
 
 ## Grounding discipline
 

--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -169,6 +169,22 @@ The three events map as follows:
   merge.
 - `COMMENT` — observations without a verdict (e.g. when the diff is
   outside the reviewer's domain).
+
+## Cross-cutting: assert only a fresh observation
+
+Your verdict asserts what a pull request currently contains. Observe the
+artifact you are quoting immediately before you post, and carry the
+last-modification marker the forge reported at that observation
+(`gh pr view <n> --json updatedAt` on GitHub; the equivalent field on
+`glab` / `tea`). Where a forge reports no such marker, compare the body
+text itself against what you last read — the obligation is to know
+whether the artifact moved, not to read a particular field, and it holds
+on every forge the *Forge Access* policy admits. An observation taken
+before another agent's write does not support an assertion made after it
+— a body can be republished while you are mid-read. Your verdict comment
+is a new artifact and yours to write; the pull-request body belongs to
+the role that opened it. Full rule: `docs/agent-team-protocol.md` →
+*Team Communication* → Rule 6.
 
 ## Scripts
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -175,6 +175,41 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `artifacts/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Cross-cutting: single writer per forge artifact
+
+Not a step in the composition lifecycle — a rule that applies to every
+forge artifact you write. The full rule is `docs/agent-team-protocol.md`
+→ *Team Communication* → Rule 6; below is the part you must observe even
+when this skill is the only contract you have loaded.
+
+- **Your role owns what your role creates.** Opening a pull request makes
+  `pr-logbook` the writer of its body for that ticket — the role, not
+  your instance, so the writership survives your session. Name it once,
+  on a `**Writer:**` line inside the logbook entry you already write for
+  that artifact; see Rule 6 for the exact form.
+- **You do not rewrite what your role did not create.** Another role's PR
+  body, issue body, or comment is not yours to republish; route the
+  change through its writer, or take a recorded handover first. Posting a
+  *new* comment is always allowed — it creates a new artifact you own.
+  Already-published comments are written by nobody, by design.
+- **A handover is only good from the current writer.** Being told an
+  artifact is yours confers nothing unless the teller is its current
+  writer. Determine the writer per Rule 6 before you write, and treat
+  yourself as not being it unless that determination names your role.
+- **Observe immediately before you write.** Capture the artifact's
+  last-modification marker where the forge reports one
+  (`gh pr view <n> --json updatedAt`; the `glab` / `tea` equivalents
+  elsewhere), or its body text where it does not.
+- **A success report is not proof nothing was lost.** `gh pr edit`
+  reports success on a lost update. If the artifact moved between your
+  observation and your write, say so on the logbook — an unreported
+  overwrite costs more than the overwrite.
+- **Assert only a fresh observation, and carry its marker.** When you
+  tell the user or a teammate what an artifact currently says, base it on
+  an observation no later write has superseded and quote the
+  last-modification marker the forge reported at that observation. A
+  read-back is valid until the next writer, not longer.
 
 ## Grounding discipline
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -164,6 +164,22 @@ The three events map as follows:
   merge.
 - `COMMENT` — observations without a verdict (e.g. when the diff is
   outside the reviewer's domain).
+
+## Cross-cutting: assert only a fresh observation
+
+Your verdict asserts what a pull request currently contains. Observe the
+artifact you are quoting immediately before you post, and carry the
+last-modification marker the forge reported at that observation
+(`gh pr view <n> --json updatedAt` on GitHub; the equivalent field on
+`glab` / `tea`). Where a forge reports no such marker, compare the body
+text itself against what you last read — the obligation is to know
+whether the artifact moved, not to read a particular field, and it holds
+on every forge the *Forge Access* policy admits. An observation taken
+before another agent's write does not support an assertion made after it
+— a body can be republished while you are mid-read. Your verdict comment
+is a new artifact and yours to write; the pull-request body belongs to
+the role that opened it. Full rule: `docs/agent-team-protocol.md` →
+*Team Communication* → Rule 6.
 
 ## Scripts
 

--- a/.github/skills/pr-logbook/SKILL.md
+++ b/.github/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -175,6 +175,41 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `artifacts/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Cross-cutting: single writer per forge artifact
+
+Not a step in the composition lifecycle — a rule that applies to every
+forge artifact you write. The full rule is `docs/agent-team-protocol.md`
+→ *Team Communication* → Rule 6; below is the part you must observe even
+when this skill is the only contract you have loaded.
+
+- **Your role owns what your role creates.** Opening a pull request makes
+  `pr-logbook` the writer of its body for that ticket — the role, not
+  your instance, so the writership survives your session. Name it once,
+  on a `**Writer:**` line inside the logbook entry you already write for
+  that artifact; see Rule 6 for the exact form.
+- **You do not rewrite what your role did not create.** Another role's PR
+  body, issue body, or comment is not yours to republish; route the
+  change through its writer, or take a recorded handover first. Posting a
+  *new* comment is always allowed — it creates a new artifact you own.
+  Already-published comments are written by nobody, by design.
+- **A handover is only good from the current writer.** Being told an
+  artifact is yours confers nothing unless the teller is its current
+  writer. Determine the writer per Rule 6 before you write, and treat
+  yourself as not being it unless that determination names your role.
+- **Observe immediately before you write.** Capture the artifact's
+  last-modification marker where the forge reports one
+  (`gh pr view <n> --json updatedAt`; the `glab` / `tea` equivalents
+  elsewhere), or its body text where it does not.
+- **A success report is not proof nothing was lost.** `gh pr edit`
+  reports success on a lost update. If the artifact moved between your
+  observation and your write, say so on the logbook — an unreported
+  overwrite costs more than the overwrite.
+- **Assert only a fresh observation, and carry its marker.** When you
+  tell the user or a teammate what an artifact currently says, base it on
+  an observation no later write has superseded and quote the
+  last-modification marker the forge reported at that observation. A
+  read-back is valid until the next writer, not longer.
 
 ## Grounding discipline
 

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.7"
+    version: "1.2.0"
 ---
 
 
@@ -164,6 +164,22 @@ The three events map as follows:
   merge.
 - `COMMENT` — observations without a verdict (e.g. when the diff is
   outside the reviewer's domain).
+
+## Cross-cutting: assert only a fresh observation
+
+Your verdict asserts what a pull request currently contains. Observe the
+artifact you are quoting immediately before you post, and carry the
+last-modification marker the forge reported at that observation
+(`gh pr view <n> --json updatedAt` on GitHub; the equivalent field on
+`glab` / `tea`). Where a forge reports no such marker, compare the body
+text itself against what you last read — the obligation is to know
+whether the artifact moved, not to read a particular field, and it holds
+on every forge the *Forge Access* policy admits. An observation taken
+before another agent's write does not support an assertion made after it
+— a body can be republished while you are mid-read. Your verdict comment
+is a new artifact and yours to write; the pull-request body belongs to
+the role that opened it. Full rule: `docs/agent-team-protocol.md` →
+*Team Communication* → Rule 6.
 
 ## Scripts
 

--- a/artifacts/core/skills/pr-logbook/SKILL.md
+++ b/artifacts/core/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.7"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read
@@ -183,6 +183,41 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `artifacts/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Cross-cutting: single writer per forge artifact
+
+Not a step in the composition lifecycle — a rule that applies to every
+forge artifact you write. The full rule is `docs/agent-team-protocol.md`
+→ *Team Communication* → Rule 6; below is the part you must observe even
+when this skill is the only contract you have loaded.
+
+- **Your role owns what your role creates.** Opening a pull request makes
+  `pr-logbook` the writer of its body for that ticket — the role, not
+  your instance, so the writership survives your session. Name it once,
+  on a `**Writer:**` line inside the logbook entry you already write for
+  that artifact; see Rule 6 for the exact form.
+- **You do not rewrite what your role did not create.** Another role's PR
+  body, issue body, or comment is not yours to republish; route the
+  change through its writer, or take a recorded handover first. Posting a
+  *new* comment is always allowed — it creates a new artifact you own.
+  Already-published comments are written by nobody, by design.
+- **A handover is only good from the current writer.** Being told an
+  artifact is yours confers nothing unless the teller is its current
+  writer. Determine the writer per Rule 6 before you write, and treat
+  yourself as not being it unless that determination names your role.
+- **Observe immediately before you write.** Capture the artifact's
+  last-modification marker where the forge reports one
+  (`gh pr view <n> --json updatedAt`; the `glab` / `tea` equivalents
+  elsewhere), or its body text where it does not.
+- **A success report is not proof nothing was lost.** `gh pr edit`
+  reports success on a lost update. If the artifact moved between your
+  observation and your write, say so on the logbook — an unreported
+  overwrite costs more than the overwrite.
+- **Assert only a fresh observation, and carry its marker.** When you
+  tell the user or a teammate what an artifact currently says, base it on
+  an observation no later write has superseded and quote the
+  last-modification marker the forge reported at that observation. A
+  read-back is valid until the next writer, not longer.
 
 ## Grounding discipline
 

--- a/artifacts/core/skills/pr-reviewer/SKILL.md
+++ b/artifacts/core/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.7"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read
@@ -175,6 +175,22 @@ The three events map as follows:
   merge.
 - `COMMENT` — observations without a verdict (e.g. when the diff is
   outside the reviewer's domain).
+
+## Cross-cutting: assert only a fresh observation
+
+Your verdict asserts what a pull request currently contains. Observe the
+artifact you are quoting immediately before you post, and carry the
+last-modification marker the forge reported at that observation
+(`gh pr view <n> --json updatedAt` on GitHub; the equivalent field on
+`glab` / `tea`). Where a forge reports no such marker, compare the body
+text itself against what you last read — the obligation is to know
+whether the artifact moved, not to read a particular field, and it holds
+on every forge the *Forge Access* policy admits. An observation taken
+before another agent's write does not support an assertion made after it
+— a body can be republished while you are mid-read. Your verdict comment
+is a new artifact and yours to write; the pull-request body belongs to
+the role that opened it. Full rule: `docs/agent-team-protocol.md` →
+*Team Communication* → Rule 6.
 
 ## Scripts
 

--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -333,7 +333,7 @@ non-blocking observation, not a blocking finding.
 
 ## Team Communication
 
-Five rules govern how teammates report back inside a team and how the team-lead interprets their signals.
+Six rules govern how teammates report back inside a team and how the team-lead interprets their signals.
 
 **Rule 1 — Report before idle.** Every agent operating inside a team
 (delegated via `Agent` and tracked via `TaskCreate`) MUST send a message to
@@ -458,6 +458,97 @@ Harness Curator's `concurrent-deliverable-edit` friction cluster
 a file the sub-agent was still editing, on the strength of an idle
 notification alone, producing duplicate content that required manual
 reconciliation.
+
+**Rule 6 — Single writer per forge artifact.** A **forge artifact** is
+the mutable text body of a pull request, of an issue, or of a comment on
+either, and has exactly one writer at any instant. Publishing a **new**
+comment creates a new artifact whose writer is its author, leaving the
+incremental-logbook practice of `AGENTS.md` → *Logbook Issues → Rule B*
+untouched: only editing an already-published body or comment is governed.
+
+**The writer is a role on a ticket, not an agent instance.** Writership
+is established at creation and rests with the **role** of the creating
+agent, scoped to the artifact's ticket. Any agent of that role acting on
+that ticket is the writer, whether or not it created the artifact; one
+instance concluding ends nothing and makes no artifact unwritable. No
+per-instance identifier or register is wanted.
+
+**Determining the writer, without asking it.** An agent about to write
+resolves writership in this order:
+
+1. **A recorded handover** — the most recent `**Writership handover:**`
+   line on the ticket's logbook for that artifact names the writer.
+2. **Otherwise, the creator's role** — the `**Writer:**` line the
+   creating role posts inside the logbook entry it already writes for
+   that artifact. Both lines ride in comments the ticket already gets;
+   the forge's own authorship field names the *account*, not the role.
+3. **Otherwise, you are not the writer.** An agent that cannot determine
+   the writer treats itself as not being it.
+
+```markdown
+**Writer:** `pr-logbook` — PR #734 body
+**Writership handover:** PR #734 body — `pr-logbook` → `team-lead`
+```
+
+**Already-published comments resolve at rung 3, by design.** A
+`**Writer:**` line is posted for a pull-request or issue body, never per
+comment, so a published comment has no determinable writer and is
+written by nobody — effectively append-only, as `docs/plan-format.md` →
+*Append-only revisions* and Rule B already require. No per-comment
+writer line is owed; correct a published comment by posting a new one.
+
+**A non-writer does not write.** An agent that is not the writer and
+judges the artifact needs a change either routes it through the current
+writer or first receives writership; those two branches are the whole
+set. A concluded creating instance does not exhaust them — routing
+through the current writer is satisfied by any agent of the writer role
+on the ticket — and is never grounds to take writership: not on a
+confirmed conclusion, not on a landed completion report, not on an
+observed side effect of its work.
+
+**Two live agents of one role — the orchestrator's obligation.** Rule 2's
+fresh-spawn remedy can leave two agents of the writer role live on one
+ticket. An orchestrator that brings a further agent of that role live
+does not direct more than one of them to write a given artifact: each
+resolves the ladder above to its own role and cannot see that the other
+is live. The assertion and lost-update obligations below hold between
+agents of one role exactly as between agents of different roles.
+
+**Handover, and who may perform one.** Writership changes hands only
+through an explicit handover recorded where a writer determination reads.
+A nomination, designation, or purported transfer by an agent that is not
+the current writer confers nothing — however explicitly stated, wherever
+recorded. An agent offered writership determines the current writer per
+the ladder *before* writing, and treats itself as not being the writer
+unless that determination names its **role**. Writership never transfers
+by assumption, elapsed time, an `idle_notification`, apparent inactivity,
+or a peer having finished something related.
+
+**Assert only what you have just observed.** An agent that tells the user
+or a peer what a forge artifact currently contains bases that on an
+observation no later write has superseded, and carries with it the
+last-modification marker the forge reported at that observation. A
+read-back is valid until the next writer, not longer.
+
+**Detect the lost update; a success report is not proof.** Observe the
+artifact immediately before writing it, then determine whether it moved
+between that observation and your write — comparing the last-modification
+marker where the forge reports one and the body text itself where it does
+not, since the point is to know whether it moved, not to read a
+particular field. `gh pr edit` reports success on a lost update, so a
+success report is never evidence that nothing was discarded. When it did
+move, say so on the ticket's logbook: your write may have discarded
+another agent's content, and no ticket carries an unreported overwrite.
+
+**Relation to Rule 5, and to worktree isolation.** Rule 6 is the
+forge-side counterpart to Rule 5's file-side edit fence, with one
+asymmetry: Rule 5 is conditional — it holds *while* a file is delegated
+and lifts when the sub-agent concludes — whereas Rule 6's writership is
+unconditional, which is why an instance's conclusion is precisely the
+event that must not move it. Worktree isolation affords a forge artifact
+no protection whatever, because it lives outside every worktree: two
+agents in two isolated worktrees still write one pull-request body
+through one forge. Rule 6 closes the race seen on ticket #726 / PR #734.
 
 ## Team Shutdown
 

--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -497,10 +497,10 @@ authorship field names the *account*, not the role.
 **Writership handover:** PR #734 body — `pr-logbook` → `team-lead`
 ```
 
-**Already-published comments resolve at rung 3, by design.** A
+**Already-published comments resolve at step 3, by design.** A
 `**Writer:**` line is posted for a pull-request or issue body, never per
 comment. A comment's writer is its author when it is published, but
-nothing records that, so every later determination resolves at rung 3
+nothing records that, so every later determination resolves at step 3
 and the comment is written by nobody from then on — effectively
 append-only, as `docs/plan-format.md` → *Append-only revisions* and Rule
 B already require. No per-comment writer line is owed; correct a

--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -473,17 +473,24 @@ that ticket is the writer, whether or not it created the artifact; one
 instance concluding ends nothing and makes no artifact unwritable. No
 per-instance identifier or register is wanted.
 
-**Determining the writer, without asking it.** An agent about to write
-resolves writership in this order:
+**Determining the writer, without asking it.** Writership starts at
+creation and moves only forward, so an agent about to write walks it
+forward rather than reading the latest line:
 
-1. **A recorded handover** — the most recent `**Writership handover:**`
-   line on the ticket's logbook for that artifact names the writer.
-2. **Otherwise, the creator's role** — the `**Writer:**` line the
-   creating role posts inside the logbook entry it already writes for
-   that artifact. Both lines ride in comments the ticket already gets;
-   the forge's own authorship field names the *account*, not the role.
+1. **Start at the creator's role** — the `**Writer:**` line the creating
+   role posts inside the logbook entry it already writes for that
+   artifact. That role is the writer until a valid handover moves it.
+2. **Then apply the handovers, oldest first** — a
+   `**Writership handover:**` line moves writership only where its
+   left-hand role is the writer the walk has reached, that role being
+   the one who posts it. A line naming anyone else on the left is void
+   (see *Handover* below), contributes nothing, and does not halt the
+   walk: the most recent line is not the answer unless it survives.
 3. **Otherwise, you are not the writer.** An agent that cannot determine
    the writer treats itself as not being it.
+
+Both lines ride in comments the ticket already gets; the forge's own
+authorship field names the *account*, not the role.
 
 ```markdown
 **Writer:** `pr-logbook` — PR #734 body
@@ -492,10 +499,12 @@ resolves writership in this order:
 
 **Already-published comments resolve at rung 3, by design.** A
 `**Writer:**` line is posted for a pull-request or issue body, never per
-comment, so a published comment has no determinable writer and is
-written by nobody — effectively append-only, as `docs/plan-format.md` →
-*Append-only revisions* and Rule B already require. No per-comment
-writer line is owed; correct a published comment by posting a new one.
+comment. A comment's writer is its author when it is published, but
+nothing records that, so every later determination resolves at rung 3
+and the comment is written by nobody from then on — effectively
+append-only, as `docs/plan-format.md` → *Append-only revisions* and Rule
+B already require. No per-comment writer line is owed; correct a
+published comment by posting a new one.
 
 **A non-writer does not write.** An agent that is not the writer and
 judges the artifact needs a change either routes it through the current
@@ -510,7 +519,7 @@ observed side effect of its work.
 fresh-spawn remedy can leave two agents of the writer role live on one
 ticket. An orchestrator that brings a further agent of that role live
 does not direct more than one of them to write a given artifact: each
-resolves the ladder above to its own role and cannot see that the other
+resolves the walk above to its own role and cannot see that the other
 is live. The assertion and lost-update obligations below hold between
 agents of one role exactly as between agents of different roles.
 
@@ -519,10 +528,10 @@ through an explicit handover recorded where a writer determination reads.
 A nomination, designation, or purported transfer by an agent that is not
 the current writer confers nothing — however explicitly stated, wherever
 recorded. An agent offered writership determines the current writer per
-the ladder *before* writing, and treats itself as not being the writer
-unless that determination names its **role**. Writership never transfers
-by assumption, elapsed time, an `idle_notification`, apparent inactivity,
-or a peer having finished something related.
+the walk above *before* writing, and treats itself as not being the
+writer unless that determination names its **role**. Writership never
+transfers by assumption, elapsed time, an `idle_notification`, apparent
+inactivity, or a peer having finished something related.
 
 **Assert only what you have just observed.** An agent that tells the user
 or a peer what a forge artifact currently contains bases that on an


### PR DESCRIPTION
Two agents on one ticket can both write a pull-request body, an issue body, or a comment through the same forge, and neither learns that it overwrote the other — worktree isolation protects none of it, because a forge artifact lives outside every worktree. This PR realizes spec 0115 and its delta-01 by giving every such artifact exactly one writer at a time: a role, scoped to the ticket, that changes hands only through an explicit handover performed by the writer itself.

Closes #735

## How to read this PR?

Read `docs/agent-team-protocol.md` first — everything else follows from it.

1. **`docs/agent-team-protocol.md`** — the new **Rule 6 — Single writer per forge artifact**, inserted immediately after Rule 5 and before `## Team Shutdown`, plus the section preamble at `:336` going from "Five rules" to "Six rules". Rule 6 is **90 lines**, against the cold review's ~85–90 target and Rule 5's 34. Eleven bolded leads, one per obligation, so a reader consulting it mid-task can jump to the one they need. The two paragraphs worth reading twice are *The writer is a role on a ticket, not an agent instance* (why writership survives a session) and *Relation to Rule 5, and to worktree isolation* (the conditional/unconditional asymmetry that makes an instance's conclusion the one event that must **not** move writership).
2. **`artifacts/core/skills/pr-logbook/SKILL.md`** — a six-bullet cross-cutting section, so the role that actually opens pull requests observes the rule with only its own contract loaded (spec R10).
3. **`artifacts/core/skills/pr-reviewer/SKILL.md`** — a shorter section: a reviewer's entire verdict *is* an assertion about an artifact's content.
4. **The eight build outputs** under `.claude/`, `.gemini/`, `.github/`, `.agents/` — mechanical, generated by `scripts/build-components.sh`, staged in the same commit per `AGENTS.md` → *Built components*. Skim or skip.

**Two non-obvious decisions, both deliberate:**

- **`AGENTS.md` is not touched.** Rule 5 — which spec R11 makes Rule 6's counterpart — is itself absent from `AGENTS.md`'s *Critical rules* list (`AGENTS.md:256-262`), so Rule 6 inherits exactly Rule 5's discoverability, which is the parity R11 asks for. `AGENTS.md` → *Agent Team Protocol* already points every team at this document for the team-communication rules in aggregate. (The byte budget agrees but is the weaker argument: 21 879 B against a `-ge 22000` gate leaves 120 B of headroom, and this PR spends none of it.)
- **`docs/cli-matrix.md` is consulted but unchanged.** The trigger surface is hit via `artifacts/**` and the *Protocol-only exemption* does not apply. Both skills are already covered generically by matrix row 3 (*Skill definitions directory (built output)*); this change adds prose to existing components and introduces no path, command, hook, or per-CLI configuration, so no cell moves. Four merged precedents did the same — `7d56c91` (#646), `bf785d8` (#649), `df22b0b` (#634), `c51e938` (#652), each touching `artifacts/core/skills/*/SKILL.md` with zero `docs/cli-matrix.md` hunks (verified in this worktree with `git show --name-only`). The absent hunk is a conclusion, not an omission.

## How to test this PR?

No new check ships — spec R12 forecloses mechanical enforcement, and the four existing CI jobs cover every mechanical consequence. From a worktree on this branch:

```sh
# 1. Built outputs match their sources (CI: check-components)
bash scripts/build-components.sh --target all --check
# → exit 0 — "OK: All generated files match source."

# 2. Both skill sources carry a version bump (CI: check-skill-versions)
bash scripts/check-skill-versions.sh
# → exit 0 — pr-logbook and pr-reviewer both OK

# 3. AGENTS.md still under budget (CI: check-agents-size)
bash scripts/check-agents-size.sh
# → exit 0 — 21879 bytes, threshold 22000, unchanged by this PR

# 4. Markdown, exactly as CI runs it (CI: lint-markdown)
npx markdownlint-cli "**/*.md" --ignore node_modules --ignore extension-skeleton \
  --ignore communication --ignore 'extensions/**/commands/*.md'
# → exit 0

# 5. Specs (CI: lint-specs)
node scripts/lib/spec-linter.js specs/
# → exit 0 — 0114's draft-status breakage is cured on main

# 6. Byte-level hygiene: no tool scaffolding leaked into any authored file
/usr/bin/grep -nE '</?(content|invoke|parameter|function_calls|antml)' \
  docs/agent-team-protocol.md artifacts/core/skills/pr-{logbook,reviewer}/SKILL.md
# → exit 1, no match. Run this rather than trusting a linter: the spec linter
#   returned exit 0 on a file that shipped literal closing-tag scaffolding
#   earlier on this very ticket. A green check answers its own question,
#   not the one you are asking.
```

The behavioural obligation itself is verified by reading, not by executing — that is what R12 chose. Read Rule 6 against the fourteen requirements of `specs/0115-forge-artifact-single-writer.md` as amended by `specs/0115-forge-artifact-single-writer.delta-01.md`; the traceability table in `## PLAN v2` on #735 maps each one to its paragraph.

## Detailed description (for agents)

### `docs/agent-team-protocol.md`

**Added — Rule 6, 90 lines, after Rule 5 and before `## Team Shutdown`.** Eleven paragraphs, each opening with a bolded lead naming its obligation:

| Paragraph | Carries |
|---|---|
| *Rule 6 — Single writer per forge artifact* | R2 (definition + new-comment carve-out), R3 first clause |
| *The writer is a role on a ticket, not an agent instance* | R3 as replaced by delta-01 — role-scoped, ticket-bound, an instance's conclusion ends nothing; no per-instance register wanted (delta *Out of scope* 6) |
| *Determining the writer, without asking it* | R4 — a forward walk of the writership chain, resolving without an exchange with the current writer and defaulting to "you are not the writer". Starts at the creating role's `**Writer:**` line and applies each handover oldest first, accepting one only where its left-hand role is the writer the walk has reached |
| *Already-published comments resolve at rung 3, by design* | The PLAN's decision 6, answering the v1 review's Finding 3 — comments are out of the recording mechanism **intentionally**, no per-comment writer line is owed |
| *A non-writer does not write* | R5 as replaced — the remediation set closed at two branches, naming the three limbs it refuses (a confirmed conclusion, a landed completion report, an observed side effect) |
| *Two live agents of one role — the orchestrator's obligation* | R13 as amended — binds the **orchestrator**, not the two agents, since each resolves the ladder to its own role and cannot observe the other; R7/R8 still bind each writing agent |
| *Handover, and who may perform one* | R6 + R14 — only the current writer may hand over; a nomination from anyone else confers nothing however explicitly stated or recorded; the recipient determines per R4 and treats itself as non-writer unless the determination names **its role**. The walk above enforces this procedurally, so an agent following the steps literally cannot reach a nominee (REVIEW iter:1, `911a059`) |
| *Assert only what you have just observed* | R7, **both halves** — an unsuperseded observation *and* the last-modification marker carried with the assertion |
| *Detect the lost update; a success report is not proof* | R8 + R9 — content-level comparison as the obligation, the forge's marker as the cheap form where one exists, and the logbook report when the artifact moved |
| *Relation to Rule 5, and to worktree isolation* | R11 — the counterpart declaration, the conditional/unconditional asymmetry, and that worktree isolation affords a forge artifact nothing |

The two record forms — `**Writer:**` and `**Writership handover:**` — ship as one fenced `markdown` block serving both rungs, rather than a fence per rung. Both lines ride inside logbook comments the ticket already gets; no separate register comment is created, which is the cost decision the PLAN's decision 1 turns on.

**Modified — `:336`.** `Five rules govern…` → `Six rules govern…`. The preamble is not the text of Rules 1–5, so it sits outside spec 0115's out-of-scope bullet; `088af38` set the identical precedent under spec 0095's identically-worded bullet.

**Not modified.** Rules 1–5 and *Worktree Isolation* keep their existing text, per that same out-of-scope bullet. The only new coupling is the outward reference Rule 6 makes to Rule 5.

**On length.** The cold re-review recorded Rule 6's drafted text at 119 lines against Rule 5's 24 and asked for ~85–90 without dropping a paragraph. Delivered at 90, then **99** after REVIEW iter:1 added the chain-validation clause and reconciled a comment's writer — the reviewer relaxed the constraint for that fix. The cuts are the four spans it named — the derivation of role-scoping (which delta-01 argues at length), the measurement behind "the authorship field names the account", the cost rationale for rejecting per-comment writer lines, and the PR #734 re-narration. Every obligation survives; only the *why* was thinned, and it remains recoverable from the spec, the delta, and the plan.

### `artifacts/core/skills/pr-logbook/SKILL.md` — `1.1.7` → `1.2.0`

New `## Cross-cutting: single writer per forge artifact`, placed after the existing version-bump cross-cutting section. Six bullets: your role owns what it creates (and names itself on a `**Writer:**` line); you do not rewrite what your role did not create; a handover is only good from the current writer (R14); observe immediately before you write; a success report is not proof nothing was lost; **assert only a fresh observation, and carry its marker**.

That last bullet is the v1 review's Finding 4, `pr-logbook` half. The draft carried only R7's freshness clause and left the marker to a bullet framed around *writing*, which is R8. The marker-with-the-assertion is the half that actually failed on PR #734, so it belongs in the assertion bullet — an agent holding only this contract is now told to carry it.

MINOR per `AGENTS.md` → *Version Bump Convention*: a new section, additive, no existing obligation withdrawn.

### `artifacts/core/skills/pr-reviewer/SKILL.md` — `1.1.7` → `1.2.0`

New `## Cross-cutting: assert only a fresh observation`, placed after `### 6. Post the review`. Spec R10's "at minimum" does not name this role; it is included because a reviewer's verdict *is* an assertion about an artifact's current content, and the friction report records a cold reviewer mid-read while PR #734's body was being republished under it.

The section carries the marker instruction **and** R9's marker-absent fallback — the v1 review's Finding 4, `pr-reviewer` half: "Where a forge reports no such marker, compare the body text itself against what you last read — the obligation is to know whether the artifact moved, not to read a particular field, and it holds on every forge the *Forge Access* policy admits." No `glab` or `tea` field name is written anywhere in this diff: the PLAN flagged those as unverified, and decision 4 makes the obligation content-level so an unknown field name degrades to a body comparison rather than to no detection.

### Build outputs — 8 files

`{.claude,.gemini,.github,.agents}/skills/{pr-logbook,pr-reviewer}/SKILL.md`, regenerated by `bash scripts/build-components.sh` and staged in the same commit per `AGENTS.md` → *Agent Team Protocol* → *Built components*. None was hand-edited; `--target all --check` passes.

### Not touched, deliberately

`AGENTS.md` (see *How to read this PR?*); `artifacts/core/agents/{pr-logbook,pr-reviewer}/AGENT.md` — both personas already route to their skill, and restating there costs two more version bumps and eight more outputs to carry a pointer that can drift; `docs/cli-matrix.md`; every file under `scripts/`; `.crewrig/core-paths.txt` — `docs/layers.md` gains and loses no path; `docs/index.json` — `docs/agent-team-protocol.md` stays `published=false`, and `build-docs-index.sh --check` confirms no drift.

### Traceability

All fourteen requirements are covered. R1 (`complexity: standard`) is a team-composition requirement rather than a file edit — `architect` reviewed at PLAN and the plan was re-reviewed cold before DEV. The remaining thirteen map to the paragraphs and bullets tabulated above; the full requirement→step table lives in `## PLAN v2` on #735.

---

**REVIEW iter:1** (`911a059`) — the determination's first rung accepted the most recent handover line without testing who wrote it, so a nomination from a non-writer resolved to the nominee: delta-01 Scenario 5 failed against the shipped procedure, which is the incident R14 exists to prevent. The norm was in the document three paragraphs below, but a procedure that terminates with an answer is never abandoned partway for a principle stated later. The determination now walks the chain forward from the creating role's `**Writer:**` line, accepting a handover only where its left-hand role is the writer the walk has reached. Also reconciled a comment's two writers — its author at publication, nobody thereafter. The scenario walk that verifies it is on the [logbook](https://github.com/crewrig/crewrig/issues/735#issuecomment-5230736155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
