### PR TITLE
🐛 Run git at the repository root so the base-branch check cannot silently pass

### DIFF
--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -100,11 +100,39 @@ function isExcludedSpecPath(relPath, entries) {
 // legitimately `draft` until its own merge mechanic flips it, while a spec
 // already on the base branch carrying `draft` is the contradiction R1 forbids.
 
-// gitCapture(args) — run git, capturing both streams. Returns the exit status
-// and stdout; never throws and never leaks git's own stderr into the linter's
-// output, so callers can probe git freely (including outside a repository).
-function gitCapture(args) {
-    const result = spawnSync('git', args, { encoding: 'utf8' });
+// gitCwd — the directory every git invocation in this file runs in, assigned once
+// the work tree has been located (see resolveBaseContext). It enforces one
+// invariant: **git in this file runs at the repository root** (spec 0109
+// delta-03 R14).
+//
+// A default rather than an argument at each call site, because R15 requires the
+// mechanism to be structural. The defect delta-03 fixes existed precisely
+// because two path-sensitive invocations — `ls-tree`'s pathspecs and `diff`'s
+// output paths — were each written without their author classifying them as
+// path-sensitive; from a subdirectory the first returned an empty set and the
+// check reported `Linting passed!` on a live violation. A remedy that depends on
+// that classification being made correctly next time does not remove the failure
+// mode. As a default, an invocation added later inherits the guarantee without
+// having to know it exists.
+//
+// One invocation is necessarily exempt: the one that DISCOVERS the work tree runs
+// while this is still `null`, so it resolves against the caller's directory —
+// which is what lets it answer which repository the run is about. Pinning it
+// would be circular.
+let gitCwd = null;
+
+// gitCapture(args, cwd) — run git, capturing both streams. Returns the exit
+// status and stdout; never throws and never leaks git's own stderr into the
+// linter's output, so callers can probe git freely (including outside a
+// repository). `cwd` overrides the module default for a single call; omitting it
+// (the normal case) takes `gitCwd`, and `undefined` inherits this process's
+// directory — which is what every pre-work-tree and non-repository path does,
+// exactly as before this file had a default at all.
+function gitCapture(args, cwd) {
+    const result = spawnSync('git', args, {
+        encoding: 'utf8',
+        cwd: cwd !== undefined ? cwd : (gitCwd !== null ? gitCwd : undefined),
+    });
     return {
         status: result.status,
         stdout: typeof result.stdout === 'string' ? result.stdout : '',
@@ -247,6 +275,13 @@ function resolveBaseContext(files) {
     // (a symlinked checkout, /tmp on macOS) would otherwise resolve "outside"
     // the repository and be silently exempted from the check.
     const repoRoot = fs.realpathSync(toplevel.stdout.trim());
+
+    // From here on, every git invocation runs at the repository root (R14/R15).
+    // Assigned immediately after the root is known and before the first
+    // path-sensitive read, so resolveBaseRef(), baseBranchPaths() and
+    // changedPaths() are all covered without this line naming any of them —
+    // which is the point: the next one is covered too.
+    gitCwd = repoRoot;
 
     const { ref, error } = resolveBaseRef();
     if (error) {

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -788,6 +788,16 @@ run_base_case "Case 38 — attribution that cannot be derived blocks, and says s
 # -------------------------------------------------------------------------
 # Cases 39-40 (delta-03 R16, covering R14/R15) — WORKING-DIRECTORY INDEPENDENCE.
 #
+# Both cases assert on `Non-delta specs present on the base branch` — the banner
+# only this check emits — and NOT on the offending file's path. The path is also
+# printed by markdownlint on any rule violation in the fixture, and markdownlint's
+# own failure is exit 1, so a fixture that drifts out of conformance would satisfy
+# a path-plus-exit-code assertion while the check never executed. Measured: with
+# an MD001 violation injected and run against a linter WITHOUT the fix, exit is 1
+# and the path appears. For cases guarding a check whose defect was passing
+# without checking, that is the one false-pass that must not be possible. The
+# fixture holds exactly one spec, so asserting the banner loses no identity.
+#
 # A fixture whose specs AND markdownlint configuration both sit under `sub/`.
 # The nested configuration is not incidental: `-c .markdownlintrc` is resolved
 # against the working directory, so without a config there the run dies at
@@ -818,9 +828,11 @@ render_spec "0240" "nested-layout" "draft" > "$GITFIX4/sub/specs/0240-nested-lay
 # reported `Linting passed!` with exit 0 on a live violation. Remove the
 # `gitCwd = repoRoot` assignment and this case goes red.
 # -------------------------------------------------------------------------
+git -C "$GITFIX4" checkout -q -- .
+git -C "$GITFIX4" config --unset-all diff.relative 2>/dev/null || true
 run_base_case "Case 39 — an offender is identified from a subdirectory (R14)" \
   "$GITFIX4/sub" "specs" 1 "main" \
-  "specs/0240-nested-layout.md" "-"
+  "Non-delta specs present on the base branch" "-"
 
 # -------------------------------------------------------------------------
 # Case 40 (R14, the attribution half) — same subdirectory run, with
@@ -839,12 +851,17 @@ run_base_case "Case 39 — an offender is identified from a subdirectory (R14)" 
 # observable through the command line, since the only working directory where
 # `diff` misbehaves is one where `ls-tree` has already returned nothing. Stated
 # rather than implied, so the case is not read as stronger than it is.
+#
+# Like cases 35-37 on $GITFIX2, these two do NOT depend on each other's order:
+# each resets the work tree and the `diff.relative` setting, then applies only
+# what it measures. A third case added here inherits neither.
 # -------------------------------------------------------------------------
+git -C "$GITFIX4" checkout -q -- .
 git -C "$GITFIX4" config diff.relative true
 printf '\nEdited by the change under test.\n' >> "$GITFIX4/sub/specs/0240-nested-layout.md"
 run_base_case "Case 40 — attribution stays root-anchored under diff.relative (R14)" \
   "$GITFIX4/sub" "specs" 1 "main" \
-  "specs/0240-nested-layout.md" "[WARN]"
+  "Non-delta specs present on the base branch" "[WARN]"
 
 # -------------------------------------------------------------------------
 # Summary

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -786,6 +786,67 @@ run_base_case "Case 38 — attribution that cannot be derived blocks, and says s
   "could not be derived" "[WARN]"
 
 # -------------------------------------------------------------------------
+# Cases 39-40 (delta-03 R16, covering R14/R15) — WORKING-DIRECTORY INDEPENDENCE.
+#
+# A fixture whose specs AND markdownlint configuration both sit under `sub/`.
+# The nested configuration is not incidental: `-c .markdownlintrc` is resolved
+# against the working directory, so without a config there the run dies at
+# markdownlint and never reaches the check. That is exactly why this defect was
+# first believed unreachable, and it is what these cases exist to keep reachable.
+# -------------------------------------------------------------------------
+GITFIX4="$TMP_ROOT/gitfix4"
+mkdir -p "$GITFIX4/sub/specs"
+cp "$ROOT_DIR/.markdownlintrc" "$GITFIX4/sub/"
+ln -s "$ROOT_DIR/node_modules" "$GITFIX4/sub/node_modules"
+render_spec "0240" "nested-layout" "draft" > "$GITFIX4/sub/specs/0240-nested-layout.md"
+(
+  cd "$GITFIX4" || exit 1
+  git init -q
+  git symbolic-ref HEAD refs/heads/main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+  git add sub/specs
+  git commit -q -m "draft non-delta spec on the base branch, under sub/"
+)
+
+# -------------------------------------------------------------------------
+# Case 39 (R14) — the offender is identified when the linter runs from a
+# SUBDIRECTORY. Before delta-03, `git ls-tree` resolved the repo-root-relative
+# pathspec against the working directory, matched nothing, and returned an empty
+# set — so no file was ever identified as present on the base branch and the run
+# reported `Linting passed!` with exit 0 on a live violation. Remove the
+# `gitCwd = repoRoot` assignment and this case goes red.
+# -------------------------------------------------------------------------
+run_base_case "Case 39 — an offender is identified from a subdirectory (R14)" \
+  "$GITFIX4/sub" "specs" 1 "main" \
+  "specs/0240-nested-layout.md" "-"
+
+# -------------------------------------------------------------------------
+# Case 40 (R14, the attribution half) — same subdirectory run, with
+# `diff.relative=true` and the offending spec MODIFIED in the tree. It must fail,
+# because a change that touches the offender is the change that pays
+# (delta-02 R2 as replaced).
+#
+# This is the case that discriminates a PARTIAL fix, which is why it exists
+# alongside Case 39: pin `ls-tree` alone and the offender is identified, but
+# `git diff` still reports `specs/0240-nested-layout.md` relative to `sub/`, the
+# `changed` set never matches `sub/specs/0240-nested-layout.md`, the offender
+# degrades to a bystander, and the run passes with a [WARN]. Hence the assertion
+# on the ABSENCE of [WARN] rather than on the exit code alone.
+#
+# It does not isolate the `diff` derivation from the `ls-tree` one — that is not
+# observable through the command line, since the only working directory where
+# `diff` misbehaves is one where `ls-tree` has already returned nothing. Stated
+# rather than implied, so the case is not read as stronger than it is.
+# -------------------------------------------------------------------------
+git -C "$GITFIX4" config diff.relative true
+printf '\nEdited by the change under test.\n' >> "$GITFIX4/sub/specs/0240-nested-layout.md"
+run_base_case "Case 40 — attribution stays root-anchored under diff.relative (R14)" \
+  "$GITFIX4/sub" "specs" 1 "main" \
+  "specs/0240-nested-layout.md" "[WARN]"
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
The base-branch `status: draft` check silently passed when the linter ran from a subdirectory: `git ls-tree` resolved repo-root-relative pathspecs against the working directory, matched nothing, and no spec was ever identified as present on the base branch. Pinning git to the repository root — structurally, not per call site — makes the check trustworthy wherever it runs.

Implements `specs/0109-spec-status-invariant-on-main.delta-03.md` (R14–R16). Closes #768.

## How to read this PR?

Two files, and the interesting part is *why the fix has the shape it has* rather than what it does.

1. **`scripts/lib/spec-linter.js`** — a module-level `gitCwd`, assigned once in `resolveBaseContext()` right after the work tree is located, used as `gitCapture`'s default `cwd`. Three lines of behaviour; the comment above `gitCwd` carries the argument.
2. **`scripts/tests/test-spec-linter.sh`** — cases 39 and 40 on a new `$GITFIX4` whose specs **and** `.markdownlintrc` both sit under `sub/`.

Three things worth pausing on:

- **Why a default and not an argument at each call site.** `--full-name` on `ls-tree` and `--no-relative` on `diff` would satisfy R14 for the two invocations that carry them. R15 rejects that, on evidence rather than taste: this defect exists *because* two path-sensitive invocations were each written without their author classifying them as path-sensitive. A remedy requiring that classification to be made correctly next time does not remove the failure mode. As a default, invocation number eight inherits the guarantee without knowing it exists. (`--no-relative` also imposes a git ≥ 2.28 floor, and an unrecognised flag is a hard error, not a degradation.)
- **The one invocation that must stay unpinned.** `rev-parse --show-toplevel` runs while `gitCwd` is still `null`, so it resolves against the caller — which is what lets it answer *which repository* the run is about. Pinning it would be circular. This falls out of assignment order rather than needing an exemption anyone maintains.
- **The nested `.markdownlintrc` in the fixture is load-bearing, not incidental.** `-c .markdownlintrc` is resolved against the working directory, so a subdirectory run without a config there dies at markdownlint and never reaches the check. That is precisely why I first filed #768 claiming the hazard was unreachable — the reasoning assumed the only config in existence is the root one. The fixture exists to keep the path reachable.

## How to test this PR?

```sh
ln -s /path/to/main/checkout/node_modules node_modules   # or npm install
bash scripts/tests/test-spec-linter.sh                   # expect: 41 passed, 0 failed
BASE_REF=crewrig/main node scripts/lib/spec-linter.js    # whole corpus
```

**The probe from the issue, before and after.** One throwaway repository, one non-delta spec on the base branch at `status: draft`, under `sub/specs/`, with `sub/.markdownlintrc` present:

```console
$ cd "$FIX/sub" && BASE_REF=main node <main-checkout>/scripts/lib/spec-linter.js specs
Linting passed!                                    [exit 0]   ← the violation is NOT reported

$ cd "$FIX/sub" && BASE_REF=main node <this-branch>/scripts/lib/spec-linter.js specs
  A spec reaches the base branch only by its own merged spec-PR, …
Linting failed: 1 files contain errors.            [exit 1]   ← named
```

**Falsification.** Both new cases were shown to fail when the behaviour they cover is removed, and the two mutations discriminate between a complete and a partial fix:

| Mutation | Case 39 | Case 40 |
|---|---|---|
| `gitCwd = repoRoot` assignment removed | **FAIL** (exit 0) | **FAIL** (exit 0) |
| `ls-tree` pinned, `git diff` left unpinned (`process.cwd()`) | pass | **FAIL** (exit 0) |

The second row is why Case 40 exists: with `ls-tree` pinned the offender *is* identified, but an unpinned `git diff` reports `specs/0240-nested-layout.md` relative to `sub/`, so it never matches `sub/specs/0240-nested-layout.md`, the offender degrades to a bystander, and the run passes with a `[WARN]`. Hence Case 40 asserts on the **absence** of `[WARN]`, not on the exit code alone.

Mutations were run under `env -i bash --noprofile --norc` with `/bin/cp -f` restores verified by `diff -q`. Not ceremony: in the sibling ticket #732 an aliased `cp -i` silently no-opped three restores while exiting `0`, so three different mutations were measured against the same file and produced identical results.

## Detailed description (for agents)

### `scripts/lib/spec-linter.js`

**Added `let gitCwd = null;`** above `gitCapture`, with the invariant stated once: git in this file runs at the repository root.

**`gitCapture(args)` → `gitCapture(args, cwd)`.** Resolution order is explicit argument → `gitCwd` → `undefined`. The `undefined` rung preserves today's behaviour exactly for every pre-work-tree and non-repository path — Case 33 (outside a git work tree) and the whole flat `$TMP_ROOT` fixture set exercise it, and all of them still pass unchanged.

**Assigned `gitCwd = repoRoot` in `resolveBaseContext()`**, immediately after `fs.realpathSync(toplevel…)` and before the first path-sensitive read. That single line covers all seven non-discovery invocations — `resolveBaseRef()`'s four (`remote`, two `rev-parse --verify`, `fetch`), `baseBranchPaths()`'s `ls-tree`, and `changedPaths()`'s `merge-base` and `diff` — without naming any of them. `repoRoot` is already canonicalised via `realpathSync` for the symlinked-checkout case, and pinning to the canonical form is what keeps it consistent with the `relPathByFile` comparison built on the same form.

Only two of those seven were path-sensitive; the other five are pinned as a side effect and are unaffected (`git fetch` writes to the repository rather than reading paths — the only *writing* call, called out because it is the one where an unexamined cwd change could plausibly matter, and Cases 28–38 exercise the resolution path it lives in).

### `scripts/tests/test-spec-linter.sh`

**`$GITFIX4`** — `sub/specs/0240-nested-layout.md` at `status: draft` committed on `main`, with `sub/.markdownlintrc` and a `sub/node_modules` symlink. No remote; both cases pass `BASE_REF` explicitly.

- **Case 39** (R14) — run with `sub/` as the working directory, target `specs`, expect exit 1 with the offender named. This is the defect, reachable through the ordinary CLI entry point.
- **Case 40** (R14, attribution half) — same run with `diff.relative=true` and the offending spec modified in the tree, expect exit 1 and no `[WARN]`. Discriminates the partial fix, as tabulated above. Its comment states plainly that it does **not** isolate the `diff` derivation from the `ls-tree` one — the only working directory where `diff` misbehaves is one where `ls-tree` has already returned nothing, so isolation is not observable through the command line. Recorded so the case is not read as stronger than it is.

Suite: **41 passed, 0 failed**.

### Not triggered, checked rather than assumed

- **Docs:** none. Unlike delta-02's R12, delta-03 imposes no documentation obligation — nothing a spec author or reader does changes, so `docs/spec-format.md` is untouched.
- **CLI matrix:** `scripts/lib/` and `scripts/tests/` are not trigger surfaces. No `docs/cli-matrix.md` edit due; `check-ci-parity` and `gitlab-ci-check` unaffected.
- **CI wiring:** unchanged in both engines. No new variable, no new parity surface.
- **Version bump:** no skill or agent source touched. The spec-side bump (`2.1.0`) shipped in #774.
- **Build outputs / core-paths manifest:** none; nothing under `artifacts/`, no layer reclassified.
- **Behaviour change visible to a user:** the linter starts *reporting* offenders it previously missed. No repository-nested spec layout exists on `main` today (all specs sit at `specs/`, and `specs/org/` is manifest-excluded), so nothing here changes state — confirmed by the whole-corpus run passing.
