### PR TITLE
🔐 Sign the graft commit wherever the fork signs its own commits

### DIFF
--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -682,9 +682,19 @@ if [ "$PRESERVE_HISTORY" = true ]; then
   # reachable: a signing program that exits 0 without writing a signature
   # makes `commit-tree -S` exit 0 and produce a commit with no gpgsig header.
   # The `sed -n '/^$/q;p'` slice stops at the blank line that ends the header
-  # block, so a message body beginning with `gpgsig ` cannot pass for one.
+  # block, so a message body beginning with `gpgsig` cannot pass for one.
+  #
+  # The pattern carries NO trailing space, deliberately: git's signature
+  # header name is hash-algorithm dependent — `gpgsig` in a SHA-1 repository,
+  # `gpgsig-sha256` in one created with `--object-format=sha256`. A trailing
+  # space matches the first and misses the second, which would make this
+  # post-condition refuse a signature it had just successfully produced. Not
+  # anchoring on the right stays safe inside the slice: only header lines are
+  # visible there, the signature's own continuation lines begin with a space,
+  # and `gpgsig-sha256` is the only other header name that can match. Case jj
+  # fails if the space comes back.
   if [ "$GRAFT_SIGN" = true ] && \
-     ! git -C "$REPO_DIR" cat-file commit "$GRAFT_COMMIT" | sed -n '/^$/q;p' | grep -q '^gpgsig '; then
+     ! git -C "$REPO_DIR" cat-file commit "$GRAFT_COMMIT" | sed -n '/^$/q;p' | grep -q '^gpgsig'; then
     echo "Error: --preserve-history built an unsigned commit though this repository is configured to sign; refusing to move the branch tip." >&2
     exit 1
   fi

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -40,8 +40,10 @@
 # branch: it creates a single commit whose tree is byte-identical to what the
 # restore alone produced and whose second parent is FETCH_HEAD, so later
 # history-inspection commands (`git log`, `git merge-base`, `git bisect`)
-# surface the upstream lineage directly. Two failure modes apply only in this
-# mode:
+# surface the upstream lineage directly. That one commit inherits the
+# repository's own commit.gpgsign setting (spec 0122): it is signed wherever
+# an ordinary `git commit` in that repository would be. Three failure modes
+# apply only in this mode:
 #
 #   - Shallow-clone refusal: exits non-zero before any fetch, restore, or
 #     commit when the local repository is a shallow clone. This is a
@@ -54,6 +56,11 @@
 #     — every `strict`/`adopt-on-edit` manifest entry, minus any nested
 #     `excluded` child — plus the .crewrig/.synced-markers/ bookkeeping
 #     directory.
+#   - Signing refusal: aborts the history-preserving step (same posture as
+#     the anti-pollution guard — no commit, branch tip unmoved, restored
+#     files left in the working tree) when the repository is configured to
+#     sign commits but the signature cannot be determined or produced.
+#     Degrading to an unsigned commit is never an accepted outcome.
 #
 # When FETCH_HEAD is already an ancestor of the current branch tip, the mode
 # is a no-op: no commit is created and the script exits zero.
@@ -575,7 +582,8 @@ for i in "${!PATHS[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# --preserve-history: history-preserving graft commit (spec 0086 R5-R9, R11).
+# --preserve-history: history-preserving graft commit (spec 0086 R5-R9, R11;
+# spec 0122 R1-R8 for that commit's signature status).
 # Reached only when the policy-aware restore above completed without
 # aborting (R4) — the strict dirty-core guard and any per-path failure exit
 # earlier, above this point, so no ancestry is ever recorded on that path.
@@ -625,9 +633,68 @@ if [ "$PRESERVE_HISTORY" = true ]; then
   GRAFT_TREE="$(git -C "$REPO_DIR" write-tree)"
   UPSTREAM_SHA="$(git -C "$REPO_DIR" rev-parse FETCH_HEAD)"
   COMMIT_MSG="🔀 Graft upstream history via --preserve-history ($(git -C "$REPO_DIR" rev-parse --short FETCH_HEAD))"
-  GRAFT_COMMIT="$(git -C "$REPO_DIR" commit-tree "$GRAFT_TREE" -p "$BRANCH_TIP" -p "$UPSTREAM_SHA" -m "$COMMIT_MSG")"
+
+  # spec 0122 R1-R2 — commit-tree neither reads commit.gpgsign nor is
+  # overridden by it, so neither direction is automatic: resolve the
+  # repository's own setting and pass -S ourselves.
+  #
+  # The presence probe stays an `if` condition because there a non-zero status
+  # legitimately means "unset". The VALUE read must not be one: git exits 128
+  # on a malformed boolean, and a command substitution in the word of a
+  # `[ … ]` test — or anywhere inside an `if` condition, where errexit is
+  # suspended — discards that status twice over, silently yielding an
+  # unsigned commit and exit 0. An assignment propagates it. The explicit
+  # branch below names the cause in English because git's own diagnostic here
+  # is localized, so it is not something an operator or a test can rely on.
+  GRAFT_SIGN=false
+  GRAFT_SIGN_ARGS=()
+  if git -C "$REPO_DIR" config --get commit.gpgsign >/dev/null 2>&1; then
+    if ! GRAFT_SIGN_RAW="$(git -C "$REPO_DIR" config --bool --get commit.gpgsign)"; then
+      echo "Error: --preserve-history cannot determine whether to sign this commit — commit.gpgsign holds a value git cannot read as a boolean; see the git error above." >&2
+      echo "The branch tip is unchanged and the restored files remain in the working tree. Correct commit.gpgsign and re-run." >&2
+      exit 1
+    fi
+    if [ "$GRAFT_SIGN_RAW" = true ]; then
+      GRAFT_SIGN=true
+      GRAFT_SIGN_ARGS=(-S)
+    fi
+  fi
+
+  # The array expansion is guarded per docs/scripting-conventions.md Rule 5's
+  # fourth, deliberately non-grep-detectable trap: under `set -u` Bash 3.2
+  # treats an empty array as unset, and empty is exactly what
+  # GRAFT_SIGN_ARGS holds on the non-signing path — every fork spec 0122 R3
+  # exists to leave alone.
+  if ! GRAFT_COMMIT="$(git -C "$REPO_DIR" commit-tree "$GRAFT_TREE" \
+    -p "$BRANCH_TIP" -p "$UPSTREAM_SHA" ${GRAFT_SIGN_ARGS[@]+"${GRAFT_SIGN_ARGS[@]}"} -m "$COMMIT_MSG")"; then
+    if [ "$GRAFT_SIGN" = true ]; then
+      echo "Error: --preserve-history refuses to commit — this repository is configured to sign commits (commit.gpgsign) but the signature could not be produced; see the git error above." >&2
+      echo "The branch tip is unchanged and the restored files remain in the working tree. Fix the signing setup (key, agent, gpg.format) and re-run, or clear commit.gpgsign for this repository." >&2
+    else
+      echo "Error: --preserve-history could not create the graft commit; see the git error above." >&2
+    fi
+    exit 1
+  fi
+
+  # spec 0122 R5 — refuse a degraded (unsigned) commit BEFORE the ref moves.
+  # The identical check placed after update-ref would leave the branch tip
+  # sitting on the unsigned commit, satisfying R5 by violating R4. The path is
+  # reachable: a signing program that exits 0 without writing a signature
+  # makes `commit-tree -S` exit 0 and produce a commit with no gpgsig header.
+  # The `sed -n '/^$/q;p'` slice stops at the blank line that ends the header
+  # block, so a message body beginning with `gpgsig ` cannot pass for one.
+  if [ "$GRAFT_SIGN" = true ] && \
+     ! git -C "$REPO_DIR" cat-file commit "$GRAFT_COMMIT" | sed -n '/^$/q;p' | grep -q '^gpgsig '; then
+    echo "Error: --preserve-history built an unsigned commit though this repository is configured to sign; refusing to move the branch tip." >&2
+    exit 1
+  fi
+
   git -C "$REPO_DIR" update-ref -m "sync-from-upstream --preserve-history" HEAD "$GRAFT_COMMIT"
