### PR TITLE
✨ Add metadata.claude.model to core agents to optimize token usage

### DIFF
--- a/.agents/agents/accessibility-auditor/AGENT.md
+++ b/.agents/agents/accessibility-auditor/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/accessibility-tester/AGENT.md
+++ b/.agents/agents/accessibility-tester/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.agents/agents/architect/AGENT.md
+++ b/.agents/agents/architect/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.agents/agents/astro-developer/AGENT.md
+++ b/.agents/agents/astro-developer/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.agents/agents/ci-configurator/AGENT.md
+++ b/.agents/agents/ci-configurator/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 

--- a/.agents/agents/ci-debugger/AGENT.md
+++ b/.agents/agents/ci-debugger/AGENT.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/ci-parity/AGENT.md
+++ b/.agents/agents/ci-parity/AGENT.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 

--- a/.agents/agents/copywriter/AGENT.md
+++ b/.agents/agents/copywriter/AGENT.md
@@ -8,7 +8,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/designer/AGENT.md
+++ b/.agents/agents/designer/AGENT.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/developer/AGENT.md
+++ b/.agents/agents/developer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.2"
+    version: "1.2.3"
 ---
 
 

--- a/.agents/agents/doc-writer/AGENT.md
+++ b/.agents/agents/doc-writer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.agents/agents/frontend-developer/AGENT.md
+++ b/.agents/agents/frontend-developer/AGENT.md
@@ -8,7 +8,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/pr-logbook/AGENT.md
+++ b/.agents/agents/pr-logbook/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 

--- a/.agents/agents/pr-reviewer/AGENT.md
+++ b/.agents/agents/pr-reviewer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.agents/agents/regression-sentinel/AGENT.md
+++ b/.agents/agents/regression-sentinel/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.agents/agents/scenario-author/AGENT.md
+++ b/.agents/agents/scenario-author/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/security/AGENT.md
+++ b/.agents/agents/security/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.agents/agents/seo-specialist/AGENT.md
+++ b/.agents/agents/seo-specialist/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/spec-author/AGENT.md
+++ b/.agents/agents/spec-author/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 

--- a/.agents/agents/tester/AGENT.md
+++ b/.agents/agents/tester/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.agents/agents/visual-regression-tester/AGENT.md
+++ b/.agents/agents/visual-regression-tester/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.agents/agents/web-conformity-checker/AGENT.md
+++ b/.agents/agents/web-conformity-checker/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.claude/agents/accessibility-auditor/AGENT.md
+++ b/.claude/agents/accessibility-auditor/AGENT.md
@@ -5,11 +5,12 @@ manually verifies keyboard navigation, color contrast, interactive element
 accessibility, image alt text quality, ARIA correctness, and motion preferences.
 Produces a structured findings report (violation → warning → informational).
 Does not implement fixes — hands the report to frontend-developer or astro-developer."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/accessibility-auditor/AGENT.md
+++ b/.claude/agents/accessibility-auditor/AGENT.md
@@ -5,6 +5,7 @@ manually verifies keyboard navigation, color contrast, interactive element
 accessibility, image alt text quality, ARIA correctness, and motion preferences.
 Produces a structured findings report (violation → warning → informational).
 Does not implement fixes — hands the report to frontend-developer or astro-developer."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/accessibility-tester/AGENT.md
+++ b/.claude/agents/accessibility-tester/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: accessibility-tester
 description: "Runs WCAG 2.1/2.2 (AA/AAA) compliance checks on a page or user flow using axe-core. Reports violations by impact level with remediation guidance and outputs a CI-ready test suite."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.claude/agents/accessibility-tester/AGENT.md
+++ b/.claude/agents/accessibility-tester/AGENT.md
@@ -1,6 +1,7 @@
 ---
 name: accessibility-tester
 description: "Runs WCAG 2.1/2.2 (AA/AAA) compliance checks on a page or user flow using axe-core. Reports violations by impact level with remediation guidance and outputs a CI-ready test suite."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: architect
 description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius."
