### PR TITLE
📝 Add spec 0123 — Antigravity components land where the CLI finds them

### DIFF
--- a/specs/0123-antigravity-components-discoverable.md
+++ b/specs/0123-antigravity-components-discoverable.md
@@ -1,7 +1,7 @@
 ---
 id: "0123"
 slug: antigravity-components-discoverable
-status: draft
+status: approved
 complexity: standard
 interaction-mode: AUTO
 related-issue: 761

--- a/specs/0123-antigravity-components-discoverable.md
+++ b/specs/0123-antigravity-components-discoverable.md
@@ -1,0 +1,206 @@
+---
+id: "0123"
+slug: antigravity-components-discoverable
+status: draft
+complexity: standard
+interaction-mode: AUTO
+related-issue: 761
+version: 1.0.0
+---
+
+# Antigravity components land where the CLI finds them
+
+## Intent
+
+A skill or an agent that the framework installs for Antigravity CLI is one
+that Antigravity CLI actually finds. Today it is not: the skills the setup
+run reports as installed are placed where the assistant never looks, so every
+framework skill shipped to that assistant is inert on the user's machine,
+and no agent is placed at all — the install step announces nothing and
+completes as though it had succeeded. A user who has run the Antigravity
+setup therefore sees none of the framework's skills offered in a session and
+none of its agents in the agent list, with nothing in the run's output to
+suggest anything is missing. After this spec is realized, a completed
+Antigravity setup leaves every component it claims to have installed where
+the assistant finds it, a machine set up under the superseded placement keeps
+no orphaned framework component behind, an install step that places nothing
+says so instead of passing quietly, and the framework's own record of where
+Antigravity components live states what has been observed of the assistant
+rather than what its documentation implies.
+
+## Requirements
+
+1. Every skill and every agent the framework installs for Antigravity CLI
+   SHALL be placed at a location Antigravity CLI discovers.
+2. The framework SHALL install skills and agents for Antigravity CLI under a
+   single customization root, and that root SHALL be the machine-local
+   customization root the vendor documents.
+3. An installed Antigravity component SHALL carry the on-disk shape
+   Antigravity CLI recognizes for its kind, whether or not that shape matches
+   the one the build stages.
+4. Every component the build stages for Antigravity CLI in a tier a setup run
+   serves SHALL be present at the install target once that run completes.
+5. A setup run SHALL NOT report a component as installed for Antigravity CLI
+   unless that component is present at the install target when the run ends.
+6. A setup run that finds staged Antigravity components and places none of
+   them SHALL report the discrepancy and SHALL NOT complete as though the
+   tier had been installed.
+7. Every per-component install surface the framework offers for Antigravity
+   CLI SHALL place a component at the same location a full setup run places
+   it.
+8. A setup run on a machine set up under the superseded placement SHALL leave
+   no framework-installed skill or agent at the superseded location.
+9. A setup run SHALL leave content at the superseded location that the
+   framework did not install untouched.
+10. Every statement in the framework's CLI capability matrix that records
+    where Antigravity skills or agents are placed, staged, or found SHALL
+    agree with the observed behaviour of Antigravity CLI.
+11. A recorded Antigravity placement that observed behaviour contradicts and
+    that cannot be brought into agreement SHALL carry a gap marker whose
+    stated evidence is the observation that contradicts it.
+12. The framework's record of Antigravity discovery SHALL state, for each
+    component kind, whether the discovery claim rests on vendor
+    documentation, on observation of the assistant, or on both.
+13. The framework SHALL retain a re-runnable procedure that re-establishes
+    which locations Antigravity CLI discovers for each component kind.
+14. The procedure of requirement 13 SHALL distinguish a component the
+    assistant does not find from an assistant that failed to answer, so that
+    a transient non-answer is not recorded as absence.
+
+## Scenarios
+
+**Scenario:** a freshly set-up machine offers the framework's Antigravity skills
+
+```text
+Given a machine with no prior Antigravity customization root
+When  `task setup-antigravity-interactive` completes its component install
+      step for the `library` tier
+Then  each installed skill is present under `~/.gemini/config/skills/<name>/`
+      and a subsequent `agy` session lists that skill among the skills it can
+      activate
+```
+
+**Scenario:** a freshly set-up machine offers the framework's Antigravity agents
+
+```text
+Given the build has staged one or more agents for Antigravity in the
+      `library` tier
+When  `task setup-antigravity-interactive` completes its component install
+      step
+Then  each staged agent is present under the same customization root as the
+      skills, and `agy agents` lists it
+```
+
+**Scenario:** a per-component install lands where the full run lands
+
+```text
+Given a named component the framework serves for Antigravity
+When  `scripts/manage-antigravity-component.sh` installs it
+Then  it is placed at the same location `task setup-antigravity-interactive`
+      would place it, and `agy` finds it there
+```
+
+**Scenario:** an install step that places nothing does not pass quietly
+
+```text
+Given the build has staged one or more agents for Antigravity in a served
+      tier
+When  a setup run completes its Antigravity component install step and places
+      none of those agents at the install target
+Then  the run reports the discrepancy and exits non-zero, instead of
+      completing silently as though the tier had been installed
+```
+
+**Scenario:** a machine set up under the superseded placement is migrated
+
+```text
+Given a machine whose `~/.gemini/antigravity-cli/skills/` holds framework
+      skills installed under the superseded placement, alongside a directory
+      the user placed there themselves
+When  `task setup-antigravity-interactive` runs again
+Then  no framework-installed skill remains under
+      `~/.gemini/antigravity-cli/skills/`, and the user's own directory is
+      still present and unmodified
+```
+
+**Scenario:** the recorded placement is contradicted by the assistant
+
+```text
+Given a re-run of the procedure of requirement 13 shows that a location is
+      not a discovery location for a component kind
+When  a row of `docs/cli-matrix.md` records that location as where the
+      framework installs that kind
+Then  the disagreement is reported as a defect against the record, and the
+      row is either corrected or carries a `[GAP]` naming that re-run as its
+      evidence
+```
+
+## Out of scope
+
+- **Registering the superseded location through `skills.json` instead of
+  moving the components.** The vendor documents `skills.json` as the escape
+  hatch for customizations kept outside the default discovery locations, and
+  it is a genuine third option alongside moving and leaving. It is rejected
+  here on three grounds: it ranks last in the vendor's own loading
+  precedence, below plain global discovery; it introduces a second
+  user-owned JSON file the framework would have to merge into without
+  clobbering operator entries, a cost the framework already pays once for
+  the MCP configuration; and its behaviour has never been observed on this
+  assistant, whereas directory discovery under the documented root has been
+  observed for both component kinds. Choosing an unobserved mechanism to fix
+  a defect caused by trusting documentation over observation would repeat
+  the mistake this ticket exists to correct.
+- **Keeping agents at `~/.gemini/antigravity-cli/agents/` because that
+  location was observed to work.** It was, and so was
+  `~/.gemini/config/agents/`; both are discovery locations for agents, so
+  moving costs nothing in discoverability. The superseded location is
+  application data the vendor never documents as a customization root and is
+  free to restructure on any upgrade, and keeping the two halves of one
+  install on two roots would leave a placement asymmetry inside a single CLI
+  that every later reader must be told is deliberate. Observed-today is not
+  contracted-forever; the documented root is preferred for both kinds.
+- **Automated enforcement of the discovery claim in continuous
+  integration.** Establishing which locations the assistant discovers
+  requires the vendor binary, a model-driven session, and minutes of wall
+  time, none of which the project's checks have. Requirement 13 mandates a
+  re-runnable procedure a human or an agent invokes deliberately, not a
+  gate.
+- **The placement of Antigravity rules and MCP server declarations.** The
+  per-component install surface targets `~/.gemini/antigravity-cli/rules`
+  and `~/.gemini/antigravity-cli/settings.json`, while the setup run writes
+  its MCP configuration to `~/.gemini/config/mcp_config.json` — a
+  disagreement of the same shape as the one this spec resolves for skills
+  and agents. It is excluded because no observation covers those two kinds;
+  asserting a defect there would rest on exactly the documentation-only
+  reasoning that the observation for agents refuted. It warrants its own
+  ticket, opened with a probe of its own.
+- **The workspace-level customization root.** Per-project customizations
+  discovered from a repository's own `.agents/` directory are unaffected;
+  this spec concerns only what a setup run places in the user's home.
+- **The priority-ordered context files, hooks, settings and history under
+  the Antigravity application-data directory.** Those are not discovered as
+  customizations: the context files are concatenated into the documented
+  root's `AGENTS.md` per spec 0061, and the transcript hooks already deploy
+  to the documented root per spec 0116. They stay where they are.
+- **The install targets of the three sibling CLIs.** Nothing observed about
+  Antigravity CLI says anything about Claude Code, Gemini CLI, or GitHub
+  Copilot CLI, and none of their install paths changes here.
+- **Whether Antigravity CLI reading the Gemini CLI agent root is desirable.**
+  It was observed to do so. The framework neither relies on that coupling
+  nor removes it, and this spec leaves the question untouched.
+
+## Open questions
+
+None. Four questions this spec carried while drafting are closed by decision
+rather than left open. Whether the two component kinds move together is
+settled in favour of a single root, with the reasoning recorded in `Out of
+scope` above. Whether registration replaces relocation is settled in favour
+of relocation, likewise recorded above. Whether components that are staged
+but never placed belong to this ticket is settled by requirements 4 to 6: the
+central property — that an installed component is one the assistant finds —
+is unverifiable for a kind that is never installed at all, so excluding it
+would leave half the spec vacuous. Whether the on-disk shape the build stages
+for an agent is the shape the assistant recognizes is settled by requirements
+3 and 13 together: the shape is constrained to whatever observation shows the
+assistant to accept, and the observation is required to be re-runnable rather
+than asserted once here.


