### PR TITLE
🧹 Make the forbidden-construct set have one reader

### DIFF
--- a/scripts/check-bash32-portability.sh
+++ b/scripts/check-bash32-portability.sh
@@ -40,15 +40,53 @@
 # included, on the same terms as the scripts it ships.
 #
 # Usage:
-#   bash scripts/check-bash32-portability.sh
+#   bash scripts/check-bash32-portability.sh                  # render a verdict
+#   bash scripts/check-bash32-portability.sh --list-constructs # report what it read
 #
 # Override the repository root with CREWRIG_REPO_DIR (used by the self-test
 # against temporary fixtures), mirroring the sibling check-*.sh guards.
 #
 # Exits 0 when no governed script uses a declared construct, non-zero (naming
 # every offending file and line) otherwise.
+#
+# Contract of the second invocation (spec 0120, requirements 1-3 and 5). It
+# exists so that this guard is the repository's single interpretation of the
+# declared set's row format: a consumer that needs to know what the declared set
+# contains asks the enforcement instead of parsing ci/bash32-forbidden.txt a
+# second time. What is promised:
+#   - Rows on stdout, one per declared construct, in the shape
+#     <kind><TAB><token> — the two fields requirement 2 names, drawn from the
+#     alphabets this script already validates (kind is `command` or
+#     `declare-flag`, token is letters, digits, underscore and hyphen).
+#   - The row *set*, and therefore the row count, is exactly what the parse loop
+#     below accepted. Nothing is scanned and no verdict is rendered.
+#   - Exit 0 with rows; exit 2 for any refusal — every declared set this script
+#     refuses when asked for a verdict is refused here too, and the converse.
+#     Never exit 1: exit 1 is a verdict, and this invocation renders none.
+# What is deliberately NOT promised, so that the surface stays cheap to keep:
+#   - Row order. A consumer that depends on it is depending on file order, which
+#     is not part of this contract.
+#   - The wording of anything written to stderr.
+#   - Any third field. The reason column is free text that may itself hold tabs,
+#     which is the field-boundary ambiguity this invocation exists to remove; it
+#     is not reported.
 
 set -euo pipefail
+
+# Mode selection happens before the repository root is resolved and before
+# anything is read, so an unrecognised argument cannot scan the tree (R3).
+MODE=verdict
+if [ "$#" -gt 0 ]; then
+  # `[ "$#" -gt 0 ]` before touching `$1`: this script runs under `set -u`,
+  # where a bare `$1` with no arguments aborts on `$1: unbound variable`.
+  if [ "$#" -eq 1 ] && [ "$1" = "--list-constructs" ]; then
+    MODE=list
+  else
+    echo "Error: unrecognised argument(s): $*" >&2
+    echo "Usage: bash ${0##*/} [--list-constructs]" >&2
+    exit 2
+  fi
+fi
 
 REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
 FORBIDDEN="$REPO_DIR/ci/bash32-forbidden.txt"
@@ -66,10 +104,14 @@ fi
 # the failure class this script exists to catch, and it would be invisible to
 # both the grep rule below (not grep-detectable) and CI (which runs Bash 5).
 # `while read` rather than the Bash 4 line-reading builtin, for the same reason.
+# LISTING is the report the second invocation returns: the same rows, joined by
+# newlines rather than held in an array, for the reason above.
 CMD_ALT=""
 FLAG_ALT=""
 declared=0
 TAB="$(printf '\t')"
+NL=$'\n'
+LISTING=""
 
 while IFS= read -r line || [ -n "$line" ]; do
   line="${line%$'\r'}"                       # tolerate CRLF
@@ -119,11 +161,27 @@ while IFS= read -r line || [ -n "$line" ]; do
       ;;
   esac
   declared=$((declared + 1))
+  # Accumulated, never emitted here: a malformed row later in the file must be
+  # refused with no partial report already on stdout, so the report is written
+  # once, below, after the whole file has been accepted.
+  LISTING="${LISTING:+$LISTING$NL}$kind$TAB$token"
 done < "$FORBIDDEN"
 
 if [ "$declared" -eq 0 ]; then
   echo "Error: $FORBIDDEN declares no construct — the guard would pass vacuously." >&2
   exit 2
+fi
+
+# --- Report what was read, when that is what was asked ----------------------
+# Placed here on purpose, and the placement is the whole design: everything
+# upstream of this point is shared with the verdict path — the missing
+# declared-set file, every refusal inside the parse loop, and the vacuous-set
+# refusal above — so both invocations refuse exactly the same declared sets
+# (R5) without a duplicated condition. Everything downstream is the tree scan
+# the report must not perform (R3).
+if [ "$MODE" = list ]; then
+  printf '%s\n' "$LISTING"
+  exit 0
 fi
 
 # --- Compose the match pattern ----------------------------------------------

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -19,16 +19,29 @@
 #      (scenario 4, R10).
 #   e. A forbidden construct in a *test* script is rejected on the same terms as
 #      in a shipped script (scenario 6, R5).
-#   f. Every token in ci/bash32-forbidden.txt is named in Rule 5 of
+#   f. Every construct in the declared set is named in Rule 5 of
 #      docs/scripting-conventions.md (R2's "one place both the enforcement and
 #      the documentation refer to"). This is the doc-to-data link that no other