+model: opus
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.claude/agents/astro-developer/AGENT.md
+++ b/.claude/agents/astro-developer/AGENT.md
@@ -5,6 +5,7 @@ projects, implements pages/layouts/components, wires Content Collections,
 configures integrations, handles deployment, and diagnoses build failures.
 Receives tokens from designer, copy from copywriter, and hands off to
 seo-specialist and accessibility-auditor."
+license: Apache-2.0
 model: sonnet
 metadata:
   provenance:

--- a/.claude/agents/astro-developer/AGENT.md
+++ b/.claude/agents/astro-developer/AGENT.md
@@ -5,11 +5,12 @@ projects, implements pages/layouts/components, wires Content Collections,
 configures integrations, handles deployment, and diagnoses build failures.
 Receives tokens from designer, copy from copywriter, and hands off to
 seo-specialist and accessibility-auditor."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.claude/agents/ci-configurator/AGENT.md
+++ b/.claude/agents/ci-configurator/AGENT.md
@@ -5,11 +5,12 @@ engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
 produces a commit-ready pipeline (hand-authored for GitHub Actions,
 derived from the platform-neutral capability reference for GitLab),
 and validates its own output before delivery."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 

--- a/.claude/agents/ci-configurator/AGENT.md
+++ b/.claude/agents/ci-configurator/AGENT.md
@@ -5,6 +5,7 @@ engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
 produces a commit-ready pipeline (hand-authored for GitHub Actions,
 derived from the platform-neutral capability reference for GitLab),
 and validates its own output before delivery."
+license: Apache-2.0
 model: sonnet
 metadata:
   provenance:

--- a/.claude/agents/ci-debugger/AGENT.md
+++ b/.claude/agents/ci-debugger/AGENT.md
@@ -3,11 +3,12 @@ name: ci-debugger
 description: "Specialist agent for diagnosing and fixing failing GitHub Actions
 pipelines. Systematically produces a
 symptom → hypothesis → evidence → fix chain."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/ci-debugger/AGENT.md
+++ b/.claude/agents/ci-debugger/AGENT.md
@@ -3,6 +3,7 @@ name: ci-debugger
 description: "Specialist agent for diagnosing and fixing failing GitHub Actions
 pipelines. Systematically produces a
 symptom → hypothesis → evidence → fix chain."
+license: Apache-2.0
 model: sonnet
 metadata:
   provenance:

--- a/.claude/agents/ci-parity/AGENT.md
+++ b/.claude/agents/ci-parity/AGENT.md
@@ -6,6 +6,7 @@ interprets its fail-closed output, classifies each divergence by kind,
 and reconciles it — auto-applying only the deterministic
 regenerate-and-re-verify case, and diagnosing-and-proposing for every
 judgment-bearing case."
+license: Apache-2.0
 model: sonnet
 metadata:
   provenance:

--- a/.claude/agents/ci-parity/AGENT.md
+++ b/.claude/agents/ci-parity/AGENT.md
@@ -6,11 +6,12 @@ interprets its fail-closed output, classifies each divergence by kind,
 and reconciles it — auto-applying only the deterministic
 regenerate-and-re-verify case, and diagnosing-and-proposing for every
 judgment-bearing case."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 

--- a/.claude/agents/copywriter/AGENT.md
+++ b/.claude/agents/copywriter/AGENT.md
@@ -4,6 +4,7 @@ description: "Content production specialist. Interviews the product brief, produ
 content outline for review, then writes final page copy (hero, features,
 social proof, CTA). Delivers structured Markdown ready for handoff to
 frontend-developer or astro-developer. Does NOT make layout or visual decisions."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/copywriter/AGENT.md
+++ b/.claude/agents/copywriter/AGENT.md
@@ -4,11 +4,12 @@ description: "Content production specialist. Interviews the product brief, produ
 content outline for review, then writes final page copy (hero, features,
 social proof, CTA). Delivers structured Markdown ready for handoff to
 frontend-developer or astro-developer. Does NOT make layout or visual decisions."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/designer/AGENT.md
+++ b/.claude/agents/designer/AGENT.md
@@ -3,11 +3,12 @@ name: designer
 description: "Visual design specialist. Produces color palette tokens, typographic scale,
 spacing scale, tokens.css, and Tailwind config extensions. Delivers component
 anatomy specifications and design rationale. Does NOT write application code."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/designer/AGENT.md
