### PR TITLE
📝 Mark spec 0121 implemented

### DIFF
--- a/specs/0121-antigravity-outputs-in-core-paths.md
+++ b/specs/0121-antigravity-outputs-in-core-paths.md
@@ -1,7 +1,7 @@
 ---
 id: "0121"
 slug: antigravity-outputs-in-core-paths
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 755


### PR DESCRIPTION
Records the `approved` → `implemented` transition for spec 0121, now that its implementation has merged. One line, no behaviour change.

## How to read this PR?

One frontmatter field in `specs/0121-antigravity-outputs-in-core-paths.md`. The diff is `-status: approved` / `+status: implemented` and nothing else — `docs/spec-format.md` → *Recording a post-merge transition* confines this edit to lifecycle metadata, so no body line, no `id`, no `slug` and no `version` may move.

## How to test this PR?

```sh
task spec:lint
git diff main...HEAD --stat    # 1 file, 1 insertion, 1 deletion
```

The trigger the lifecycle table requires is verifiable on `main` rather than asserted here:

```sh
git log --oneline -1 5a1e6c2                                   # the implementation merge (PR #800)
gh issue view 755 --json state,stateReason                     # CLOSED / COMPLETED
git show "main:.crewrig/core-paths.txt" | grep '^\.agents/'     # both entries present
```

## Detailed description (for agents)

**Changed:** `specs/0121-antigravity-outputs-in-core-paths.md` frontmatter, `status` only.

**What spec 0121 obliged.** Every directory the component build writes outputs into carries the same upstream-synchronisation guarantee — expressed as a property over the whole class rather than as two manifest entries, so the next output root anyone teaches the build to write inherits the guarantee instead of the gap. R5 requires CI to fail naming any written-into directory that carries none; R6 requires that guard to be exercised on every run against a case it must reject.

**Why the ticket needed five review rounds.** The manifest name set was right from the first draft. What took the rounds was the *verification*: R6 was not discharged by the original case set (the guard could go blind while the suite reported 14/14), the coverage predicate diverged from the sync's own `path_is_governed()` on an excluded-ancestor shape, the 3.2 gate meant to protect the new accumulators was itself inert because the harness spawned its subject through `$PATH`, and the extractor saw a helper call only as the first token of its line. Every one was found by prototyping and mutating; none by reading.

**The one worth carrying forward.** Widening the call-site matcher to close that last gap made the pattern indentation-insensitive, which silently retired the mutation that had pinned the trim — a check certified by nothing, created as a side effect of fixing its neighbour. Nothing in the diff showed it; only re-running the whole mutation table afterwards did.

**Two follow-ups stay open**, neither blocked by this transition: **#798** (no Bash 3.2 interpreter in CI, and the local gate is inert repo-wide) and **#804** (the guard parses the build script, so a write that is not a helper call is invisible — disclosed in the shipped header as a precondition it cannot check, not mechanised).

Issue #805 tracks this transition and is closed on merge. This body carries no closing keyword for #755, which is already closed per Rule C.