### PR TITLE
📝 Mark spec 0119 implemented

### DIFF
--- a/specs/0119-overlay-tier-component-resolution.md
+++ b/specs/0119-overlay-tier-component-resolution.md
@@ -1,7 +1,7 @@
 ---
 id: "0119"
 slug: overlay-tier-component-resolution
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 789


### PR DESCRIPTION
Spec 0119's recorded status is behind the repository: the implementation is merged, the spec still reads `approved`.

`docs/spec-format.md`'s status-transition table assigns the `implemented` transition to the merge of the implementation PR for the spec's `related-issue`. That merge is #791, squash-merged at `6e00019`, closing issue #789.

## How to read this PR?

One line. `status: approved` → `status: implemented` in `specs/0119-overlay-tier-component-resolution.md`. Nothing else in the file moves — spec content is append-only after merge, and lifecycle metadata is the documented exception.

## How to test this PR?

`task spec:lint` — exit 0. The check enforces the spec 0109 invariant that a non-delta spec on the base branch does not carry `status: draft`; this transition moves in the direction that invariant wants.

## Detailed description (for agents)

The spec was authored under ticket #789, a `harness-feedback` friction report about `manage-*-component.sh` being unable to install an `org`-tier component. Four gate rounds turned that report over: the script it held up as the correct pattern to copy was the most deviant of the four, and the fix ultimately removed five defects where the report named one.

Nothing here re-opens any of that. This records that the work landed.

Closes #792