+++ b/.claude/agents/designer/AGENT.md
@@ -3,6 +3,7 @@ name: designer
 description: "Visual design specialist. Produces color palette tokens, typographic scale,
 spacing scale, tokens.css, and Tailwind config extensions. Delivers component
 anatomy specifications and design rationale. Does NOT write application code."
+license: Apache-2.0
 model: sonnet
 metadata:
   provenance:

--- a/.claude/agents/developer/AGENT.md
+++ b/.claude/agents/developer/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: developer
 description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.2"
+    version: "1.2.3"
 ---
 
 

--- a/.claude/agents/doc-writer/AGENT.md
+++ b/.claude/agents/doc-writer/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: doc-writer
 description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimizes for documents that age well and stays close to the code where possible."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.claude/agents/frontend-developer/AGENT.md
+++ b/.claude/agents/frontend-developer/AGENT.md
@@ -4,11 +4,12 @@ description: "UI implementation specialist. Translates designer token files and 
 anatomy specs into production-ready CSS and markup. Ensures WCAG 2.1 AA
 compliance, optimizes asset delivery, and hands off to astro-developer for
 framework wiring. Does NOT own Astro-specific build concerns."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/frontend-developer/AGENT.md
+++ b/.claude/agents/frontend-developer/AGENT.md
@@ -4,6 +4,7 @@ description: "UI implementation specialist. Translates designer token files and 
 anatomy specs into production-ready CSS and markup. Ensures WCAG 2.1 AA
 compliance, optimizes asset delivery, and hands off to astro-developer for
 framework wiring. Does NOT own Astro-specific build concerns."
+license: Apache-2.0
 model: sonnet
 metadata:
   provenance:

--- a/.claude/agents/pr-logbook/AGENT.md
+++ b/.claude/agents/pr-logbook/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: pr-logbook
 description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 

