### PR TITLE
📝 Add spec 0121 — Antigravity built outputs carry the upstream-sync guarantee

### DIFF
--- a/specs/0121-antigravity-outputs-in-core-paths.md
+++ b/specs/0121-antigravity-outputs-in-core-paths.md
@@ -1,0 +1,147 @@
+---
+id: "0121"
+slug: antigravity-outputs-in-core-paths
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 755
+version: 1.0.0
+---
+
+# Antigravity built outputs carry the same upstream-sync guarantee as their siblings
+
+## Intent
+
+A fork that synchronises from upstream today comes away with current Claude
+Code, Gemini CLI, and GitHub Copilot CLI component outputs but with whatever
+Antigravity component outputs it happened to already have, and nothing says
+so at the time; the divergence only surfaces later, when a drift check on the
+built components fails for no apparent reason and the adopter has to work
+backwards to the cause. After this spec, every set of built component outputs
+the repository ships carries the same synchronisation guarantee whichever CLI
+it targets, a locally edited Antigravity output stops a synchronisation the
+same way a locally edited Claude Code output already does, and a further set
+of built outputs cannot enter the repository while that guarantee is missing.
+
+## Requirements
+
+1. A fork that synchronises from upstream SHALL come away with its Antigravity
+   component outputs at the same upstream revision as its Claude Code, Gemini
+   CLI, and GitHub Copilot CLI component outputs.
+2. Every directory that the component build writes component outputs into
+   SHALL carry the same upstream-synchronisation guarantee as every other such
+   directory, and no such directory SHALL be left without one.
+3. A local modification to a built Antigravity component output SHALL halt an
+   upstream synchronisation and name the affected core-layer path, exactly as
+   a local modification to a built Claude Code, Gemini CLI, or GitHub Copilot
+   CLI component output does.
+4. Adopter-local Antigravity CLI state SHALL remain outside the
+   upstream-synchronisation guarantee, so that it is never restored over and
+   never halts a synchronisation.
+5. The continuous-integration build SHALL fail whenever a directory that the
+   component build writes component outputs into carries no
+   upstream-synchronisation guarantee, and SHALL name that directory in its
+   output.
+6. The guard required in requirement 5 SHALL itself be exercised on every
+   continuous-integration run against at least one case it is expected to
+   reject, so that a guard which has stopped detecting the condition fails the
+   build instead of passing it.
+7. The core-layer classification of the Antigravity component output
+   directories SHALL be stated in both the human-readable and the
+   machine-readable record of the core layer, and the two statements SHALL
+   agree.
+
+## Scenarios
+
+**Scenario:** an upstream sync brings a fork's Antigravity outputs up to date
+
+```text
+Given a fork whose `.agents/skills/spec-author/SKILL.md` and
+      `.agents/agents/spec-author/AGENT.md` sit at an older upstream revision
+When  the adopter synchronises from upstream across the commit that changed
+      those two files
+Then  both files match upstream's content at the synchronised revision, and a
+      subsequent drift check over the built components reports no drift
+```
+
+**Scenario:** a locally edited Antigravity output halts the synchronisation
+
+```text
+Given an adopter has hand-edited `.agents/agents/developer/AGENT.md`
+When  the adopter synchronises from upstream
+Then  the synchronisation halts without restoring anything, and names the
+      Antigravity output directory among the core-layer paths carrying local
+      modifications, exactly as a hand-edited `.claude/agents/developer/AGENT.md`
+      makes it name the Claude Code one
+```
+
+**Scenario:** adopter-local Antigravity state survives a synchronisation
+
+```text
+Given an adopter has written `.agents/settings.local.json` with local settings
+When  the adopter synchronises from upstream
+Then  the synchronisation neither halts on that file nor changes its content
+```
+
+**Scenario:** a built output directory without the guarantee fails the build
+
+```text
+Given a change that teaches the component build to write component outputs
+      into a directory that carries no upstream-synchronisation guarantee
+When  continuous integration runs on that change
+Then  the build fails and names that directory
+```
+
+**Scenario:** a guard that has stopped detecting the condition fails the build
+
+```text
+Given the guard required in requirement 5 no longer reports a built output
+      directory that carries no upstream-synchronisation guarantee
+When  continuous integration runs
+Then  the build fails, rather than reporting the repository clean
+```
+
+## Out of scope
+
+- `.agents/ANTIGRAVITY.md` and `.agents/settings.local.json.example`. Both are
+  tracked, and neither is written by the component build, so requirement 2
+  does not reach them and this spec leaves their classification unchanged.
+  This is deliberate and follows the standing shape of the manifest: no CLI
+  output root is claimed whole — each is claimed through the subdirectories
+  the build writes — and `.claude/settings.json` and
+  `.claude/scheduled_tasks.lock` are tracked and unguaranteed for the same
+  reason. Claiming the `.agents` root whole would hand Antigravity a broader
+  guarantee than any sibling holds, and would sweep in a settings template of
+  exactly the class that already needed a carve-out on the Copilot side
+  (`.github/copilot/settings.json`, spec 0097). Whether those two files
+  deserve a guarantee of their own is a separate classification decision and
+  belongs to a separate ticket.
+- `.agents/settings.local.json`. It is already untracked and adopter-local, so
+  requirement 4 records the property rather than changing anything.
+- Any path that is not a directory the component build writes component
+  outputs into — per-CLI source material and configuration in particular.
+  Requirement 2's property is bounded to built outputs, and this spec changes
+  no other path's classification.
+- Repairing forks that already carry stale Antigravity outputs. Re-running the
+  component build regenerates them from the synchronised sources, so no
+  migration path is specified here.
+- Any change to what the component build produces for Antigravity, or to which
+  CLIs it targets. This spec is about the guarantee over the outputs, not
+  about the outputs themselves.
+- Extending requirement 5's guard to output paths the build writes outside the
+  repository tree, such as a CLI's user-level installation directory. Those
+  are installed, not committed, and no synchronisation guarantee applies to
+  them.
+
+## Open questions
+
+None. The two decisions this spec carried while drafting are closed rather
+than parked: the granularity question (claim the `.agents` root whole, or the
+two subdirectories the build writes) is settled in favour of the
+subdirectories, with the sibling precedent and the two excluded files recorded
+in `Out of scope`; and the question of whether a `small`-tier ticket warrants
+a mechanical guard rather than a corrected record alone is settled in favour
+of the guard, in requirements 5 and 6 — the record already drifted once
+without anything noticing, and a guard for the opposite direction of the same
+property already runs in continuous integration, so the marginal cost is an
+extension of an existing check rather than a new one.