-  echo "History-preserving commit created: $GRAFT_COMMIT (parents: $BRANCH_TIP, $UPSTREAM_SHA)"
+  # The suffix reports the signature the check above observed on the object,
+  # not the fact that -S was passed (docs/scripting-conventions.md Rule 2).
+  GRAFT_SIGN_NOTE=""
+  if [ "$GRAFT_SIGN" = true ]; then GRAFT_SIGN_NOTE=" (signed)"; fi
+  echo "History-preserving commit created: $GRAFT_COMMIT$GRAFT_SIGN_NOTE (parents: $BRANCH_TIP, $UPSTREAM_SHA)"
 fi
 
 echo "Sync complete. Review the changes with 'git diff' before committing."

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -101,6 +101,39 @@
 #      produced by `backup_file()`, and does NOT match the sibling
 #      `extension.json` (pattern stayed narrow).
 #
+# Spec-0122 signed-graft-commit cases (issue #756):
+#  cc. R1, R2, R6, R7 — a repository configured to sign (gpg.format ssh, an
+#      ephemeral ed25519 key, commit.gpgsign true) gets a SIGNED graft commit
+#      that still carries both parents, whose second parent is the fetched
+#      upstream commit byte-for-byte, and whose creation is reported with a
+#      `(signed)` suffix on stdout.
+#  dd. R3 — a repository that does not sign (commit.gpgsign false) gets an
+#      unsigned graft commit, exit 0, no `(signed)` on stdout, and no
+#      signing-related line on stderr: the non-signing path gains nothing.
+#  ee. R4, R5 — commit.gpgsign true with a user.signingkey that does not
+#      exist: the sync refuses, creates no commit, leaves the branch tip
+#      where it stood, leaves the restored content in the working tree, and
+#      names the unproducible signature in its OWN message. git's signing
+#      diagnostic is localized, so no assertion here may read it.
+#  ff. R8 — the no-op path (FETCH_HEAD already an ancestor) still exits 0 in
+#      a repository configured to sign but unable to: no commit means no
+#      signature to produce, so signing capability is never probed.
+#  gg. R1, R5 — commit.gpgsign holds a value git cannot read as a boolean.
+#      `git commit` itself exits 128 in such a repository, so reporting a
+#      successful sync would breach R1 on its face. Guards the shape of the
+#      predicate: a config read placed in the word of a `[ … ]` test inside
+#      an `if` condition discards git's 128 (errexit is suspended there) and
+#      silently produces an unsigned commit with exit 0.
+#  hh. R5 ordering — a gpg.ssh.program that exits 0 without writing a
+#      signature makes `commit-tree -S` exit 0 and produce a commit with no
+#      gpgsig header. The sync must refuse with the branch tip UNMOVED; the
+#      same check placed after update-ref would refuse with the tip already
+#      on the unsigned commit, satisfying R5 by violating R4.
+#  ii. R3 by absence — commit.gpgsign unset, which is the modal non-signing
+#      shape and the one no other case reaches (init_git_repo pins it to
+#      `false`). Invoked with the operator's own configuration neutralised,
+#      because the predicate resolves through global config too.
+#
 # Usage:
 #   bash scripts/tests/test-sync-from-upstream.sh
 
@@ -134,6 +167,15 @@ init_git_repo() {
   git -C "$dir" config user.email "test@example.com"
   git -C "$dir" config user.name "Test"
   git -C "$dir" config commit.gpgsign false
+}
+
+# commit_is_signed <repo> <rev>
+# True when <rev> carries a gpgsig header. The sed slice stops at the blank
+# line that ends the header block: `git cat-file commit` also prints the
+# message, so a naive full-output match reports SIGNED for an unsigned commit
+# whose message body happens to begin with `gpgsig `.
+commit_is_signed() {
+  git -C "$1" cat-file commit "$2" | sed -n '/^$/q;p' | grep -q '^gpgsig '
 }
 
 # make_initial_commit <repo> [<file> <content>]...