--- a/.claude/agents/pr-reviewer/AGENT.md
+++ b/.claude/agents/pr-reviewer/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: pr-reviewer
 description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`)."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.claude/agents/regression-sentinel/AGENT.md
+++ b/.claude/agents/regression-sentinel/AGENT.md
@@ -1,6 +1,7 @@
 ---
 name: regression-sentinel
 description: "Runs a smoke or regression pass against a staging or production URL. Diffs results against a stored baseline and surfaces new failures with screenshots and traces."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/regression-sentinel/AGENT.md
+++ b/.claude/agents/regression-sentinel/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: regression-sentinel
 description: "Runs a smoke or regression pass against a staging or production URL. Diffs results against a stored baseline and surfaces new failures with screenshots and traces."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.claude/agents/scenario-author/AGENT.md
+++ b/.claude/agents/scenario-author/AGENT.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-author
 description: "Writes automated test scenarios from a natural-language description of a user journey. Generates Playwright TypeScript or RobotFramework .robot files with page-object model, fixtures, and meaningful assertions."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/scenario-author/AGENT.md
+++ b/.claude/agents/scenario-author/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: scenario-author
 description: "Writes automated test scenarios from a natural-language description of a user journey. Generates Playwright TypeScript or RobotFramework .robot files with page-object model, fixtures, and meaningful assertions."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/security/AGENT.md
+++ b/.claude/agents/security/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: security
 description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.claude/agents/seo-specialist/AGENT.md
+++ b/.claude/agents/seo-specialist/AGENT.md
@@ -5,6 +5,7 @@ structured data (JSON-LD), heading hierarchy, sitemap/robots.txt, internal links
 and performance signals with direct SEO impact. Produces a prioritized findings
 report (critical → high → low). Does not write copy — hands recommendations to
 copywriter or astro-developer."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/seo-specialist/AGENT.md
+++ b/.claude/agents/seo-specialist/AGENT.md
@@ -5,11 +5,12 @@ structured data (JSON-LD), heading hierarchy, sitemap/robots.txt, internal links
 and performance signals with direct SEO impact. Produces a prioritized findings
 report (critical → high → low). Does not write copy — hands recommendations to
 copywriter or astro-developer."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/spec-author/AGENT.md
+++ b/.claude/agents/spec-author/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: spec-author
 description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 

--- a/.claude/agents/tester/AGENT.md
+++ b/.claude/agents/tester/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: tester
 description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug."
+model: sonnet
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.claude/agents/visual-regression-tester/AGENT.md
+++ b/.claude/agents/visual-regression-tester/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: visual-regression-tester
 description: "Detects unintended visual changes between two states of a page by comparing screenshots at multiple viewports. Uses Playwright's toHaveScreenshot or equivalent diff thresholds."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.claude/agents/visual-regression-tester/AGENT.md
+++ b/.claude/agents/visual-regression-tester/AGENT.md
@@ -1,6 +1,7 @@
 ---
 name: visual-regression-tester
 description: "Detects unintended visual changes between two states of a page by comparing screenshots at multiple viewports. Uses Playwright's toHaveScreenshot or equivalent diff thresholds."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.claude/agents/web-conformity-checker/AGENT.md
+++ b/.claude/agents/web-conformity-checker/AGENT.md
@@ -1,11 +1,12 @@
 ---
 name: web-conformity-checker
 description: "Verifies that a page or site matches a given specification — design system, functional requirements, or API contract. Produces a gap report and optionally a Playwright assertion script."
+model: haiku
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.claude/agents/web-conformity-checker/AGENT.md
+++ b/.claude/agents/web-conformity-checker/AGENT.md
@@ -1,6 +1,7 @@
 ---
 name: web-conformity-checker
 description: "Verifies that a page or site matches a given specification — design system, functional requirements, or API contract. Produces a gap report and optionally a Playwright assertion script."
+license: Apache-2.0
 model: haiku
 metadata:
   provenance:

--- a/.gemini/agents/accessibility-auditor.md
+++ b/.gemini/agents/accessibility-auditor.md
@@ -6,7 +6,7 @@ accessibility, image alt text quality, ARIA correctness, and motion preferences.
 Produces a structured findings report (violation → warning → informational).
 Does not implement fixes — hands the report to frontend-developer or astro-developer."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Accessibility Auditor Agent
 

--- a/.gemini/agents/accessibility-tester.md
+++ b/.gemini/agents/accessibility-tester.md
@@ -2,7 +2,7 @@
 name: accessibility-tester
 description: "Runs WCAG 2.1/2.2 (AA/AAA) compliance checks on a page or user flow using axe-core. Reports violations by impact level with remediation guidance and outputs a CI-ready test suite."
 ---
-<!-- crewrig-provenance: version="1.0.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Accessibility Tester Agent
 

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius."
 ---
-<!-- crewrig-provenance: version="1.1.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Architect Agent
 

--- a/.gemini/agents/astro-developer.md
+++ b/.gemini/agents/astro-developer.md
@@ -6,7 +6,7 @@ configures integrations, handles deployment, and diagnoses build failures.
 Receives tokens from designer, copy from copywriter, and hands off to
 seo-specialist and accessibility-auditor."
 ---
-<!-- crewrig-provenance: version="1.0.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Astro Developer Agent
 

--- a/.gemini/agents/ci-configurator.md
+++ b/.gemini/agents/ci-configurator.md
@@ -6,7 +6,7 @@ produces a commit-ready pipeline (hand-authored for GitHub Actions,
 derived from the platform-neutral capability reference for GitLab),
 and validates its own output before delivery."
 ---
-<!-- crewrig-provenance: version="1.1.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # CI Configurator Agent
 

--- a/.gemini/agents/ci-debugger.md
+++ b/.gemini/agents/ci-debugger.md
@@ -4,7 +4,7 @@ description: "Specialist agent for diagnosing and fixing failing GitHub Actions
 pipelines. Systematically produces a
 symptom → hypothesis → evidence → fix chain."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # CI Debugger Agent
 

--- a/.gemini/agents/ci-parity.md
+++ b/.gemini/agents/ci-parity.md
@@ -7,7 +7,7 @@ and reconciles it — auto-applying only the deterministic
 regenerate-and-re-verify case, and diagnosing-and-proposing for every
 judgment-bearing case."
 ---
-<!-- crewrig-provenance: version="1.0.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # CI Parity Agent
 

--- a/.gemini/agents/copywriter.md
+++ b/.gemini/agents/copywriter.md
@@ -5,7 +5,7 @@ content outline for review, then writes final page copy (hero, features,
 social proof, CTA). Delivers structured Markdown ready for handoff to
 frontend-developer or astro-developer. Does NOT make layout or visual decisions."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Copywriter Agent
 

--- a/.gemini/agents/designer.md
+++ b/.gemini/agents/designer.md
@@ -4,7 +4,7 @@ description: "Visual design specialist. Produces color palette tokens, typograph
 spacing scale, tokens.css, and Tailwind config extensions. Delivers component
 anatomy specifications and design rationale. Does NOT write application code."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Designer Agent
 

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -2,7 +2,7 @@
 name: developer
 description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done."
 ---
-<!-- crewrig-provenance: version="1.2.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.2.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Developer Agent
 

--- a/.gemini/agents/doc-writer.md
+++ b/.gemini/agents/doc-writer.md
@@ -2,7 +2,7 @@
 name: doc-writer
 description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimizes for documents that age well and stays close to the code where possible."
 ---
-<!-- crewrig-provenance: version="1.1.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Doc Writer Agent
 

--- a/.gemini/agents/frontend-developer.md
+++ b/.gemini/agents/frontend-developer.md
@@ -5,7 +5,7 @@ anatomy specs into production-ready CSS and markup. Ensures WCAG 2.1 AA
 compliance, optimizes asset delivery, and hands off to astro-developer for
 framework wiring. Does NOT own Astro-specific build concerns."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Frontend Developer Agent
 

--- a/.gemini/agents/pr-logbook.md
+++ b/.gemini/agents/pr-logbook.md
@@ -2,7 +2,7 @@
 name: pr-logbook
 description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions."
 ---
-<!-- crewrig-provenance: version="1.1.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # PR & Logbook Agent
 

--- a/.gemini/agents/pr-reviewer.md
+++ b/.gemini/agents/pr-reviewer.md
@@ -2,7 +2,7 @@
 name: pr-reviewer
 description: "Independent PR reviewer agent. Spawns cold — receives only a PR number, no authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`)."
 ---
