### PR TITLE
📝 Add spec 0118 — a merge that would put a draft spec on the base branch is refused

### DIFF
--- a/specs/0118-spec-pr-merge-status-guard.md
+++ b/specs/0118-spec-pr-merge-status-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0118"
 slug: spec-pr-merge-status-guard
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 766

--- a/specs/0118-spec-pr-merge-status-guard.md
+++ b/specs/0118-spec-pr-merge-status-guard.md
@@ -1,0 +1,157 @@
+---
+id: "0118"
+slug: spec-pr-merge-status-guard
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 766
+version: 1.0.0
+---
+
+# A merge that would put a draft spec on the base branch is refused
+
+## Intent
+
+`specs/0109-spec-status-invariant-on-main.md` R1 states that no non-delta spec on
+`main` may carry `status: draft`. Everything around that invariant is now built
+except the one thing that would keep it: the invariant is **detected** after the
+fact (the base branch's own build fails, `specs/0109…delta-02.md` R10) and the
+blast radius of a violation has been **contained** (delta-02 R9), but nothing
+prevents the merge that violates it.
+
+The step that prevents it — the `draft` → `approved` commit that
+`docs/spec-format.md` requires inside the spec-PR, before the squash — has been
+omitted **twice in twenty-four hours by two different sessions**, each time
+putting a `draft` spec on `main` and failing `lint-specs` repository-wide. Two
+independent actors missing one step is a property of the step's position in the
+procedure, not of either actor's diligence: it sits between "CI is green" and
+"merge", the moment a lifecycle feels finished, with nothing standing between
+those two acts.
+
+This spec puts something between them. It is **one rule on the surface
+`specs/0117-tool-boundary-command-guard.md` defines**, not a mechanism of its own
+— which is what that surface's R3 exists to make possible, and the reason this
+spec is small.
+
+The rule is stated as what it protects rather than as what it pattern-matches: a
+merge is refused when it **would land a non-delta spec carrying `status: draft` on
+the base branch**. That is spec 0109 R1, evaluated one moment earlier than the
+build that currently catches it.
+
+## Requirements
+
+1. A command that would merge a pull request SHALL be refused before it executes
+   when the merge would result in a non-delta spec file carrying `status: draft`
+   being present on the pull request's base branch.
+2. The condition of requirement 1 SHALL be evaluated against the **head tree of
+   the pull request being merged**, not the working tree of the agent issuing the
+   command. An agent may merge from any directory, and its working tree may
+   legitimately differ from the branch under merge.
+3. Delta-specs SHALL be exempt, consistent with `specs/0109` R2 and with the
+   deliberate non-decision recorded in that spec's *Out of scope* about what
+   status a delta should carry. A rule stricter than the invariant it enforces
+   would refuse merges the repository permits.
+4. The `status` field SHALL be read through the **same frontmatter reader the spec
+   linter uses**, not a second parser written for this rule. Two readers of one
+   field is the divergence `specs/0117` R4 forbids: the guard and the linter would
+   be able to disagree about whether a spec is a draft, and the guard's answer is
+   the one nobody sees until it is wrong.
+5. The rule SHALL be expressed as **data on the guard's rule table**, adding no
+   branch to the guard's decision path, per `specs/0117` R3. If honouring this
+   spec requires editing that decision path, the surface has not satisfied its own
+   R3 and the defect is there rather than here.
+6. A refusal SHALL name the offending spec file and SHALL state the remedy as the
+   procedure that exists: record `status: approved` in a **new commit** on the
+   spec-PR branch, push, then merge. A guard that refuses without naming the next
+   action converts a missed step into a stuck agent.
+7. When the condition of requirement 1 **cannot be determined** — the pull request
+   cannot be resolved from the command, its head tree cannot be read, the forge is
+   unreachable — the merge SHALL be refused, and the refusal SHALL state that the
+   determination failed rather than implying a violation was found. Refusing here
+   is the safe direction: the cost is a merge an operator retries or overrides,
+   against a silent violation that blocks every open pull request in the
+   repository. This is `specs/0117` R6 applied to this rule — an indeterminate
+   evaluation denies **only** the merge command it matched, and never any other
+   tool call.
+8. A merge that satisfies the invariant SHALL be allowed without any additional
+   step, prompt, or confirmation. The guard's cost to a conforming merge SHALL be
+   its latency alone, within the budget `specs/0117` R7 requires.
+9. The rule SHALL be covered by a regression suite with at least one case for each
+   of: a merge landing a `draft` non-delta spec refused; the same merge allowed
+   once the status is `approved`; a merge landing a `draft` **delta**-spec allowed
+   (requirement 3); a merge touching no spec allowed; and an indeterminate
+   evaluation refused with the determination-failed reason (requirement 7). Each
+   case SHALL fail if the behaviour it covers is removed.
+10. `docs/spec-format.md` → *Recording a status transition* SHALL state that the
+    merge mechanic is enforced by this rule, so that a reader of the obligation
+    learns it is mechanically checked rather than trusted. The mechanic's own
+    wording is already correct and SHALL NOT change.
+
+## Scenarios
+
+**Scenario:** the omission that happened twice is now refused
+
+```text
+Given a spec-PR whose head tree carries a non-delta spec at status: draft
+When  an agent issues the command that would merge it
+Then  the merge is refused before it executes
+And   the reason names that spec file and the new-commit remedy
+```
+
+**Scenario:** the conforming merge is untouched
+
+```text
+Given the same spec-PR after status is recorded as approved
+When  an agent issues the command that would merge it
+Then  the merge proceeds with no additional step
+```
+
+**Scenario:** a delta-spec at draft does not block its merge
+
+```text
+Given a spec-PR whose head tree carries only a delta-spec at status: draft
+When  an agent issues the command that would merge it
+Then  the merge proceeds
+```
+
+**Scenario:** an indeterminate evaluation refuses the merge and says why
+
+```text
+Given a merge command whose pull request cannot be resolved
+When  the guard evaluates this rule
+Then  the merge is refused
+And   the reason states that the determination failed, not that a spec is draft
+And   no other tool call is affected
+```
+
+## Out of scope
+
+- **The guard surface itself.** `specs/0117-tool-boundary-command-guard.md` owns
+  the mechanism, the per-CLI events, the rule-table shape and the latency budget.
+  This spec adds a rule and depends on that surface existing; it specifies none of
+  it. **Implementation of this spec is therefore blocked until spec 0117 is
+  implemented**, which is itself waiting on `scripts/worktree-claim.sh` reaching
+  `main` (`#771`, PR #773).
+- **The whole-tree git prohibitions of `specs/0114`.** The other rule on the same
+  surface, with a different authority. That the two share a surface and share no
+  logic is the property `specs/0117` R3 is meant to demonstrate.
+- **Changing the `draft` → `approved` mechanic.** It is already correct and has
+  been since PR #664; requirement 10 documents that it is now enforced and changes
+  no word of it. The defect was never the mechanic's content.
+- **Changing spec 0109's invariant, its linter check, or the attribution of
+  delta-02.** This rule enforces R1 earlier; it does not restate or amend it.
+- **Deciding what status a delta-spec should carry.** Left unresolved by
+  `specs/0109` on measured grounds, and requirement 3 inherits that exemption
+  rather than settling it.
+- **Refusing a merge for any reason other than requirement 1.** The rule is not a
+  general merge policy. A merge blocked by CI, by review state, or by branch
+  protection is already handled by the forge, and duplicating those checks here
+  would put a second answer in front of an existing one.
+- **A guard on the moment a spec-PR is *opened*.** A spec-PR under review carries
+  `draft` legitimately — `specs/0109` R2 has always exempted it and delta-02 keeps
+  it exempt. Only the merge is the wrong moment for `draft`, which is why this rule
+  attaches there and nowhere earlier.
+
+## Open questions
+
+None.


### PR DESCRIPTION
Spec 0118 refuses a merge that would land a non-delta spec carrying `status: draft` on the base branch. That omission has happened twice in twenty-four hours by two different sessions, each time blocking `lint-specs` repository-wide. Related `#766`.

## How to read this PR?

One new file: `specs/0118-spec-pr-merge-status-guard.md`.

The framing is the thing to read for, because it decides how small the spec is. `#766` describes the problem as "the `draft` → `approved` flip is missed at merge time" and invites a guard on *that step*. This spec instead states the rule as **what it protects**: a merge is refused when it *would land a non-delta spec at `status: draft` on the base branch*. That is `specs/0109` R1, evaluated one moment earlier than the build that already catches it — so the rule needs no new invariant, inherits R2's delta exemption for free, and cannot drift from the thing it enforces.

Read in this order:

1. **`## Intent`** — why this is a position-in-the-procedure defect rather than a diligence defect. The obligation sits between "CI is green" and "merge", and nothing stood between those two acts.
2. **R1–R3** — the rule. R2 is the non-obvious one: evaluate the **head tree of the pull request**, not the agent's working tree, because an agent may merge from anywhere and its tree may legitimately differ from the branch under merge.
3. **R4** — read `status` through the **linter's own frontmatter reader**, never a second parser. Two readers of one field is the divergence `specs/0117` R4 forbids, and here the guard's answer is the one nobody sees until it is wrong.
4. **R5** — the rule is **data on the 0117 rule table**, adding no branch to the guard's decision path. Stated as a falsifiable claim about the *surface*: "If honouring this spec requires editing that decision path, the surface has not satisfied its own R3 and the defect is there rather than here."
5. **R7** — the fail direction, argued rather than assumed. An indeterminate evaluation **refuses**, because the cost is a merge an operator retries, against a silent violation that blocks every open pull request. And per `specs/0117` R6 it denies only the merge command it matched — never any other tool call.

## How to test this PR?

The spec-PR carries no implementation.

```sh
BASE_REF=crewrig/main node scripts/lib/spec-linter.js \
  specs/0118-spec-pr-merge-status-guard.md          # expect: Linting passed!
BASE_REF=crewrig/main node scripts/lib/spec-linter.js    # whole corpus

CREWRIG_SPEC_ID_ORIGIN=same BASE_REF=crewrig/main bash scripts/check-spec-id-reserved.sh
#   OK specs/0118-… — id '0118' secured for issue #766 at refs/spec-ids/0118 (no stale mark)
```

Run the id guard **against the commit**, not a working-tree file: before `git add` it reports `Specs added or renamed by this change: 0` and exits `OK` — green because it found nothing.

Worth checking by eye: `related-issue: 766` (this ticket, not `#771`), and that every requirement referencing the guard surface cites `specs/0117` rather than restating it.

## Detailed description (for agents)

**Added — one file** (one-file rule): `specs/0118-spec-pr-merge-status-guard.md`. Frontmatter: `id: "0118"` secured at `refs/spec-ids/0118` for issue #766 before the branch was cut, `status: draft` at authoring time, `complexity: small`, `interaction-mode: AUTO`, `related-issue: 766`, `version: 1.0.0`.

**Why `small`.** The deliverable is one rule plus its regression cases on a surface another spec owns. No per-CLI work (the surface handles that), no new mechanism, no protocol document amended beyond one sentence (R10). The tier would be wrong if this spec specified the guard; it deliberately does not.

**The ten requirements.**

- **R1–R2** — refuse before execution when the merge would land a `draft` non-delta spec on the base branch, evaluated against the pull request's head tree rather than the agent's working tree.
- **R3** — delta-specs exempt, inheriting `specs/0109` R2 and its recorded non-decision about what status a delta should carry. A rule stricter than its invariant would refuse merges the repository permits.
- **R4** — one frontmatter reader, shared with the linter.
- **R5** — the rule is data on the 0117 table; needing a branch in the decision path is a defect *in the surface*.
- **R6** — the refusal names the file and the remedy (record `approved` in a **new** commit, push, merge). "A guard that refuses without naming the next action converts a missed step into a stuck agent."
- **R7** — indeterminate ⇒ refuse, with a reason that says the determination failed rather than implying a violation; scoped to the matched merge command only.
- **R8** — a conforming merge pays latency and nothing else: no extra step, prompt, or confirmation.
- **R9** — five falsifiable cases: `draft` non-delta refused; allowed once `approved`; `draft` **delta** allowed; no-spec merge allowed; indeterminate refused with the right reason.
- **R10** — `docs/spec-format.md` → *Recording a status transition* states that the mechanic is now enforced. The mechanic's own wording is already correct and does not change.

**Out of scope, each with its reason in the file:** the guard surface itself (`specs/0117` owns the mechanism, the per-CLI events, the rule-table shape, the latency budget); the whole-tree git prohibitions of `specs/0114` (the other rule on the same surface, different authority — that the two share a surface and share no logic is what `specs/0117` R3 is meant to demonstrate); changing the `draft` → `approved` mechanic (correct since PR #664 — the defect was never its content); amending spec 0109; deciding a delta's status; refusing a merge for any other reason (CI, review state and branch protection are the forge's job, and duplicating them would put a second answer in front of an existing one); and a guard at spec-PR *open* time (a spec-PR under review is legitimately `draft` — only the merge is the wrong moment).

**Implementation is blocked, and the spec says so.** This rule needs `specs/0117`'s surface, whose own implementation waits on `scripts/worktree-claim.sh` reaching `main` (`#771`, PR #773 — currently `CLEAN` with 13/13 green, owned by the `#736` session). SPECS was not blocked: the rule's authority is the spec file's own frontmatter, available today, and the surface is specified on `main` as of `77c04cc`.

**No closing keyword.** `#766` is this ticket's shared logbook anchor, so per `docs/spec-pr-workflow.md` → *Independence rule* this body carries none adjacent to it.
