### PR TITLE
📝 Mark spec 0120 implemented

### DIFF
--- a/specs/0120-bash32-declared-set-single-parser.md
+++ b/specs/0120-bash32-declared-set-single-parser.md
@@ -1,7 +1,7 @@
 ---
 id: "0120"
 slug: bash32-declared-set-single-parser
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 721


### PR DESCRIPTION
Records the `approved` → `implemented` transition for spec 0120, now that its implementation has merged. One line, no behaviour change.

## How to read this PR?

One frontmatter field in `specs/0120-bash32-declared-set-single-parser.md`. The diff is `-status: approved` / `+status: implemented` and nothing else — `docs/spec-format.md` → *Recording a post-merge transition* confines this edit to lifecycle metadata, so no body line, no `id`, no `slug` and no `version` may move, and a diff that altered normative content under cover of a status bump would be a violation.

## How to test this PR?

```sh
task spec:lint
git diff main...HEAD --stat    # 1 file, 1 insertion, 1 deletion
```

The trigger the lifecycle table requires is verifiable on `main` rather than asserted here:

```sh
git log --oneline -1 9cba467                                          # the implementation merge (PR #799)
gh issue view 721 --json state,stateReason                            # CLOSED / COMPLETED
git show "main:scripts/check-bash32-portability.sh" | grep -c list-constructs   # 3
```

## Detailed description (for agents)

**Changed:** `specs/0120-bash32-declared-set-single-parser.md` frontmatter, `status` only.

**Why now.** `docs/spec-format.md` → *Lifecycle states* assigns the `implemented` transition to the implementation team's `pr-logbook`, triggered by the implementation PR for `related-issue` merging on `main`. That happened at `9cba467`: PR #799 implemented spec 0120's ten requirements, the cold REVIEW pass returned APPROVE with zero findings of any class, CI was green 13/13 on the reviewed head `fc385f2`, and issue #721 was closed `completed`. The transition is recorded in its own pull request because the spec had already merged; only the `draft` → `approved` transition is folded into the spec-PR's own commit.

**What spec 0120 obliged, for a reader arriving here later.** The portability guard becomes the repository's single interpretation of `ci/bash32-forbidden.txt`: it can be asked what it read (`--list-constructs`), and the synchronisation check in `case f` consumes that answer instead of forming its own. R1 makes that answer a supported interface with a published contract — including what is deliberately *not* promised: row order, stderr wording, any third field.

**Process note worth the record.** The plan took five revisions and two REQUEST CHANGES rounds, and the pull request one more. All three findings were produced by prototyping and mutating rather than by reading — a discrimination prescribed as load-bearing and asserted by nothing, row assertions pinned to the declared set's contents, and a spec scenario clause implemented and asserted by nothing. Reading had verified some twenty line citations and six shell measurements and found none of them.

**Not a closing-keyword PR for #721** — that issue is already closed per Rule C. Issue #801 tracks this transition and is closed on merge.