-#      gate covers.
+#      gate covers. Per spec 0120 it no longer parses ci/bash32-forbidden.txt
+#      itself: it consumes the report the enforcement returns for the set it
+#      actually read (`--list-constructs`), through the `sync_status` helper,
+#      which echoes one of `ok:<n>` / `missing:<list>` / `vacuous` / `unaskable`.
+#      Three call sites assert that discrimination — the repository (`ok:<n>`
+#      with n > 0, cross-checked against the verdict run's own count), a
+#      comment-only declared set (`unaskable`), and a set holding a construct
+#      absent from Rule 5 (`missing:<list>`).
 #   g. A declared set with no usable entry fails closed rather than passing
 #      vacuously (docs/scripting-conventions.md Rule 4).
 #   h. No array expansion in the six suites corrected under R6 is unguarded —
 #      the standing half of scenario 5 (R8). See `bare_expansions_in`.
 #   i. That detector is itself probed on 13 fixtures in both directions, so a
 #      future narrowing of it fails here rather than silently going quiet.
+#   j. Asking the guard what it read neither scans the governed tree nor renders
+#      a verdict, and an unrecognised argument is refused rather than falling
+#      through to a verdict run (spec 0120 R3).
+#   k. Both requests refuse the same declared sets and accept the same ones —
+#      case g's five malformed shapes replayed against each, plus the converse on
+#      a well-formed set (spec 0120 R5).
 #
 # Scenario 5 — a corrected suite reports the same verdicts on both shells — is
 # only partly scriptable here: comparing two shells needs two Bash binaries, and
@@ -60,6 +73,17 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DECLARED_SET="$REPO_ROOT/ci/bash32-forbidden.txt"
 CONVENTIONS_DOC="$REPO_ROOT/docs/scripting-conventions.md"
 
+TAB="$(printf '\t')"
+
+# The row shape the guard publishes for `--list-constructs` in its header
+# contract: <kind><TAB><token>, both fields drawn from alphabets the guard
+# itself validates. Cases j and k assert this shape rather than the rows'
+# contents or their order — the contract promises the shape and the row set, and
+# explicitly declines to promise order, so an assertion pinned to a literal
+# block would consume a guarantee that was never given and would turn red on the
+# next legitimate growth of ci/bash32-forbidden.txt (spec 0111 R2's floor).
+ROW_SHAPE='^(command|declare-flag)'"$TAB"'[A-Za-z0-9_-]+$'
+
 if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
   echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
   exit 2
@@ -86,14 +110,19 @@ mk_fixture() {
   cp "$DECLARED_SET" "$1/ci/bash32-forbidden.txt"
 }
 
