### PR TITLE
🔒 Enforce uniform array-value guarding for Bash 3.2 portability

### DIFF
--- a/docs/scripting-conventions.md
+++ b/docs/scripting-conventions.md
@@ -232,6 +232,16 @@ declared set — but it breaks a script just as thoroughly. Under `set -u`, Bash
 expansion is interpolated into a message string. This bites accumulator arrays
 hardest, because an accumulator is empty on precisely the success path.
 
+The array-guard rule is **enforced**, not merely recommended: the same
+`check-bash32-portability.sh` pass scans every governed `*.sh` file for array
+value expansions and fails when any is unguarded. Every `"${arr[@]}"` /
+`"${arr[*]}"` value expansion must be guarded — the canonical form
+`${arr[@]+"${arr[@]}"}` (drop the outer quotes; the guard carries its own), or
+`${arr[*]:-}` when interpolated inside a double-quoted string. A literal
+mention of an expansion in a comment or a grep pattern is not a use, but a
+script that deliberately requires a newer shell tags the line with
+`# acknowledged-exception: <reason>` and the check honours it.
+
 ### Why
 
 `mapfile` and `declare -A` had spread into six of the repository's own test

--- a/scripts/build-docs-index.sh
+++ b/scripts/build-docs-index.sh
@@ -251,7 +251,7 @@ fi
 # ---------------------------------------------------------------------------
 if [ "${#LINT_ERRORS[@]}" -gt 0 ]; then
   echo "Documentation publication contract violations:" >&2
-  for e in "${LINT_ERRORS[@]}"; do
+  for e in ${LINT_ERRORS[@]+"${LINT_ERRORS[@]}"}; do
     echo "  - $e" >&2
   done
   exit 1