### PR DESCRIPTION
Adds spec 0123, which requires every skill and agent the framework installs for Antigravity CLI to land where that CLI actually finds it — and requires the framework's own record of those locations to state what has been *observed*, not what vendor documentation implies. This is the SPECS-stage artifact for issue #761; no implementation ships here.

## How to read this PR?

One file, `specs/0123-antigravity-components-discoverable.md`. **Read the probe result on issue #761 first** — it is what the spec is built on and it refutes half of what the issue originally assumed:

| Location | Skills | Agents |
|---|---|---|
| `~/.gemini/antigravity-cli/` — what we install today | **not discovered** | **discovered** |
| `~/.gemini/config/` — the documented global root | discovered | discovered |
| `~/.gemini/skills`, `~/.gemini/agents` — Gemini CLI roots | not discovered | discovered |

Then read the spec's `## Out of scope`, because that is where the three real decisions live and each one is a rejection with a reason:

1. **Registering the current location through `skills.json` instead of moving** — rejected on three grounds, of which the third is the one that matters: `skills.json` behaviour has never been observed on this assistant, whereas directory discovery under the documented root has been observed for both kinds. Choosing an unobserved mechanism to fix a defect caused by trusting documentation over observation would repeat the mistake this ticket exists to correct.
2. **Keeping agents where they are, since that location demonstrably works** — rejected. It does work; so does the documented root, for agents. Moving therefore costs nothing in discoverability, and the current location is application data the vendor never documents as a customization root and is free to restructure on any upgrade. "Observed-today is not contracted-forever."
3. **Automated CI enforcement of the discovery claim** — rejected as infeasible (it needs the vendor binary, a model-driven session, and minutes of wall time). Requirement 13 mandates a *re-runnable procedure* instead of a gate, and requirement 14 obliges that procedure to distinguish "the assistant does not find it" from "the assistant failed to answer" — which is not hypothetical: `agy agents` hung for over two minutes during the probe and answered normally on retry.

