### PR TITLE
📝 Mark spec 0115 implemented

### DIFF
--- a/specs/0115-forge-artifact-single-writer.md
+++ b/specs/0115-forge-artifact-single-writer.md
@@ -1,7 +1,7 @@
 ---
 id: "0115"
 slug: forge-artifact-single-writer
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 735


### PR DESCRIPTION
Records the `approved` → `implemented` transition of spec 0115 now that its implementation is on `main`.

## How to read this PR?

One line, one file. `specs/0115-forge-artifact-single-writer.md` frontmatter, `status: approved` → `status: implemented`. No body line changes, no `id`, no `slug`, no `version`.

The delta-spec `specs/0115-forge-artifact-single-writer.delta-01.md` deliberately stays `approved` — the same convention already applied to `0109.delta-01`.

## How to test this PR?

`node scripts/lib/spec-linter.js specs/` — exit 0, `Linting passed!`. The spec-0109 invariant is satisfied either way here, since it constrains `draft` on the base branch; this change concerns the later transition.

## Detailed description (for agents)

`docs/spec-format.md` → *Recording a status transition* splits the lifecycle transitions in two. The initial `draft` → `approved` is recorded inside the spec-PR's own commit, so the spec lands on `main` already approved — done for 0115 in #760 and for its delta in #767. Every later transition is recorded **after** the spec has merged, by a metadata-only edit, which is what this PR is.

The implementation merged as PR #770 (`424c064`) and closed #735. Review terminated at iteration 3 with an APPROVE verdict, zero findings of any class, and CI green on the reviewed head.

Closes #775