### PR TITLE
🐛 Guarantee upstream sync for Antigravity built outputs

### DIFF
--- a/.crewrig/core-paths.txt
+++ b/.crewrig/core-paths.txt
@@ -91,6 +91,16 @@ artifacts/library
 .github/skills
 .github/agents
 .github/workflows
+# The `.agents` root is deliberately NOT claimed whole (spec 0121 → Out of
+# scope): no CLI output root is, and claiming this one would sweep in
+# `.agents/ANTIGRAVITY.md` and `.agents/settings.local.json.example` — the
+# latter exactly the class of settings template that already needed the
+# `.github/copilot/settings.json` carve-out above. Only the two
+# subdirectories the component build writes are claimed.
+# `.agents/settings.local.json` is untracked (.gitignore) and stays unlisted,
+# so it is never guarded and never restored (spec 0121 R4).
+.agents/skills
+.agents/agents
 
 # Extension distribution channel
 extension-skeleton

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -166,6 +166,8 @@ exist, how org artifacts integrate) is defined in spec 0012 sub-spec E2.
 | `.github/workflows/` | CI/CD pipeline definitions. |
 | `.github/copilot/` | GitHub Copilot workspace configuration. |
 | `.github/copilot/settings.json` | Committed workspace settings, `strict` by default as a member of `.github/copilot/` above — except its `hooks` key, which the transcript-hooks opt-in in `setup-copilot-interactive.sh` deliberately rewrites locally with an absolute path (ADR-0001 Discovery finding #8). Reclassified `excluded`, nested under the strict `.github/copilot/` parent (spec 0097 / issue #605), so that designed-in local mutation no longer aborts `scripts/sync-from-upstream.sh`; sibling members such as `extension.json` remain `strict` and still abort on a local diff. |
+| `.agents/skills/` | Compiled Antigravity CLI skill definitions. |
+| `.agents/agents/` | Compiled Antigravity CLI agent definitions. |
 
 ### Extension distribution channel
 

--- a/scripts/check-core-paths.sh
+++ b/scripts/check-core-paths.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
-# check-core-paths.sh — Reject phantom entries in the core-paths manifest.
+# check-core-paths.sh — Keep the core-paths manifest and the tree in agreement,
+# in BOTH directions.
 #
-# Per spec 0031 (Requirement 5), continuous integration MUST fail a pull
-# request when any entry in .crewrig/core-paths.txt does not resolve to
-# tracked content at the repository HEAD. A "phantom" entry — a manifest
-# line naming a path with no tracked content — makes an adopter's
+# Forward direction — manifest to tree (spec 0031 R5). Continuous integration
+# MUST fail a pull request when any entry in .crewrig/core-paths.txt does not
+# resolve to tracked content at the repository HEAD. A "phantom" entry — a
+# manifest line naming a path with no tracked content — makes an adopter's
 # sync-from-upstream.sh run skip-with-warning at best, and historically
 # aborted the whole sync. This guard catches such an entry before it can
 # reach the canonical branch.
+#
+# Reverse direction — tree to manifest (spec 0121 R5). Continuous integration
+# MUST fail when a directory the component build writes component outputs into
+# carries no upstream-synchronisation guarantee, and MUST name that directory.
+# The forward direction is structurally blind to this: it walks the manifest,
+# so a built-output directory the manifest never mentions is invisible to it.
+# That blindness is why `.agents/skills` and `.agents/agents` sat unguaranteed
+# through a fully green CI (issue #755).
 #
 # Policy semantics (spec 0020) mirror sync-from-upstream.sh:
 #   strict / adopt-on-edit  Upstream-owned content — MUST resolve at HEAD.
@@ -18,11 +27,41 @@
 # second token = policy, default `strict`; blank/`#` lines skipped; CRLF
 # tolerated).
 #
+# Two deliberate scoping decisions in the reverse direction:
+#
+#   1. Depth-2 extraction. Only a `$out_root/<a>/<b>` target yields a
+#      directory, because `<a>/<b>` is the granularity the manifest itself
+#      claims (`.claude/skills`, not `.claude`). A future top-level output —
+#      `"$out_root/AGENTS.md"` — therefore yields nothing and trips the
+#      fail-closed rule below. That is loud by design, not a false positive:
+#      such an output needs a manifest classification decision, and this guard
+#      is where the decision gets forced rather than skipped.
+#   2. Bounded identity with sync-from-upstream.sh's path_is_governed().
+#      dir_is_governed() below mirrors it EXCEPT for the
+#      `.crewrig/.synced-markers` short-circuit (sync-from-upstream.sh:369),
+#      which is the R8 marker-bookkeeping carve-out and can never name a build
+#      output. Everything else — the strict/adopt-on-edit policy filter, the
+#      nested-`excluded`-child carve-out, and continuing the scan rather than
+#      concluding when such a child matches — is the identical rule.
+#
+# Known limitation, named here so it is not rediscovered the hard way: a write
+# site reachable only for a non-`core` tier would demand a manifest entry for a
+# path with no tracked content at HEAD, which the forward direction would then
+# reject as a phantom — an unsatisfiable pair, since output_root_for_tier() in
+# build-components.sh sends non-core tiers to `dist/<tier>`. The escape is to
+# teach build-components.sh to declare its own output directories (e.g. a
+# `--list-output-dirs` query mode) and consume that here instead of parsing
+# call sites; a declaration can distinguish tiers, this extraction cannot.
+#
 # Usage:
 #   bash scripts/check-core-paths.sh
 #
-# Exits 0 if every strict/adopt-on-edit entry resolves at HEAD, non-zero
-# (with a per-entry failure list) otherwise.
+# Exit codes:
+#   0  Both directions agree.
+#   1  A manifest entry does not resolve at HEAD (forward), or a built-output
+#      directory carries no guarantee (reverse). Failing items are listed.
+#   2  A required input is missing or unclassifiable: the manifest, the build
+#      script, or a write-helper call site whose target yields no directory.
 
 set -euo pipefail
 
@@ -52,6 +91,125 @@ while IFS= read -r line || [ -n "$line" ]; do
   PATHS+=("$path")
   POLICIES+=("$policy")
 done < "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Reverse direction, part 1 — derive the built-output directory set from the
+# build script itself (spec 0121 R5).
+#
+# Deriving rather than declaring is the whole point: a list held here would
+# drift from the build exactly as the manifest just did, which is the failure
+# this guard exists to end. Every output write in build-components.sh funnels
+# through one of two helpers, and every call site passes a target beginning
+# `"$out_root/`, so the call sites ARE the declaration.
+# ---------------------------------------------------------------------------
+BUILD_SCRIPT="$REPO_DIR/scripts/build-components.sh"
+
+if [ ! -f "$BUILD_SCRIPT" ]; then
+  echo "Error: build script not found: $BUILD_SCRIPT" >&2
+  echo "The reverse direction (spec 0121 R5) derives the built-output directory" >&2
+  echo "set from this file. A rename must be followed here — it must never" >&2
+  echo "silently retire the guard." >&2
+  exit 2
+fi
+
+DERIVED=()
+bs_lineno=0
+while IFS= read -r bs_line || [ -n "$bs_line" ]; do
+  bs_lineno=$((bs_lineno + 1))
+  bs_line="${bs_line%$'\r'}"
+
+  # Match on the TRIMMED line, and this is load-bearing: the real call sites
+  # are indented inside `for`/`if` bodies, so a matcher tested against the raw
+  # line matches only column-0 stubs and derives nothing from the real script.
+  trimmed="${bs_line#"${bs_line%%[![:space:]]*}"}"
+
+  case "$trimmed" in
+    # Comment skip first — it is what excludes the prose mentions of both
+    # helper names. The definition lines (`check_or_write() {`) are excluded
+    # naturally instead: they carry `(`, not a space, after the name.
+    \#*) continue ;;
+    "check_or_write "*|"propagate_skill_resources "*) ;;
+    *) continue ;;
+  esac
+
+  yielded=0
+  rest="$trimmed"
+  while :; do
+    case "$rest" in
+      *'$out_root/'*) ;;
+      *) break ;;
+    esac
+    rest="${rest#*'$out_root/'}"
+
+    seg_a="${rest%%/*}"
+    seg_b="${rest#*/}"
+    seg_b="${seg_b%%/*}"
+
+    # Depth-2 only: both segments must be literal directory names.
+    case "$seg_a" in ''|*'"'*|*'$'*|*/*) continue ;; esac
+    case "$seg_b" in ''|*'"'*|*'$'*|*/*) continue ;; esac
+
+    yielded=1
+    dir="$seg_a/$seg_b"
+    seen=0
+    for d in ${DERIVED[@]+"${DERIVED[@]}"}; do
+      [ "$d" = "$dir" ] && { seen=1; break; }
+    done
+    [ "$seen" -eq 0 ] && DERIVED+=("$dir")
+  done
+
+  # Fail closed. A write-helper call whose target this guard cannot classify is
+  # an output directory it cannot check — indistinguishable, from the outside,
+  # from a repository with nothing to report. Refusing to run is the only
+  # answer that cannot be mistaken for a clean bill of health.
+  if [ "$yielded" -eq 0 ]; then
+    echo "Error: unclassifiable write-helper call site" >&2
+    echo "  $BUILD_SCRIPT:$bs_lineno" >&2
+    echo "  $trimmed" >&2
+    echo "" >&2
+    echo "This guard extracts an output directory from a \$out_root/<a>/<b>" >&2
+    echo "target and found none on this line. Depth-2 is deliberate — see the" >&2
+    echo "header comment of this script. A top-level or tier-conditional output" >&2
+    echo "needs a manifest classification decision before it can be built." >&2
+    exit 2
+  fi
+done < "$BUILD_SCRIPT"
+
+# ---------------------------------------------------------------------------
+# dir_is_governed <dir>
+# Mirror of path_is_governed() in sync-from-upstream.sh (line 366), minus its
+# `.crewrig/.synced-markers` short-circuit — no build output can live there.
+# Governed iff some strict/adopt-on-edit entry covers <dir>, with no `excluded`
+# entry nested strictly under THAT entry covering it. Consulting excluded
+# ancestors, or concluding on the first excluded match instead of continuing
+# the scan, would both be stricter than the sync actually is — and reachable:
+# `.agents excluded` + `.agents/skills strict` is governed for the sync.
+# ---------------------------------------------------------------------------
+dir_is_governed() {
+  local dir="$1" i j gov skip
+  for i in "${!PATHS[@]}"; do
+    case "${POLICIES[$i]}" in
+      strict|adopt-on-edit) ;;
+      *) continue ;;
+    esac
+    gov="${PATHS[$i]}"
+    case "$dir" in
+      "$gov"|"$gov"/*)
+        skip=0
+        for j in "${!PATHS[@]}"; do
+          [ "${POLICIES[$j]}" = "excluded" ] || continue
+          case "${PATHS[$j]}" in "$gov"/*) ;; *) continue ;; esac
+          case "$dir" in
+            "${PATHS[$j]}"|"${PATHS[$j]}"/*) skip=1; break ;;
+          esac
+        done
+        [ "$skip" -eq 1 ] && continue
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
 
 failures=()
 checked=0
@@ -84,3 +242,30 @@ if [ "${#failures[@]}" -gt 0 ]; then
 fi
 
 echo "OK: all $checked strict/adopt-on-edit core-paths entries resolve at HEAD."
+
+# ---------------------------------------------------------------------------
+# Reverse direction, part 2 — every derived directory must carry a guarantee
+# (spec 0121 R2/R5). No exemption allowlist: R2 admits none, and an allowlist
+# is how this class of guard usually decays.
+# ---------------------------------------------------------------------------
+UNGOVERNED=()
+for d in ${DERIVED[@]+"${DERIVED[@]}"}; do
+  dir_is_governed "$d" || UNGOVERNED+=("$d")
+done
+
+if [ "${#UNGOVERNED[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "FAILED: ${#UNGOVERNED[@]} of ${#DERIVED[@]} built-output director(y/ies) derived from" >&2
+  echo "scripts/build-components.sh carry no upstream-sync guarantee:" >&2
+  for d in ${UNGOVERNED[@]+"${UNGOVERNED[@]}"}; do
+    echo "  - $d" >&2
+  done
+  echo "" >&2
+  echo "Every directory the component build writes component outputs into must be" >&2
+  echo "governed by .crewrig/core-paths.txt with a strict or adopt-on-edit policy" >&2
+  echo "(spec 0121 R2). Add the entry, and its docs/layers.md row in the same diff" >&2
+  echo "per the co-maintenance rule in AGENTS.md." >&2
+  exit 1
+fi
+
+echo "OK: all ${#DERIVED[@]} built-output directories derived from scripts/build-components.sh are governed."

--- a/scripts/check-core-paths.sh
+++ b/scripts/check-core-paths.sh
@@ -27,7 +27,8 @@
 # second token = policy, default `strict`; blank/`#` lines skipped; CRLF
 # tolerated).
 #
-# Two deliberate scoping decisions in the reverse direction:
+# Three limits on what the reverse direction can see. The first two are
+# deliberate scoping decisions; the third is a precondition it cannot check:
 #
 #   1. Depth-2 extraction. Only a `$out_root/<a>/<b>` target yields a
 #      directory, because `<a>/<b>` is the granularity the manifest itself
@@ -43,6 +44,17 @@
 #      output. Everything else — the strict/adopt-on-edit policy filter, the
 #      nested-`excluded`-child carve-out, and continuing the scan rather than
 #      concluding when such a child matches — is the identical rule.
+#   3. PRECONDITION, not a fact: every output write goes through one of the two
+#      helpers. True at the time of writing and verified then, but nothing here
+#      enforces it, and no matcher can — a call-site parser cannot see a write
+#      that is not a call. A direct redirection,
+#          printf '%s' "$content" > "$out_root/.newcli/skills/$name/SKILL.md"
+#      writes an ungoverned directory and this guard reports the repository
+#      clean. Teaching the build a third write path therefore retires the
+#      reverse direction for whatever that path writes, silently. If one is
+#      ever added, either route it through a helper or move to the
+#      `--list-output-dirs` escape below — which closes this class too, since a
+#      declaration covers every write regardless of how it is spelled.
 #
 # Known limitation, named here so it is not rediscovered the hard way: a write
 # site reachable only for a non-`core` tier would demand a manifest entry for a
@@ -98,9 +110,11 @@ done < "$MANIFEST"
 #
 # Deriving rather than declaring is the whole point: a list held here would
 # drift from the build exactly as the manifest just did, which is the failure
-# this guard exists to end. Every output write in build-components.sh funnels
-# through one of two helpers, and every call site passes a target beginning
-# `"$out_root/`, so the call sites ARE the declaration.
+# this guard exists to end.
+#
+# This works only while every output write goes through one of the two helpers
+# — a precondition, not a property this guard can verify (header, limit 3). So
+# long as it holds, the call sites are the declaration.
 # ---------------------------------------------------------------------------
 BUILD_SCRIPT="$REPO_DIR/scripts/build-components.sh"
 
@@ -128,7 +142,14 @@ while IFS= read -r bs_line || [ -n "$bs_line" ]; do
     # helper names. The definition lines (`check_or_write() {`) are excluded
     # naturally instead: they carry `(`, not a space, after the name.
     \#*) continue ;;
-    "check_or_write "*|"propagate_skill_resources "*) ;;
+    # Leading `*` deliberately: a helper call need not be the first token of
+    # its line. `if ! check_or_write …`, `for … do check_or_write …` and
+    # `[ -n "$x" ] && check_or_write …` all write output, and a prefix-anchored
+    # pattern discarded them here — silently, because the fail-closed rule
+    # below only ever sees lines that already matched. All sixteen call sites
+    # happen to be bare today, which is exactly why measuring the matcher
+    # against the real build script could not surface the gap.
+    *"check_or_write "*|*"propagate_skill_resources "*) ;;
     *) continue ;;
   esac
 

--- a/scripts/tests/test-check-core-paths.sh
+++ b/scripts/tests/test-check-core-paths.sh
@@ -6,14 +6,46 @@
 # not resolve to tracked content at HEAD. This is the parity sibling mandated by
 # the repo convention "every check-*.sh has a test-*.sh".
 #
+# Since spec 0121 the same script also guards the reverse direction — every
+# directory the component build writes component outputs into must carry an
+# upstream-sync guarantee — so cases e-i exercise that half.
+#
 # Cases:
+#   Forward direction (manifest → tree, spec 0031 R5)
 #   a. Phantom strict entry → exit 1, stderr names the failing entry.
 #   b. Phantom adopt-on-edit entry → exit 1, stderr names the failing entry.
 #   c. Fully resolvable manifest → exit 0 with the OK line on stdout.
 #   d. Phantom excluded entry → exit 0 (excluded is org-owned, NOT checked).
 #
+#   Reverse direction (tree → manifest, spec 0121 R5)
+#   e. Built output absent from the manifest → exit 1, stderr names it.
+#   f. Same tree, manifest lists it → exit 0. The control that makes e
+#      informative: it isolates the manifest omission as e's cause.
+#   g. Write-helper call site with no $out_root/ target → non-zero, names the
+#      line (fail-closed: unclassifiable is not the same as nothing to report).
+#   h. Built output covered only by an `excluded` entry → exit 1. `excluded` is
+#      the absence of a guarantee, and R2 admits no directory without one.
+#   i. The repository's REAL build script + a manifest naming no built output →
+#      exit 1 naming `.agents/skills` and `.agents/agents`, 9 derived. The only
+#      case run against the real script's real shape, so the only one a
+#      matcher-blinding change cannot pass.
+#
+# Cases a-d commit a stub `scripts/build-components.sh` with no call sites, so
+# the derived set is empty in half the suite — the accumulator-empty path the
+# array guards in check-core-paths.sh must survive under bash 3.2 `set -u`. The
+# stub is committed, not merely written, so the fixtures hold up if the guard
+# ever reads the build script from HEAD instead of from disk.
+#
+# Case i reads `scripts/build-components.sh`. That coupling is deliberate: a
+# legitimate tenth output directory turns case i red on its count until the
+# literal is updated. That is the forcing function working, not flakiness.
+#
 # Usage:
 #   bash scripts/tests/test-check-core-paths.sh
+#   /bin/bash scripts/tests/test-check-core-paths.sh   # the bash 3.2 gate;
+#       real only because run_check spawns via "${BASH:-bash}". No CI job runs
+#       a 3.2 interpreter, so this local run is the only place the empty-array
+#       trap is caught.
 
 # -e intentionally omitted: pass/fail counters control the harness; adding -e
 # would abort on expected non-zero exits from the script under test.
@@ -74,11 +106,40 @@ run_check() {
   out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
   err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
   CHECK_EXIT=0
-  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  # `${BASH:-bash}`, not bare `bash`: bare `bash` resolves from $PATH, so
+  # launching this harness as `/bin/bash test-check-core-paths.sh` would run the
+  # harness on 3.2.57 and the script under test on whatever modern bash $PATH
+  # supplies — making the 3.2 gate below inert. The `:-` default keeps it safe
+  # under `set -u`. (Repo-wide, 19 of 68 suites still carry the bare form; #798.)
+  ( CREWRIG_REPO_DIR="$repo" "${BASH:-bash}" "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
   CHECK_STDOUT="$(cat "$out_file")"
   CHECK_STDERR="$(cat "$err_file")"
   rm -f "$out_file" "$err_file"
 }
+
+# ---------------------------------------------------------------------------
+# Stub build scripts. Single-quoted so `$out_root` stays literal.
+#
+# Deliberately written at column 0, unlike the real script's six-space-indented
+# call sites: a matcher that tested the raw line instead of the trimmed one
+# would still match these stubs and only case i would catch it.
+# ---------------------------------------------------------------------------
+
+# No write-helper call site → the derived set is empty.
+BUILD_STUB_NONE='#!/bin/bash
+# Stub build script: no write-helper call sites.
+echo "stub"
+'
+
+# One call site writing into .newcli/skills.
+BUILD_STUB_NEWCLI='#!/bin/bash
+check_or_write "$out_root/.newcli/skills/$name/SKILL.md" "$content" "$source"
+'
+
+# One call site whose target this guard cannot classify (line 2).
+BUILD_STUB_UNCLASSIFIABLE='#!/bin/bash
+check_or_write "$some_other_root/x.md" "$content"
+'
 
 # ---------------------------------------------------------------------------
 # Case a — Phantom strict entry → exit 1, stderr names the failing entry.
@@ -86,7 +147,9 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   init_git_repo "$repo"
-  make_initial_commit "$repo" "real.txt" "tracked content"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    "scripts/build-components.sh" "$BUILD_STUB_NONE"
   write_manifest "$repo" $'real.txt\tstrict\nphantom.txt\tstrict\n'
 
   run_check "$repo"
@@ -115,7 +178,9 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   init_git_repo "$repo"
-  make_initial_commit "$repo" "real.txt" "tracked content"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    "scripts/build-components.sh" "$BUILD_STUB_NONE"
   write_manifest "$repo" $'real.txt\tstrict\nphantom.txt\tadopt-on-edit\n'
 
   run_check "$repo"
@@ -146,7 +211,8 @@ run_check() {
   init_git_repo "$repo"
   make_initial_commit "$repo" \
     "real.txt"  "tracked content" \
-    "other.txt" "other tracked content"
+    "other.txt" "other tracked content" \
+    "scripts/build-components.sh" "$BUILD_STUB_NONE"
   write_manifest "$repo" $'real.txt\tstrict\nother.txt\tadopt-on-edit\n'
 
   run_check "$repo"
@@ -177,7 +243,9 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   init_git_repo "$repo"
-  make_initial_commit "$repo" "real.txt" "tracked content"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    "scripts/build-components.sh" "$BUILD_STUB_NONE"
   # phantom-excluded.txt resolves nowhere at HEAD, but `excluded` is skipped.
   write_manifest "$repo" $'real.txt\tstrict\nphantom-excluded.txt\texcluded\n'
 
@@ -199,6 +267,216 @@ run_check() {
   else
     echo "FAIL  case-d: excluded entry was counted or OK line malformed"
     echo "      actual stdout: $CHECK_STDOUT"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case e — A built-output directory absent from the manifest → exit 1, and
+#          stderr names it. The reverse direction (spec 0121 R5); this is the
+#          shape of the bug in issue #755.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    ".newcli/skills/demo/SKILL.md" "built output" \
+    "scripts/build-components.sh" "$BUILD_STUB_NEWCLI"
+  # The manifest never mentions .newcli/skills — the whole point of the case.
+  write_manifest "$repo" $'real.txt\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-e: ungoverned built-output directory fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-e: expected exit 1, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF -- "- .newcli/skills"; then
+    echo "PASS  case-e: stderr names the ungoverned directory"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-e: stderr did not name .newcli/skills"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case f — The control for case e. Byte-identical tree; the manifest lists the
+#          directory → exit 0. Without this, case e's exit 1 could as easily be
+#          caused by the fixture existing at all as by the manifest omission.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    ".newcli/skills/demo/SKILL.md" "built output" \
+    "scripts/build-components.sh" "$BUILD_STUB_NEWCLI"
+  write_manifest "$repo" $'real.txt\tstrict\n.newcli/skills\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-f: the same tree passes once the manifest lists it (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-f: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  # Exit status only, deliberately. Case f's job is to be the green control
+  # that isolates case e's cause; asserting the reverse direction's success
+  # line here would make the control sensitive to the reverse block existing,
+  # which is precisely what case e is for.
+}
+
+# ---------------------------------------------------------------------------
+# Case g — A write-helper call site with no $out_root/ target → non-zero,
+#          naming the line. Fail-closed: a target the guard cannot classify is
+#          an output it cannot check, which must not read as nothing to report.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    "scripts/build-components.sh" "$BUILD_STUB_UNCLASSIFIABLE"
+  write_manifest "$repo" $'real.txt\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -ne 0 ]; then
+    echo "PASS  case-g: unclassifiable call site fails the check (exit $CHECK_EXIT)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-g: expected non-zero exit, got 0"
+    echo "      actual stdout: $CHECK_STDOUT"
+    fail=$((fail + 1))
+  fi
+
+  # Naming the line is what distinguishes a fail-closed refusal from an
+  # unrelated crash that happens to exit non-zero.
+  if echo "$CHECK_STDERR" | grep -qF "build-components.sh:2"; then
+    echo "PASS  case-g: stderr names the offending build-script line"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-g: stderr did not name build-components.sh:2"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case h — A built output covered only by an `excluded` entry nested under a
+#          governed parent → exit 1. `excluded` is the absence of a guarantee
+#          (the sync never restores it), and R2 leaves no built-output
+#          directory without one. Also exercises the nested-carve-out rule
+#          this guard shares with sync-from-upstream.sh.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    ".newcli/skills/demo/SKILL.md" "built output" \
+    "scripts/build-components.sh" "$BUILD_STUB_NEWCLI"
+  # .newcli is strict, but the excluded child carves the built output back out.
+  write_manifest "$repo" $'real.txt\tstrict\n.newcli\tstrict\n.newcli/skills\texcluded\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-h: an excluded built-output directory fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-h: expected exit 1, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF -- "- .newcli/skills"; then
+    echo "PASS  case-h: stderr names the excluded built-output directory"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-h: stderr did not name .newcli/skills"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case i — The repository's REAL build script against a manifest naming no
+#          built-output directory (spec 0121 R6).
+#
+# Every case above runs the guard against a stub whose shape this file chose.
+# This one runs it against the real script's real shape — six-space-indented
+# call sites, real quoting, all sixteen of them — so it is the only case a
+# matcher-blinding change cannot pass: the derived set goes empty, the reverse
+# direction turns vacuous, exit becomes 0, and case i alone turns red.
+#
+# Driven down the FAILURE path on purpose: the success path prints a count and
+# no identities, so a mutation deriving nine wrong directories would pass an
+# `OK: all 9 …` assertion. The failure path names each one, pinning the
+# identities as well as the count. The expected names are literals here, never
+# re-derived by re-running the guard's own extraction — a test that re-derives
+# agrees with the parser instead of checking it.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" "real.txt" "tracked content"
+  mkdir -p "$repo/scripts"
+  cp "$SCRIPT_DIR/build-components.sh" "$repo/scripts/build-components.sh"
+  # One trivially-resolvable entry, so the forward direction passes and the
+  # non-zero exit is unambiguously the reverse direction's.
+  write_manifest "$repo" $'real.txt\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-i: the real build script against a bare manifest fails (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-i: expected exit 1, got $CHECK_EXIT"
+    echo "      actual stdout: $CHECK_STDOUT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF -- "- .agents/skills"; then
+    echo "PASS  case-i: stderr names .agents/skills"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-i: stderr did not name .agents/skills"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF -- "- .agents/agents"; then
+    echo "PASS  case-i: stderr names .agents/agents"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-i: stderr did not name .agents/agents"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  # 9 derived directories today. A legitimate tenth output turns this red until
+  # the literal is updated — the forcing function, not flakiness.
+  if echo "$CHECK_STDERR" | grep -qF "9 of 9 built-output"; then
+    echo "PASS  case-i: reverse-direction summary reports 9 derived directories"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-i: expected '9 of 9 built-output' in the failure summary"
+    echo "      actual stderr: $CHECK_STDERR"
     fail=$((fail + 1))
   fi
 }

--- a/scripts/tests/test-check-core-paths.sh
+++ b/scripts/tests/test-check-core-paths.sh
@@ -29,6 +29,13 @@
 #      exit 1 naming `.agents/skills` and `.agents/agents`, 9 derived. The only
 #      case run against the real script's real shape, so the only one a
 #      matcher-blinding change cannot pass.
+#   j. A call site that is not the first token of its line → exit 1, named.
+#      Case i cannot cover this: all sixteen real call sites are bare.
+#   k. An `excluded` ANCESTOR over a governed child → exit 0. Pins the half of
+#      dir_is_governed() that keeps it from being stricter than the sync.
+#   l. An indented comment naming a helper → still a comment. Pins the trim,
+#      which no other case constrains now that the matcher accepts non-leading
+#      calls and is therefore indentation-insensitive.
 #
 # Cases a-d commit a stub `scripts/build-components.sh` with no call sites, so
 # the derived set is empty in half the suite — the accumulator-empty path the
@@ -139,6 +146,31 @@ check_or_write "$out_root/.newcli/skills/$name/SKILL.md" "$content" "$source"
 # One call site whose target this guard cannot classify (line 2).
 BUILD_STUB_UNCLASSIFIABLE='#!/bin/bash
 check_or_write "$some_other_root/x.md" "$content"
+'
+
+# A call site that is NOT the first token of its line. All sixteen real call
+# sites are bare, so case i cannot exercise this shape — and a prefix-anchored
+# matcher discarded it silently, the fail-closed rule never seeing a line that
+# failed to match in the first place.
+BUILD_STUB_NESTED_CALL='#!/bin/bash
+for name in demo; do
+  if ! check_or_write "$out_root/.newcli/skills/$name/SKILL.md" "$content" "$source"; then
+    exit 1
+  fi
+done
+'
+
+# An INDENTED comment naming a helper, above a real call site. The comment skip
+# runs on the trimmed line; on the raw line an indented comment is not seen as a
+# comment, matches the helper pattern instead, yields no directory, and trips
+# the fail-closed rule. build-components.sh carries such a comment today (:625),
+# but it ends at the helper name with no trailing space, so it happens not to
+# match — which would leave the trim pinned by nothing.
+BUILD_STUB_INDENTED_COMMENT='#!/bin/bash
+for name in demo; do
+    # check_or_write is how the compiled skill gets written
+  check_or_write "$out_root/.newcli/skills/$name/SKILL.md" "$content" "$source"
+done
 '
 
 # ---------------------------------------------------------------------------
@@ -476,6 +508,125 @@ check_or_write "$some_other_root/x.md" "$content"
     pass=$((pass + 1))
   else
     echo "FAIL  case-i: expected '9 of 9 built-output' in the failure summary"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case j — A call site that is not the first token of its line → exit 1,
+#          stderr names the directory.
+#
+# The matcher was prefix-anchored and discarded such lines at the `case`, so
+# they never reached the fail-closed rule: three real shapes (`if ! …`,
+# `for … do …`, `[ … ] && …`) wrote into an ungoverned directory while the
+# guard printed `OK: all 9 … are governed`. No other case catches this — case i
+# runs the real build script, where all sixteen call sites happen to be bare,
+# which is exactly why measuring the matcher against that script could not
+# surface the gap.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    ".newcli/skills/demo/SKILL.md" "built output" \
+    "scripts/build-components.sh" "$BUILD_STUB_NESTED_CALL"
+  write_manifest "$repo" $'real.txt\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-j: a non-leading call site is still extracted (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-j: expected exit 1, got $CHECK_EXIT"
+    echo "      actual stdout: $CHECK_STDOUT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF -- "- .newcli/skills"; then
+    echo "PASS  case-j: stderr names the directory written from a nested call"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-j: stderr did not name .newcli/skills"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case k — An `excluded` ANCESTOR must not disqualify a governed child →
+#          exit 0.
+#
+# dir_is_governed() consults only `excluded` entries nested under the matched
+# governing entry, because that is what sync-from-upstream.sh does
+# (excluded_children_of). Consulting excluded ancestors instead would be
+# stricter than the sync — and reachable, which is the point: on
+# `.newcli excluded` + `.newcli/skills strict` the sync governs
+# `.newcli/skills`, so this guard must too, or it fails a build the sync would
+# have synchronised happily.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    ".newcli/skills/demo/SKILL.md" "built output" \
+    "scripts/build-components.sh" "$BUILD_STUB_NEWCLI"
+  write_manifest "$repo" $'real.txt\tstrict\n.newcli\texcluded\n.newcli/skills\tstrict\n'
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-k: an excluded ancestor does not disqualify a governed child"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-k: expected exit 0, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case l — An indented comment naming a helper is still a comment → exit 1 for
+#          the real call site below it, not exit 2 for the comment.
+#
+# Pins the trim. Before the matcher was widened to accept non-leading calls,
+# the trim was what made the matcher see indented call sites, and mutating it
+# to the raw line turned case i red. Widening the matcher made it
+# indentation-insensitive, so that mutation stopped discriminating and the trim
+# was left pinned by nothing — the comment skip being the one place it still
+# matters. This case restores that.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  init_git_repo "$repo"
+  make_initial_commit "$repo" \
+    "real.txt" "tracked content" \
+    ".newcli/skills/demo/SKILL.md" "built output" \
+    "scripts/build-components.sh" "$BUILD_STUB_INDENTED_COMMENT"
+  write_manifest "$repo" $'real.txt\tstrict\n'
+
+  run_check "$repo"
+
+  # Exit 1 (ungoverned), NOT exit 2 (unclassifiable): reaching exit 2 means the
+  # comment was parsed as a call site.
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-l: an indented comment naming a helper is skipped (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-l: expected exit 1, got $CHECK_EXIT"
+    echo "      actual stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -qF -- "- .newcli/skills"; then
+    echo "PASS  case-l: the real call site below the comment is still extracted"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-l: stderr did not name .newcli/skills"
     echo "      actual stderr: $CHECK_STDERR"
     fail=$((fail + 1))
   fi


### PR DESCRIPTION
Adds `.agents/skills` and `.agents/agents` to the core-paths manifest, and — the substance of the change — teaches `scripts/check-core-paths.sh` the direction it was structurally blind to, so the omission cannot recur for the next output root anyone teaches the build to write. Implements spec 0121 for issue #755.

## ⚠️ This is a live behaviour change for existing forks, not a pure addition

**A fork that has hand-edited anything under `.agents/skills` or `.agents/agents` will now have its next `scripts/sync-from-upstream.sh` run halt**, naming those paths, where it previously proceeded without a word. Those two subdirectories, and not the `.agents` root: an edit confined to `.agents/ANTIGRAVITY.md` or `.agents/settings.local.json.example` still does **not** halt, which is the R4 design this body defends further down. Sixty-five of the sixty-seven tracked files under `.agents/` are covered. That is spec 0121 R3 working as specified — a local modification to a built Antigravity output must halt a sync exactly as a local modification to a built Claude Code output already does — but it will look like a regression to whoever meets it first, and it is stated here rather than discovered in the field.

Who it actually reaches: a fork that hand-edited a *built output* was already living dangerously, since `scripts/build-components.sh` regenerates those files from `artifacts/` and `--check` already reports the drift. The halt surfaces a problem that existed silently.

## How to read this PR?

**Start with why CI was green while the bug stood**, because it is the whole point of the change. `scripts/check-core-paths.sh` has run in CI on both forges since June, checking spec 0031 R5: every manifest entry resolves to tracked content at HEAD. That is **manifest → tree**. This issue is **tree → manifest** — **65** tracked files (43 under `.agents/skills`, 22 under `.agents/agents`) that the build writes and the manifest never names. *(An earlier draft said 67. That is the whole `.agents/` root, and it therefore counts the two files this very body argues must **not** be swept in — a figure inherited from the issue text without re-deriving it against the argument it was supporting.)* The guard was certifying the neighbouring property, so its output was identical whether or not the property this issue is about held.

Read in this order:

1. **`.crewrig/core-paths.txt`** — two entries plus a comment block recording why the `.agents` root is not claimed whole. No policy column, matching every sibling and relying on the documented `strict` default; `strict` is not merely conventional here, since R3 requires a local edit to *halt*, which `adopt-on-edit` (preserve, never abort) and `excluded` (never guarded) both fail to do.
2. **`docs/layers.md`** rows 169-170 — R7 requires the human-readable and machine-readable records to agree.
3. **`scripts/check-core-paths.sh`** — the reverse direction. It **derives** the built-output set by reading `scripts/build-components.sh` rather than carrying a copy that can drift. All sixteen output writes funnel through two helpers, `check_or_write` and `propagate_skill_resources`, and every one passes a target literally beginning `"$out_root/`; extracting `$out_root/<a>/<b>` yields exactly nine directories. The bug is *computed*, not asserted, and the granularity falls out with no special-casing.
4. **`scripts/tests/test-check-core-paths.sh`** — cases e through **l**, and one line in `run_check`.

Two details worth pausing on. **A write-helper call site whose *target* yields no directory fails the run**, naming file and line — that fail-closed rule converts *target* indirection from a silent under-report into a loud failure. It does not cover *call-site position*: the rule only sees lines that already matched the helper pattern, so until `1997b99` a call preceded by anything (`if ! …`, `for … do …`, `[ … ] && …`) was discarded before reaching it — three shapes in which the build wrote into an ungoverned directory and the guard reported the repository clean. Found in review, fixed in `1997b99`, pinned by case j. And **`run_check` now passes the harness's interpreter through** (`"${BASH:-bash}"`): without it, `/bin/bash scripts/tests/test-check-core-paths.sh` runs the harness on 3.2.57 and the guard on `$PATH`'s bash, so the 3.2 gate certifies nothing about the guard. That idiom is repo-wide and is issue #798; this PR fixes only the suite it touches.

## How to test this PR?

```sh
bash scripts/check-core-paths.sh
/bin/bash scripts/tests/test-check-core-paths.sh    # 24/24
bash      scripts/tests/test-check-core-paths.sh    # 24/24
```

On the real tree the guard now reports both directions:

```
OK: all 52 strict/adopt-on-edit core-paths entries resolve at HEAD.
OK: all 9 built-output directories derived from scripts/build-components.sh are governed.
```

Revert the two manifest entries and it reproduces the original bug exactly:

```
FAILED: 2 of 9 built-output director(y/ies) derived from
scripts/build-components.sh carry no upstream-sync guarantee:
  - .agents/skills
  - .agents/agents
```

**The mutation table is the evidence, and every row below is observed at `1997b99` rather than predicted.** Each was a throwaway working-tree edit, reverted immediately, with the 24/24 baseline re-confirmed between.

| Mutation | Observed (5.3.15 / 3.2.57) |
|---|---|
| (a) reverse block deleted | **10/24** both shells |
| (b) matcher + comment skip on the raw line instead of the trimmed line | **22/24** both shells — **case l** red |
| (c) 17th write site added to the real build script | guard exits 1 naming `.newcli/skills`; **23/24** both |
| (d1) array guard dropped, **governance** loop | **24/24 on 5.x**, **22/24 on 3.2** |
| (d2) array guard dropped, **dedupe** loop | **24/24 on 5.x**, **15/24 on 3.2** |
| (d3) array guard dropped, ungoverned-report loop | **24/24 on both** — that guard sits behind a `-gt 0` check and is dead code |
| (e) matcher re-anchored to the start of the line | **22/24** both — **case j** red |
| (f) nested-child restriction dropped from the coverage predicate | **23/24** both — **case k** red; the real tree stays green |
| (g) the `#`-comment skip at `check-core-paths.sh:144` removed, so a commented line reaches the helper patterns | **18/24** both |

Rows **(d1)** and **(d2)** justify the `run_check` change: red on 3.2, green on 5.x. Without the interpreter passthrough both are green on both shells — which is what the plan shipped with until cold review caught it. Row **(d3)** is recorded because a green run there would otherwise read as a completed mutation.

Row **(e)** pins the fix this PR gained in review. Until `1997b99` the extractor matched a helper call only as the **first token** of its line, so `if ! check_or_write "$out_root/.newcli/skills/…"`, the same call in a `for` body, and the same call after `[ … ] &&` were each discarded before reaching the fail-closed rule — three shapes where the build wrote into an ungoverned directory and the guard printed `OK: all 9 … are governed`, exit 0, suite fully green. Both stated preconditions held in all three. The fix widens the pattern by two characters; case j is its only pin.

Row **(b)** is where this PR's own history is worth reading, because **widening the matcher had a second-order consequence nobody had asked about**. It made the pattern indentation-insensitive, which silently retired the mutation that had pinned the trim: (b) was 15/19 red before the fix and **green afterwards**, leaving the trim certified by nothing. Case **l** — an indented comment naming a helper must stay a comment rather than parse as a call site — re-pins the one place the trim still decides an outcome, and (b) kills again at 22/24. *Closing a check can retire a neighbouring one, and only re-running the whole table afterwards shows it.*

Rows **(b)** and **(g)** are a pair, and each names the exact line it removes so a reader can reproduce them without this description: (b) drops the trim before `case` matching, (g) drops the `#`-comment skip at `check-core-paths.sh:144`. Between them they cover the two things the trim-and-skip block still decides.

Row **(f)** covers the coverage predicate's excluded-**ancestor** half, which no fixture reached before. Note the direction: the unpinned variant fails **loud** (a false red), and the dangerous too-loose direction is already covered by case h — so this is cheap insurance rather than a closed hole.

**Cases j, k and l are new in `1997b99`**, added with the review findings they pin. Case **i** remains the R6 discriminator for the *derivation*: it copies the **real** build script into a fixture paired with a manifest naming no built output, driving the guard down the **failure** path where it names each directory — the success path prints only a count, so only the failure path pins identities.

## Detailed description (for agents)

**One divergence from the plan's wording, recorded rather than smoothed over.** Step 13(d) predicts "cases a-d MUST abort" under the array-guard mutation; observed is c and d only. Cases a and b assert exit 1 for a *forward*-direction phantom, and the forward direction exits before reaching the reverse block, so they never reach the empty accumulator — they pass for the reason they were written to pass. This follows from placing the reverse *verdict* after the forward loop, which the plan pins for the *enumeration* (step 3) but never for the verdict. The placement is required by the plan's own step 12: case i gives its fixture one trivially-resolvable entry "so the forward direction passes and the non-zero exit is unambiguously the reverse direction's" — a sentence that only means anything if the forward direction runs first. The load-bearing property is unchanged and confirmed by (d1)/(d2). The plan's prediction was imprecise; its requirement is met.

**Requirement coverage.** R1 by construction plus the existing forward guard. R2 the guard is written over the derived class, not over `.agents`. R3 `strict` with no policy column. R4 discharged by omission — `.agents/ANTIGRAVITY.md`, `.agents/settings.local.json.example` and `.agents/settings.local.json` appear only inside comments, never as entries, and `.gitignore:47` keeps the last untracked. R5 the reverse verdict names each ungoverned directory. R6 case e with its discriminating twin case f for the *rejection*, and case **i** for the anti-blinding half — the clause requiring a guard that has stopped detecting the condition to fail the build. Case i is exercised by rows **(a)** and **(g)**, whose red sets are `e g h i j l` and `i l` respectively. **Not** by row (b): (b) carried that role until the matcher was widened, and no longer does — see the paragraph on it above. R7 manifest lines 102-103 against `docs/layers.md` rows 169-170.

**Case design notes from DEV.** Case f asserts exit 0 **only** — an earlier draft also asserted the reverse-direction success line, which would have turned the *control* case red under mutation (a) and destroyed the e-red/f-green contrast the pair exists to create. Case h uses the **nested** carve-out form (`.newcli strict` + `.newcli/skills excluded`), mirroring the real `.github/copilot/settings.json` shape; a top-level `excluded` entry never enters the carve-out branch and would exercise none of the logic mirrored from `path_is_governed()`. Case g asserts non-zero **and** that stderr names `build-components.sh:2`, since "non-zero" alone would be satisfied by an unrelated crash. The 16 call sites were verified by instrumenting the guard, not assumed: lines 447, 448, 517, 518, 549, 550, 582, 583, 620, 630, 660, 679, 737, 752, 770, 785, zero unmatched; instrumentation reverted.

**Plan history.** Three cold-review rounds, four findings. The manifest name set was keyed correctly from the start; what needed three rounds was the *verification*: R6 was not discharged by the original case set (the guard could go blind with the suite at 14/14), the coverage predicate diverged from `path_is_governed()` on an `excluded`-ancestor shape, and the 3.2 gate meant to protect the new accumulators was itself inert. The third is the one worth carrying forward — the plan verified the hazard and never verified the path to it.

**Blast radius.** No build outputs, no `artifacts/` source, no version bump. **No CLI-matrix trigger** — `check-*.sh` and `tests/test-*.sh` are on neither list in `docs/cli-matrix-maintenance.md`, and `check-core-paths.sh` is not named individually in the manifest (only `sync-from-upstream.sh` and `build-docs-index.sh` are named individually — at `:135` and `:138` **at this PR's head**, which is `:125`/`:128` on `main`, the ten-line shift being this PR's own manifest addition; the guard falls under the blanket `scripts` entry). No CI file changes: guard and suite are already wired at `build.yml:107,110`, `.gitlab-ci.yml:59-60`, `ci-capabilities.yml:68-69`, so R6's "every CI run" is satisfied by inheritance. `check-ci-parity.sh` and `check-test-wiring.sh` stay green untouched.

**Known and deliberately not fixed here.** Every other test suite that spawns its subject without propagating the interpreter is issue #798. Measured with Python rather than a `grep` on a `${…}` pattern, because this repository's `grep` is `ugrep` and silently returned 0 on such patterns twice this session: of the **68** suites under `scripts/tests/`, **0 propagate the interpreter on `main`**, and **1 does at this PR's head** — the one suite this PR touches, at `test-check-core-paths.sh:121`. Sweeping the rest belongs to #798; each needs its own two-shell re-run.

Issue #755 is the logbook per `AGENTS.md` → *Logbook Issues → Rule A*, and is closed manually after merge per Rule C — this body carries no closing keyword.