-<!-- crewrig-provenance: version="1.1.6" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.7" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # PR Reviewer Agent
 

--- a/.gemini/agents/regression-sentinel.md
+++ b/.gemini/agents/regression-sentinel.md
@@ -2,7 +2,7 @@
 name: regression-sentinel
 description: "Runs a smoke or regression pass against a staging or production URL. Diffs results against a stored baseline and surfaces new failures with screenshots and traces."
 ---
-<!-- crewrig-provenance: version="1.0.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Regression Sentinel Agent
 

--- a/.gemini/agents/scenario-author.md
+++ b/.gemini/agents/scenario-author.md
@@ -2,7 +2,7 @@
 name: scenario-author
 description: "Writes automated test scenarios from a natural-language description of a user journey. Generates Playwright TypeScript or RobotFramework .robot files with page-object model, fixtures, and meaningful assertions."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Scenario Author Agent
 

--- a/.gemini/agents/security.md
+++ b/.gemini/agents/security.md
@@ -2,7 +2,7 @@
 name: security
 description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked."
 ---
-<!-- crewrig-provenance: version="1.1.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Security Agent
 

--- a/.gemini/agents/seo-specialist.md
+++ b/.gemini/agents/seo-specialist.md
@@ -6,7 +6,7 @@ and performance signals with direct SEO impact. Produces a prioritized findings
 report (critical → high → low). Does not write copy — hands recommendations to
 copywriter or astro-developer."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # SEO Specialist Agent
 

--- a/.gemini/agents/spec-author.md
+++ b/.gemini/agents/spec-author.md
@@ -2,7 +2,7 @@
 name: spec-author
 description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket."
 ---
-<!-- crewrig-provenance: version="1.1.0" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Spec Author Agent
 

--- a/.gemini/agents/tester.md
+++ b/.gemini/agents/tester.md
@@ -2,7 +2,7 @@
 name: tester
 description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug."
 ---
