### PR TITLE
📝 Add spec 0126: the command a claim wraps runs in the tree the gate certified

### DIFF
--- a/specs/0126-claim-gate-tree-convergence.md
+++ b/specs/0126-claim-gate-tree-convergence.md
@@ -1,0 +1,153 @@
+---
+id: "0126"
+slug: claim-gate-tree-convergence
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 779
+version: 1.0.0
+---
+
+# The command a claim wraps runs in the tree the gate certified
+
+## Intent
+
+`scripts/worktree-claim.sh` refuses a whole-tree git operation while the
+worktree carries uncommitted work — the gate that `specs/0114-shared-worktree-agent-isolation.md`
+requirements 2 and 4 exist to provide. The gate reads one tree. The command
+`run` wraps executes in another whenever the two are allowed to differ, because
+a wrapped command is a child process and inherits the working directory of
+whoever invoked the script, while the gate reads the toplevel named by
+`CREWRIG_REPO_DIR`. Point that variable at one tree while standing in another
+and the result is a clean bill of health for a tree nobody was about to touch.
+
+This is not hypothetical. It happened during the implementation of #736: the
+gate passed against a temporary fixture while `git clean -fdx` ran against the
+real `.worktrees/736`. Nothing was lost, and the reason is worth stating
+exactly — that worktree happened to carry no untracked or ignored files at that
+moment. Luck, not a safeguard.
+
+After this spec, the tree the gate certifies and the tree the wrapped command
+acts on are **the same tree, always, with nothing to configure and nothing to
+check**. The divergence stops being a condition that must be detected and
+becomes a state the mechanism cannot enter.
+
+## Requirements
+
+1. `scripts/worktree-claim.sh run` SHALL execute the wrapped command with its
+   working directory set to the toplevel that the clean-tree gate evaluated.
+2. Requirement 1 SHALL hold unconditionally: whether or not `CREWRIG_REPO_DIR`
+   is set, and whatever working directory the caller invoked the script from. A
+   rule that applies only when a divergence is detected is a second code path
+   that can itself be wrong; the guarantee is worth more than the compatibility
+   it costs.
+3. A consequence of requirement 2 SHALL be accepted deliberately: a `run`
+   invoked from a subdirectory of the worktree executes its wrapped command at
+   the worktree root, so a wrapped command naming a relative path resolves that
+   path against the root rather than against the caller's directory. This is a
+   breaking change to the `run` contract and SHALL be documented as one.
+4. The exit-code contract of `run` SHALL be unchanged — the wrapped command's
+   own status propagates, and the refusal codes keep their current meaning.
+   This spec changes where the wrapped command executes and nothing else about
+   what `run` returns.
+5. The subcommands that wrap no command — `take`, `release`, `takeover`,
+   `status`, `history` — SHALL be unaffected. They launch no child process, so
+   they have no working directory to reconcile, and `CREWRIG_REPO_DIR` keeps its
+   present meaning for them: which repository this script inspects.
+6. The `Environment` block in the script header SHALL state the contract
+   requirements 1 through 3 establish. Its current text describes the divergence
+   as a permanent boundary of the mechanism, which will be false once this spec
+   is realized, and a header that documents a hazard the code no longer has is
+   worse than one that documents nothing.
+7. A regression case SHALL cover requirement 1 against a divergence: the
+   override naming one repository while the caller stands in another, asserting
+   that the wrapped command acted on the certified tree and left the caller's
+   tree untouched. The assertion SHALL be a mutation the case observes, not a
+   diagnostic string the case reads. This case SHALL fail against the behaviour
+   that precedes this spec.
+8. A regression case SHALL cover requirement 3: a `run` invoked from a
+   subdirectory of the worktree, asserting the wrapped command's working
+   directory is the worktree root. The accepted consequence is pinned by a test
+   or it is not accepted, only asserted.
+9. The existing coverage of `CREWRIG_REPO_DIR` for a subcommand that wraps no
+   command SHALL be preserved, so that requirement 5 is held by the suite rather
+   than by intention.
+10. `docs/agent-team-protocol.md` → *Worktree Isolation* SHALL state the working
+    directory a wrapped command runs in, because that document is where an agent
+    reads how to invoke the mechanism and it currently says nothing on the
+    subject.
+
+## Scenarios
+
+**Scenario:** the divergence that misled an agent no longer exists
+
+```text
+Given a repository A that is clean and a worktree B that is clean
+And   a caller standing in B with the override naming A
+When  the caller runs a wrapped command that creates a file
+Then  the file exists in A, the tree the gate certified
+And   B is unchanged
+```
+
+**Scenario:** the ordinary invocation is unaffected
+
+```text
+Given an agent standing at the root of a clean ticket worktree
+And   no override set
+When  the agent wraps a whole-tree git operation in a claim
+Then  the operation runs in that worktree exactly as before
+And   the wrapped command's exit code is propagated unchanged
+```
+
+**Scenario:** the accepted consequence, pinned
+
+```text
+Given an agent standing in a subdirectory of a clean ticket worktree
+When  the agent wraps a command that reports its working directory
+Then  the reported directory is the worktree root, not the subdirectory
+```
+
+**Scenario:** a dirty tree is still refused before anything executes
+
+```text
+Given a ticket worktree carrying an uncommitted change
+When  an agent wraps any command in a claim
+Then  the command does not execute
+And   the refusal names the tree it read and exits 5
+```
+
+## Out of scope
+
+- **The meaning of `CREWRIG_REPO_DIR` in the eleven other scripts that read
+  it.** They default to the repository root derived from their own location and
+  mean "which repository to inspect"; none of them launches a child command
+  whose working directory could diverge from that answer. This spec changes one
+  script's contract, not a repository-wide convention.
+- **Refusing a divergence.** An ancestor check that rejects a caller standing
+  outside the certified tree was considered and rejected: it leaves the
+  divergence reachable as a refusal path, where requirements 1 and 2 leave it
+  unreachable. Note for the record that the reason #779 gives for not taking
+  that path — that it would break a regression suite driving its fixtures
+  through the divergence by design — does not hold: exactly one case in
+  `scripts/tests/test-worktree-claim.sh` sets the override, and it wraps no
+  command. The path was rejected on the strength of the alternative, not on that
+  cost.
+- **Announcing the certified tree in the gate's diagnostic.** Also considered
+  and rejected. It makes the divergence observable to an operator who reads the
+  output rather than impossible, which is the shape of defect this repository
+  already carries in several open tickets.
+- **Blocking a prohibited command that never goes through this script.**
+  `specs/0117-tool-boundary-command-guard.md` (issue #771) owns that surface and
+  delegates its decision to this script, which is why this spec is upstream of
+  it.
+- **The overlap between `run`'s own refusal codes and a wrapped command's exit
+  status.** Reported and deliberately not resolved in #773; unchanged here, per
+  requirement 4.
+
+## Open questions
+
+None. The one design question the ticket posed — whether `CREWRIG_REPO_DIR` is
+a test-harness affordance permitted to diverge from the caller's directory or a
+repository override that must agree with it — is answered by requirements 1 and
+2: neither. The variable keeps naming the tree, and the tree stops being
+something a command can escape.


### PR DESCRIPTION
Qualifies the WHAT for issue #779: the clean-tree gate in `scripts/worktree-claim.sh` certifies one tree while the command `run` wraps executes in another whenever `CREWRIG_REPO_DIR` and the caller's working directory are allowed to differ. This spec makes the two the same tree by construction, so the divergence stops being a condition to detect and becomes a state the mechanism cannot enter.

## How to read this PR?

One file, `specs/0126-claim-gate-tree-convergence.md`. Read it in this order:

1. **`## Intent`** — the mechanism, the divergence, and the incident during #736 where the gate passed against a temporary fixture while `git clean -fdx` ran against the real `.worktrees/736`. Nothing was lost because that tree happened to carry no untracked files at that moment; the spec says so explicitly rather than describing the outcome as a near miss the guard handled.

2. **Requirements 1 through 3** — the whole contract. R1 states where the wrapped command runs. R2 makes it unconditional. R3 is the part worth pausing on: it accepts a breaking consequence rather than hiding it. A `run` invoked from a subdirectory of the worktree now executes at the worktree root, so a wrapped command naming a relative path resolves it differently than before. The uniform contract was chosen over a conditional one that would have preserved the caller's directory when it already sat under the certified toplevel — one code path that always holds beats two that each have to be right.

3. **`## Out of scope`, second bullet** — the non-obvious point. Issue #779 rejects the ancestor-check alternative on the grounds that it "breaks the regression suite, which drives its fixtures through exactly this divergence by design". That is false. Of the 25 cases defined in `scripts/tests/test-worktree-claim.sh`, exactly one sets the override (`case_11`, line 829) and it passes `status`, which wraps no command — so the divergence is never exercised for `run` at all. The spec keeps the chosen option but replaces the ticket's reasoning with the one that holds: unreachable beats refused.

4. **Requirements 7 through 9** — the coverage the behaviour has never had. R7 mandates a case that fails against the behaviour preceding this spec, asserting on an observed mutation rather than on a diagnostic string.

## How to test this PR?

This PR adds a specification and changes no executable behaviour, so the checks are conformance checks.

```sh
# From the repository root, on this branch.
task spec:lint
```

Expected: `Linting passed!` over the full corpus.

To confirm the linter actually inspects the new file rather than passing over it, mutate it and observe a targeted failure:

```sh
cp specs/0126-claim-gate-tree-convergence.md /tmp/0126.bak
sed -i '' 's/^## Open questions$/## Questions/' specs/0126-claim-gate-tree-convergence.md
node scripts/lib/spec-linter.js   # expect: [FAIL] … 0126 … Heading #5 MUST be "## Open questions"
/bin/cp -f /tmp/0126.bak specs/0126-claim-gate-tree-convergence.md
diff -q /tmp/0126.bak specs/0126-claim-gate-tree-convergence.md
```

Confirm the id is secured for this ticket and not merely allocated:

```sh
CREWRIG_SPEC_ID_ORIGIN=same bash scripts/check-spec-id-reserved.sh
```

Expected: `1` spec added, `id '0126' secured for issue #779 at refs/spec-ids/0126 (no stale mark)`. Note that this check diffs against `crewrig/main`, so it reports `0` specs and passes vacuously while the file is uncommitted — run it against the commit, not the working tree.

## Detailed description (for agents)

**Added:** `specs/0126-claim-gate-tree-convergence.md` (id `0126`, status `draft`, complexity `small`, interaction-mode `INTERMEDIATE`, related-issue `779`, version `1.0.0`). No other file is touched.

**The defect being qualified.** `scripts/worktree-claim.sh` line 193 reads `REPO_DIR="${CREWRIG_REPO_DIR:-$PWD}"`. It is the only consumer of that variable defaulting to `$PWD`; the eleven others default to the repository root derived from `$0` and mean "which repository to inspect". It is also the only consumer that launches a child command, whose working directory the variable does not govern. The gate — `tree_is_clean()`, evaluated twice in `cmd_run` for the pre-claim check and the TOCTOU re-check — reads `git -C "$TOPLEVEL" status`. The wrapped command inherits the caller's directory. In normal use the two coincide because the default is the current directory; the override is what decouples them.

**Prior art.** PR #773 shipped commit `e0fe55a`, documentation only: the header's `Environment` block now states the boundary instead of implying a guarantee. Behaviour unchanged, and untested — issue #779 point 4. Requirement 6 of this spec obsoletes that wording, since it will describe a hazard the code no longer has.

**Design decisions taken at the SPECS gate, recorded so DEV does not re-open them:**

- The wrapped command runs in the certified toplevel. Convergence by construction, not by a check (R1, R2).
- Applied unconditionally rather than only on detected divergence. The conditional variant was considered and declined: it preserves compatibility for a `run` invoked from a subdirectory, at the cost of a second execution path (R2).
- The resulting break is accepted and pinned by a test rather than absorbed silently (R3, R8).
- `run`'s exit-code contract is untouched, including the documented overlap between its own refusal codes and a wrapped command's status — reported and deliberately unresolved in #773 (R4).

**Downstream dependency.** `specs/0117-tool-boundary-command-guard.md` (issue #771, status `approved`) delegates its decision to this script. #779 therefore sequences before #771: a tool-boundary block built on this gate would inherit the tree-resolution defect.

**Scope boundaries.** No `docs/cli-matrix.md` row is affected — the file contains zero occurrences of `worktree-claim`, and the script matches none of the trigger prefixes in AGENTS.md → *CLI Matrix Maintenance*. No `artifacts/` source is touched, so no component rebuild and no `metadata.provenance.version` bump applies.

Refs #779
