### PR TITLE
📝 Mark spec 0122 implemented

### DIFF
--- a/specs/0122-signed-graft-commit.md
+++ b/specs/0122-signed-graft-commit.md
@@ -1,7 +1,7 @@
 ---
 id: "0122"
 slug: signed-graft-commit
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 756


### PR DESCRIPTION
Records the `approved` → `implemented` transition for spec 0122, now that its implementation has merged. One line, no behaviour change.

## How to read this PR?

One frontmatter field in `specs/0122-signed-graft-commit.md`. The diff is `-status: approved` / `+status: implemented` and nothing else.

## How to test this PR?

```sh
task spec:lint
git diff main...HEAD --stat    # 1 file, 1 insertion, 1 deletion
```

The trigger is verifiable on `main` rather than asserted here:

```sh
git log --oneline -1 6840cc1                        # the implementation merge (PR #803)
gh issue view 756 --json state,stateReason          # CLOSED / COMPLETED
```

## Detailed description (for agents)

**What spec 0122 obliged.** The one commit `scripts/sync-from-upstream.sh` authors under `--preserve-history` carries the same signature status as any other commit that repository would create, and never degrades silently to an unsigned one. `git commit-tree` is plumbing — it neither reads `commit.gpgsign` nor is overridden by it — so the conditional `-S` is a real branch, and R3's promise that a non-signing fork is unchanged had to be tested rather than assumed.

**Eight findings across five review rounds, none produced by reading.** Three shared one shape: a property checked on one instance and written as a property of the whole.

- The signature header name was checked on SHA-1 and asserted for every repository. A repository created `--object-format=sha256` writes `gpgsig-sha256`, so its **correctly signed** graft commit was refused as unsigned — and applying the one-character fix left the suite at 64/64, which is the instructive half: the assertions could not tell the corrected predicate from the broken one, so closing it needed a case rather than the edit.
- A conclusion inferred from a correct `argv` measurement was published under a heading asserting the list was measured.
- An assertion named the one cause its author had in mind rather than the set its disjunct admits.

Each was caught by making something fail on purpose — a reversion mutation, a stub swap, a broken signer.

**One design choice worth reusing.** The capability preconditions **FAIL naming what is missing** rather than skipping. That turned a single CI log line — `PASS case-jj` — into simultaneous evidence for two capabilities on `ubuntu-latest` (`ssh-keygen` signing support and `git init --object-format=sha256`) that had until then been unmeasured assumptions. A precondition that skips tells you nothing; one that fails loudly makes the build a measurement.

**One follow-up not taken here**, raised in review: the `cc`/`hh`/`jj` precondition tests key *generation* while its message names *signing* support, so an environment that can generate but not sign clears it. One `ssh-keygen -Y sign` smoke check in the shared precondition fixes all three and retires a disjunct asymmetry in the same edit.

Issue #809 tracks this transition and is closed on merge. This body carries no closing keyword for #756, which is already closed per Rule C.