@@ -1628,6 +1670,531 @@ run_case_stderr() {
   else
     echo "PASS  case-bb: sibling extension.json is NOT gitignored (pattern stayed narrow)"
     pass=$((pass + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case cc — spec 0122 R1, R2, R6, R7: a repository configured to sign its
+# commits gets a SIGNED graft commit that still carries both parents, the
+# second of them the fetched upstream commit byte-for-byte.
+#
+# The signing key lives OUTSIDE the adopter worktree. Inside it, the R8
+# anti-pollution guard would see an untracked, ungoverned path and abort the
+# history-preserving step before `git add -A` ever runs — and the resulting
+# failure reads as a signing failure, which is what makes it worth naming.
+#
+# The signing configuration is applied AFTER the fixture's own commits, so
+# those commits stay hermetic under init_git_repo's `commit.gpgsign false`
+# pin and the case remains constructible on a machine whose global config
+# points at a key this process cannot use.
+# ---------------------------------------------------------------------------
+{
+  ok=1
+  keydir="$(mktemp -d "$TMP_ROOT/signkey.XXXXXX")"
+  if ! ssh-keygen -t ed25519 -N '' -f "$keydir/signer" -q 2>/dev/null; then
+    echo "FAIL  case-cc: could not create an ed25519 key — ssh-keygen signing support (OpenSSH >= 8.2) is a precondition of this case, not an optional capability"
+    ok=0
+  fi
+
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+  upstream_sha="$(git -C "$upstream" rev-parse HEAD)"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  git -C "$adopter" config gpg.format ssh
+  git -C "$adopter" config user.signingkey "$keydir/signer.pub"
+  git -C "$adopter" config commit.gpgsign true
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  actual_exit=0
+  stdout_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history 2>/dev/null)" || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  if [ "$actual_exit" -ne 0 ]; then
+    echo "FAIL  case-cc: expected exit 0, got $actual_exit"
+    ok=0
+  fi
+  if [ "$head_after" = "$tip_before" ]; then
+    echo "FAIL  case-cc: HEAD did not move — no graft commit was created"
+    ok=0
+  fi
+  if ! commit_is_signed "$adopter" HEAD; then
+    echo "FAIL  case-cc: the graft commit carries no gpgsig header though commit.gpgsign is true"
+    ok=0
+  fi
+  parent_count="$(git -C "$adopter" cat-file commit HEAD | sed -n '/^$/q;p' | grep -c '^parent ')"
+  if [ "$parent_count" -ne 2 ]; then
+    echo "FAIL  case-cc: the graft commit carries $parent_count parent(s), expected 2"
+    ok=0
+  fi
+  first_parent="$(git -C "$adopter" rev-parse 'HEAD^1' 2>/dev/null || true)"
+  second_parent="$(git -C "$adopter" rev-parse 'HEAD^2' 2>/dev/null || true)"
+  if [ "$first_parent" != "$tip_before" ]; then
+    echo "FAIL  case-cc: first parent is '$first_parent', expected the pre-run tip '$tip_before'"
+    ok=0
+  fi
+  if [ "$second_parent" != "$upstream_sha" ]; then
+    echo "FAIL  case-cc: second parent is '$second_parent', expected the fetched upstream commit '$upstream_sha' unchanged (R7)"
+    ok=0
+  fi
+  if ! git -C "$adopter" merge-base --is-ancestor "$upstream_sha" HEAD 2>/dev/null; then
+    echo "FAIL  case-cc: the fetched upstream commit is not an ancestor of the new branch tip"
+    ok=0
+  fi
+  if ! echo "$stdout_out" | grep -qF "(signed)"; then
+    echo "FAIL  case-cc: stdout does not report the commit as signed"
+    echo "      actual stdout: $stdout_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-cc: signing repository gets a signed graft commit with both parents intact"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case dd — spec 0122 R3: a repository that does not sign its commits is
+# untouched by the change. init_git_repo pins `commit.gpgsign false` locally,
+# which is what makes the case hermetic: the predicate resolves through global
+# config too, so an unpinned fixture would inherit the operator's own setting.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  stdout_file="$(mktemp "$TMP_ROOT/dd-stdout.XXXXXX")"
+  stderr_file="$(mktemp "$TMP_ROOT/dd-stderr.XXXXXX")"
+  actual_exit=0
+  ( cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history >"$stdout_file" 2>"$stderr_file" ) || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  ok=1
+  if [ "$actual_exit" -ne 0 ]; then
+    echo "FAIL  case-dd: expected exit 0, got $actual_exit"
+    echo "      stderr: $(cat "$stderr_file")"
+    ok=0
+  fi
+  if [ "$head_after" = "$tip_before" ]; then
+    echo "FAIL  case-dd: HEAD did not move — no graft commit was created"
+    ok=0
+  fi
+  if commit_is_signed "$adopter" HEAD; then
+    echo "FAIL  case-dd: the graft commit carries a gpgsig header though commit.gpgsign is false"
+    ok=0
+  fi
+  if grep -qF "(signed)" "$stdout_file"; then
+    echo "FAIL  case-dd: stdout reports the commit as signed"
+    echo "      actual stdout: $(cat "$stdout_file")"
+    ok=0
+  fi
+  if grep -q "[Ss]ign" "$stderr_file"; then
+    echo "FAIL  case-dd: stderr carries a signing-related line on the non-signing path"
+    echo "      actual stderr: $(cat "$stderr_file")"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-dd: non-signing repository gets an unsigned graft commit, exit 0, no signing noise"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case ee — spec 0122 R4, R5: commit.gpgsign true with a user.signingkey that
+# does not exist. The sync refuses AFTER the policy-aware restore (spec 0122's
+# closed open question), so the restored upstream content is already in the
+# working tree when it does.
+#
+# The stderr assertion reads the script's OWN message. git's signing
+# diagnostic is localized — on a French-locale machine it opens `erreur :` —
+# so an assertion on git's wording would pass in CI and fail on a maintainer's
+# laptop for a reason having nothing to do with the requirement.
+# ---------------------------------------------------------------------------
+{
+  keydir="$(mktemp -d "$TMP_ROOT/signkey.XXXXXX")"
+
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  git -C "$adopter" config gpg.format ssh
+  git -C "$adopter" config user.signingkey "$keydir/absent-key.pub"
+  git -C "$adopter" config commit.gpgsign true
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  actual_exit=0
+  stderr_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history 2>&1 >/dev/null)" || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  ok=1
+  if [ "$actual_exit" -eq 0 ]; then
+    echo "FAIL  case-ee: expected a non-zero exit when the configured signature cannot be produced, got 0"
+    ok=0
+  fi
+  if [ "$head_after" != "$tip_before" ]; then
+    echo "FAIL  case-ee: the branch tip moved despite the signing refusal ('$tip_before' -> '$head_after')"
+    ok=0
+  fi
+  content_after="$(cat "$adopter/core-file.txt" 2>/dev/null)"
+  if [ "$content_after" != "upstream v2 content" ]; then
+    echo "FAIL  case-ee: the restored files are not in the working tree (core-file.txt = '$content_after')"
+    ok=0
+  fi
+  if ! echo "$stderr_out" | grep -qF "refuses to commit — this repository is configured to sign"; then
+    echo "FAIL  case-ee: stderr does not name the unproducible signature in the script's own words"
+    echo "      actual stderr: $stderr_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-ee: unproducible signature refuses with no commit, tip unmoved, restore intact"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case ff — spec 0122 R8: the no-op path still exits 0 in a repository that
+# is configured to sign but cannot. No commit is created, so no signature is
+# needed and signing capability is never probed. Case u's clone shape, where
+# FETCH_HEAD is already an ancestor of the branch tip.
+#
+# Placing a signing probe before the no-op short-circuit is exactly the
+# regression this case catches.
+# ---------------------------------------------------------------------------
+{
+  keydir="$(mktemp -d "$TMP_ROOT/signkey.XXXXXX")"
+
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" "core-file.txt" "upstream content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  rm -rf "$adopter"
+  git clone -q "file://$upstream" "$adopter"
+  git -C "$adopter" config user.email "test@example.com"
+  git -C "$adopter" config user.name "Test"
+  git -C "$adopter" config commit.gpgsign false
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  git -C "$adopter" add crewrig.config.toml .crewrig/core-paths.txt
+  git -C "$adopter" commit -q -m "adopter config"
+
+  git -C "$adopter" config gpg.format ssh
+  git -C "$adopter" config user.signingkey "$keydir/absent-key.pub"
+  git -C "$adopter" config commit.gpgsign true
+
+  head_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  actual_exit=0
+  stdout_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history 2>/dev/null)" || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  ok=1
+  if [ "$actual_exit" -ne 0 ]; then
+    echo "FAIL  case-ff: expected exit 0 on the no-op path, got $actual_exit"
+    ok=0
+  fi
+  if [ "$head_after" != "$head_before" ]; then
+    echo "FAIL  case-ff: HEAD moved (a commit was created) though FETCH_HEAD was already an ancestor"
+    ok=0
+  fi
+  if ! echo "$stdout_out" | grep -qF "no-op"; then
+    echo "FAIL  case-ff: stdout missing the no-op acknowledgement"
+    echo "      actual stdout: $stdout_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-ff: no-op path exits 0 in a signing repository that cannot sign"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case gg — spec 0122 R1, R5: commit.gpgsign holds a value git cannot read as
+# a boolean, and no signing key is configured at all. `git commit` itself
+# exits 128 in such a repository, so a sync reporting success here breaches R1
+# on its face.
+#
+# This is the case that pins the SHAPE of the predicate. Reading the value in
+# the word of a `[ … ]` test inside an `if` condition — where errexit is
+# suspended — discards git's 128 twice over and yields an unsigned commit with
+# exit 0. The assertion is on the script's own English message, not on git's
+# localized `fatal :` line.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  git -C "$adopter" config commit.gpgsign yesplease
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  actual_exit=0
+  stderr_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history 2>&1 >/dev/null)" || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  ok=1
+  if [ "$actual_exit" -eq 0 ]; then
+    echo "FAIL  case-gg: expected a non-zero exit on an unreadable commit.gpgsign, got 0"
+    ok=0
+  fi
+  if [ "$head_after" != "$tip_before" ]; then
+    echo "FAIL  case-gg: the branch tip moved despite the unreadable commit.gpgsign ('$tip_before' -> '$head_after')"
+    ok=0
+  fi
+  if ! echo "$stderr_out" | grep -qF "cannot determine whether to sign"; then
+    echo "FAIL  case-gg: stderr does not name the unreadable commit.gpgsign in the script's own words"
+    echo "      actual stderr: $stderr_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-gg: unreadable commit.gpgsign refuses with no commit and the tip unmoved"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case hh — spec 0122 R5 ordering: a gpg.ssh.program that exits 0 without
+# writing a signature makes `commit-tree -S` exit 0 and hand back a commit
+# with no gpgsig header. That is the degradation R5 forbids, and it is
+# reachable from a black-box fixture — the shape of a mis-wired signing
+# wrapper.
+#
+# The HEAD assertion is what pins the post-condition's PLACEMENT. Run before
+# update-ref, the refusal leaves the tip where it stood; run after, the same
+# refusal leaves the tip on the unsigned commit — satisfying R5 by violating
+# R4. The stub lives outside the adopter worktree for the same reason case
+# cc's key does: the R8 guard rejects an ungoverned path first.
+# ---------------------------------------------------------------------------
+{
+  ok=1
+  keydir="$(mktemp -d "$TMP_ROOT/signkey.XXXXXX")"
+  if ! ssh-keygen -t ed25519 -N '' -f "$keydir/signer" -q 2>/dev/null; then
+    echo "FAIL  case-hh: could not create an ed25519 key — ssh-keygen signing support (OpenSSH >= 8.2) is a precondition of this case, not an optional capability"
+    ok=0
+  fi
+  # git invokes the signing program as
+  # `<prog> -Y sign -n git -f <pubkey> <buffer>` and then reads
+  # `<buffer>.sig`. The stub creates that file empty and reports success.
+  # Taking the LAST argument keeps the stub independent of git's argument
+  # order.
+  cat > "$keydir/emptysig.sh" <<'STUB'
+#!/bin/sh
+for arg in "$@"; do buffer="$arg"; done
+: > "$buffer.sig"
+exit 0
+STUB
+  chmod +x "$keydir/emptysig.sh"
+
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  git -C "$adopter" config gpg.format ssh
+  git -C "$adopter" config user.signingkey "$keydir/signer.pub"
+  git -C "$adopter" config gpg.ssh.program "$keydir/emptysig.sh"
+  git -C "$adopter" config commit.gpgsign true
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  actual_exit=0
+  stderr_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history 2>&1 >/dev/null)" || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  if [ "$actual_exit" -eq 0 ]; then
+    echo "FAIL  case-hh: expected a non-zero exit when commit-tree returns an unsigned commit, got 0"
+    ok=0
+  fi
+  if [ "$head_after" != "$tip_before" ]; then
+    echo "FAIL  case-hh: the branch tip moved onto the unsigned commit — the post-condition runs after update-ref ('$tip_before' -> '$head_after')"
+    ok=0
+  fi
+  if ! echo "$stderr_out" | grep -qF "built an unsigned commit"; then
+    echo "FAIL  case-hh: stderr does not name the unsigned-commit refusal"
+    echo "      actual stderr: $stderr_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-hh: an unsigned commit from a successful commit-tree -S refuses before the tip moves"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case ii — spec 0122 R3 by absence: commit.gpgsign UNSET, which is the modal
+# non-signing shape and the one no other case reaches (init_git_repo pins the
+# key to `false`, so every other fixture takes the explicitly-false branch and
+# the presence probe always succeeds).
+#
+# The `--unset` comes AFTER the fixture's own commits, and the script is
+# invoked with the operator's configuration neutralised. Both are mandatory,
+# not hygiene. Without the isolation, a repository with no local key resolves
+# commit.gpgsign to `true` from a maintainer's ~/.gitconfig, so the case would
+# be a SIGNING fixture locally and a non-signing one in CI. And with the unset
+# applied before the fixture's commits, those commits would be signed with the
+# operator's own key — harmless where it works, unconstructible where it does
+# not. GIT_CONFIG_NOSYSTEM + HOME + XDG_CONFIG_HOME is preferred over
+# GIT_CONFIG_GLOBAL (git >= 2.32) so the suite's git floor is not raised.
+# ---------------------------------------------------------------------------
+{
+  isolated="$(mktemp -d "$TMP_ROOT/isolated-home.XXXXXX")"
+
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  git -C "$adopter" config --unset commit.gpgsign
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  stdout_file="$(mktemp "$TMP_ROOT/ii-stdout.XXXXXX")"
+  stderr_file="$(mktemp "$TMP_ROOT/ii-stderr.XXXXXX")"
+  actual_exit=0
+  ( cd "$adopter" \
+    && GIT_CONFIG_NOSYSTEM=1 HOME="$isolated" XDG_CONFIG_HOME="$isolated" \
+       CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history \
+       >"$stdout_file" 2>"$stderr_file" ) || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  ok=1
+  if [ "$actual_exit" -ne 0 ]; then
+    echo "FAIL  case-ii: expected exit 0 with commit.gpgsign unset, got $actual_exit"
+    echo "      stderr: $(cat "$stderr_file")"
+    ok=0
+  fi
+  if [ "$head_after" = "$tip_before" ]; then
+    echo "FAIL  case-ii: HEAD did not move — no graft commit was created"
+    ok=0
+  fi
+  if commit_is_signed "$adopter" HEAD; then
+    echo "FAIL  case-ii: the graft commit is signed though commit.gpgsign is unset"
+    ok=0
+  fi
+  if grep -qF "(signed)" "$stdout_file"; then
+    echo "FAIL  case-ii: stdout reports the commit as signed"
+    echo "      actual stdout: $(cat "$stdout_file")"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-ii: unset commit.gpgsign grafts an unsigned commit and exits 0"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
   fi
 }
 

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -133,6 +133,13 @@
 #      shape and the one no other case reaches (init_git_repo pins it to
 #      `false`). Invoked with the operator's own configuration neutralised,
 #      because the predicate resolves through global config too.
+#  jj. R1, R2 in a SHA-256 repository (PR #803 review) — git's signature
+#      header name is hash-algorithm dependent: `gpgsig` under SHA-1,
+#      `gpgsig-sha256` under `--object-format=sha256`. A `^gpgsig ` pattern
+#      WITH a trailing space matches the first and misses the second, so the
+#      R5 post-condition refuses a signature it had just produced and reports
+#      the opposite of what happened. Guards both readers of that pattern —
+#      the script's post-condition and commit_is_signed.
 #
 # Usage:
 #   bash scripts/tests/test-sync-from-upstream.sh
@@ -173,9 +180,14 @@ init_git_repo() {
 # True when <rev> carries a gpgsig header. The sed slice stops at the blank
 # line that ends the header block: `git cat-file commit` also prints the
 # message, so a naive full-output match reports SIGNED for an unsigned commit
-# whose message body happens to begin with `gpgsig `.
+# whose message body happens to begin with `gpgsig`.
+#
+# NO trailing space in the pattern, deliberately: the header name is
+# hash-algorithm dependent (`gpgsig` under SHA-1, `gpgsig-sha256` under
+# --object-format=sha256), and a trailing space would report a signed SHA-256
+# commit as unsigned. Case jj fails if the space comes back.
 commit_is_signed() {
-  git -C "$1" cat-file commit "$2" | sed -n '/^$/q;p' | grep -q '^gpgsig '
+  git -C "$1" cat-file commit "$2" | sed -n '/^$/q;p' | grep -q '^gpgsig'
 }
 
 # make_initial_commit <repo> [<file> <content>]...
@@ -2192,6 +2204,124 @@ STUB
 
   if [ "$ok" -eq 1 ]; then
     echo "PASS  case-ii: unset commit.gpgsign grafts an unsigned commit and exits 0"
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case jj — spec 0122 R1, R2 in a SHA-256 repository (PR #803 cold review).
+# Git's signature header name is hash-algorithm dependent: `gpgsig` in a SHA-1
+# repository, `gpgsig-sha256` in one created with --object-format=sha256. A
+# `^gpgsig ` pattern WITH a trailing space matches the first and misses the
+# second, so the R5 post-condition refuses a signature it had just
+# successfully produced: no commit at all where an ordinary `git commit` makes
+# a signed one. That breaches R1 and R2 rather than serving R5, and the
+# refusal message names a cause that did not occur.
+#
+# Both readers of the pattern are covered, independently:
+#   - restore the space in sync-from-upstream.sh -> fails on exit code, on the
+#     unmoved HEAD, and on the missing `(signed)`;
+#   - restore it in commit_is_signed only        -> fails on that assertion
+#     alone, with the sync itself still green.
+#
+# Reachability is narrow and worth stating: a SHA-256 fork of a SHA-1 upstream
+# never gets here, because `git fetch` refuses the object-format mismatch
+# first. The fixture therefore needs SHA-256 on BOTH ends — which
+# `canonical_repo` permits.
+#
+# The object format is fixed at init time, so `git init` runs with the flag
+# first; a plain re-init inside init_git_repo preserves it (measured) and
+# supplies the identity plus the `commit.gpgsign false` pin that keeps the
+# fixture's own commits hermetic before the signing config goes on.
+# ---------------------------------------------------------------------------
+{
+  ok=1
+  keydir="$(mktemp -d "$TMP_ROOT/signkey.XXXXXX")"
+  if ! ssh-keygen -t ed25519 -N '' -f "$keydir/signer" -q 2>/dev/null; then
+    echo "FAIL  case-jj: could not create an ed25519 key — ssh-keygen signing support (OpenSSH >= 8.2) is a precondition of this case, not an optional capability"
+    ok=0
+  fi
+
+  upstream="$(mktemp -d "$TMP_ROOT/upstream-sha256.XXXXXX")"
+  adopter="$(mktemp -d "$TMP_ROOT/adopter-sha256.XXXXXX")"
+  if ! git init -q --object-format=sha256 "$upstream" 2>/dev/null \
+     || ! git init -q --object-format=sha256 "$adopter" 2>/dev/null; then
+    echo "FAIL  case-jj: this git cannot create a --object-format=sha256 repository (needs git >= 2.29) — a precondition of this case, not an optional capability"
+    ok=0
+  fi
+  init_git_repo "$upstream"
+  init_git_repo "$adopter"
+
+  # Fixture sanity: without this, a silent fallback to SHA-1 would leave the
+  # case green while exercising the very header name it exists to NOT test.
+  for r in "$upstream" "$adopter"; do
+    fmt="$(git -C "$r" rev-parse --show-object-format 2>/dev/null || true)"
+    if [ "$fmt" != "sha256" ]; then
+      echo "FAIL  case-jj: fixture repo $r reports object format '$fmt', expected 'sha256' — the case would test the SHA-1 header name instead"
+      ok=0
+    fi
+  done
+
+  make_initial_commit "$upstream" \
+    "core-file.txt" "upstream v1 content" \
+    "other.txt"     "other content"
+  commit_files "$upstream" "advance core-file" \
+    "core-file.txt" "upstream v2 content"
+
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'core-file.txt\n' > "$adopter/.crewrig/core-paths.txt"
+  printf '%s' "upstream v1 content" > "$adopter/core-file.txt"
+  printf '%s' "other content" > "$adopter/other.txt"
+  git -C "$adopter" add -A
+  git -C "$adopter" commit -q -m initial
+
+  git -C "$adopter" config gpg.format ssh
+  git -C "$adopter" config user.signingkey "$keydir/signer.pub"
+  git -C "$adopter" config commit.gpgsign true
+
+  # Premise check, deliberately BEFORE the sync and independent of it: this
+  # fixture must really produce the hash-dependent header name, or the case
+  # stops being evidence about the trailing space. Asserting it afterwards on
+  # the graft commit would conflate "git renamed the header" with "the script
+  # refused the commit" — under a restored trailing space HEAD never moves, so
+  # the check would fail while pointing at the wrong cause. The throwaway
+  # commit is referenced by nothing and changes no ref, index, or file.
+  probe_commit="$(git -C "$adopter" commit-tree "$(git -C "$adopter" rev-parse 'HEAD^{tree}')" -m sha256-header-probe -S 2>/dev/null || true)"
+  if [ -z "$probe_commit" ] || ! git -C "$adopter" cat-file commit "$probe_commit" 2>/dev/null | sed -n '/^$/q;p' | grep -q '^gpgsig-sha256 '; then
+    echo "FAIL  case-jj: this fixture does not produce a 'gpgsig-sha256' header — the case no longer exercises the hash-dependent header name it exists to cover"
+    ok=0
+  fi
+
+  tip_before="$(git -C "$adopter" rev-parse HEAD)"
+
+  actual_exit=0
+  stdout_out="$(cd "$adopter" && CREWRIG_REPO_DIR="$adopter" bash "$SCRIPT_UNDER_TEST" --preserve-history 2>/dev/null)" || actual_exit=$?
+
+  head_after="$(git -C "$adopter" rev-parse HEAD)"
+
+  if [ "$actual_exit" -ne 0 ]; then
+    echo "FAIL  case-jj: expected exit 0, got $actual_exit — a signature that WAS produced was read as absent"
+    ok=0
+  fi
+  if [ "$head_after" = "$tip_before" ]; then
+    echo "FAIL  case-jj: HEAD did not move — the graft commit was refused though the repository can sign"
+    ok=0
+  fi
+  if ! commit_is_signed "$adopter" HEAD; then
+    echo "FAIL  case-jj: commit_is_signed reports the graft commit unsigned in a SHA-256 repository"
+    ok=0
+  fi
+  if ! echo "$stdout_out" | grep -qF "(signed)"; then
+    echo "FAIL  case-jj: stdout does not report the commit as signed"
+    echo "      actual stdout: $stdout_out"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  case-jj: SHA-256 repository gets a signed graft commit (gpgsig-sha256 recognised)"
     pass=$((pass + 1))
   else
     fail=$((fail + 1))


### PR DESCRIPTION
Makes the one commit `scripts/sync-from-upstream.sh` authors under `--preserve-history` carry the same signature status as any other commit that repository would create — and forbids it from silently degrading to an unsigned one. Implements spec 0122 for issue #756.

## ⚠️ One adopter-visible break

`scripts/sync-from-upstream.sh` is a `strict` core path, so adopters receive this without opting in. **A fork whose signing configuration cannot be satisfied or parsed now exits non-zero where it previously produced an unsigned commit and exited 0.** That is spec 0122 R5 working as specified — degrading to an unsigned commit is not an outcome the script accepts, warning or no warning — but it is a behaviour change, and a fork with a broken signing setup meets it on its next sync rather than in a release note.

A fork that does not sign gets the same commit it got before, with no new interaction and no new failure mode (R3). One exit code moves on a path that already failed: a `commit-tree` failure unrelated to signing now surfaces as 1 rather than 128, because the call is wrapped. Nothing that succeeded before fails now.

## How to read this PR?

`git commit-tree` is plumbing. It **neither reads `commit.gpgsign` nor is overridden by it** — both measured — so neither direction is automatic and the script must resolve the setting itself and pass `-S` conditionally. R3 is therefore a real branch in the code, not a property that falls out for free.

Read the guard block at `scripts/sync-from-upstream.sh:637-707` and pay attention to three things. (A narrower `:645-675` in an earlier draft excluded the post-condition at `:679-700` and the `update-ref` at `:702` — the subject of point 2 below.)

**1. The presence probe is an `if` condition; the value read is not.** That asymmetry is the fix for a defect a plan review caught before it shipped. A non-zero status from the *presence* probe legitimately means "unset". But git exits **128** on a malformed boolean, and a command substitution in the word of a `[ … ]` test — or anywhere inside an `if` condition, where `errexit` is suspended — discards that status **twice over**, yielding an unsigned commit and exit 0. An assignment propagates it. Reproduced end to end: with `commit.gpgsign = yesplease`, the v1 shape prints `History-preserving commit created` and `Sync complete.`, exits 0, unsigned.

**2. The refusal is checked *before* `update-ref`.** Refusing after the ref has moved would satisfy R5 by violating R4's "leave the branch tip where it stood".

**3. The script emits its own English cause, and that is not decoration.** Git's signing diagnostic is **localized**. The same failing run:

```
erreur : Couldn't load public key …/absent-key.pub: No such file or directory?   # default locale
error: Couldn't load public key …/absent-key.pub: No such file or directory?     # LC_ALL=C
```

R4 requires a message naming the unproducible signature as the cause; git's cannot be that message, and no test may assert on it. **No assertion depends on git's wording for a positive match.** (`dd`'s grep does span git's fetch stderr; measured across C, fr_FR and de_DE it is two git lines, none matching, so the conclusion holds — but the stronger phrasing "nothing in the suite reads git's line" would be wrong.) That single artifact — one run, two locales, our line unmoved — is the R4 evidence.

## How to test this PR?

```sh
/bin/bash scripts/tests/test-sync-from-upstream.sh                                 # 65/65 on 3.2.57
bash      scripts/tests/test-sync-from-upstream.sh                                 # 65/65 on 5.3.15
GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash scripts/tests/test-sync-from-upstream.sh   # 65/65 hermetic
```

Eight new cases, `cc` through `jj`. The refusal on a configured-but-unsignable repository, verbatim:

```
Error: --preserve-history refuses to commit — this repository is configured to sign
commits (commit.gpgsign) but the signature could not be produced; see the git error above.
The branch tip is unchanged and the restored files remain in the working tree.
[exit=1]
HEAD before: 7b41c38f…
HEAD after : 7b41c38f…   (unmoved: R4)
core-file.txt in the working tree: 'v2'   (restored content kept: R4)
```

**The mutation table is the evidence.** Thirteen mutations, every result observed rather than predicted, and reported as **red-case counts** rather than pass totals — the suite grew from 64 to 65, so `62/64 → 62/65` would read as "no change" where one row genuinely changed:

| # | Mutation | Red cases | Which |
|---|---|---|---|
| M1 | drop the flag | **3** | `cc`, `ee`, **`jj`** — was 2 before `jj` existed |
| M2 | unconditional `-S` | 2 | `dd` signed; `ii` exit 1 |
| M3a | `\|\| true` | 1 | `ee`, stderr only |
| M3b | degrade via retry | 1 | `ee`, stderr only — FAIL line byte-identical to M3a |
| M4 | probe too early | 3 | `ff`, `ee`, `ii` — `jj` stays green, correctly |
| M5 | header-slice growth | 2 | `dd`, `ii` — `jj` stays green, correctly |
| M6 | relocate the post-condition after `update-ref` | 1 | `hh`, **HEAD assertion only** |
| M7 | delete the post-condition | 1 | `hh`, all three assertions |
| M8 | revert the config read to the swallowing shape | 1 | `gg`, all three |
| M9 | make the presence probe fatal | 1 | **`ii` alone** |
| M10script | restore the trailing space in `sync-from-upstream.sh` only | 1 | `jj`, **4 assertions** |
| M10helper | restore it in `commit_is_signed` only | 1 | `jj`, **1 assertion** — the sync itself stays green |
| M10both | the full reversion of the SHA-256 fix | 1 | `jj`, 4 assertions |

**M1 is the row that genuinely changed**: dropping `-S` breaks SHA-256 signing exactly as it breaks SHA-1, so `jj` now reddens beside `cc` and `ee`. M4 and M5 leave `jj` green and that is correct — `jj` has a usable key, so an early probe succeeds, and its commit is genuinely signed, so a full-output match still finds the header.

The three **M10** rows are what close the review finding. They matter separately: `M10script` and `M10helper` show each of the two readers is covered **independently**, which single-file mutations prove and a combined one only asserts.

**M6 versus M7 is the pair worth re-running** — one assertion red versus three. `hh` discriminates a *misplaced* post-condition from an *absent* one, not merely "something is wrong".

Each mutation was applied through a harness that **aborts when its anchor is not found exactly once**, so "the mutation did not take" cannot masquerade as "the mutation had no effect", and reverted from a byte-exact snapshot verified two ways (`diff -q` plus the suite back to 65) before the next.

Gates, with `$?` captured plainly rather than read off an OK line: `check-bash32-portability.sh` 0 · `check-core-paths.sh` 0 · `check-test-wiring.sh` 0 · `check-ci-parity.sh` 0 · `task lint-markdown` 0 (it prints no verdict — the rc is the whole signal) · `task spec:lint` 0 · the Rule 1 and Rule 3 convention greps, zero hits each · `shellcheck -S warning` clean.

## Detailed description (for agents)

**Requirement coverage.** R1/R2 the graft commit inherits the repository's own setting, signed under its designated identity. R3 a non-signing fork is unchanged — new case `dd`. R4 refusal leaves no commit, the tip unmoved, the restored files in the tree, and names the cause in a locale-stable line. R5 no unsigned-when-configured outcome is accepted — new cases `gg` (malformed value), `hh` (empty-signature degrade) and the post-condition before `update-ref`. R6/R7 both parents survive and imported SHAs are untouched — asserted with two **genuinely distinct** parents, since git deduplicates a repeated parent with a warning and yields a one-parent commit, which would assert the invariant against a commit that never had two parents to lose. R8 the no-op path exits zero even where signing is impossible — new case `ff`. R9 the three mandated configurations plus `ff` and `ii`.

**The signature-header predicate is `^gpgsig`, not `^gpgsig `.** Git's signature header name is hash-algorithm dependent: a repository created `--object-format=sha256` writes `gpgsig-sha256`, which a trailing space cannot match. Before this fix, such a repository had its **correctly signed** graft commit refused as unsigned — `commit-tree -S` exited 0 and produced a commit carrying `gpgsig-sha256` and `BEGIN SSH SIGNATURE`, and the script answered *"built an unsigned commit"* with exit 1. That breaches R1 and R2 rather than serving R5: for that fork an ordinary `git commit` yields a signed commit, while `--preserve-history` yielded **no commit at all** where it previously yielded an unsigned one.

Found by cold review, not by the suite — and the second half of the finding is the instructive one. **Applying the one-character fix as a mutation left the suite at 64/64**: the assertions could not tell the corrected predicate from the broken one, so the edit alone would have closed nothing. New case `jj` is what closes it, and the three `M10*` rows above prove it does.

Reach, stated rather than inflated: a SHA-256 fork of a SHA-1 upstream cannot reach the site at all — `git fetch` refuses first with an algorithm mismatch — so this needs a fully SHA-256 pair, which `canonical_repo` permits but no adopter has today. The direction was fail-safe throughout: no unsigned commit was ever produced, and the tip never moved. Narrow, not absent.

Dropping the space stays safe because the `sed -n '/^$/q;p'` slice exposes only header lines, continuation lines begin with a space, and `gpgsig-sha256` is the only other header that can match.

**One assertion inside `jj` was moved rather than written once.** A first draft checked the `gpgsig-sha256` header name *after* the sync, on the graft commit. Under the script-only reversion that assertion fired with *"this case no longer exercises the hash-dependent header name"* — which is false: the fixture produces the header fine, the script misreads it, and since HEAD never moves the check was reading the old tip and naming a cause that had not occurred. That is Finding 1's own defect class — a message naming a cause that did not happen — so the premise is now checked **before** the sync against a throwaway `commit-tree -S` that is referenced by nothing and moves no ref. It stays correctly green under the reversion.

**What that premise check does and does not promise.** It has two disjuncts, and the first fires whenever the probe cannot produce a signature **at all** — so it covers a superset of "git's header naming changed", and on the part outside that set its message names a cause that did not occur. Measured: with the signing program pointed at a nonexistent path and header naming untouched, `jj` reddens on five lines, the premise first. An earlier draft of this paragraph claimed it fires *only* on a naming change; that is false, and it is the same defect class the paragraph documents fixing, one level down. Splitting the disjuncts into two messages would let the stronger claim stand and is the natural follow-up; it is not done here.

The premise check earns its place regardless, and one mutation shows why: with the fixture silently **not** SHA-256, all four of `jj`'s behavioural assertions stay green — a SHA-1 fixture syncs fine — so without this check plus the format sanity loop, `jj` would report PASS while exercising the SHA-1 header name. Those two guards are the only thing that catches it.

**Signature presence is asserted without any verification infrastructure**, which matters because spec 0122 excludes verification from scope: the commit object's header block is sliced with `sed -n '/^$/q;p'` before matching `^gpgsig`. An unanchored `grep '^gpgsig'` over the whole object **false-positives** on an unsigned commit whose message body contains a line starting `gpgsig ` — measured, and the reason M5 exists.

**Four things DEV found that no review had named**, all measured:

- **The `gpg.ssh.program` stub must take the *last* argument, not `$3`.** Git invokes `<prog> -Y sign -n git -f <pubkey> <buffer>` — captured argv: `ARGC=7`, buffer last — so a `$3`-based stub would target `-n`, sign the wrong file, and make `commit-tree -S` fail. The stub loops to the last argument, staying independent of git's argument order. **Correction:** an earlier draft of this bullet added that a `$3` stub would therefore make `hh` *pass* for the wrong reason, refusing at step 2 instead of step 3. Cold review measured both stubs against `hh`'s own fixture and that is **false** — the `$3` stub makes `hh` **fail**, because `hh`'s third assertion requires the script's own `built an unsigned commit`, which is precisely what separates step 2's refusal from step 3's. The bullet understated the test it described: `hh` already discriminates the case it warned about. The mechanism was right, the conclusion drawn from it was not, and it appeared under a heading asserting the list was measured.
- **`ff` needs no signing capability**, contrary to the plan's Risks note: the R11 no-op short-circuit returns before `commit-tree` is reached, so it uses an unreachable key path and calls `ssh-keygen` not at all. Only `cc` and `hh` generate a key, and both carry an explicit precondition that **FAILs naming the capability** rather than skipping.
- **M4's count matched but its composition is environment-dependent.** Here the reds were `ff`, `ee`, `ii` — not `dd`, because the probe signs successfully with the operator's global key. On CI, or with no usable key, `dd` reddens too and the count drops below 61. `ff` is the row that pins the hazard; the rest is collateral from `set -e` aborting before the real path.
- **M3a and M3b are indistinguishable by design.** Both `rc=1`, HEAD unmoved, both landing on the post-condition's message. The only differing byte is `fatal : Not a valid object name` — localized, therefore unassertable on principle. `ee`'s stderr assertion separates the *config* refusal from the *post-condition* refusal; it does not separate M3a from M3b, and nothing in the suite does or should.

**One deliberate deviation from the plan**, flagged rather than hoped to read as in-scope: step 5 said "add one line to the file's front comment". DEV also added a third failure-mode bullet and changed *"Two failure modes apply only in this mode"* to *"Three"* — adding a refusal path while leaving the count at two would have shipped a false statement in the file's own front comment.

**Blast radius.** No build outputs, no `artifacts/` source, no version bump. **CLI matrix not triggered** — `sync-from-upstream.sh` matches none of `scripts/{build,install,setup,import,manage}-*.sh` and `docs/cli-matrix.md` has zero occurrences of it. Both files are `strict` core paths (`.crewrig/core-paths.txt:125` and the blanket `scripts` entry at `:51`), which is why the adopter-visible break is stated at the top of this body. `docs/adoption-guide.md`'s `--preserve-history` subsection deserves a paragraph on the new refusal; deliberately deferred to a follow-up and recorded here as a conscious omission rather than left silent.

**Known and accepted.** The refusal path leaves the index staged, because `git add -A` runs before the new code. R4's clause about the working tree holds; unwinding the index would discard whatever the operator had staged.

**Plan history.** Four revisions, two REQUEST CHANGES rounds, five findings — every one produced by prototyping and mutating rather than reading. The sharpest is the one in *How to read this PR?* point 1: the plan rejected `|| true` for swallowing a status, then shipped a substitution inside an `if` condition that swallows it twice over. The plan's own `### Risks` section ended up carrying an inventory of claims made without measuring; its count was wrong twice before it was right.

Issue #756 is the logbook per `AGENTS.md` → *Logbook Issues → Rule A*, and is closed manually after merge per Rule C — this body carries no closing keyword. Spec 0122's `status` moves `approved` → `implemented` in its own metadata-only pull request afterwards.



