### PR TITLE
📝 Mark spec 0116 implemented

### DIFF
--- a/specs/0116-antigravity-transcript-activation.md
+++ b/specs/0116-antigravity-transcript-activation.md
@@ -1,7 +1,7 @@
 ---
 id: "0116"
 slug: antigravity-transcript-activation
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 724


### PR DESCRIPTION
Metadata-only status transition for `specs/0116-antigravity-transcript-activation.md`.

Closes #785

## How to read this PR?

One line. `status: approved` → `status: implemented` on the parent spec.

## How to test this PR?

`task spec:lint`.

## Detailed description (for agents)

- Trigger: PR #769 merged on `main` at `eaf59b9`, which
  `docs/spec-format.md` → *Lifecycle states* assigns to `implemented`.
- Nothing else is touched — no body line, no `id`, no `slug`, no `version`. The
  `version` field on a merged original stays immutable; the cumulative version
  lives on the highest-numbered delta (`2.1.0`, on delta-02).
- The two delta-specs keep their own `status` untouched:
  `specs/0109-spec-status-invariant-on-main.md` → *Out of scope* deliberately
  leaves the delta case unsettled, and the linter exempts delta files from the
  no-draft-on-main invariant for that reason.