-<!-- crewrig-provenance: version="1.1.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.1.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Tester Agent
 

--- a/.gemini/agents/visual-regression-tester.md
+++ b/.gemini/agents/visual-regression-tester.md
@@ -2,7 +2,7 @@
 name: visual-regression-tester
 description: "Detects unintended visual changes between two states of a page by comparing screenshots at multiple viewports. Uses Playwright's toHaveScreenshot or equivalent diff thresholds."
 ---
-<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.3" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Visual Regression Tester Agent
 

--- a/.gemini/agents/web-conformity-checker.md
+++ b/.gemini/agents/web-conformity-checker.md
@@ -2,7 +2,7 @@
 name: web-conformity-checker
 description: "Verifies that a page or site matches a given specification — design system, functional requirements, or API contract. Produces a gap report and optionally a Playwright assertion script."
 ---
-<!-- crewrig-provenance: version="1.0.1" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
+<!-- crewrig-provenance: version="1.0.2" canonical="https://github.com/crewrig/crewrig" feedback="https://github.com/crewrig/crewrig" -->
 
 # Web Conformity Checker Agent
 

--- a/.github/agents/accessibility-auditor.md
+++ b/.github/agents/accessibility-auditor.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/accessibility-tester.md
+++ b/.github/agents/accessibility-tester.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.github/agents/astro-developer.md
+++ b/.github/agents/astro-developer.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.github/agents/ci-configurator.md
+++ b/.github/agents/ci-configurator.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 

--- a/.github/agents/ci-debugger.md
+++ b/.github/agents/ci-debugger.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/ci-parity.md
+++ b/.github/agents/ci-parity.md
@@ -10,7 +10,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 

--- a/.github/agents/copywriter.md
+++ b/.github/agents/copywriter.md
@@ -8,7 +8,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/designer.md
+++ b/.github/agents/designer.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/developer.md
+++ b/.github/agents/developer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.2"
+    version: "1.2.3"
 ---
 
 

--- a/.github/agents/doc-writer.md
+++ b/.github/agents/doc-writer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.github/agents/frontend-developer.md
+++ b/.github/agents/frontend-developer.md
@@ -8,7 +8,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/pr-logbook.md
+++ b/.github/agents/pr-logbook.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 

--- a/.github/agents/regression-sentinel.md
+++ b/.github/agents/regression-sentinel.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/.github/agents/scenario-author.md
+++ b/.github/agents/scenario-author.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/security.md
+++ b/.github/agents/security.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.github/agents/seo-specialist.md
+++ b/.github/agents/seo-specialist.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/spec-author.md
+++ b/.github/agents/spec-author.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 

--- a/.github/agents/tester.md
+++ b/.github/agents/tester.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 

--- a/.github/agents/visual-regression-tester.md
+++ b/.github/agents/visual-regression-tester.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 

--- a/.github/agents/web-conformity-checker.md
+++ b/.github/agents/web-conformity-checker.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 

--- a/artifacts/core/agents/accessibility-auditor/AGENT.md
+++ b/artifacts/core/agents/accessibility-auditor/AGENT.md
@@ -9,10 +9,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # Accessibility Auditor Agent

--- a/artifacts/core/agents/accessibility-tester/AGENT.md
+++ b/artifacts/core/agents/accessibility-tester/AGENT.md
@@ -6,10 +6,12 @@ description: "Runs WCAG 2.1/2.2 (AA/AAA) compliance checks on a page or user
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 # Accessibility Tester Agent

--- a/artifacts/core/agents/architect/AGENT.md
+++ b/artifacts/core/agents/architect/AGENT.md
@@ -4,10 +4,12 @@ description: "Generic architecture agent. Drafts ADRs, runs design reviews,
   proposes alternatives with explicit trade-offs, and maps blast radius."
 type: agent
 metadata:
+  claude:
+    model: opus
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 # Architect Agent

--- a/artifacts/core/agents/astro-developer/AGENT.md
+++ b/artifacts/core/agents/astro-developer/AGENT.md
@@ -9,10 +9,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 # Astro Developer Agent