--- a/specs/0121-antigravity-outputs-in-core-paths.md
+++ b/specs/0121-antigravity-outputs-in-core-paths.md
@@ -2,7 +2,7 @@
 id: "0121"
 slug: antigravity-outputs-in-core-paths
 status: draft
-complexity: small
+complexity: standard
 interaction-mode: AUTO
 related-issue: 755
 version: 1.0.0

--- a/specs/0121-antigravity-outputs-in-core-paths.md
+++ b/specs/0121-antigravity-outputs-in-core-paths.md
@@ -1,7 +1,7 @@
 ---
 id: "0121"
 slug: antigravity-outputs-in-core-paths
-status: draft
+status: approved
 complexity: standard
 interaction-mode: AUTO
 related-issue: 755


### PR DESCRIPTION
Adds spec 0121, which requires every directory the component build writes outputs into to carry the same upstream-synchronisation guarantee — closing the gap issue #755 reports, where three of four CLI output roots are guarded and the Antigravity one is not. This is the SPECS-stage artifact for issue #755; no implementation ships here.

## How to read this PR?

One file, `specs/0121-antigravity-outputs-in-core-paths.md`. Read `## Intent`, then jump straight to the two decisions the drafting had to take, both recorded in `## Open questions` and argued in `## Out of scope`:

**Granularity — the `.agents` root, or the two subdirectories under it?** The issue proposes "add `.agents`". The spec takes the narrower option, and the first `## Out of scope` bullet says why: `.agents/` holds four things, of which only `skills/` and `agents/` are build products; `ANTIGRAVITY.md` and `settings.local.json.example` are not written by the build. Claiming the root whole would hand Antigravity a broader guarantee than any sibling holds — no CLI output root in the manifest is claimed whole today — and would sweep in a settings template of exactly the class that already needed a carve-out on the Copilot side (spec 0097). The sibling precedent is symmetric: `.claude/settings.json` and `.claude/scheduled_tasks.lock` are tracked and unguaranteed for the same reason.

