### PR TITLE
🚑 Record spec 0126 as approved

### DIFF
--- a/specs/0126-claim-gate-tree-convergence.md
+++ b/specs/0126-claim-gate-tree-convergence.md
@@ -1,7 +1,7 @@
 ---
 id: "0126"
 slug: claim-gate-tree-convergence
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 779


### PR DESCRIPTION
Unblocks `lint-specs` repository-wide.

`specs/0126-claim-gate-tree-convergence.md` reached `main` at 1d88da5 (spec-PR #824) carrying `status: draft`, violating `specs/0109-spec-status-invariant-on-main.md` R1 and failing the spec linter for every open pull request.

## How to read this PR?

One line. `status: draft` → `status: approved` in the spec's frontmatter. No body change.

The omission it repairs is the one tracked in #766 — the `draft` → `approved` commit that `docs/spec-format.md` requires **inside the spec-PR, before the squash**. This is its third recorded occurrence, after PR #727 and PR #759.

## How to test this PR?

```sh
task spec:lint
```

Expected: `Linting passed!`. On `main` without this change the same command reports `[FAIL] specs/0126-claim-gate-tree-convergence.md`.

## Detailed description (for agents)

**Modified:** `specs/0126-claim-gate-tree-convergence.md` frontmatter, `status` field only.

**No version bump.** `metadata.provenance.version` does not apply — the file is a spec, not a skill or agent source. The spec's own `version` field stays `1.0.0`: the body is byte-identical to the content the SPECS-stage content-approval gate approved and that merged as #824. A status transition is not a content revision.

**Precedent.** Matches the repair path taken for spec 0109 (PR #711), spec 0114 (PR #788) and the #731 repair of the first occurrence: a dedicated transition PR carrying the metadata edit alone, anchored to its own tracking issue.

Closes #826
Refs #779, #766