--- a/artifacts/core/agents/ci-configurator/AGENT.md
+++ b/artifacts/core/agents/ci-configurator/AGENT.md
@@ -9,10 +9,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 # CI Configurator Agent

--- a/artifacts/core/agents/ci-debugger/AGENT.md
+++ b/artifacts/core/agents/ci-debugger/AGENT.md
@@ -7,10 +7,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # CI Debugger Agent

--- a/artifacts/core/agents/ci-parity/AGENT.md
+++ b/artifacts/core/agents/ci-parity/AGENT.md
@@ -10,10 +10,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 # CI Parity Agent

--- a/artifacts/core/agents/copywriter/AGENT.md
+++ b/artifacts/core/agents/copywriter/AGENT.md
@@ -8,10 +8,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # Copywriter Agent

--- a/artifacts/core/agents/designer/AGENT.md
+++ b/artifacts/core/agents/designer/AGENT.md
@@ -7,10 +7,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # Designer Agent

--- a/artifacts/core/agents/developer/AGENT.md
+++ b/artifacts/core/agents/developer/AGENT.md
@@ -4,10 +4,12 @@ description: "Generic implementation agent. Writes, edits, and refactors code
   with the smallest correct change. Verifies locally before reporting done."
 type: agent
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.2.2"
+    version: "1.2.3"
 ---
 
 # Developer Agent

--- a/artifacts/core/agents/doc-writer/AGENT.md
+++ b/artifacts/core/agents/doc-writer/AGENT.md
@@ -5,10 +5,12 @@ description: "Generic documentation agent. Drafts ADRs, READMEs, in-code
   and stays close to the code where possible."
 type: agent
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 # Doc Writer Agent

--- a/artifacts/core/agents/frontend-developer/AGENT.md
+++ b/artifacts/core/agents/frontend-developer/AGENT.md
@@ -8,10 +8,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # Frontend Developer Agent

--- a/artifacts/core/agents/pr-logbook/AGENT.md
+++ b/artifacts/core/agents/pr-logbook/AGENT.md
@@ -5,10 +5,12 @@ description: "Generic PR and logbook composer agent. Drafts titles, bodies,
   to the project's AGENTS.md conventions."
 type: agent
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 # PR & Logbook Agent

--- a/artifacts/core/agents/pr-reviewer/AGENT.md
+++ b/artifacts/core/agents/pr-reviewer/AGENT.md
@@ -6,10 +6,12 @@ description: "Independent PR reviewer agent. Spawns cold — receives only a PR
   review verdict via the forge CLI (`gh`)."
 type: agent
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.6"
+    version: "1.1.7"
 ---
 
 # PR Reviewer Agent

--- a/artifacts/core/agents/regression-sentinel/AGENT.md
+++ b/artifacts/core/agents/regression-sentinel/AGENT.md
@@ -6,10 +6,12 @@ description: "Runs a smoke or regression pass against a staging or production
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 # Regression Sentinel Agent

--- a/artifacts/core/agents/scenario-author/AGENT.md
+++ b/artifacts/core/agents/scenario-author/AGENT.md
@@ -7,10 +7,12 @@ description: "Writes automated test scenarios from a natural-language
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # Scenario Author Agent

--- a/artifacts/core/agents/security/AGENT.md
+++ b/artifacts/core/agents/security/AGENT.md
@@ -5,10 +5,12 @@ description: "Generic security review agent. Threat modeling, secret hygiene,
   implement fixes unless explicitly asked."
 type: agent
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 # Security Agent

--- a/artifacts/core/agents/seo-specialist/AGENT.md
+++ b/artifacts/core/agents/seo-specialist/AGENT.md
@@ -9,10 +9,12 @@ description: |
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # SEO Specialist Agent

--- a/artifacts/core/agents/spec-author/AGENT.md
+++ b/artifacts/core/agents/spec-author/AGENT.md
@@ -5,10 +5,12 @@ description: "Specification authoring agent. Turns a raw user intent into
   in the interaction mode declared by the parent ticket."
 type: agent
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 # Spec Author Agent