-# run_check <dir> — run the guard with CREWRIG_REPO_DIR set, capturing stdout,
-# stderr and exit code into CHECK_EXIT / CHECK_STDOUT / CHECK_STDERR.
+# run_check <dir> [arg…] — run the guard with CREWRIG_REPO_DIR set, capturing
+# stdout, stderr and exit code into CHECK_EXIT / CHECK_STDOUT / CHECK_STDERR.
+# Any argument after <dir> is forwarded to the guard, which is how the cases
+# below reach its `--list-constructs` invocation. Verified on 3.2.57: `"$@"`
+# with no remaining positional parameters expands to nothing under `set -u`
+# rather than aborting, so every existing zero-argument caller is unaffected.
 run_check() {
   local repo="$1" out_file err_file
+  shift
   out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
   err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
   CHECK_EXIT=0
-  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" "$@" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
   CHECK_STDOUT="$(cat "$out_file")"
   CHECK_STDERR="$(cat "$err_file")"
   rm -f "$out_file" "$err_file"
@@ -301,7 +330,80 @@ bare_expansions_in() {
 }
 
 # ---------------------------------------------------------------------------
-# Case f — Declared set and Rule 5 stay in sync (R2).
+# sync_status <repo> — check a repository's declared set against Rule 5, and
+# ECHO which of four outcomes it reached rather than calling ok/bad itself.
+#
+# Echoing a token instead of recording a verdict is what lets a call site assert
+# a *failure* outcome — `unaskable`, `missing:` — without incrementing the
+# suite's fail counter, so "this must fail" is expressible other than by turning
+# the suite red.
+#
+# It obtains the declared set's contents from the enforcement (spec 0120 R1):
+# this suite no longer interprets ci/bash32-forbidden.txt, it reads the rows the
+# guard reports for the set it actually parsed. Reads the caller's `rule5`, which
+# case f assigns before its first call site.
+#
+# The four outcomes, in this evaluation order:
+sync_status() {
+  local repo="$1" missing checked row kind token needle
+  run_check "$repo" --list-constructs
+
+  # `unaskable` FIRST, before anything reads the rows. The order is load-bearing
+  # rather than stylistic: a guard that never ran leaves the same empty stdout as
+  # a guard that ran and reported nothing, so testing the rows first would report
+  # every "could not be asked" as "reported no construct" — the confusion R6
+  # exists to remove, and the failure mode consuming a *program* has that reading
+  # a *file* does not.
+  if [ "$CHECK_EXIT" -ne 0 ]; then
+    echo "unaskable"
+    return 0
+  fi
+
+  missing=""
+  checked=0
+  # Fed by an unquoted here-document rather than `printf … | while read`: the
+  # pipeline is a subshell, so `checked` and `missing` would die at the `done`
+  # and this helper would report `vacuous` on a healthy declared set. And a
+  # `while read` loop rather than the Bash 4 line-reading builtin, because this
+  # file is governed by the very guard it tests (R10) and CI runs Bash 5, where
+  # that mistake is invisible. Same idiom as cases h and i below.
+  while IFS= read -r row || [ -n "$row" ]; do
+    [ -n "$row" ] || continue
+    kind=$(printf '%s' "$row" | cut -f1)
+    token=$(printf '%s' "$row" | cut -f2)
+    [ -n "$token" ] || continue
+    # A bare flag letter would match almost any prose, so a declare-flag entry
+    # is required to appear in its usable form.
+    needle="$token"
+    if [ "$kind" = "declare-flag" ]; then
+      needle="declare -$token"
+    fi
+    checked=$((checked + 1))
+    if ! printf '%s\n' "$rule5" | grep -qF -- "$needle"; then
+      missing="${missing:+$missing, }$needle"
+    fi
+  done <<SYNC_ROWS
+$CHECK_STDOUT
+SYNC_ROWS
+
+  if [ "$checked" -eq 0 ]; then
+    # `vacuous` — the anti-vacuity floor case f has carried since spec 0111,
+    # preserved verbatim in meaning. It is unreachable through the shipped guard:
+    # a declared set holding no construct is already refused with exit 2, which
+    # arrives here as `unaskable`. Kept as defence against a future guard that
+    # stops refusing it, which is why no fixture below reaches it.
+    echo "vacuous"
+  elif [ -n "$missing" ]; then
+    echo "missing:$missing"
+  else
+    echo "ok:$checked"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case f — Declared set and Rule 5 stay in sync (R2), with the declared set's
+#          contents obtained from the enforcement (spec 0120 R1) and the
+#          discrimination R6 demands asserted at three call sites.
 # ---------------------------------------------------------------------------
 {
   # The Rule 5 section only, so a token named under some other rule does not
@@ -314,36 +416,70 @@ bare_expansions_in() {
     bad "case-f: no '## Rule 5 ' section found in $CONVENTIONS_DOC (R11)"
   fi
 
-  # Walk the declared set with `while read` — no array, so this loop cannot
-  # abort on an empty accumulator under bash 3.2 `set -u`.
-  missing=""
-  checked=0
-  while IFS= read -r line || [ -n "$line" ]; do
-    line="${line%$'\r'}"
-    [[ -z "$line" || "$line" == \#* ]] && continue
-    kind="${line%%[[:space:]]*}"
-    rest="${line#"$kind"}"
-    rest="${rest#"${rest%%[![:space:]]*}"}"
-    token="${rest%%[[:space:]]*}"
-    [ -n "$token" ] || continue
-    # A bare flag letter would match almost any prose, so a declare-flag entry
-    # is required to appear in its usable form.
-    needle="$token"
-    if [ "$kind" = "declare-flag" ]; then
-      needle="declare -$token"
-    fi
-    checked=$((checked + 1))
-    if ! printf '%s\n' "$rule5" | grep -qF -- "$needle"; then
-      missing="${missing:+$missing, }$needle"
-    fi
-  done < "$DECLARED_SET"
+  # --- Call site 1: the repository as it stands, which must be in sync.
+  f_status="$(sync_status "$REPO_ROOT")"
+  case "$f_status" in
+    ok:[1-9]*)
+      ok "case-f: all ${f_status#ok:} declared construct(s) are named in Rule 5 (R2)"
+      ;;
+    *)
+      # `ok:0` lands here too, which is the point: it is what deleting the
+      # helper's anti-vacuity floor would produce, and the declared set's size
+      # is deliberately not pinned (spec 0111 R2 makes it a floor, not a
+      # ceiling), so `n > 0` is the assertion that stays true as the set grows.
+      bad "case-f: expected ok:<n> with n greater than 0 from the enforcement's report, got '$f_status' (R2/R6/R7)"
+      ;;
+  esac
 
-  if [ "$checked" -eq 0 ]; then
-    bad "case-f: parsed 0 entries from $DECLARED_SET — the sync case would pass vacuously"
-  elif [ -z "$missing" ]; then
-    ok "case-f: all $checked declared construct(s) are named in Rule 5 (R2)"
+  # --- Call site 1, second assertion: the row count the query reported equals
+  # the count the verdict run reports on its own OK line. Both numbers come out
+  # of the enforcement — one from its rows, one from its verdict — so this
+  # compares the single parser against itself and pins nothing to the declared
+  # set's current size. Depending on the OK line's wording is safe here: R4
+  # freezes the verdict path byte-for-byte, and case b already greps its sibling
+  # `file(s) scanned` field.
+  run_check "$REPO_ROOT"
+  f_verdict_n="$(printf '%s\n' "$CHECK_STDOUT" \
+    | grep -oE '\([0-9]+ declared construct' | grep -oE '[0-9]+' | head -1)"
+  f_rows_n="${f_status#ok:}"
+  if [ "$f_rows_n" != "$f_status" ] && [ -n "$f_verdict_n" ] \
+     && [ "$f_rows_n" = "$f_verdict_n" ]; then
+    ok "case-f: the query's row count ($f_rows_n) is the count the verdict reports ($f_verdict_n)"
   else
-    bad "case-f: declared construct(s) missing from Rule 5 (R2): $missing"
+    bad "case-f: row count '$f_rows_n' and verdict count '$f_verdict_n' disagree (status was '$f_status')"
+  fi
+
+  # --- Call site 2: a guard that cannot be asked at all is reported as
+  # `unaskable`, not as an empty report (R6). A comment-only declared set is
+  # refused by the shipped guard with exit 2 and empty stdout, so no stub is
+  # involved: this is R6's reachable branch, reached with case g's own fixture
+  # idiom. The fixture carries ci/ only — the query returns before the governed
+  # tree is resolved, so there is nothing to scan.
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mkdir -p "$repo/ci"
+  printf '%s\n' '# every line here is a comment, so no construct is declared' \
+    > "$repo/ci/bash32-forbidden.txt"
+
+  f_status="$(sync_status "$repo")"
+  if [ "$f_status" = "unaskable" ]; then
+    ok "case-f: a guard that could not be asked is reported as unaskable, not as an empty report (R6)"
+  else
+    bad "case-f: expected 'unaskable' from a comment-only declared set, got '$f_status' (R6)"
+  fi
+
+  # --- Call site 3: a declared construct absent from Rule 5 still fails, and is
+  # named in the form Rule 5 is expected to carry it (R7). `coproc` is a valid
+  # token by the guard's own alphabet and is genuinely absent from Rule 5.
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\t%s\t%s\n' 'command' 'coproc' 'a valid token deliberately absent from Rule 5' \
+    >> "$repo/ci/bash32-forbidden.txt"
+
+  f_status="$(sync_status "$repo")"
+  if [ "$f_status" = "missing:coproc" ]; then
+    ok "case-f: a declared construct absent from Rule 5 is named as missing (R7)"
+  else
+    bad "case-f: expected 'missing:coproc' from a set holding an undocumented construct, got '$f_status' (R7)"
   fi
 }
 
@@ -578,6 +714,144 @@ DETECTOR_PROBE
     bad "case-i: expected 13 detector probes, ran $i_total"
   elif [ "$i_fail" -eq 0 ]; then
     ok "case-i: the bare-expansion detector is correct on all 13 probes, both directions"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case j — Asking the guard what it read neither scans the tree nor renders a
+#          verdict (spec 0120 R3).
+#
+# Every row assertion here is the published shape predicate, never a literal
+# block: the guard's contract promises the row shape and the row set, and
+# declines to promise row order, so pinning these cases to contents would consume
+# a guarantee that was never given and would turn red on the next legitimate
+# growth of ci/bash32-forbidden.txt — green at merge, red for a reason nobody
+# would connect back to this case.
+# ---------------------------------------------------------------------------
+{
+  # (a) A tree holding a real violation. The verdict would exit 1 here; the query
+  # must return its rows and no verdict at all.
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  printf '%s\n' '#!/bin/bash' 'mapfile -t x < f' > "$repo/scripts/offender.sh"
+
+  run_check "$repo" --list-constructs
+  j_ill="$(printf '%s\n' "$CHECK_STDOUT" | grep -cvE "$ROW_SHAPE")"
+  j_rows="$(printf '%s\n' "$CHECK_STDOUT" | wc -l | tr -d '[:space:]')"
+
+  if [ "$CHECK_EXIT" -eq 0 ] && [ "$j_ill" -eq 0 ] && [ "$j_rows" -gt 0 ]; then
+    ok "case-j: the query exits 0 and returns well-shaped rows from a tree the verdict would fail (R3)"
+  else
+    bad "case-j: query on a violating tree gave exit $CHECK_EXIT, $j_ill ill-shaped of $j_rows row(s) (stdout: $CHECK_STDOUT)"
+  fi
+
+  if ! printf '%s\n' "$CHECK_STDOUT" | grep -qE '^(OK|FAILED):'; then
+    ok "case-j: the query renders no verdict — neither an OK nor a FAILED line (R3)"
+  else
+    bad "case-j: the query emitted a verdict line (stdout: $CHECK_STDOUT)"
+  fi
+
+  # (b) A tree the verdict refuses to scan at all — ci/ only, no scripts/ and no
+  # hooks/. The verdict exits 2 there while the query still answers, which is the
+  # direct proof that the query returns before the governed tree is resolved.
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mkdir -p "$repo/ci"
+  cp "$DECLARED_SET" "$repo/ci/bash32-forbidden.txt"
+
+  run_check "$repo"
+  j_verdict_exit="$CHECK_EXIT"
+  run_check "$repo" --list-constructs
+  j_ill="$(printf '%s\n' "$CHECK_STDOUT" | grep -cvE "$ROW_SHAPE")"
+  j_rows="$(printf '%s\n' "$CHECK_STDOUT" | wc -l | tr -d '[:space:]')"
+
+  if [ "$j_verdict_exit" -eq 2 ] && [ "$CHECK_EXIT" -eq 0 ] \
+     && [ "$j_ill" -eq 0 ] && [ "$j_rows" -gt 0 ]; then
+    ok "case-j: the query answers on a tree the verdict refuses to scan (R3)"
+  else
+    bad "case-j: unscannable tree gave verdict exit $j_verdict_exit, query exit $CHECK_EXIT, $j_ill ill-shaped of $j_rows row(s)"
+  fi
+
+  # (c) An unrecognised argument is refused rather than falling through to a
+  # verdict run, which would scan the tree and reach case f as empty stdout,
+  # where it would be misdiagnosed.
+  run_check "$repo" --bogus-argument
+  if [ "$CHECK_EXIT" -eq 2 ] \
+     && printf '%s\n' "$CHECK_STDERR" | grep -qF -- '--bogus-argument' \
+     && ! printf '%s\n' "$CHECK_STDOUT" | grep -qE '^OK:'; then
+    ok "case-j: an unrecognised argument exits 2 and names itself, with no verdict on stdout"
+  else
+    bad "case-j: unrecognised argument gave exit $CHECK_EXIT (stdout: $CHECK_STDOUT) (stderr: $CHECK_STDERR)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case k — Both requests refuse the same declared sets, and accept the same ones
+#          (spec 0120 R5).
+#
+# This case asserts the guard's refusal parity only — the *input* side. What the
+# synchronisation check does with each outcome is case f's three call sites, not
+# this case's business; conflating the two is how "the guard refuses" gets
+# written up as "the consumer discriminates".
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  # A genuinely violating tree, so the well-formed leg below cannot pass by
+  # finding nothing.
+  printf '%s\n' '#!/bin/bash' 'mapfile -t x < f' > "$repo/scripts/offender.sh"
+
+  # Case g's five malformed shapes, written once each and replayed against both
+  # requests. Same shapes, same file, deliberately: a set case g proves the
+  # verdict refuses is the set this case proves the query refuses too.
+  k_sets="$(mktemp -d "$TMP_ROOT/ksets.XXXXXX")"
+  printf '%s\n' '# every line here is a comment, so no construct is declared' \
+    > "$k_sets/comment-only"
+  printf '%s\t%s\t%s\n' 'bogus-kind' 'mapfile' 'a kind the guard does not know' \
+    > "$k_sets/unknown-kind"
+  printf '%s\t%s\t%s\n' 'command' '(' 'a token with a metacharacter' \
+    > "$k_sets/metacharacter-token"
+  printf '%s\t%s\t%s\n' 'command' '' 'a reason that used to slide into the token' \
+    > "$k_sets/empty-token"
+  printf '%s\n' 'command mapfile a space separated row' \
+    > "$k_sets/tabless-row"
+
+  k_fail=0
+  k_total=0
+  for k_name in comment-only unknown-kind metacharacter-token empty-token tabless-row; do
+    cp "$k_sets/$k_name" "$repo/ci/bash32-forbidden.txt"
+    k_total=$((k_total + 1))
+    run_check "$repo"
+    k_verdict_exit="$CHECK_EXIT"
+    run_check "$repo" --list-constructs
+    if [ "$k_verdict_exit" -ne 2 ] || [ "$CHECK_EXIT" -ne 2 ] || [ -z "$CHECK_STDERR" ]; then
+      bad "case-k: $k_name — verdict exit $k_verdict_exit, query exit $CHECK_EXIT, query stderr '$CHECK_STDERR' (expected 2, 2, non-empty)"
+      k_fail=$((k_fail + 1))
+    fi
+  done
+
+  if [ "$k_total" -ne 5 ]; then
+    bad "case-k: expected 5 malformed declared sets, ran $k_total"
+  elif [ "$k_fail" -eq 0 ]; then
+    ok "case-k: all 5 malformed declared sets are refused with exit 2 by both requests (R5)"
+  fi
+
+  # The converse: a declared set neither request refuses. The verdict renders its
+  # verdict — exit 1 on this violating tree — while the query answers with rows,
+  # asserted by shape and not by count. Three is the declared set's size today,
+  # and pinning to it would couple this case to a file spec 0120 requires to stay
+  # independently growable.
+  cp "$DECLARED_SET" "$repo/ci/bash32-forbidden.txt"
+  run_check "$repo"
+  k_verdict_exit="$CHECK_EXIT"
+  run_check "$repo" --list-constructs
+  k_ill="$(printf '%s\n' "$CHECK_STDOUT" | grep -cvE "$ROW_SHAPE")"
+  k_rows="$(printf '%s\n' "$CHECK_STDOUT" | wc -l | tr -d '[:space:]')"
+
+  if [ "$k_verdict_exit" -eq 1 ] && [ "$CHECK_EXIT" -eq 0 ] \
+     && [ "$k_ill" -eq 0 ] && [ "$k_rows" -gt 0 ]; then
+    ok "case-k: a well-formed declared set is accepted by both requests (R5)"
+  else
+    bad "case-k: well-formed set gave verdict exit $k_verdict_exit, query exit $CHECK_EXIT, $k_ill ill-shaped of $k_rows row(s)"
   fi
 }
 

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -40,8 +40,10 @@
 #      a verdict, and an unrecognised argument is refused rather than falling
 #      through to a verdict run (spec 0120 R3).
 #   k. Both requests refuse the same declared sets and accept the same ones —
-#      case g's five malformed shapes replayed against each, plus the converse on
-#      a well-formed set (spec 0120 R5).
+#      case g's five malformed shapes replayed against each, plus a sixth whose
+#      malformed row follows two valid ones, plus the converse on a well-formed
+#      set (spec 0120 R5). Each refusal is asserted on exit status, stderr AND
+#      empty stdout, the last being the scenario's "it reports no construct".
 #
 # Scenario 5 — a corrected suite reports the same verdicts on both shells — is
 # only partly scriptable here: comparing two shells needs two Bash binaries, and
@@ -786,12 +788,19 @@ DETECTOR_PROBE
 
 # ---------------------------------------------------------------------------
 # Case k — Both requests refuse the same declared sets, and accept the same ones
-#          (spec 0120 R5).
+#          (spec 0120 R5), and a refused set leaves no construct reported.
 #
 # This case asserts the guard's refusal parity only — the *input* side. What the
 # synchronisation check does with each outcome is case f's three call sites, not
 # this case's business; conflating the two is how "the guard refuses" gets
 # written up as "the consumer discriminates".
+#
+# A refusal is asserted on three observables, not two: the exit status, non-empty
+# stderr, and **empty stdout**. The third is spec 0120's own second clause — "a
+# malformed row is refused on both requests → And it reports no construct" — and
+# it is the only assertion anywhere that a per-row emission would fail. Checking
+# it needs a fixture that can leak, which is why the sixth shape below exists;
+# on a single-row set the clause is true whatever the guard does.
 # ---------------------------------------------------------------------------
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
@@ -815,24 +824,44 @@ DETECTOR_PROBE
   printf '%s\n' 'command mapfile a space separated row' \
     > "$k_sets/tabless-row"
 
+  # A sixth shape, and the only one of the six that can fail the "reports no
+  # construct" clause below: two well-formed rows the parse loop accepts BEFORE
+  # it reaches the malformed one. Every other fixture here and in case g is
+  # single-row or comment-only, so the guard has nothing accepted to leak and the
+  # clause would hold on them however the report were emitted — vacuously.
+  # A guard that emitted each row as it validated would leave two rows on stdout
+  # here and still exit 2, which satisfies every other assertion in this case.
+  printf '%s\t%s\t%s\n' \
+    'command' 'mapfile'   'a valid row, accepted before the malformed one is reached' \
+    'command' 'readarray' 'a second valid row, so a leak would be two rows deep' \
+    'command' ''          'the malformed row: an empty token field, arriving third' \
+    > "$k_sets/valid-rows-then-malformed"
+
   k_fail=0
   k_total=0
-  for k_name in comment-only unknown-kind metacharacter-token empty-token tabless-row; do
+  for k_name in comment-only unknown-kind metacharacter-token empty-token \
+                tabless-row valid-rows-then-malformed; do
     cp "$k_sets/$k_name" "$repo/ci/bash32-forbidden.txt"
     k_total=$((k_total + 1))
     run_check "$repo"
     k_verdict_exit="$CHECK_EXIT"
     run_check "$repo" --list-constructs
-    if [ "$k_verdict_exit" -ne 2 ] || [ "$CHECK_EXIT" -ne 2 ] || [ -z "$CHECK_STDERR" ]; then
-      bad "case-k: $k_name — verdict exit $k_verdict_exit, query exit $CHECK_EXIT, query stderr '$CHECK_STDERR' (expected 2, 2, non-empty)"
+    # `[ -z "$CHECK_STDOUT" ]` is the scenario's second clause — "And it reports
+    # no construct" — and it is what makes the guard's accumulate-then-emit
+    # placement load-bearing rather than incidental: a report written row by row
+    # would leave the rows it had already accepted on stdout ahead of a late
+    # refusal. Asserted on the query, which is the request the scenario names.
+    if [ "$k_verdict_exit" -ne 2 ] || [ "$CHECK_EXIT" -ne 2 ] \
+       || [ -z "$CHECK_STDERR" ] || [ -n "$CHECK_STDOUT" ]; then
+      bad "case-k: $k_name — verdict exit $k_verdict_exit, query exit $CHECK_EXIT, query stderr '$CHECK_STDERR', query stdout '$CHECK_STDOUT' (expected 2, 2, non-empty, empty)"
       k_fail=$((k_fail + 1))
     fi
   done
 
-  if [ "$k_total" -ne 5 ]; then
-    bad "case-k: expected 5 malformed declared sets, ran $k_total"
+  if [ "$k_total" -ne 6 ]; then
+    bad "case-k: expected 6 malformed declared sets, ran $k_total"
   elif [ "$k_fail" -eq 0 ]; then
-    ok "case-k: all 5 malformed declared sets are refused with exit 2 by both requests (R5)"
+    ok "case-k: all 6 malformed declared sets are refused with exit 2 by both requests, reporting no construct (R5)"
   fi
 
   # The converse: a declared set neither request refuses. The verdict renders its


### PR DESCRIPTION
Makes `scripts/check-bash32-portability.sh` the repository's single reader of `ci/bash32-forbidden.txt`: it gains a `--list-constructs` invocation that reports what its own parse loop accepted, and the sync check in `case f` consumes that report instead of forming a second reading. Implements spec 0120 for issue #721.

## How to read this PR?

Two files. Read the guard first.

**`scripts/check-bash32-portability.sh` (+60).** Three additions and one of them is the interesting one. Mode selection sits *before* the repository root is resolved, so an unrecognised argument can never scan the tree. The parse loop gains one accumulator (a newline-joined string, never an array — Bash 3.2 treats an empty array as unset under `set -u`, which is what the file's lines 61-68 have always been about). And the query returns from **a single point, placed after the vacuous-set refusal at 124-127 and before the pattern composition at 129**. That one placement is the whole design: every refusal predicated on the declared set is upstream of it and therefore shared code, and everything downstream is the tree scan the query must not perform — so the two invocations refuse exactly the same declared sets with no duplicated condition.

The header gains a contract block. Read it: it states what is promised (the row set, and therefore the count) and, deliberately, **what is not** — row order, stderr wording, any third field. Naming the non-promises is what keeps a published surface affordable at this size.

**`scripts/tests/test-check-bash32-portability.sh` (+334/-31).** `case f` stops reading the declared set and becomes a `sync_status <repo>` helper that *echoes* one of four tokens — `ok:<n>`, `unaskable`, `vacuous`, `missing:<list>` — called from three sites. Echoing rather than asserting is what lets a negative call site assert a *failure* outcome without incrementing the suite's fail counter. Cases `j` and `k` are new.

The ordering inside `sync_status` is load-bearing rather than stylistic: **exit status is branched on before the row count.** A guard that never ran produces the same empty stdout as a guard that ran and found nothing, so testing rows first would report every "could not be asked" as "reported no construct" — the exact confusion spec 0120 R6 exists to remove, and a failure mode that reading a file does not have.

## How to test this PR?

The suite must run on the shell this ticket is about:

```sh
/bin/bash scripts/tests/test-check-bash32-portability.sh   # 31/31 on 3.2.57
task check-bash32-portability
```

**Read that first command precisely, because it certifies less than it appears to.** `run_check` invokes the script under test as bare `bash` resolved from `$PATH` (line 125), so launching the harness with `/bin/bash` runs the **harness** on 3.2.57 and the **guard** on whatever `bash` comes first — 5.x on a typical machine. The 31/31 is a real result about the suite; it is not on its own evidence that the guard's new code runs on 3.2. That idiom is repo-wide (19 of 68 suites) and is recorded as issue #798; this PR deliberately does not fix it.

The guard's own 3.2 behaviour was therefore established **separately, by invoking it directly**, and all three modes are clean:

```sh
$ /bin/bash scripts/check-bash32-portability.sh
OK: no forbidden Bash 4+ construct in scripts hooks (3 declared construct(s), 151 file(s) scanned).   # exit 0

$ /bin/bash scripts/check-bash32-portability.sh --list-constructs
command<TAB>mapfile
command<TAB>readarray
declare-flag<TAB>A                                                                                    # exit 0

$ /bin/bash scripts/check-bash32-portability.sh --bogus
Error: unrecognised argument(s): --bogus                                                              # exit 2
```

Reproduce those three if you reproduce nothing else — they are the only evidence in this PR that the added code runs on the shell the ticket is about.

Cold review went one better and ran the **whole suite with `$PATH` bash shimmed to 3.2.57 → 31/31**, which certifies both halves at once and is a stronger result than the three commands above. Recorded here rather than left in a review comment, since it is the best evidence this change has. The added code uses no array, so the empty-array trap that motivates #798 does not apply to it; the accumulator is a newline-joined string precisely for that reason.

**The mutation table is the part worth re-running**, because this ticket's whole subject is a test that could pass without checking. Each is a throwaway working-tree edit, reverted immediately:

| # | Mutation | Expected | Observed |
|---|---|---|---|
| 1 | Delete `sync_status`'s exit-status branch | RED | RED 30/31 — `expected 'unaskable' … got 'vacuous'` |
| 2 | Delete both discrimination branches | RED | RED 30/31 — `got 'ok:0'` |
| 3 | Swap the two branch messages | RED | RED 30/31 — `got 'vacuous'` |
| 4 | Evaluate the row count before the exit status | RED | RED 30/31 — `got 'vacuous'` |
| 5 | **Growth** — append a construct plus its Rule 5 row | **GREEN** | **GREEN 31/31** |
| 6 | Emit each row *inside* the parse loop | RED | **RED 30/31** — the leaked rows are named in the failure message |
| 6b | Mutation 6, with the sixth fixture removed | **GREEN** | **GREEN 31/31** |

**Mutations 6 and 6b are a pair and must be read together — they are the record of a finding this PR shipped with and then fixed.** Cold review found that spec 0120's malformed-row scenario has two clauses — *"refuses with the same non-zero outcome **And it reports no construct**"* — and that the suite asserted only the first: `case k` never examined `CHECK_STDOUT`. That clause is the reason the guard accumulates and emits after the loop rather than per row, and this body quoted it as the design's justification while nothing asserted it.

Mutation 6 demonstrates the gap: move the emission inside the parse loop and partial rows leak, with the suite fully green. **6b is why the fix is two parts and not one.** With the `CHECK_STDOUT` assertion present but the sixth fixture removed, the same mutation goes green again — every other fixture is single-row or comment-only, so nothing can leak and the new assertion passes vacuously on all five. The sixth fixture, a valid row *preceding* the malformed one, is the only shape the assertion can fail on. Adding the assertion alone would have been a false green about a false green.

Fixed in `fc385f2`, one file, the suite only — the guard needed no change.

**The assertion count does not move (31/31, delta 0), and that is not a shortfall.** The new fixture joins `case k`'s existing aggregate loop and the clause joins an existing predicate, so neither adds an `ok` call. The visible difference is one relabelled line:

```diff
- PASS  case-k: all 5 malformed declared sets are refused with exit 2 by both requests (R5)
+ PASS  case-k: all 6 malformed declared sets are refused with exit 2 by both requests, reporting no construct (R5)
```

Splitting it into a separate `ok` was considered and declined: the pair 6/6b establishes the discriminating power, and a second `ok` line would add visibility without adding a case the suite can fail on.

Mutation 5 is a different kind and it is not optional. Mutating only toward red proves assertions fail when the contract breaks; it cannot detect **over-coupling**, which is the failure that ships green — an assertion pinned to today's contents passes at merge and breaks on the first legitimate growth of the declared set, for a reason nobody would connect back to this change. Under mutation 5 the two count-bearing assertions *track* the growth (`all 4 declared construct(s)`, `row count (4) … verdict reports (4)`) instead of resisting it.

For mutation 5, use a token disjoint from every fixture's — `growthprobe`, not `coproc`. `coproc` is what `case f`'s third call site uses as the construct deliberately absent from Rule 5; growing the shipped set with it would flip that site to `ok:5`, a red with nothing wrong in the code.

R4 (the verdict path is unchanged) was verified by two independent byte-diffs of stdout, stderr and exit code: pristine-guard-on-pristine-tree versus modified-on-modified, and pristine versus modified guard on the *same* tree, isolating the guard change from the tree change. Both identical. If you reproduce it, pin `CREWRIG_REPO_DIR` on both sides — the guard resolves its root from `dirname "$0"`, so a pristine copy in `/tmp` looks for `/tmp/ci/bash32-forbidden.txt` and exits 2.

Other gates, all green: `check-core-paths.sh`, `test-check-core-paths.sh` (8/8), `check-test-wiring.sh`, `task lint-markdown`, `task spec:lint`. `shellcheck -x` finding set unchanged from the pristine files.

## Detailed description (for agents)

**Added to `scripts/check-bash32-portability.sh`:** a `MODE` selector accepting zero arguments (verdict, unchanged) or exactly `--list-constructs` (query), and rejecting anything else with exit 2 naming the offending argument. Silent tolerance was rejected in plan review: a typo would fall through to a verdict run, which scans the tree and reaches `case f` as empty stdout, where it is misdiagnosed as "reported no construct" rather than "wrong argument". A `LISTING` accumulator is filled inside the existing parse loop and emitted only after it completes — emitting per row would leave partial output before a late malformed row, contradicting spec 0120's scenario "a malformed row is refused on both requests → it reports no construct". A header contract block documents the surface and its non-promises.

**Rewritten in the test suite:** `case f`'s `while read` over `ci/bash32-forbidden.txt` is gone. `run_check` forwards `"$@"` (safe with zero remaining positionals under `set -u` on 3.2.57, so all pre-existing callers are unaffected). Rows are read with a here-document-fed `while IFS= read -r` — **not** `printf … | while read`, which is a pipeline and therefore a subshell, where `checked` and `missing` die at the `done` and the case reports zero rows on a healthy set, a false failure that reads exactly like the anti-vacuity guard firing. Fields are split with `cut -f1`/`cut -f2`, matching `case i`'s existing idiom.

**Row assertions are shape-based, never content-based.** `case j`(a) and (b) and `case k`'s converse assert that every emitted row matches `^(command|declare-flag)<TAB>[A-Za-z0-9_-]+$` with at least one row present — order-free, silent about *which* constructs are declared, therefore growth-proof. `case f`'s first call site additionally cross-checks the query's row count against the verdict's own `(N declared construct(s)` figure; both numbers come from the enforcement, so the declared set is still read exactly once and the test interprets neither its row format nor its contents.

**Requirement coverage.** R1 one interpretation, with the contract published in the guard header. R2 kind and token. R3 verified empirically against a `ci/`-only tree, where the verdict exits 2 at 151-154 while the query exits 0 with rows — direct proof the query returns before target resolution. R4 byte-identical. R5 verified in both directions on all five malformed shapes plus the missing-file case. R6 and R7 now **asserted** rather than preserved by code alone; `case f`'s third call site is the first executable discharge anywhere in the suite of spec 0120's scenario "a declared construct is absent from the written conventions". R8 no declared-set or Rule 5 entry gained or lost. R9 all 22 pre-change assertions present and passing, established by `comm -23` against a pristine copy (left-only set empty; the pristine suite also passes 22/22 against the modified guard). R10 the suite runs to completion on 3.2.57.

**Deliberately not changed.** `bare_expansions_in` and cases `h`/`i`; the guard's own reading rules, anchor, scan scope and verdict exit codes (settled across the seven REVIEW iterations of issue #697); the contents of `ci/bash32-forbidden.txt` and of Rule 5 — the prose restatement there is the duplication `case f` exists to police and is deliberately not derived.

**Blast radius.** No build outputs (nothing under `artifacts/`), no version bump (neither file carries a provenance block), **no CLI-matrix trigger** — re-derived against `docs/cli-matrix-maintenance.md`, whose trigger list names `scripts/build-components.sh` and `scripts/{build,install,setup,import,manage}-*.sh`; `check-*.sh` and `tests/test-*.sh` match neither. All seven downstream invocation sites (`scripting-conventions.yml:64`, `build.yml:277`, `.gitlab-ci.yml:114` and `:227`, `ci-capabilities.yml:130` and `:303`, `Taskfile.yml:355`) pass zero arguments and therefore keep the verdict path R4 freezes; no CI file is edited.

**Process.** Spec 0120 merged as `780b860` (PR #794). The plan needed **five revisions and two REQUEST CHANGES rounds**, both findings produced by prototyping and mutating rather than reading: the R6 discrimination was prescribed as load-bearing and asserted by nothing (three mutations left the suite fully green), and the row assertions were pinned to the declared set's contents. Issue #721 is the logbook per `AGENTS.md` → *Logbook Issues → Rule A* and is closed manually after merge per Rule C — this body carries no closing keyword.