**A corrected record, or a guard?** Requirements 5 and 6 choose the guard. The reasoning is in `## Open questions`: the record already drifted once with nothing noticing, which is the whole of issue #755. Requirement 6 is the part worth pausing on — it obliges the guard to be exercised against a case it is expected to *reject*, on every run, so a guard that has quietly stopped detecting the condition fails the build instead of reporting the repository clean.

## How to test this PR?

```sh
task spec:lint
npx markdownlint specs/0121-antigravity-outputs-in-core-paths.md
```

Both pass on this branch. No behaviour changes; the spec is a document.

To see the gap the spec addresses, on `main`:

```sh
grep -n 'agents' .crewrig/core-paths.txt      # three lines, all siblings; nothing under .agents
git ls-files .agents | wc -l                  # 67 tracked files
grep -n 'out_root/\.agents' scripts/build-components.sh   # lines 582 and 785 write them
```

## Detailed description (for agents)

**Added:** `specs/0121-antigravity-outputs-in-core-paths.md` (id `0121`, slug `antigravity-outputs-in-core-paths`, `complexity: standard`, `interaction-mode: AUTO`, `related-issue: 755`, `version: 1.0.0`). The id was secured on the reference repository before authoring via `scripts/reserve-spec-id.sh --issue 755` (`refs/spec-ids/0121`), so the frontmatter carries no `unsecured-id` mark.

**Nothing modified, nothing removed.** One-file spec-PR per `docs/spec-pr-workflow.md` → *one-file rule*.

**The complexity tier was corrected on this branch, from `small` to `standard`, in commit `e498e58`.** `small` was the orchestrator's instruction to the spec author, issued before the spec's shape was known. The spec that came back obliges a mechanical guard (R5) that is itself exercised against a rejecting case on every run (R6); authoring that guard and its self-test is `tester` work, and ADR-0010 → *Complexity tiers and team sizing* seats no `tester` on a `small` team. ADR-0010 routes a mid-lifecycle escalation through PLAN as an `arch` finding and forbids de-escalation outright, so correcting the tier before the spec merges avoids both paths.

**Seven requirements.** R1 states the outcome for a synchronising fork. R2 generalises it: every directory the build writes outputs into carries the guarantee, and none is left without one — this is the issue's closing ask ("worth checking whether any other Antigravity-specific output path shares the omission") turned into a testable property rather than a to-do. R3 requires symmetric halt-on-local-modification behaviour. R4 keeps adopter-local Antigravity state outside the guarantee. R5 requires CI to fail, naming the directory, when a written-into directory carries no guarantee. R6 is the anti-false-green clause on R5's guard. R7 requires the human-readable (`docs/layers.md`) and machine-readable (`.crewrig/core-paths.txt`) records of the core layer to state the classification and to agree — which is the co-maintenance obligation in `AGENTS.md` → *Core-paths manifest co-maintenance*, expressed as a property of the artifacts rather than as a rule about pull requests.

**Five scenarios:** an upstream sync bringing stale `.agents/**/spec-author/*` files up to date and a subsequent drift check reporting clean (the exact failure the issue observed); a hand-edited `.agents/agents/developer/AGENT.md` halting the sync as its `.claude/` counterpart already does; `.agents/settings.local.json` surviving untouched; a newly-written-into directory without a guarantee failing the build; and a guard that has stopped detecting the condition failing the build rather than reporting clean.

**Out of scope, explicitly:** `.agents/ANTIGRAVITY.md` and `.agents/settings.local.json.example` (tracked, not build products — their classification is a separate ticket); `.agents/settings.local.json` (already untracked, already adopter-local, so R4 records rather than changes); any path that is not a build-output directory; repairing forks already carrying stale outputs (re-running the build regenerates them); any change to what the build produces or which CLIs it targets; and extending R5's guard to install paths outside the repository tree, which are installed rather than committed and carry no synchronisation guarantee.

**Process notes.** Issue #755 is the logbook per `AGENTS.md` → *Logbook Issues → Rule A*. Per `docs/spec-pr-workflow.md` → *independence rule*, this PR carries no GitHub closing keyword for issue #755: the issue stays open to anchor PLAN, DEV and REVIEW. `status` flips from `draft` to `approved` in its own commit on this branch immediately before the squash-merge, per `docs/spec-format.md` → *Merge mechanic*. `## Open questions` is empty at approval, as that document requires.