--- a/artifacts/core/agents/tester/AGENT.md
+++ b/artifacts/core/agents/tester/AGENT.md
@@ -5,10 +5,12 @@ description: "Generic test-authoring agent. Writes high-signal regression tests,
   the test against the bug."
 type: agent
 metadata:
+  claude:
+    model: sonnet
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 # Tester Agent

--- a/artifacts/core/agents/visual-regression-tester/AGENT.md
+++ b/artifacts/core/agents/visual-regression-tester/AGENT.md
@@ -6,10 +6,12 @@ description: "Detects unintended visual changes between two states of a page
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.2"
+    version: "1.0.3"
 ---
 
 # Visual Regression Tester Agent

--- a/artifacts/core/agents/web-conformity-checker/AGENT.md
+++ b/artifacts/core/agents/web-conformity-checker/AGENT.md
@@ -6,10 +6,12 @@ description: "Verifies that a page or site matches a given specification —
 type: agent
 license: Apache-2.0
 metadata:
+  claude:
+    model: haiku
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.0.1"
+    version: "1.0.2"
 ---
 
 # Web Conformity Checker Agent

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -742,6 +742,18 @@ GEMINI_EOF
       local claude_frontmatter="name: $name
 description: \"$description\""
 
+      local license compatibility
+      license=$(yaml_field "$source" "license")
+      compatibility=$(yaml_field "$source" "compatibility")
+      if [ -n "$license" ] && [ "$license" != "null" ]; then
+        claude_frontmatter="$claude_frontmatter
+license: $license"
+      fi
+      if [ -n "$compatibility" ] && [ "$compatibility" != "null" ]; then
+        claude_frontmatter="$claude_frontmatter
+compatibility: \"$compatibility\""
+      fi
+
       local claude_model
       claude_model=$(extract_frontmatter "$source" | yq -r '.metadata.claude.model // .claude.model // ""' 2>/dev/null)
       if [ -n "$claude_model" ] && [ "$claude_model" != "null" ]; then

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -739,11 +739,20 @@ GEMINI_EOF
 
     # --- Claude Code output: AGENT.md (with frontmatter) ---
     if [ "$TARGET" = "claude" ] || [ "$TARGET" = "all" ]; then
+      local claude_frontmatter="name: $name
+description: \"$description\""
+
+      local claude_model
+      claude_model=$(extract_frontmatter "$source" | yq -r '.metadata.claude.model // .claude.model // ""' 2>/dev/null)
+      if [ -n "$claude_model" ] && [ "$claude_model" != "null" ]; then
+        claude_frontmatter="$claude_frontmatter
+model: $claude_model"
+      fi
+
       local claude_content
       claude_content=$(cat <<CLAUDE_EOF
 ---
-name: $name
-description: "$description"
+$claude_frontmatter
 ---
 
 $body


### PR DESCRIPTION
## Purpose
This PR adds explicit Claude model metadata (`metadata.claude.model`) across all 22 CrewRig core agents in `artifacts/core/agents/` and updates `scripts/build-components.sh` to compile `model: <value>` into `.claude/agents/*/AGENT.md` frontmatter. This allows users on Claude CLI to control and optimize token consumption per agent capability tier.

## How to read this PR?
- `scripts/build-components.sh`: In `build_agents()`, extracts `metadata.claude.model` (or `claude.model`) from source frontmatter and injects `model: <value>` into `.claude/agents/*/AGENT.md` frontmatter.
- `artifacts/core/agents/*/AGENT.md`: Core agent definitions updated with `metadata.claude.model` (`haiku`, `sonnet`, `opus`) and patch version bumps in `metadata.provenance.version`.
- `.claude/agents/*/AGENT.md`, `.gemini/agents/`, `.github/agents/`, `.agents/agents/`: Compiled deliverables regenerated via `build-components.sh`.

## How to test this PR?
1. Run `bash scripts/check-skill-versions.sh` to verify provenance version bumps.
2. Run `bash scripts/build-components.sh --check` to verify zero build drift.
3. Inspect `.claude/agents/architect/AGENT.md` (shows `model: opus`), `.claude/agents/developer/AGENT.md` (shows `model: sonnet`), `.claude/agents/doc-writer/AGENT.md` (shows `model: haiku`).

Closes #816