@@ -269,11 +269,11 @@ emit_index() {
 
   local first_section=1
   local sec
-  for sec in "${SECTION_KEYS[@]}"; do
+  for sec in ${SECTION_KEYS[@]+"${SECTION_KEYS[@]}"}; do
     # Gather rows for this section, sort by nav_order then path.
     local sec_rows=()
     local row
-    for row in "${ROWS[@]}"; do
+    for row in ${ROWS[@]+"${ROWS[@]}"}; do
       [ "${row%%$'\t'*}" = "$sec" ] && sec_rows+=("$row")
     done
     [ "${#sec_rows[@]}" -eq 0 ] && continue
@@ -282,7 +282,7 @@ emit_index() {
     local sorted=()
     while IFS= read -r row; do
       sorted+=("$row")
-    done < <(printf '%s\n' "${sec_rows[@]}" | sort -t$'\t' -k2,2n -k3,3)
+    done < <(printf '%s\n' ${sec_rows[@]+"${sec_rows[@]}"} | sort -t$'\t' -k2,2n -k3,3)
 
     if [ "$first_section" -eq 1 ]; then
       first_section=0
@@ -295,7 +295,7 @@ emit_index() {
     printf '      "pages": [\n'
 
     local first_page=1
-    for row in "${sorted[@]}"; do
+    for row in ${sorted[@]+"${sorted[@]}"}; do
       local r_nav r_path r_title rest2
       rest2="${row#*$'\t'}"            # drop section
       r_nav="${rest2%%$'\t'*}"

--- a/scripts/build-extension-pivot.sh
+++ b/scripts/build-extension-pivot.sh
@@ -135,7 +135,7 @@ render_extension() {
 # Collect the target extension dirs.
 ext_dirs=()
 if [ "${#EXT_ARGS[@]}" -gt 0 ]; then
-  for arg in "${EXT_ARGS[@]}"; do
+  for arg in ${EXT_ARGS[@]+"${EXT_ARGS[@]}"}; do
     ext_dirs+=("$(resolve_extension_dir "$arg")")
   done
 else
@@ -151,7 +151,7 @@ else
   echo "Extension pivot render — BUILD"
 fi
 
-for ext_dir in "${ext_dirs[@]}"; do
+for ext_dir in ${ext_dirs[@]+"${ext_dirs[@]}"}; do
   render_extension "$ext_dir"
 done
 

--- a/scripts/check-bash32-portability.sh
+++ b/scripts/check-bash32-portability.sh
@@ -266,5 +266,34 @@ if [ -n "$HITS" ]; then
   exit 1
 fi
 
-echo "OK: no forbidden Bash 4+ construct in $SCAN_TARGETS" \
-     "($declared declared construct(s), $scanned file(s) scanned)."
+# --- Phase 2: empty-array guard (Bash 3.2) -----------------------------------
+# Every `${name[@]}` / `${name[*]}` value expansion must be guarded, because on
+# the Bash 3.2 that ships with macOS an empty array is treated as unset and an
+# unguarded expansion aborts under `set -u`. This is a second, `.sh`-scoped
+# scan, folded in after the declared-set grep above so a single OK means both
+# rules held. The lib is sourced here — in the verdict path only, after the
+# list-mode exit — so `--list-constructs` still queries without scanning.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/bash32-array-guard.sh
+. "$SCRIPT_DIR/lib/bash32-array-guard.sh"
+
+array_guard_scan "$REPO_DIR"
+if [ -n "$ARRAY_GUARD_HITS" ]; then
+  ag_hits_count="$(printf '%s\n' "$ARRAY_GUARD_HITS" | wc -l | tr -d '[:space:]')"
+  echo "FAILED: $ag_hits_count array value expansion(s) are unguarded:" >&2
+  echo "" >&2
+  printf '%s\n' "$ARRAY_GUARD_HITS" >&2
+  echo "" >&2
+  echo "Each line expands an array value (the \${name[...]} brace form)" >&2
+  echo "without guarding against the empty array. On the Bash 3.2 that ships" >&2
+  echo "with macOS an empty array is treated as unset, so under set -u the" >&2
+  echo "expansion aborts with 'unbound variable' — silently, because suites" >&2
+  echo "run set -uo pipefail WITHOUT -e, so the child subshell dies and the" >&2
+  echo "suite can exit 0 with cases skipped (the false green of issue #697)." >&2
+  echo "Guard the expansion per Rule 5 (docs/scripting-conventions.md)." >&2
+  exit 1
+fi
+
+echo "OK: no forbidden Bash 4+ construct and no unguarded array value expansion" \
+     "in $SCAN_TARGETS ($declared declared construct(s), $scanned file(s) scanned," \
+     "$ARRAY_GUARD_SH_FILES .sh file(s) array-scanned)."

--- a/scripts/check-ci-parity.sh
+++ b/scripts/check-ci-parity.sh
@@ -218,7 +218,7 @@ done
 
 if [ "${#validity_errors[@]}" -gt 0 ]; then
   echo "FAILED: ${#validity_errors[@]} reference-validity violation(s) in $REFERENCE:" >&2
-  for e in "${validity_errors[@]}"; do
+  for e in ${validity_errors[@]+"${validity_errors[@]}"}; do
     echo "  - $e" >&2
   done
   echo "" >&2

--- a/scripts/check-core-paths.sh
+++ b/scripts/check-core-paths.sh
@@ -251,7 +251,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo "" >&2
   echo "FAILED: ${#failures[@]} core-paths manifest entr(y/ies) do not resolve at HEAD:" >&2
-  for p in "${failures[@]}"; do
+  for p in ${failures[@]+"${failures[@]}"}; do
     echo "  - $p" >&2
   done
   echo "" >&2

--- a/scripts/check-extension-manifest-version.sh
+++ b/scripts/check-extension-manifest-version.sh
@@ -62,7 +62,7 @@ while IFS= read -r d; do
   [ -z "$d" ] && continue
   ext_dirs+=("$d")
 done < <(
-  for root in "${TIER_ROOTS[@]}"; do
+  for root in ${TIER_ROOTS[@]+"${TIER_ROOTS[@]}"}; do
     [ -d "$root" ] || continue
     # extensions/<tier>/<name>/package.json — one level of <name> under the root.
     for pkg in "$root"/*/package.json; do
@@ -72,7 +72,7 @@ done < <(
   done | sort
 )
 
-for dir in "${ext_dirs[@]}"; do
+for dir in ${ext_dirs[@]+"${ext_dirs[@]}"}; do
   checked=$((checked + 1))
   authoritative="$(jq -r '.version // empty' "$dir/package.json")"
 
@@ -83,7 +83,7 @@ for dir in "${ext_dirs[@]}"; do
   fi
 
   dir_ok=1
-  for sib in "${SIBLINGS[@]}"; do
+  for sib in ${SIBLINGS[@]+"${SIBLINGS[@]}"}; do
     [ -f "$dir/$sib" ] || continue
     sib_version="$(jq -r '.version // empty' "$dir/$sib")"
     if [ "$sib_version" != "$authoritative" ]; then
@@ -101,7 +101,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo ""
   echo "FAILED: ${#failures[@]} manifest(s) diverge from their extension's authoritative version:"
-  for f in "${failures[@]}"; do
+  for f in ${failures[@]+"${failures[@]}"}; do
     echo "  - $f"
   done
   echo ""

--- a/scripts/check-extension-pivot.sh
+++ b/scripts/check-extension-pivot.sh
@@ -54,7 +54,7 @@ failures=()
 checked_commands=0
 checked_agents=0
 
-for root in "${TIER_ROOTS[@]}"; do
+for root in ${TIER_ROOTS[@]+"${TIER_ROOTS[@]}"}; do
   [ -d "$root" ] || continue
 
   # --- (a) command-native: orphan .toml with no sibling .md ---
@@ -90,7 +90,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo ""
   echo "FAILED: ${#failures[@]} extension component(s) are authored CLI-native instead of pivot:"
-  for f in "${failures[@]}"; do
+  for f in ${failures[@]+"${failures[@]}"}; do
     echo "  - $f"
   done
   echo ""

--- a/scripts/check-extension-provenance.sh
+++ b/scripts/check-extension-provenance.sh
@@ -73,13 +73,13 @@ while IFS= read -r f; do
   [ -z "$f" ] && continue
   sources+=("$f")
 done < <(
-  for root in "${TIER_ROOTS[@]}"; do
+  for root in ${TIER_ROOTS[@]+"${TIER_ROOTS[@]}"}; do
     [ -d "$root" ] || continue
     find "$root" -type f \( -name 'SKILL.md' -o -name 'AGENT.md' \) 2>/dev/null
   done | sort
 )
 
-for f in "${sources[@]}"; do
+for f in ${sources[@]+"${sources[@]}"}; do
   checked=$((checked + 1))
   carrier="$(first_body_line "$f")"
 
@@ -104,7 +104,7 @@ for f in "${sources[@]}"; do
   [ -z "$canonical" ] && missing+=("canonical")
   [ -z "$feedback" ]  && missing+=("feedback")
   if [ "${#missing[@]}" -gt 0 ]; then
-    echo "  FAIL $f — provenance carrier missing field(s): ${missing[*]} (R1)"
+    echo "  FAIL $f — provenance carrier missing field(s): ${missing[*]:-} (R1)"
     failures+=("$f")
     continue
   fi
@@ -122,7 +122,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo ""
   echo "FAILED: ${#failures[@]} upstream-owned extension component(s) violate the provenance contract:"
-  for f in "${failures[@]}"; do
+  for f in ${failures[@]+"${failures[@]}"}; do
     echo "  - $f"
   done
   echo ""

--- a/scripts/check-extension-version-bump.sh
+++ b/scripts/check-extension-version-bump.sh
@@ -105,7 +105,7 @@ fi
 echo "Checking version bumps on ${#modified[@]} modified extension skill/agent source(s)..."
 
 failures=()
-for f in "${modified[@]}"; do
+for f in ${modified[@]+"${modified[@]}"}; do
   [ ! -f "$f" ] && continue  # deleted file: skip (deletions don't need a bump)
 
   new_version="$(carrier_version "$f")"
@@ -146,7 +146,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo ""
   echo "FAILED: ${#failures[@]} extension source(s) changed without a version bump:"
-  for f in "${failures[@]}"; do
+  for f in ${failures[@]+"${failures[@]}"}; do
     echo "  - $f"
   done
   echo ""

--- a/scripts/check-feedback-routing.sh
+++ b/scripts/check-feedback-routing.sh
@@ -70,13 +70,13 @@ while IFS= read -r f; do
   [ -z "$f" ] && continue
   sources+=("$f")
 done < <(
-  for root in "${TIER_ROOTS[@]}"; do
+  for root in ${TIER_ROOTS[@]+"${TIER_ROOTS[@]}"}; do
     [ -d "$root" ] || continue
     find "$root" -type f \( -name 'SKILL.md' -o -name 'AGENT.md' \) 2>/dev/null
   done | sort
 )
 
-for f in "${sources[@]}"; do
+for f in ${sources[@]+"${sources[@]}"}; do
   frontmatter=$(extract_frontmatter "$f")
 
   # Skip sources with no metadata.provenance block — nothing to enforce.
@@ -109,7 +109,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo ""
   echo "FAILED: ${#failures[@]} upstream-owned source(s) route feedback away from canonical:"
-  for f in "${failures[@]}"; do
+  for f in ${failures[@]+"${failures[@]}"}; do
     echo "  - $f"
   done
   echo ""

--- a/scripts/check-gemini-overlay-enrollment.sh
+++ b/scripts/check-gemini-overlay-enrollment.sh
@@ -132,7 +132,7 @@ done <<<"$enrolled"
 # code on their own.
 if [ "${#warnings[@]}" -gt 0 ]; then
   echo "WARNING: ${#warnings[@]} overlay(s) enrolled in context.fileName but not deployed by the setup script:" >&2
-  for w in "${warnings[@]}"; do
+  for w in ${warnings[@]+"${warnings[@]}"}; do
     echo "  - $w" >&2
   done
   echo "This is drift, not a failure — either enroll a deploy for it or remove it" >&2
@@ -143,7 +143,7 @@ fi
 # Forward failures are blocking (R1).
 if [ "${#missing[@]}" -gt 0 ]; then
   echo "FAILED: ${#missing[@]} deployed Gemini overlay(s) not enrolled in context.fileName (spec 0085):" >&2
-  for m in "${missing[@]}"; do
+  for m in ${missing[@]+"${missing[@]}"}; do
     echo "  - $m" >&2
   done
   echo "" >&2

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -64,7 +64,7 @@ fi
 echo "Checking version bumps on ${#modified[@]} modified skill/agent source(s)..."
 
 failures=()
-for f in "${modified[@]}"; do
+for f in ${modified[@]+"${modified[@]}"}; do
   [ ! -f "$f" ] && continue  # deleted file: skip (deletions don't need a bump)
 
   # Look at the diff for a `version:` line addition. The
@@ -83,7 +83,7 @@ done
 if [ "${#failures[@]}" -gt 0 ]; then
   echo ""
   echo "FAILED: ${#failures[@]} source(s) changed without a version bump:"
-  for f in "${failures[@]}"; do
+  for f in ${failures[@]+"${failures[@]}"}; do
     echo "  - $f"
   done
   echo ""

--- a/scripts/check-test-wiring.sh
+++ b/scripts/check-test-wiring.sh
@@ -67,7 +67,7 @@ fi
 is_wired() {
   local token="$1" file line before after
   [ "${#SURFACES[@]}" -eq 0 ] && return 1
-  for file in "${SURFACES[@]}"; do
+  for file in ${SURFACES[@]+"${SURFACES[@]}"}; do
     while IFS= read -r line; do
       before="${line%%"$token"*}"
       case "$before" in *"#"*) continue ;; esac
@@ -138,7 +138,7 @@ failed=0
 if [ "${#orphans[@]}" -gt 0 ]; then
   failed=1
   echo "FAILED: ${#orphans[@]} test script(s) run in no CI workflow and are not exempted:" >&2
-  for n in "${orphans[@]}"; do
+  for n in ${orphans[@]+"${orphans[@]}"}; do
     echo "  - scripts/tests/$n" >&2
   done
   echo "" >&2
@@ -151,7 +151,7 @@ if [ "${#reasonless[@]}" -gt 0 ]; then
   failed=1
   echo "" >&2
   echo "FAILED: ${#reasonless[@]} exemption entr(y/ies) carry no reason:" >&2
-  for n in "${reasonless[@]}"; do
+  for n in ${reasonless[@]+"${reasonless[@]}"}; do
     echo "  - $n" >&2
   done
   echo "Every line in ci/test-wiring-exemptions.txt must be '<name.sh><TAB><reason>' (spec 0076 R3)." >&2
@@ -161,7 +161,7 @@ if [ "${#stale[@]}" -gt 0 ]; then
   failed=1
   echo "" >&2
   echo "FAILED: ${#stale[@]} exemption entr(y/ies) name a test that no longer exists:" >&2
-  for n in "${stale[@]}"; do
+  for n in ${stale[@]+"${stale[@]}"}; do
     echo "  - $n" >&2
   done
   echo "Remove the stale exemption from ci/test-wiring-exemptions.txt (spec 0076 R5)." >&2

--- a/scripts/e2e-capture-versions.sh
+++ b/scripts/e2e-capture-versions.sh
@@ -34,7 +34,7 @@ for img in "$base_img" "$claude_img" "$gemini_img" "$copilot_img" "$mempalace_im
 done
 if [ "${#missing[@]}" -gt 0 ]; then
   echo "ERROR: required image(s) not found locally:" >&2
-  printf '  - %s\n' "${missing[@]}" >&2
+  printf '  - %s\n' ${missing[@]+"${missing[@]}"} >&2
   echo "Run 'task e2e:build' first." >&2
   exit 1
 fi
@@ -117,7 +117,7 @@ cat "$LOCKFILE"
 if [ "${#empty_fields[@]}" -gt 0 ]; then
   echo >&2
   echo "ERROR: the following lockfile fields resolved to <unknown>:" >&2
-  printf '  - %s\n' "${empty_fields[@]}" >&2
+  printf '  - %s\n' ${empty_fields[@]+"${empty_fields[@]}"} >&2
   echo "Rebuild the affected image(s) and re-run." >&2
   exit 2
 fi

--- a/scripts/e2e/auth-claude.sh
+++ b/scripts/e2e/auth-claude.sh
@@ -56,7 +56,7 @@ if [[ ${#src_files[@]} -eq 0 ]]; then
   e2e_die "[$CLI] No *.md files found in ${HOST_RULES}. Run \`task setup:claude\` to deploy them."
 fi
 
-for f in "${src_files[@]}"; do
+for f in ${src_files[@]+"${src_files[@]}"}; do
   cp "$f" "${RULES_DIR}/$(basename "$f")"
 done
 e2e_info "[$CLI] Copied ${#src_files[@]} rule file(s) → ${RULES_DIR}."
@@ -98,7 +98,7 @@ missing=()
 
 if [ "${#missing[@]}" -gt 0 ]; then
   e2e_info "[$CLI] WARNING: expected credential file(s) not found in $DIR:"
-  for f in "${missing[@]}"; do e2e_info "  - $f"; done
+  for f in ${missing[@]+"${missing[@]}"}; do e2e_info "  - $f"; done
   e2e_info "[$CLI] The login flow may not have completed. Re-run \`task e2e:auth:claude\` after authenticating in the browser."
   exit 1
 fi

--- a/scripts/e2e/auth-copilot.sh
+++ b/scripts/e2e/auth-copilot.sh
@@ -50,7 +50,7 @@ if [[ ${#src_files[@]} -eq 0 ]]; then
   e2e_die "[$CLI] No *.instructions.md files found in ${HOST_INSTRUCTIONS}. Run \`task setup:copilot\` to deploy them."
 fi
 
-for f in "${src_files[@]}"; do
+for f in ${src_files[@]+"${src_files[@]}"}; do
   cp "$f" "${RULES_DIR}/$(basename "$f")"
 done
 e2e_info "[$CLI] Copied ${#src_files[@]} instruction file(s) → ${RULES_DIR}."

--- a/scripts/e2e/auth-gemini.sh
+++ b/scripts/e2e/auth-gemini.sh
@@ -79,7 +79,7 @@ missing=()
 
 if [ "${#missing[@]}" -gt 0 ]; then
   e2e_info "[$CLI] WARNING: expected credential file(s) not found in $DIR:"
-  for f in "${missing[@]}"; do e2e_info "  - $f"; done
+  for f in ${missing[@]+"${missing[@]}"}; do e2e_info "  - $f"; done
   e2e_info "[$CLI] The login flow may not have completed. Re-run \`task e2e:auth:gemini\` and finish the browser step."
   exit 1
 fi

--- a/scripts/e2e/auth-ollama.sh
+++ b/scripts/e2e/auth-ollama.sh
@@ -62,7 +62,7 @@ missing=()
 
 if [ "${#missing[@]}" -gt 0 ]; then
   e2e_info "[$CLI] WARNING: expected credential file(s) not found in $DIR:"
-  for f in "${missing[@]}"; do e2e_info "  - $f"; done
+  for f in ${missing[@]+"${missing[@]}"}; do e2e_info "  - $f"; done
   e2e_info "[$CLI] The signin flow may not have completed. Re-run \`task e2e:auth:ollama\` after authorising in the browser."
   exit 1
 fi

--- a/scripts/install-extension.sh
+++ b/scripts/install-extension.sh
@@ -65,9 +65,9 @@ fi
 if [ -n "$EXT" ]; then
   do_install "$EXT"
 else
-  tiers=("${UPSTREAM_TIERS[@]}")
+  tiers=(${UPSTREAM_TIERS[@]+"${UPSTREAM_TIERS[@]}"})
   [ -n "$INCLUDE_ORG" ] && tiers+=(org)
-  for tier in "${tiers[@]}"; do
+  for tier in ${tiers[@]+"${tiers[@]}"}; do
     for dir in "$REPO_DIR"/extensions/"$tier"/*/; do
       [ -d "$dir" ] && do_install "$(basename "$dir")"
     done

--- a/scripts/lib/bash32-array-guard.sh
+++ b/scripts/lib/bash32-array-guard.sh
@@ -1,0 +1,171 @@
+# shellcheck disable=SC2317  # functions are sourced, not executed here
+# bash32-array-guard.sh — shared detector for the empty-array guard rule.
+#
+# Sourced by BOTH the enforcement script (`scripts/check-bash32-portability.sh`)
+# and the test suite (`scripts/tests/test-check-bash32-portability.sh`). It must
+# therefore be safe to run under `set -euo pipefail` (the enforcement's regime)
+# as well as under the suite's `set -uo pipefail` (no -e). Every `grep` lookup
+# here that can legitimately return exit 1 on "no match" carries `|| true`, so a
+# missing match cannot abort the caller under `set -e`.
+#
+# This file is itself inside scripts/, so it is governed by the rule it enforces.
+# It contains no unguarded `${name[@]}` / `${name[*]}` expansion: the detector's
+# own `grep -oF` literals build subscripts from a scalar (`${_bx_nm}[${_bx_sub}]`)
+# at runtime, which the scan's `\[[@*]` anchor does not match, and every mention
+# of the closed forms in prose sits in a comment that `strip_comments` removes.
+
+# strip_comments <line> — echo <line> with any trailing comment removed. A `#`
+# that begins a word (start of line, or preceded by a space or tab) outside a
+# quoted string opens a comment; everything from there to end of line is dropped.
+# Quote-aware so a `#` inside a single- or double-quoted string is literal (it
+# does not open a comment), and a backslash-escaped `\"` inside double quotes is
+# a literal quote that does not toggle the quote state. Purely substring
+# arithmetic — no external commands — so it is identical on Bash 3.2 and 5.x.
+strip_comments() {
+  _sc_line="$1"
+  _sc_out=''
+  _sc_in_single=0
+  _sc_in_double=0
+  _sc_len=${#_sc_line}
+  _sc_i=0
+  while [ "$_sc_i" -lt "$_sc_len" ]; do
+    _sc_ch="${_sc_line:$_sc_i:1}"
+    case "$_sc_ch" in
+      "'")
+        if [ "$_sc_in_double" -eq 0 ]; then
+          if [ "$_sc_in_single" -eq 1 ]; then _sc_in_single=0; else _sc_in_single=1; fi
+        fi
+        _sc_out="${_sc_out}'"
+        ;;
+      '"')
+        if [ "$_sc_in_single" -eq 0 ]; then
+          # A backslash-escaped quote inside double quotes is a literal quote
+          # and does not toggle state; any other quote toggles it.
+          _sc_prev=''
+          [ "$_sc_i" -gt 0 ] && _sc_prev="${_sc_line:$_sc_i-1:1}"
+          if [ "$_sc_prev" = '\' ]; then
+            :
+          else
+            if [ "$_sc_in_double" -eq 1 ]; then _sc_in_double=0; else _sc_in_double=1; fi
+          fi
+        fi
+        _sc_out="${_sc_out}\""
+        ;;
+      '#')
+        if [ "$_sc_in_single" -eq 0 ] && [ "$_sc_in_double" -eq 0 ]; then
+          _sc_prev=''
+          [ "$_sc_i" -gt 0 ] && _sc_prev="${_sc_line:$_sc_i-1:1}"
+          if [ "$_sc_i" -eq 0 ] || [ "$_sc_prev" = ' ' ] || [ "$_sc_prev" = "$(printf '\t')" ]; then
+            break
+          fi
+        fi
+        _sc_out="${_sc_out}#"
+        ;;
+      *)
+        _sc_out="${_sc_out}${_sc_ch}"
+        ;;
+    esac
+    _sc_i=$((_sc_i + 1))
+  done
+  printf '%s' "$_sc_out"
+}
+
+# bare_expansions_in <line> — echo the `name[subscript]` of every array expansion
+# on the line that would abort under `set -u` when the array is empty, or nothing
+# when the line is safe. Used by the enforcement scan and probed by the suite.
+#
+# It works by CONSUMPTION, not by tallying, and that distinction is the whole
+# history of this function. Three successive tally designs each left a hole:
+#
+#   1. Per line, guarded-vs-bare counts: a guard anywhere on the line hid a bare
+#      expansion elsewhere on it.
+#   2. Per line with comment lines dropped: fixed a false positive, not the tally.
+#   3. Per array name: narrowed *who* could spend the slack without removing it.
+#
+# The slack is a property of the guard SPELLING. `${A[@]+"${A[@]}"}` contains one
+# closed `${A[@]}` and is worth one; `${A[*]:-}` contains no closed form and is
+# worth zero — so on `"${A[*]:-} ${A[@]}"` any tally balances while `A` is bare.
+# That shape reproduces the very false green this ticket exists to remove:
+# `A=(); s="${A[*]:-}"; out=$(printf '%s' "${A[@]}")` prints
+# `A[@]: unbound variable` to stderr and still exits 0.
+#
+# So: count the closed forms `${name[@]}` / `${name[*]}`, then subtract only the
+# ones a complete canonical guard `${name[@]+"${name[@]}"}` accounts for. Anything
+# left is genuinely bare. `${name[*]:-…}` contributes no closed form, so it needs
+# no special case. Matching is done with `grep -oF` on literals built per name, so
+# there is no regex to escape and no BSD-versus-GNU divergence to reason about.
+#
+# Deliberately not matched, all verified safe on an empty array under `set -u` on
+# 3.2.57: `${#name[@]}` (length), `${name[@]:1}` (slice), `${!name[@]}` (keys).
+bare_expansions_in() {
+  _bx_line="$1"
+  _bx_out=''
+  # Array names on the line, deduplicated. `tr -d` rather than a sed capture:
+  # BSD sed reads `\{` as an interval and errors "braces not balanced".
+  _bx_names=$(printf '%s\n' "$_bx_line" \
+    | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[' | tr -d '${[' | sort -u) || true
+  for _bx_nm in $_bx_names; do
+    for _bx_sub in '@' '*'; do
+      # Braced interpolation (`${var}[`) rather than `$var[`: the latter is a
+      # literal string being built for `grep -oF`, but shellcheck reads it as an
+      # array expansion and raises SC1087 at error level.
+      _bx_closed=$(printf '%s\n' "$_bx_line" \
+        | grep -oF "\${${_bx_nm}[${_bx_sub}]}" | wc -l | tr -d ' ') || true
+      _bx_wrapped=$(printf '%s\n' "$_bx_line" \
+        | grep -oF "\${${_bx_nm}[${_bx_sub}]+\"\${${_bx_nm}[${_bx_sub}]}\"}" \
+        | wc -l | tr -d ' ') || true
+      if [ "$_bx_closed" -gt "$_bx_wrapped" ]; then
+        _bx_out="${_bx_out}${_bx_nm}[${_bx_sub}] "
+      fi
+    done
+  done
+  # Trailing space trimmed without a bashism, so the caller can test -n cleanly.
+  printf '%s' "$_bx_out" | sed -e 's/[[:space:]]*$//'
+}
+
+# array_guard_scan <repo-dir> — walk every `*.sh` file under scripts/ and hooks/
+# and emit, per unguarded expansion, one line:
+#   <dir>/<file>:<line>:<name[subscript]>
+# where <line> is the source line with comments stripped. Emits nothing when the
+# tree is clean. `acknowledged-exception:` lines are skipped on the RAW line,
+# before comment stripping, mirroring the declared-set scan's escape hatch. Sets:
+#   ARRAY_GUARD_SH_FILES  — number of *.sh files walked (fail-closed signal)
+#   ARRAY_GUARD_HITS      — the collected hit text ("" when clean)
+# Both are read by the enforcement script after the call.
+array_guard_scan() {
+  _ag_repo="$1"
+  ARRAY_GUARD_SH_FILES=0
+  ARRAY_GUARD_HITS=''
+  for _ag_d in scripts hooks; do
+    [ -d "$_ag_repo/$_ag_d" ] || continue
+    _ag_files="$( find "$_ag_repo/$_ag_d" -type f -name '*.sh' 2>/dev/null )"
+    while IFS= read -r _ag_f || [ -n "$_ag_f" ]; do
+      [ -n "$_ag_f" ] || continue
+      ARRAY_GUARD_SH_FILES=$((ARRAY_GUARD_SH_FILES + 1))
+      _ag_fname="${_ag_f#$_ag_repo/}"
+      # Candidate lines only — those containing a `${name[@` / `${name[*`. The
+      # `|| true` is safe here: a no-match (exit 1) is a legitimate empty result
+      # and the loop body simply continues.
+      _ag_raw="$( grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]' \
+        "$_ag_f" 2>/dev/null )" || true
+      [ -n "$_ag_raw" ] || continue
+      while IFS= read -r _ag_ln || [ -n "$_ag_ln" ]; do
+        [ -n "$_ag_ln" ] || continue
+        _ag_lineno="${_ag_ln%%:*}"
+        _ag_content="${_ag_ln#*:}"
+        case "$_ag_content" in
+          *'acknowledged-exception:'*) continue ;;
+        esac
+        _ag_stripped="$( strip_comments "$_ag_content" )"
+        _ag_hit="$( bare_expansions_in "$_ag_stripped" )"
+        [ -n "$_ag_hit" ] || continue
+        ARRAY_GUARD_HITS="${ARRAY_GUARD_HITS}${_ag_fname}:$_ag_lineno:$_ag_hit
+"
+      done <<EOF
+$_ag_raw
+EOF
+    done <<EOF
+$_ag_files
+EOF
+  done
+}

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -93,7 +93,7 @@ merge_preexisting_mcp_servers() {
   # framework-wins replacement (name still present after the framework write)
   # from the decline removal (name absent after the write).
   local name
-  for name in "${MCP_RESERVED_NAMES[@]}"; do
+  for name in ${MCP_RESERVED_NAMES[@]+"${MCP_RESERVED_NAMES[@]}"}; do
     if printf '%s' "$pre_run" | jq -e --arg n "$name" 'has($n)' >/dev/null 2>&1; then
       if jq -e --arg n "$name" '(.mcpServers // {}) | has($n)' "$config_path" >/dev/null 2>&1; then
         echo "  WARNING: '$name' is a framework-managed MCP server — your prior '$name' entry was replaced (framework wins)."
@@ -106,7 +106,7 @@ merge_preexisting_mcp_servers() {
 
   # The reserved set as a JSON array, so the jq program stays declarative.
   local reserved_json
-  reserved_json="$(jq -cn '$ARGS.positional' --args "${MCP_RESERVED_NAMES[@]}")"
+  reserved_json="$(jq -cn '$ARGS.positional' --args ${MCP_RESERVED_NAMES[@]+"${MCP_RESERVED_NAMES[@]}"})"
 
   # Right-biased merge. `preserved` = operator servers minus reserved names, so
   # framework reserved entries survive and operator non-reserved entries win
@@ -232,11 +232,11 @@ apply_org_mcp_servers() {
   fi
 
   local reserved_json
-  reserved_json="$(jq -cn '$ARGS.positional' --args "${MCP_RESERVED_NAMES[@]}")"
+  reserved_json="$(jq -cn '$ARGS.positional' --args ${MCP_RESERVED_NAMES[@]+"${MCP_RESERVED_NAMES[@]}"})"
 
   # R10 — an org declaration under a framework-reserved name is NOT applied.
   local name
-  for name in "${MCP_RESERVED_NAMES[@]}"; do
+  for name in ${MCP_RESERVED_NAMES[@]+"${MCP_RESERVED_NAMES[@]}"}; do
     if printf '%s' "$org_native" | jq -e --arg n "$name" 'has($n)' >/dev/null 2>&1; then
       echo "  WARNING: '$name' is a framework-managed MCP server — the org declaration for '$name' was NOT applied (framework wins)."
     fi
@@ -310,7 +310,7 @@ register_org_mcp_claude() {
     [ -n "$name" ] || continue
 
     is_reserved=0
-    for r in "${MCP_RESERVED_NAMES[@]}"; do
+    for r in ${MCP_RESERVED_NAMES[@]+"${MCP_RESERVED_NAMES[@]}"}; do
       [ "$r" = "$name" ] && is_reserved=1
     done
     if [ "$is_reserved" -eq 1 ]; then
@@ -328,7 +328,7 @@ register_org_mcp_claude() {
       echo "  WARNING: org-declared MCP server '$name' overrides your pre-existing '$name' entry (org declaration wins)."
       saved="$(jq -c --arg n "$name" '.mcpServers[$n] // empty' "$claude_config" 2>/dev/null || true)"
       claude mcp remove --scope user "$name" >/dev/null 2>&1 || true
-      if claude mcp add "${argv[@]}" >/dev/null 2>&1; then
+      if claude mcp add ${argv[@]+"${argv[@]}"} >/dev/null 2>&1; then
         echo "  ${name}: org declaration registered (replaced prior entry)"
       else
         echo "  ${name}: FAILED to register org declaration — restoring your prior entry."
@@ -345,10 +345,10 @@ register_org_mcp_claude() {
         fi
       fi
     else
-      if claude mcp add "${argv[@]}" >/dev/null 2>&1; then
+      if claude mcp add ${argv[@]+"${argv[@]}"} >/dev/null 2>&1; then
         echo "  ${name}: org declaration registered"
       else
-        echo "  ${name}: FAILED to register org declaration — re-run manually: claude mcp add ${argv[*]}"
+        echo "  ${name}: FAILED to register org declaration — re-run manually: claude mcp add ${argv[*]:-}"
       fi
     fi
   done <<< "$names"
@@ -424,7 +424,7 @@ pick_catalogue_entry() {
   fi
 
   local choice
-  choice="$(printf '%s\n' "${candidates[@]}" \
+  choice="$(printf '%s\n' ${candidates[@]+"${candidates[@]}"} \
     | fzf --height 40% --preview "head -20 $category_dir/{}.md" || true)"
   if [ -z "$choice" ]; then
     echo "No $category_label selected — skipping $category_label selection." >&2
@@ -498,7 +498,7 @@ mempalace_python_candidates() {
   fi
   candidates+=("python3")
   local py
-  for py in "${candidates[@]}"; do
+  for py in ${candidates[@]+"${candidates[@]}"}; do
     [ -n "$py" ] && printf '%s\n' "$py"
   done
 }
@@ -1895,7 +1895,7 @@ migrate_antigravity_superseded_components() {
     local dest="$superseded_root/$kind"
 
     if [ ${#explicit_names[@]} -gt 0 ]; then
-      names="$(printf '%s\n' "${explicit_names[@]}")"
+      names="$(printf '%s\n' ${explicit_names[@]+"${explicit_names[@]}"})"
     else
       names="$(_antigravity_framework_names "$artifacts_root" "$kind")"
       name_count="$(printf '%s' "$names" | grep -c . || true)"
@@ -1978,7 +1978,7 @@ migrate_antigravity_superseded_components() {
   if [ ${#residue[@]} -gt 0 ]; then
     echo "  The following carry framework provenance but match no served component" >&2
     echo "  name. They were NOT removed — check them, then remove by hand:" >&2
-    for item in "${residue[@]}"; do
+    for item in ${residue[@]+"${residue[@]}"}; do
       echo "    rm -rf ${item%% (*}" >&2
     done
   fi

--- a/scripts/link-extensions.sh
+++ b/scripts/link-extensions.sh
@@ -10,7 +10,7 @@ if [ "$1" = "--include-org" ] || [ -n "${INCLUDE_ORG:-}" ]; then
   tiers+=(org)
 fi
 
-for tier in "${tiers[@]}"; do
+for tier in ${tiers[@]+"${tiers[@]}"}; do
   for dir in "$REPO_DIR"/extensions/"$tier"/*/; do
     [ -d "$dir" ] && bash "$REPO_DIR/scripts/install-extension.sh" link "$(basename "$dir")"
   done

--- a/scripts/manage-antigravity-component.sh
+++ b/scripts/manage-antigravity-component.sh
@@ -137,16 +137,16 @@ case "$TYPE" in
     mkdir -p "$DEST"
     component_set_staging_roots ".agents/skills"
     if [ -n "$NAME" ]; then
-      component_install_named install_into_dest "$NAME" "$TYPE" antigravity "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named install_into_dest "$NAME" "$TYPE" antigravity ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all install_into_dest antigravity "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all install_into_dest antigravity ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     # Keep R7's property true: a copy of the same component left at the
     # superseded placement would otherwise still be there after this run.
     # Narrow by design — only the names this invocation placed.
     if [ ${#PLACED_NAMES[@]} -gt 0 ]; then
       migrate_antigravity_superseded_components \
-        "$ANTIGRAVITY_HOME" "$REPO_DIR/artifacts" skills "${PLACED_NAMES[@]}" || exit $?
+        "$ANTIGRAVITY_HOME" "$REPO_DIR/artifacts" skills ${PLACED_NAMES[@]+"${PLACED_NAMES[@]}"} || exit $?
     fi
     ;;
 
@@ -155,18 +155,18 @@ case "$TYPE" in
     mkdir -p "$DEST"
     component_set_artifact_roots "policies"
     if [ -n "$NAME" ]; then
-      component_install_named install_into_dest "$NAME" "$TYPE" "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named install_into_dest "$NAME" "$TYPE" "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all install_into_dest "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all install_into_dest "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 
   mcp-servers)
     component_set_artifact_roots "mcp-servers"
     if [ -n "$NAME" ]; then
-      component_install_named register_json_entry "$NAME" "$TYPE" "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named register_json_entry "$NAME" "$TYPE" "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all register_json_entry "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all register_json_entry "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 

--- a/scripts/manage-claude-component.sh
+++ b/scripts/manage-claude-component.sh
@@ -101,10 +101,10 @@ register_mcp_server() {
     args+=("$arg")
   done < <(jq -r '.args // [] | .[]' "$json_file")
 
-  if claude mcp add --scope user "$entry_name" -- "$cmd" "${args[@]}" >/dev/null 2>&1; then
+  if claude mcp add --scope user "$entry_name" -- "$cmd" ${args[@]+"${args[@]}"} >/dev/null 2>&1; then
     echo "  ${entry_name}: registered (scope=user)"
   else
-    echo "  ${entry_name}: FAILED — re-run manually: claude mcp add --scope user $entry_name -- $cmd ${args[*]}"
+    echo "  ${entry_name}: FAILED — re-run manually: claude mcp add --scope user $entry_name -- $cmd ${args[*]:-}"
     return 1
   fi
 }
@@ -138,9 +138,9 @@ case "$TYPE" in
     mkdir -p "$DEST"
     component_set_staging_roots ".claude/skills"
     if [ -n "$NAME" ]; then
-      component_install_named install_into_dest "$NAME" "$TYPE" claude "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named install_into_dest "$NAME" "$TYPE" claude ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all install_into_dest claude "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all install_into_dest claude ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 
@@ -151,18 +151,18 @@ case "$TYPE" in
     mkdir -p "$DEST"
     component_set_artifact_roots "policies"
     if [ -n "$NAME" ]; then
-      component_install_named install_into_dest "$NAME" "$TYPE" "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named install_into_dest "$NAME" "$TYPE" "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all install_into_dest "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all install_into_dest "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 
   mcp-servers)
     component_set_artifact_roots "mcp-servers"
     if [ -n "$NAME" ]; then
-      component_install_named register_json_entry "$NAME" "$TYPE" "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named register_json_entry "$NAME" "$TYPE" "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all register_json_entry "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all register_json_entry "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 

--- a/scripts/manage-copilot-component.sh
+++ b/scripts/manage-copilot-component.sh
@@ -121,9 +121,9 @@ case "$TYPE" in
     mkdir -p "$DEST"
     component_set_staging_roots ".github/skills"
     if [ -n "$NAME" ]; then
-      component_install_named install_into_dest "$NAME" "$TYPE" copilot "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named install_into_dest "$NAME" "$TYPE" copilot ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all install_into_dest copilot "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all install_into_dest copilot ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 
@@ -146,9 +146,9 @@ case "$TYPE" in
   mcp-servers)
     component_set_artifact_roots "mcp-servers"
     if [ -n "$NAME" ]; then
-      component_install_named register_json_entry "$NAME" "$TYPE" "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named register_json_entry "$NAME" "$TYPE" "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all register_json_entry "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all register_json_entry "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 

--- a/scripts/manage-workspace-component.sh
+++ b/scripts/manage-workspace-component.sh
@@ -135,9 +135,9 @@ case "$TYPE" in
     esac
 
     if [ -n "$NAME" ]; then
-      component_install_named install_into_dest "$NAME" "$TYPE" "$REFRESH_CLI" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named install_into_dest "$NAME" "$TYPE" "$REFRESH_CLI" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all install_into_dest "$REFRESH_CLI" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all install_into_dest "$REFRESH_CLI" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 
@@ -147,9 +147,9 @@ case "$TYPE" in
 
     component_set_artifact_roots "$TYPE"
     if [ -n "$NAME" ]; then
-      component_install_named merge_json_entry "$NAME" "$TYPE" "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_named merge_json_entry "$NAME" "$TYPE" "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     else
-      component_install_all merge_json_entry "" "${COMPONENT_ROOTS[@]}" || exit $?
+      component_install_all merge_json_entry "" ${COMPONENT_ROOTS[@]+"${COMPONENT_ROOTS[@]}"} || exit $?
     fi
     ;;
 

--- a/scripts/package-extensions.sh
+++ b/scripts/package-extensions.sh
@@ -10,7 +10,7 @@ if [ "$1" = "--include-org" ] || [ -n "${INCLUDE_ORG:-}" ]; then
   tiers+=(org)
 fi
 
-for tier in "${tiers[@]}"; do
+for tier in ${tiers[@]+"${tiers[@]}"}; do
   for dir in "$REPO_DIR"/extensions/"$tier"/*/; do
     if [ -d "$dir" ]; then
       EXT="$(basename "$dir")" bash "$REPO_DIR/scripts/package-extension.sh"

--- a/scripts/probe-antigravity-discovery.sh
+++ b/scripts/probe-antigravity-discovery.sh
@@ -316,24 +316,24 @@ echo ""
 # Refuse to start if any sentinel name is already on disk: the probe must never
 # remove something it did not write.
 collisions=()
-for record in "${SENTINELS[@]}"; do
+for record in ${SENTINELS[@]+"${SENTINELS[@]}"}; do
   rel="$(sentinel_field "$record" 3)"
   if [ -e "$HOME/$rel" ]; then collisions+=("$HOME/$rel"); fi
 done
-for rel in "${DUP_PATHS[@]}"; do
+for rel in ${DUP_PATHS[@]+"${DUP_PATHS[@]}"}; do
   if [ -e "$HOME/$rel" ]; then collisions+=("$HOME/$rel"); fi
 done
 if [ ${#collisions[@]} -gt 0 ]; then
   echo "ERROR: sentinel paths already exist — refusing to run, and refusing to" >&2
   echo "       remove anything this probe did not write:" >&2
-  for c in "${collisions[@]}"; do echo "  - $c" >&2; done
+  for c in ${collisions[@]+"${collisions[@]}"}; do echo "  - $c" >&2; done
   exit "$EXIT_PRECONDITION"
 fi
 
 trap cleanup EXIT
 
 echo "Installing sentinels..."
-for record in "${SENTINELS[@]}"; do
+for record in ${SENTINELS[@]+"${SENTINELS[@]}"}; do
   kind="$(sentinel_field "$record" 1)"
   name="$(sentinel_field "$record" 2)"
   rel="$(sentinel_field "$record" 3)"
@@ -346,7 +346,7 @@ for record in "${SENTINELS[@]}"; do
   CREATED_PATHS+=("$HOME/$rel")
   echo "  $name  ($label)"
 done
-for rel in "${DUP_PATHS[@]}"; do
+for rel in ${DUP_PATHS[@]+"${DUP_PATHS[@]}"}; do
   write_agent_sentinel "$HOME/$rel" "$DUP_NAME" "$rel"
   CREATED_PATHS+=("$HOME/$rel")
   echo "  $DUP_NAME  (duplicate-name cell -> $rel)"
@@ -359,7 +359,7 @@ ASK_STATUS_FILE="$WORK/status"
 
 skill_names=""
 agent_names=""
-for record in "${SENTINELS[@]}"; do
+for record in ${SENTINELS[@]+"${SENTINELS[@]}"}; do
   kind="$(sentinel_field "$record" 1)"
   name="$(sentinel_field "$record" 2)"
   if [ "$kind" = "skill" ]; then
@@ -424,7 +424,7 @@ echo "=========================================================="
 echo "  Verdicts (R14: FOUND / NOT-FOUND / INDETERMINATE)"
 echo "=========================================================="
 indeterminate=0
-for record in "${SENTINELS[@]}"; do
+for record in ${SENTINELS[@]+"${SENTINELS[@]}"}; do
   kind="$(sentinel_field "$record" 1)"
   name="$(sentinel_field "$record" 2)"
   label="$(sentinel_field "$record" 4)"

--- a/scripts/setup-antigravity-interactive.sh
+++ b/scripts/setup-antigravity-interactive.sh
@@ -82,7 +82,7 @@ check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-persona
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
   echo "Cannot proceed — required identity files are missing:"
-  for item in "${MISSING_PREREQS[@]}"; do
+  for item in ${MISSING_PREREQS[@]+"${MISSING_PREREQS[@]}"}; do
     echo "  - $item"
   done
   echo ""

--- a/scripts/setup-claude-interactive.sh
+++ b/scripts/setup-claude-interactive.sh
@@ -81,7 +81,7 @@ check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-persona
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
   echo "Cannot proceed — required identity files are missing:"
-  for item in "${MISSING_PREREQS[@]}"; do
+  for item in ${MISSING_PREREQS[@]+"${MISSING_PREREQS[@]}"}; do
     echo "  - $item"
   done
   echo ""

--- a/scripts/setup-copilot-interactive.sh
+++ b/scripts/setup-copilot-interactive.sh
@@ -74,7 +74,7 @@ check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-persona
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
   echo "Cannot proceed — required identity files are missing:"
-  for item in "${MISSING_PREREQS[@]}"; do
+  for item in ${MISSING_PREREQS[@]+"${MISSING_PREREQS[@]}"}; do
     echo "  - $item"
   done
   echo ""

--- a/scripts/setup-gemini-interactive.sh
+++ b/scripts/setup-gemini-interactive.sh
@@ -74,7 +74,7 @@ check_finalized "$REPO_DIR/config/PROFILE.md" "config/PROFILE.md" "/init-persona
 
 if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
   echo "Cannot proceed — required identity files are missing:"
-  for item in "${MISSING_PREREQS[@]}"; do
+  for item in ${MISSING_PREREQS[@]+"${MISSING_PREREQS[@]}"}; do
     echo "  - $item"
   done
   echo ""

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -455,7 +455,7 @@ done
 
 if [ ${#DIRTY[@]} -gt 0 ]; then
   echo "Error: the following core-layer paths have local modifications:" >&2
-  for p in "${DIRTY[@]}"; do
+  for p in ${DIRTY[@]+"${DIRTY[@]}"}; do
     echo "  $p" >&2
   done
   echo "Revert these changes before running sync, or promote them to overlay overrides." >&2
@@ -511,7 +511,7 @@ for i in "${!PATHS[@]}"; do
         while IFS= read -r -d '' item; do
           spec+=("$item")
         done < <(pathspec_for "$path")
-        git restore --source=FETCH_HEAD --worktree -- "${spec[@]}"
+        git restore --source=FETCH_HEAD --worktree -- ${spec[@]+"${spec[@]}"}
       fi
       ;;
     adopt-on-edit)
@@ -561,7 +561,7 @@ for i in "${!PATHS[@]}"; do
         while IFS= read -r -d '' item; do
           spec+=("$item")
         done < <(pathspec_for "$path")
-        git restore --source=FETCH_HEAD --worktree -- "${spec[@]}"
+        git restore --source=FETCH_HEAD --worktree -- ${spec[@]+"${spec[@]}"}
         # Refresh the marker to the now-current upstream blob so subsequent
         # syncs short-circuit on Tier 1.
         new_sha="$(blob_sha "$path")"
@@ -617,7 +617,7 @@ if [ "$PRESERVE_HISTORY" = true ]; then
 
   if [ ${#UNGOVERNED[@]} -gt 0 ]; then
     echo "Error: --preserve-history refuses to commit — uncommitted change(s) outside the governed paths:" >&2
-    for p in "${UNGOVERNED[@]}"; do
+    for p in ${UNGOVERNED[@]+"${UNGOVERNED[@]}"}; do
       echo "  $p" >&2
     done
     echo "Commit, stash, or revert these changes (outside .crewrig/core-paths.txt and .crewrig/.synced-markers/), or omit --preserve-history." >&2

--- a/scripts/tests/fixtures/detector-probes.tsv
+++ b/scripts/tests/fixtures/detector-probes.tsv
@@ -1,0 +1,13 @@
+safe	a complete canonical guard is safe	for p in ${D[@]+"${D[@]}"}; do
+safe	two canonical guards on one line	for p in ${D[@]+"${D[@]}"} ${C[@]+"${C[@]}"}; do
+bare	bare expansion alone	printf "%s" "${D[@]}"
+bare	bare behind a guard on another name	for p in "${D[@]}" ${C[@]+"${C[@]}"}; do
+safe	a default-valued guard is safe	s="${D[*]:-}"
+safe	a default with a literal is safe	s="${D[*]:-(none)}"
+bare	bare masked by :- on ANOTHER name	s="${C[*]:-} ${D[@]}"
+bare	bare masked by :- on the SAME name	s="${D[*]:-} ${D[@]}"
+bare	bare masked by :- on SAME name AND subscript	s="${D[@]:-} ${D[@]}"
+bare	prefix names do not bleed	s="${D[*]:-}" t="${DE[@]}"
+safe	length form is safe	if [ ${#D[@]} -eq 0 ]; then
+safe	slice form is safe	echo "${D[@]:1}"
+safe	key form is safe	echo "${!D[@]}"

--- a/scripts/tests/fixtures/strip-comments.tsv
+++ b/scripts/tests/fixtures/strip-comments.tsv
@@ -1,0 +1,8 @@
+echo hi	echo full-line trailing comment	echo hi # note
+	empty	# whole line is a comment
+echo 'a # b'	# inside single quotes is literal	echo 'a # b'
+echo "a # b"	# inside double quotes is literal	echo "a # b"
+nohash#x	# mid-word is not a comment	nohash#x
+echo "say \"hi\""	escaped quote does not toggle; later # is a comment	echo "say \"hi\"" # note
+s="${D[@]}"	guard preserved before a comment	s="${D[@]}" # note
+echo hi	comment after trailing space	echo hi   # note

--- a/scripts/tests/test-antigravity-component-install.sh
+++ b/scripts/tests/test-antigravity-component-install.sh
@@ -566,9 +566,7 @@ grep -q 'DEST="\$AGY_CUSTOMIZATION_ROOT/skills"' "$MANAGE" \
 grep -qF 'PLACED_NAMES+=("$item_name")' "$MANAGE" \
   && ok "manage: place_component feeds the name it just placed into PLACED_NAMES" \
   || bad "manage: PLACED_NAMES is never fed — the per-component cleanup is a no-op branch"
-grep -qF '"$ANTIGRAVITY_HOME" "$REPO_DIR/artifacts" skills "${PLACED_NAMES[@]}"' "$MANAGE" \
-  && ok "manage: the narrow migration is called with the superseded root, the artifacts root, the kind, and the names" \
-  || bad "manage: the per-component migration call-site arguments are wrong or emptied"
+grep -qF '"$ANTIGRAVITY_HOME" "$REPO_DIR/artifacts" skills ${PLACED_NAMES[@]+"${PLACED_NAMES[@]}"}' "$MANAGE" && ok "manage: the narrow migration is called with the superseded root, the artifacts root, the kind, and the names" || bad "manage: the per-component migration call-site arguments are wrong or emptied" # acknowledged-exception: literal grep pattern (mention, not a use)
 
 # The two kinds spec 0123 explicitly EXCLUDES must not have moved. A one-line
 # edit to ANTIGRAVITY_HOME would have relocated both silently.

--- a/scripts/tests/test-assembly-verification.sh
+++ b/scripts/tests/test-assembly-verification.sh
@@ -93,7 +93,7 @@ fi
 
 if [ "${#FAILURES[@]}" -gt 0 ]; then
   echo "FAILED: assembly verification — missing components:"
-  for f in "${FAILURES[@]}"; do
+  for f in ${FAILURES[@]+"${FAILURES[@]}"}; do
     echo "  $f"
   done
   exit 1

--- a/scripts/tests/test-check-bash32-portability.sh
+++ b/scripts/tests/test-check-bash32-portability.sh
@@ -44,6 +44,14 @@
 #      malformed row follows two valid ones, plus the converse on a well-formed
 #      set (spec 0120 R5). Each refusal is asserted on exit status, stderr AND
 #      empty stdout, the last being the scenario's "it reports no construct".
+#   l. The comment stripper is probed on 8 fixtures covering quote state, so a
+#      regression in comment handling fails here rather than widening or
+#      narrowing the phase-2 scan's view of a line (spec 0124 R6).
+#
+# Cases h, i, and l all pull their fixture rows from .tsv files under
+# scripts/tests/fixtures/. Those files live outside the phase-2 scan's tree,
+# so they can hold example unguarded expansions without the enforcement
+# flagging them.
 #
 # Scenario 5 — a corrected suite reports the same verdicts on both shells — is
 # only partly scriptable here: comparing two shells needs two Bash binaries, and
@@ -74,6 +82,12 @@ SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-bash32-portability.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DECLARED_SET="$REPO_ROOT/ci/bash32-forbidden.txt"
 CONVENTIONS_DOC="$REPO_ROOT/docs/scripting-conventions.md"
+
+# The detector and the comment stripper live in the shared lib, used by both
+# this suite and the enforcement's phase-2 scan. Source it here so a single
+# definition serves both consumers.
+# shellcheck source=../lib/bash32-array-guard.sh
+. "$SCRIPT_DIR/lib/bash32-array-guard.sh"
 
 TAB="$(printf '\t')"
 
@@ -134,59 +148,11 @@ run_check() {
 ok() { echo "PASS  $1"; pass=$((pass + 1)); }
 bad() { echo "FAIL  $1"; fail=$((fail + 1)); }
 
-# bare_expansions_in <line> — echo the `name[subscript]` of every array expansion
-# on the line that would abort under `set -u` when the array is empty, or nothing
-# when the line is safe. Used by case h against the corrected suites, and probed
-# directly by case i.
-#
-# It works by CONSUMPTION, not by tallying, and that distinction is the whole
-# history of this function. Three successive tally designs each left a hole:
-#
-#   1. Per line, guarded-vs-bare counts: a guard anywhere on the line hid a bare
-#      expansion elsewhere on it.
-#   2. Per line with comment lines dropped: fixed a false positive, not the tally.
-#   3. Per array name: narrowed *who* could spend the slack without removing it.
-#
-# The slack is a property of the guard SPELLING. `${A[@]+"${A[@]}"}` contains one
-# closed `${A[@]}` and is worth one; `${A[*]:-}` contains no closed form and is
-# worth zero — so on `"${A[*]:-} ${A[@]}"` any tally balances while `A` is bare.
-# That shape reproduces the very false green this ticket exists to remove:
-# `A=(); s="${A[*]:-}"; out=$(printf '%s' "${A[@]}")` prints
-# `A[@]: unbound variable` to stderr and still exits 0.
-#
-# So: count the closed forms `${name[@]}` / `${name[*]}`, then subtract only the
-# ones a complete canonical guard `${name[@]+"${name[@]}"}` accounts for. Anything
-# left is genuinely bare. `${name[*]:-…}` contributes no closed form, so it needs
-# no special case. Matching is done with `grep -oF` on literals built per name, so
-# there is no regex to escape and no BSD-versus-GNU divergence to reason about.
-#
-# Deliberately not matched, all verified safe on an empty array under `set -u` on
-# 3.2.57: `${#name[@]}` (length), `${name[@]:1}` (slice), `${!name[@]}` (keys).
-bare_expansions_in() {
-  _bx_line="$1"
-  _bx_out=''
-  # Array names on the line, deduplicated. `tr -d` rather than a sed capture:
-  # BSD sed reads `\{` as an interval and errors "braces not balanced".
-  _bx_names=$(printf '%s\n' "$_bx_line" \
-    | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[' | tr -d '${[' | sort -u)
-  for _bx_nm in $_bx_names; do
-    for _bx_sub in '@' '*'; do
-      # Braced interpolation (`${var}[`) rather than `$var[`: the latter is a
-      # literal string being built for `grep -oF`, but shellcheck reads it as an
-      # array expansion and raises SC1087 at error level.
-      _bx_closed=$(printf '%s\n' "$_bx_line" \
-        | grep -oF "\${${_bx_nm}[${_bx_sub}]}" | wc -l | tr -d ' ')
-      _bx_wrapped=$(printf '%s\n' "$_bx_line" \
-        | grep -oF "\${${_bx_nm}[${_bx_sub}]+\"\${${_bx_nm}[${_bx_sub}]}\"}" \
-        | wc -l | tr -d ' ')
-      if [ "$_bx_closed" -gt "$_bx_wrapped" ]; then
-        _bx_out="${_bx_out}${_bx_nm}[${_bx_sub}] "
-      fi
-    done
-  done
-  # Trailing space trimmed without a bashism, so the caller can test -n cleanly.
-  printf '%s' "$_bx_out" | sed -e 's/[[:space:]]*$//'
-}
+# bare_expansions_in and strip_comments are provided by the shared lib
+# (scripts/lib/bash32-array-guard.sh), sourced at the top of this file. The
+# detector is defined in exactly one place — the lib — because it is now used
+# by BOTH the enforcement scan (phase 2 of check-bash32-portability.sh) and
+# this suite. Its design history is recorded at its definition site.
 
 # ---------------------------------------------------------------------------
 # Case a — A reintroduced forbidden construct is rejected, by file and line.
@@ -675,47 +641,35 @@ $unguarded"
 # ---------------------------------------------------------------------------
 {
   # Each row: <expect> <TAB> <description> <TAB> <line>. `expect` is `bare` when
-  # the detector must report something, `safe` when it must report nothing.
-  # Written with printf, never a heredoc, for the reason recorded in the header.
-  i_rows=$(printf '%s\n' \
-    'safe	a complete canonical guard is safe	for p in ${D[@]+"${D[@]}"}; do' \
-    'safe	two canonical guards on one line	for p in ${D[@]+"${D[@]}"} ${C[@]+"${C[@]}"}; do' \
-    'bare	bare expansion alone	printf "%s" "${D[@]}"' \
-    'bare	bare behind a guard on another name	for p in "${D[@]}" ${C[@]+"${C[@]}"}; do' \
-    'safe	a default-valued guard is safe	s="${D[*]:-}"' \
-    'safe	a default with a literal is safe	s="${D[*]:-(none)}"' \
-    'bare	bare masked by :- on ANOTHER name	s="${C[*]:-} ${D[@]}"' \
-    'bare	bare masked by :- on the SAME name	s="${D[*]:-} ${D[@]}"' \
-    'bare	bare masked by :- on SAME name AND subscript	s="${D[@]:-} ${D[@]}"' \
-    'bare	prefix names do not bleed	s="${D[*]:-}" t="${DE[@]}"' \
-    'safe	length form is safe	if [ ${#D[@]} -eq 0 ]; then' \
-    'safe	slice form is safe	echo "${D[@]:1}"' \
-    'safe	key form is safe	echo "${!D[@]}"')
+  # the detector must report something, `safe` when it must report nothing. The
+  # rows live in the fixture .tsv (see the header), outside the phase-2 scan tree.
+  fixture="$SCRIPT_DIR/tests/fixtures/detector-probes.tsv"
+  if [ ! -f "$fixture" ]; then
+    bad "case-i: fixture missing — $fixture"
+  else
+    i_fail=0
+    i_total=0
+    while IFS= read -r row || [ -n "$row" ]; do
+      [ -n "$row" ] || continue
+      expect=$(printf '%s' "$row" | cut -f1)
+      what=$(printf '%s' "$row" | cut -f2)
+      line=$(printf '%s' "$row" | cut -f3-)
+      got="$(bare_expansions_in "$line")"
+      i_total=$((i_total + 1))
+      if [ "$expect" = bare ] && [ -z "$got" ]; then
+        bad "case-i: detector missed a bare expansion — $what: $line"
+        i_fail=$((i_fail + 1))
+      elif [ "$expect" = safe ] && [ -n "$got" ]; then
+        bad "case-i: detector flagged a safe line [$got] — $what: $line"
+        i_fail=$((i_fail + 1))
+      fi
+    done < "$fixture"
 
-  i_fail=0
-  i_total=0
-  while IFS= read -r row || [ -n "$row" ]; do
-    [ -n "$row" ] || continue
-    expect=$(printf '%s' "$row" | cut -f1)
-    what=$(printf '%s' "$row" | cut -f2)
-    line=$(printf '%s' "$row" | cut -f3-)
-    got="$(bare_expansions_in "$line")"
-    i_total=$((i_total + 1))
-    if [ "$expect" = bare ] && [ -z "$got" ]; then
-      bad "case-i: detector missed a bare expansion — $what: $line"
-      i_fail=$((i_fail + 1))
-    elif [ "$expect" = safe ] && [ -n "$got" ]; then
-      bad "case-i: detector flagged a safe line [$got] — $what: $line"
-      i_fail=$((i_fail + 1))
+    if [ "$i_total" -ne 13 ]; then
+      bad "case-i: expected 13 detector probes, ran $i_total"
+    elif [ "$i_fail" -eq 0 ]; then
+      ok "case-i: the bare-expansion detector is correct on all 13 probes, both directions"
     fi
-  done <<DETECTOR_PROBE
-$i_rows
-DETECTOR_PROBE
-
-  if [ "$i_total" -ne 13 ]; then
-    bad "case-i: expected 13 detector probes, ran $i_total"
-  elif [ "$i_fail" -eq 0 ]; then
-    ok "case-i: the bare-expansion detector is correct on all 13 probes, both directions"
   fi
 }
 
@@ -881,6 +835,46 @@ DETECTOR_PROBE
     ok "case-k: a well-formed declared set is accepted by both requests (R5)"
   else
     bad "case-k: well-formed set gave verdict exit $k_verdict_exit, query exit $CHECK_EXIT, $k_ill ill-shaped of $k_rows row(s)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case l — The comment stripper is probed on quote-state fixtures (spec 0124 R6).
+#
+# The phase-2 scan strips comments before it runs the detector, so a wrong call
+# on where a comment starts — an unquoted `#` inside quotes, an escaped quote,
+# a mid-word `#` — shifts the view of a line and can either hide a bare
+# expansion or manufacture one. Case l pins that boundary down.
+# ---------------------------------------------------------------------------
+{
+  fixture="$SCRIPT_DIR/tests/fixtures/strip-comments.tsv"
+  if [ ! -f "$fixture" ]; then
+    bad "case-l: fixture missing — $fixture"
+  else
+    l_fail=0
+    l_total=0
+    while IFS= read -r row || [ -n "$row" ]; do
+      [ -n "$row" ] || continue
+      expected=$(printf '%s' "$row" | cut -f1)
+      what=$(printf '%s' "$row" | cut -f2)
+      input=$(printf '%s' "$row" | cut -f3-)
+      got="$(strip_comments "$input")"
+      # The stripper is pure substring arithmetic and keeps the whitespace that
+      # preceded the `#`. That whitespace is irrelevant to the detector's grep,
+      # so drop it here to keep the fixture expectations readable.
+      got="$(printf '%s' "$got" | sed 's/[[:space:]]*$//')"
+      l_total=$((l_total + 1))
+      if [ "$got" != "$expected" ]; then
+        bad "case-l: strip_comments mismatch — $what: got [$got], want [$expected]"
+        l_fail=$((l_fail + 1))
+      fi
+    done < "$fixture"
+
+    if [ "$l_total" -ne 8 ]; then
+      bad "case-l: expected 8 strip-comments probes, ran $l_total"
+    elif [ "$l_fail" -eq 0 ]; then
+      ok "case-l: the comment stripper is correct on all 8 quote-state probes"
+    fi
   fi
 }
 

--- a/scripts/tests/test-check-gemini-overlay-enrollment.sh
+++ b/scripts/tests/test-check-gemini-overlay-enrollment.sh
@@ -159,7 +159,7 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   make_setup_script "$repo"
-  make_settings "$repo" "${MAIN_ENROLLED[@]}"
+  make_settings "$repo" ${MAIN_ENROLLED[@]+"${MAIN_ENROLLED[@]}"}
 
   run_check "$repo"
 
@@ -266,7 +266,7 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   make_setup_script "$repo"
-  make_settings "$repo" "${MAIN_ENROLLED[@]}"
+  make_settings "$repo" ${MAIN_ENROLLED[@]+"${MAIN_ENROLLED[@]}"}
 
   run_check "$repo"
 
@@ -288,7 +288,7 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   make_setup_script "$repo"
-  make_settings "$repo" "${MAIN_ENROLLED[@]}" 99_GHOST.md
+  make_settings "$repo" ${MAIN_ENROLLED[@]+"${MAIN_ENROLLED[@]}"} 99_GHOST.md
 
   run_check "$repo"
 
@@ -320,7 +320,7 @@ run_check() {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   make_setup_script "$repo"
   append_deploy_token "$repo" "67_NewTool.md"
-  make_settings "$repo" "${MAIN_ENROLLED[@]}"   # 9 + AGENTS.md, NOT 67_NewTool.md
+  make_settings "$repo" ${MAIN_ENROLLED[@]+"${MAIN_ENROLLED[@]}"}   # 9 + AGENTS.md, NOT 67_NewTool.md
 
   run_check "$repo"
 
@@ -370,7 +370,7 @@ run_check() {
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   make_setup_script_no_tokens "$repo"
-  make_settings "$repo" "${MAIN_ENROLLED[@]}"
+  make_settings "$repo" ${MAIN_ENROLLED[@]+"${MAIN_ENROLLED[@]}"}
 
   run_check "$repo"
 

--- a/scripts/tests/test-e2e-auth-common.sh
+++ b/scripts/tests/test-e2e-auth-common.sh
@@ -46,7 +46,7 @@ rm -f /tmp/auth-common-source.err
 # --- 3. Declared helpers exist as functions ----------------------------------
 HELPERS=(e2e_die e2e_skip e2e_info e2e_require_docker e2e_require_image \
          e2e_e2e_home e2e_cli_dir e2e_chown_bootstrap)
-for fn in "${HELPERS[@]}"; do
+for fn in ${HELPERS[@]+"${HELPERS[@]}"}; do
   if bash -c "set -euo pipefail; source '$LIB'; declare -F '$fn' >/dev/null"; then
     note_pass "helper '$fn' — declared as function"
   else

--- a/scripts/tests/test-e2e-auth-scripts.sh
+++ b/scripts/tests/test-e2e-auth-scripts.sh
@@ -32,7 +32,7 @@ SCRIPTS_DIR="${REPO_DIR}/scripts/e2e"
 # ---------------------------------------------------------------------------
 SCRIPTS=(auth-claude.sh auth-gemini.sh auth-copilot.sh)
 
-for s in "${SCRIPTS[@]}"; do
+for s in ${SCRIPTS[@]+"${SCRIPTS[@]}"}; do
   path="${SCRIPTS_DIR}/$s"
 
   if [[ -f "$path" ]]; then
@@ -80,7 +80,7 @@ done
 # ---------------------------------------------------------------------------
 INTERACTIVE=(claude gemini)
 
-for cli in "${INTERACTIVE[@]}"; do
+for cli in ${INTERACTIVE[@]+"${INTERACTIVE[@]}"}; do
   s="auth-${cli}.sh"
   path="${SCRIPTS_DIR}/$s"
 

--- a/scripts/tests/test-e2e-docker-images.sh
+++ b/scripts/tests/test-e2e-docker-images.sh
@@ -55,7 +55,7 @@ IMAGES=(
   "crewrig/e2e-mempalace:latest|mempalace"
 )
 
-for entry in "${IMAGES[@]}"; do
+for entry in ${IMAGES[@]+"${IMAGES[@]}"}; do
   img="${entry%%|*}"
   cli="${entry##*|}"
   short="${img#crewrig/e2e-}"

--- a/scripts/tests/test-e2e-readme.sh
+++ b/scripts/tests/test-e2e-readme.sh
@@ -75,7 +75,7 @@ for ref in '#75' '#78' '#80' '#81'; do
   fi
 done
 if [[ "${#found_refs[@]}" -ge 1 ]]; then
-  note_pass "tests/e2e/README.md — cross-references epic/child issues (${found_refs[*]})"
+  note_pass "tests/e2e/README.md — cross-references epic/child issues (${found_refs[*]:-})"
 else
   note_fail "tests/e2e/README.md — issue cross-references" \
             "none of #75/#78/#80/#81 found"

--- a/scripts/tests/test-e2e-scenarios-parity.sh
+++ b/scripts/tests/test-e2e-scenarios-parity.sh
@@ -43,7 +43,7 @@ if [[ ! -f "$MATRIX" || ! -f "$DEFAULTS_TOML" ]]; then
 fi
 
 # --- 1. Each scenario key is mentioned in cli-matrix.md ---------------------
-for s in "${SCENARIOS[@]}"; do
+for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
   if grep -Fq "$s" "$MATRIX"; then
     note_pass "cli-matrix.md — mentions scenario key '$s'"
   else
@@ -74,7 +74,7 @@ fi
 # Strategy: for each scenario, find the `[scenarios.<name>]` header line,
 # then scan the next 10 lines for an `applies_to` assignment. This survives
 # blank lines and comments inside the table.
-for s in "${SCENARIOS[@]}"; do
+for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
   hdr_line="$(grep -n -E "^\[scenarios\.${s}\]" "$DEFAULTS_TOML" | head -1 | cut -d: -f1)"
   if [[ -z "$hdr_line" ]]; then
     note_fail "defaults.toml — applies_to for '$s'" \

--- a/scripts/tests/test-e2e-scenarios-structure.sh
+++ b/scripts/tests/test-e2e-scenarios-structure.sh
@@ -33,7 +33,7 @@ README="${SCEN_DIR}/README.md"
 SCENARIOS=(01-layered-context 02-cross-tool-memory 03-skill-build 04-harness-loop)
 
 # --- 1. Each scenario dir + run.sh present and executable --------------------
-for s in "${SCENARIOS[@]}"; do
+for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
   d="${SCEN_DIR}/${s}"
   r="${d}/run.sh"
   if [[ ! -d "$d" ]]; then
@@ -48,7 +48,7 @@ for s in "${SCENARIOS[@]}"; do
 done
 
 # --- 2. Each run.sh passes `bash -n` syntax check ----------------------------
-for s in "${SCENARIOS[@]}"; do
+for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
   r="${SCEN_DIR}/${s}/run.sh"
   [[ -f "$r" ]] || continue
   err="$(bash -n "$r" 2>&1)"
@@ -61,7 +61,7 @@ done
 
 # --- 3. Each run.sh sources a helper from $E2E_LIB_DIR -----------------------
 # Accept any of: assert.sh, structural.sh, llm_judge.sh (the v1 lib set).
-for s in "${SCENARIOS[@]}"; do
+for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
   r="${SCEN_DIR}/${s}/run.sh"
   [[ -f "$r" ]] || continue
   if grep -Eq 'source[[:space:]]+"\$\{?E2E_LIB_DIR\}?/' "$r" \
@@ -84,7 +84,7 @@ fi
 if [[ ! -f "$DEFAULTS_TOML" ]]; then
   note_fail "defaults.toml — present" "missing at $DEFAULTS_TOML"
 else
-  for s in "${SCENARIOS[@]}"; do
+  for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
     if grep -Eq "^\[scenarios\.${s}\]" "$DEFAULTS_TOML"; then
       note_pass "defaults.toml — [scenarios.${s}] table present"
     else

--- a/scripts/tests/test-e2e-taskfile.sh
+++ b/scripts/tests/test-e2e-taskfile.sh
@@ -42,7 +42,7 @@ ENTRIES=(
   "e2e:lock"
 )
 
-for entry in "${ENTRIES[@]}"; do
+for entry in ${ENTRIES[@]+"${ENTRIES[@]}"}; do
   if grep -qE "^  ${entry}:\s*$" "$TASKFILE"; then
     note_pass "entry declared: $entry"
   else
@@ -80,7 +80,7 @@ fi
 # ---------------------------------------------------------------------------
 if command -v task >/dev/null 2>&1; then
   if list_out="$( ( cd "$REPO_ROOT" && task --list 2>&1 ) )"; then
-    for entry in "${ENTRIES[@]}"; do
+    for entry in ${ENTRIES[@]+"${ENTRIES[@]}"}; do
       if printf '%s\n' "$list_out" | grep -qE "(^|\s)\* ${entry}:" \
          || printf '%s\n' "$list_out" | grep -qE "(^|\s)${entry}:"; then
         note_pass "task --list shows: $entry"

--- a/scripts/tests/test-e2e-versions-lock.sh
+++ b/scripts/tests/test-e2e-versions-lock.sh
@@ -64,7 +64,7 @@ REQUIRED_KEYS=(
   "mempalace.cli"
 )
 
-for key in "${REQUIRED_KEYS[@]}"; do
+for key in ${REQUIRED_KEYS[@]+"${REQUIRED_KEYS[@]}"}; do
   if grep -qE "^${key}=" "$LOCK_ABS"; then
     note_pass "key present: $key"
   else

--- a/scripts/tests/test-mempalace-version-range.sh
+++ b/scripts/tests/test-mempalace-version-range.sh
@@ -70,7 +70,7 @@ scan_repo() {
     [ -z "$hit" ] && continue
     echo "  STALE RANGE: $hit" >&2
     violations=$((violations + 1))
-  done < <(git -C "$repo" grep -nE "$OLD_LIT_RE" -- . "${EXCLUDES[@]}" 2>/dev/null || true)
+  done < <(git -C "$repo" grep -nE "$OLD_LIT_RE" -- . ${EXCLUDES[@]+"${EXCLUDES[@]}"} 2>/dev/null || true)
 
   # --- Check (b): every literal numeric mempalace range must equal the pin ---
   while IFS= read -r hit; do
@@ -86,7 +86,7 @@ scan_repo() {
         violations=$((violations + 1))
       fi
     done < <(printf '%s\n' "$content" | grep -oE 'mempalace>=[0-9][0-9.,<]*')
-  done < <(git -C "$repo" grep -nE 'mempalace>=[0-9]' -- . "${EXCLUDES[@]}" 2>/dev/null || true)
+  done < <(git -C "$repo" grep -nE 'mempalace>=[0-9]' -- . ${EXCLUDES[@]+"${EXCLUDES[@]}"} 2>/dev/null || true)
 
   [ "$violations" -eq 0 ]
 }

--- a/scripts/tests/test-setup-catalogue-picker.sh
+++ b/scripts/tests/test-setup-catalogue-picker.sh
@@ -165,7 +165,7 @@ extract_selection_block() {
   ' "$script"
 }
 
-for s in "${SETUP_SCRIPTS[@]}"; do
+for s in ${SETUP_SCRIPTS[@]+"${SETUP_SCRIPTS[@]}"}; do
   path="$SETUP_DIR/$s"
   if [ ! -f "$path" ]; then
     bad "$s: script not found at $path"

--- a/scripts/tests/test-system-context-store.sh
+++ b/scripts/tests/test-system-context-store.sh
@@ -59,7 +59,7 @@ if [ "${#store_files[@]}" -eq 0 ]; then
 else
   ok "${#store_files[@]} store file(s) present"
 fi
-for sf in "${store_files[@]}"; do
+for sf in ${store_files[@]+"${store_files[@]}"}; do
   if [ -s "$sf" ]; then ok "non-empty: ${sf##*/}"; else bad "empty store file: ${sf##*/}"; fi
 done
 
@@ -74,7 +74,7 @@ else
 fi
 
 # Every store file is referenced by a stub (no orphan)
-for sf in "${store_files[@]}"; do
+for sf in ${store_files[@]+"${store_files[@]}"}; do
   base="${sf##*/}"
   if grep -qF "system-context/$base" "$TOOLS_FILE"; then ok "referenced: $base"; else bad "orphan store file (no stub): $base"; fi
 done
@@ -134,7 +134,7 @@ GAP_SCRIPTS=(setup-gemini-interactive.sh setup-copilot-interactive.sh)
 PASS_SCRIPTS=(setup-claude-interactive.sh setup-antigravity-interactive.sh)
 
 # (a) the two gap CLIs call the guidance helper
-for s in "${GAP_SCRIPTS[@]}"; do
+for s in ${GAP_SCRIPTS[@]+"${GAP_SCRIPTS[@]}"}; do
   if grep -q "print_store_access_guidance" "$SETUP_DIR/$s"; then
     ok "gap CLI calls print_store_access_guidance: $s"
   else
@@ -143,7 +143,7 @@ for s in "${GAP_SCRIPTS[@]}"; do
 done
 
 # (b) the two PASS-default CLIs do NOT call it (no silent asymmetry)
-for s in "${PASS_SCRIPTS[@]}"; do
+for s in ${PASS_SCRIPTS[@]+"${PASS_SCRIPTS[@]}"}; do
   if grep -q "print_store_access_guidance" "$SETUP_DIR/$s"; then
     bad "PASS-default CLI unexpectedly calls print_store_access_guidance: $s"
   else
@@ -157,7 +157,7 @@ done
 # absence from executable (non-comment) code is the guard. Full-line comment
 # mentions (e.g. the copilot note explaining trustedFolders does NOT work) are
 # stripped first so they do not trip the check.
-for s in "${GAP_SCRIPTS[@]}" "${PASS_SCRIPTS[@]}"; do
+for s in ${GAP_SCRIPTS[@]+"${GAP_SCRIPTS[@]}"} ${PASS_SCRIPTS[@]+"${PASS_SCRIPTS[@]}"}; do
   code="$(grep -v '^[[:space:]]*#' "$SETUP_DIR/$s")"
   if echo "$code" | grep -Eq 'trustedFolders|permissions-config\.json'; then
     bad "setup writes a durable trust surface (trustedFolders/permissions-config.json): $s"

--- a/scripts/unlink-extensions.sh
+++ b/scripts/unlink-extensions.sh
@@ -13,7 +13,7 @@ if [ "$1" = "--include-org" ] || [ -n "${INCLUDE_ORG:-}" ]; then
   tiers+=(org)
 fi
 
-for tier in "${tiers[@]}"; do
+for tier in ${tiers[@]+"${tiers[@]}"}; do
   for dir in "$REPO_DIR"/extensions/"$tier"/*/; do
     [ -d "$dir" ] || continue
     name="$(basename "$dir")"


### PR DESCRIPTION
Closes #798. Enforces uniform guarding of all array value expansions across governed `.sh` scripts so the Bash 3.2 empty-array trap is caught mechanically, not just by the test suite.

## How to read this PR?

Start with `scripts/lib/bash32-array-guard.sh` (the shared detector, moved out of the test file), then `scripts/check-bash32-portability.sh` (the new enforcement phase that sources it). Read `scripts/tests/test-check-bash32-portability.sh` to see the detector probes and the new `strip_comments` case. The remaining ~45 files are mechanical guard conversions of `"${arr[@]}"`/`"${arr[*]}"` into their guarded forms.

## How to test this PR?

```sh
bash scripts/check-bash32-portability.sh        # enforcement: exit 0, OK line
/bin/bash scripts/check-bash32-portability.sh   # same on Bash 3.2
bash scripts/tests/test-check-bash32-portability.sh   # 32/32 pass
/bin/bash scripts/tests/test-check-bash32-portability.sh
```

Expected: enforcement prints `OK: no forbidden Bash 4+ construct and no unguarded array value expansion in scripts hooks (3 declared construct(s), 157 file(s) scanned, 145 .sh file(s) array-scanned).` on both bash versions, and the test suite passes 32/32 on both.

## Detailed description (for agents)

Implements spec 0124 (merged at `ae51f92`). The ticket closes a CI gap: suites run `set -uo pipefail` WITHOUT `-e`, so under `set -u` a Bash 3.2 empty-array expansion dies silently in a child subshell and the suite exits 0 with cases skipped (false-green from #697). The chosen direction promotes the existing `bare_expansions_in` detector into a general enforcement requiring uniform guarding of all array value expansions.

**New shared lib** — `scripts/lib/bash32-array-guard.sh`:
- `strip_comments` — quote-aware comment stripper (pure substring arithmetic, no external commands).
- `bare_expansions_in` — consumption-based detector moved verbatim from the test file.
- `array_guard_scan` — repo-scoped scan over all `.sh` files; requires a repo-dir argument; emits `ARRAY_GUARD_HITS` (newline-delimited scalar string).

**Enforcement wiring** — `scripts/check-bash32-portability.sh`:
- New phase 2 after the declared-set FAILED check: sources the lib, calls `array_guard_scan`, FAILED block on hits, extended OK message. `--list-constructs` mode exits before this phase.

**Test restructure** — `scripts/tests/test-check-bash32-portability.sh`:
- Sources the lib; drops the local `bare_expansions_in`; case i reads `detector-probes.tsv`; case l added for `strip_comments` reading `strip-comments.tsv` (trailing whitespace trimmed in comparison). 32/32 pass on bash 5.3.15 and 3.2.57.

**Guard conversions** (124 expansions across 45 scripts): canonical `${arr[@]+"${arr[@]}"}`/`${arr[*]+"${arr[*]}"}` for quoted uses; `${arr[*]:-}` inside double-quoted echo strings; guarded forms inside `$(...)`/`<( ... )` substitutions and function-call args; array-copy assignments use `arr=(${src[@]+"${src[@]}"})`. Special case: `test-antigravity-component-install.sh` greps the literal call-site string, so its pattern was updated to the guarded form with an `# acknowledged-exception: literal grep pattern (mention, not a use)` marker (R10 hatch for a mention, not a use).

**Docs** — `docs/scripting-conventions.md` Rule 5 now states the array-guard rule is **enforced** (not merely recommended), documenting the canonical guard form, the `${arr[*]:-}` form for double-quoted interpolation, the mention-vs-use distinction, and the acknowledged-exception hatch.

**CI parity (R9)**: the enforcement and its test already run on both engines — GitHub Actions (`.github/workflows/build.yml:283`, `.github/workflows/scripting-conventions.yml:64`) and GitLab (`ci/ci-capabilities.yml:132`, `ci/ci-capabilities.yml:305`). No new CI wiring needed.

**CLI matrix**: consulted `docs/cli-matrix.md` — no update required (portability change, not a CLI-specific integration point).
