### PR TITLE
📝 Mark spec 0124 implemented

### DIFF
--- a/specs/0124-bash32-array-guard.md
+++ b/specs/0124-bash32-array-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0124"
 slug: bash32-array-guard
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 798


### PR DESCRIPTION
Marks spec 0124 (`bash32-array-guard`) as `implemented` following the merge of implementation PR #818.