### PR TITLE
📝 Mark spec 0123 implemented

### DIFF
--- a/specs/0123-antigravity-components-discoverable.md
+++ b/specs/0123-antigravity-components-discoverable.md
@@ -1,7 +1,7 @@
 ---
 id: "0123"
 slug: antigravity-components-discoverable
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: AUTO
 related-issue: 761


### PR DESCRIPTION
Records the `approved` → `implemented` transition for spec 0123, the last of the four in this batch. One line, no behaviour change.

## How to read this PR?

One frontmatter field in `specs/0123-antigravity-components-discoverable.md`. The diff is `-status: approved` / `+status: implemented` and nothing else.

## How to test this PR?

```sh
task spec:lint
git diff main...HEAD --stat    # 1 file, 1 insertion, 1 deletion
```

The trigger is verifiable on `main` rather than asserted here:

```sh
git log --oneline -1 953f2d2                          # the implementation merge (PR #807)
gh issue view 761 --json state,stateReason            # CLOSED / COMPLETED
git show "main:scripts/lib/common.sh" | grep -c install_antigravity_tier_to_home
```

## Detailed description (for agents)

**What spec 0123 obliged.** Every skill and agent the framework installs for Antigravity CLI is one that CLI actually finds; an install step that places nothing says so instead of exiting 0 in silence; a machine set up under the superseded layout keeps no orphaned framework component; and the CLI matrix records what has been *observed* of the assistant rather than what its documentation implies.

**The ticket existed because a path contract had been inferred from documentation.** Its first requirement was therefore a live probe, and that probe **corrected the probe recorded in the issue's own first comment**: `agy agents` enumerates a registry and lists all three candidate roots, while a forced-choice query measures in-session availability and finds only the documented one. Two instruments, two questions, and the cheaper one was the permissive one.

**Eleven findings across six review rounds.** The two worth carrying are not about this code:

- *A change that **moves** code has a blast radius shaped by who references the **old** location, and no amount of testing the new location can see it.* Moving the tier-install into `scripts/lib/common.sh` blinded a sibling parity guard, whose `continue` then skipped **both** of its Antigravity assertions. CI caught it; the mutation pass structurally could not, because mutation proves *these* assertions have teeth and is silent about assertions elsewhere that a change breaks. The rule that would have caught it before the push: `grep -l -F "$changed_file" scripts/tests/*.sh` for every file the diff touches — 22 suites here, all run, one casualty, blast radius measured rather than assumed.
- *A fixture corpus that shares a naming convention cannot test a property that only non-conforming names exercise.* Every component in this repository is kebab-case, so every fixture was, so all three degradations of the served-name test passed the entire suite.

**One finding this ticket produced about the framework's own record.** Verifying the provenance carrier against the real tree rather than against `docs/cli-matrix.md` row 4b is what kept the migration from being a silent no-op: the row claims an HTML-comment carrier for Antigravity agents, and **23 of 23 built agents carry it in frontmatter instead**. Filed as #808. Had the reader been built from the row — the reasonable thing to do, since the matrix is the framework's own record — the agents sweep would have removed nothing while passing every fixture, because the fixtures would have carried the same wrong assumption.

Issue #812 tracks this transition and is closed on merge. This body carries no closing keyword for #761, which is already closed per Rule C.