Requirements 4-6 are the second defect, scoped in deliberately: `~/.gemini/antigravity-cli/agents/` is **empty** on a machine set up by `task setup-antigravity-interactive`, though the script reports installing there. The spec's reasoning for including it rather than splitting it out is in `## Open questions`: the central property — an installed component is one the assistant finds — is unverifiable for a kind that is never installed at all, so excluding it would leave half the spec vacuous.

## How to test this PR?

```sh
task spec:lint
npx markdownlint specs/0123-antigravity-components-discoverable.md
```

Both pass on this branch. No behaviour changes; the spec is a document.

To re-run the probe the spec rests on — about four minutes, and the spec's requirement 13 exists precisely so this stays cheap — install a uniquely-named sentinel skill under each of `~/.gemini/antigravity-cli/skills/`, `~/.gemini/config/skills/` and `~/.gemini/skills/`, a sentinel agent under each of the corresponding `agents/` directories, then ask:

```sh
agy -p "For each of these names, write NAME=YES if it is one of your available skills and NAME=NO if it is not: <your sentinel names>"
agy agents
```

Remove every sentinel afterwards, and restore any directory that did not exist beforehand — `~/.gemini/config/skills` and `~/.gemini/config/agents` do not exist on an unmodified machine.

## Detailed description (for agents)

