### PR TITLE
🐛 Untrack the node_modules symlink and make the ignore cover it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Runtime
-node_modules/
+node_modules
 __pycache__/
 *.pyc
 .venv/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/hoanicross/devel/perso/genai/framework/crewrig/node_modules


### PR DESCRIPTION
A symlink named `node_modules`, pointing at one contributor's absolute local path, is tracked at the repository root, so every clone materialises a dangling symlink where `npm install` expects to write. This untracks it and fixes the ignore rule that let it through.

Closes #777.

## How to read this PR?

Two lines. Read the `.gitignore` change first — it is the actual fix.

1. **`.gitignore:12`** — `node_modules/` → `node_modules`. **A pattern with a trailing slash matches only directories**, so it never covered a symlink of the same name. That is why `git add -A` in commit `f0b9c11` could see it, and why removing the file alone would not stop the next occurrence.
2. **`node_modules`** — the tracked symlink, deleted from the index. Its blob content is `/Users/hoanicross/devel/perso/genai/framework/crewrig/node_modules`.

Worth knowing: the repository's own test suite creates exactly this symlink (`scripts/tests/test-spec-linter.sh` links `node_modules` into each fixture), and any worktree that runs that suite needs one at its root. So this shape is not an accident a contributor should have avoided — it is a shape the tooling asks for, which the ignore rule silently did not cover.

## How to test this PR?

```sh
# The ignore now covers a symlink, not just a directory:
ln -sfn "$(git rev-parse --show-toplevel)/node_modules" /tmp/nm && ln -s /tmp/nm node_modules
git status --porcelain          # expect: no `?? node_modules` line

# And nothing that needed the symlink breaks:
BASE_REF=crewrig/main node scripts/lib/spec-linter.js   # expect: Linting passed!
bash scripts/tests/test-spec-linter.sh                  # expect: 39 passed, 0 failed
```

The behaviour claim was verified in an isolated repository rather than reasoned from the gitignore documentation:

```console
$ printf 'node_modules/\n' > .gitignore && ln -s target node_modules
$ git status --porcelain
?? node_modules          # NOT ignored, with the trailing slash

$ printf 'node_modules\n' > .gitignore
$ git status --porcelain
                         # ignored, without it
```

After merge, confirm the tree is clean: `git ls-tree crewrig/main node_modules` must print nothing.

## Detailed description (for agents)

**Removed:** the root `node_modules` entry from the index (mode `120000`, blob `b75a83c`). The file stays in local working trees, where it is wanted and now ignored.

**Modified:** `.gitignore:12`, dropping the trailing slash so the pattern matches a directory *and* a symlink.

**Provenance.** Introduced by `f0b9c11` (a spec status-transition commit staged with `git add -A`) and merged by PR #774 (`cde9fc2`). PR #774 therefore shipped two files where `docs/spec-pr-workflow.md` → *One-file rule* allows one. Sibling spec-PR #758 is unaffected — it used an explicit `git add <path>`.

**Not in scope, stated so the omission is visible.** All 12 checks passed on #774: nothing validates the spec-PR one-file rule, and nothing rejects a tracked symlink whose target escapes the repository. Both are plausible guards and both are separate design questions; this is a `trivial`-tier fix for a defect currently on `main`, and widening it would delay that.

**No other trigger.** `.gitignore` is not a CLI-matrix trigger surface, no skill or agent source is touched (no version bump), no core-layer path is reclassified, and no build output is regenerated.