**Added:** `specs/0123-antigravity-components-discoverable.md` (id `0123`, slug `antigravity-components-discoverable`, `complexity: standard`, `interaction-mode: AUTO`, `related-issue: 761`, `version: 1.0.0`). Id secured before authoring via `scripts/reserve-spec-id.sh --issue 761` (`refs/spec-ids/0123`); no `unsecured-id` mark.

**`complexity: standard`** because the implementation touches `scripts/setup-antigravity-interactive.sh` — a `setup-*.sh`, which is a CLI-matrix trigger surface per `AGENTS.md` → *CLI Matrix Maintenance* — plus `docs/cli-matrix.md` rows 3, 4 and 10, the per-component install surface, and a migration path for machines already set up under the old layout.

**Nothing modified, nothing removed.** One-file spec-PR per `docs/spec-pr-workflow.md` → *one-file rule*.

**Fourteen requirements, in four groups.** R1-R3 are placement: components land where the CLI discovers them, under a single documented root, in the on-disk shape the CLI recognises for their kind. R4-R6 are the install-completeness defect: everything staged for a served tier is present at the target when the run ends; nothing is reported installed unless it is; and a run that finds staged components and places none of them reports the discrepancy instead of completing quietly. R7 extends the same guarantee to the per-component install surface. R8-R9 are migration: no framework-installed component is left at the superseded location, and content there that the framework did not install is untouched — the second half matters, since a user may have put their own directories under `~/.gemini/antigravity-cli/skills/`. R10-R14 are the record: the CLI matrix must agree with observed behaviour, a contradiction that cannot be resolved carries a `[GAP]` whose evidence is the contradicting observation, the record states for each kind whether the claim rests on documentation or observation or both, and the procedure that establishes it stays re-runnable and able to tell absence from non-answer.

**Six scenarios**, two happy-path (skills and agents discoverable after a fresh setup), four failure-path (per-component install divergence, an install step that places nothing, migration alongside user-owned content, and a recorded placement contradicted by the assistant).

**`## Open questions` is empty**, with four drafting questions closed on the record rather than parked: whether the two kinds move together (yes, single root); whether registration replaces relocation (no, relocation); whether the staged-but-never-placed defect belongs here (yes, R4-R6, because excluding it leaves the central property unverifiable for agents); and whether the staged on-disk shape is the shape the assistant accepts (constrained by R3 and R13 together — whatever observation shows, re-establishable rather than asserted once).

**Also out of scope, and worth noting:** the placement of Antigravity *rules* and *MCP server declarations* shows a disagreement of exactly the same shape — the per-component install surface targets `~/.gemini/antigravity-cli/rules` and `~/.gemini/antigravity-cli/settings.json` while the setup run writes MCP configuration to `~/.gemini/config/mcp_config.json`. It is excluded because **no observation covers those two kinds**, and asserting a defect there would rest on precisely the documentation-only reasoning that the agents observation refuted. It warrants its own ticket, opened with a probe of its own.

**Process notes.** Issue #761 is the logbook per `AGENTS.md` → *Logbook Issues → Rule A*, and the probe record is its first comment. Per `docs/spec-pr-workflow.md` → *independence rule*, this PR carries no GitHub closing keyword for issue #761. `status` flips from `draft` to `approved` in its own commit on this branch immediately before the squash-merge, per `docs/spec-format.md` → *Merge mechanic*.
