### PR TITLE
📝 Delta 05 for spec 0002

### DIFF
--- a/specs/0002-spec-author-skill.delta-05.md
+++ b/specs/0002-spec-author-skill.delta-05.md
@@ -1,0 +1,25 @@
+---
+id: "0002"
+slug: spec-author-skill
+status: draft
+complexity: small
+interaction-mode: AUTO
+related-issue: 703
+version: 1.5.0
+---
+
+# 0002 — spec-author-skill (delta-05)
+
+This delta adds a new requirement to spec 0002 to enforce a self-checking habit when drafting specifications. A recurring pattern (observed across four requirements in spec 0108) consists of stating what is forbidden or what the normal case must produce, while failing to state what is permitted or what the degenerate/null case must produce. This delta introduces a mandatory checklist item for the `spec-author` skill to catch these omissions during the authoring phase.
+
+## ADDED
+
+1. **New requirement (R18) — Null-case and permitted-path self-check.** The `spec-author` skill SHALL enforce a mandatory self-check during the authoring phase of any specification. For each drafted requirement, the skill SHALL verify that the requirement explicitly answers the null/degenerate case and names a permitted path, rather than solely stating what is forbidden or describing only the happy path. If a requirement fails this check, the skill SHALL revise it before finalizing the draft.
+
+## MODIFIED
+
+(None. This delta is purely additive.)
+
+## REMOVED
+
+(None. This delta adds a new requirement without removing any existing one.)

--- a/specs/0002-spec-author-skill.delta-05.md
+++ b/specs/0002-spec-author-skill.delta-05.md
@@ -1,7 +1,7 @@
 ---
 id: "0002"
 slug: spec-author-skill
-status: draft
+status: approved
 complexity: small
 interaction-mode: AUTO
 related-issue: 703


### PR DESCRIPTION
This PR introduces delta-05 for spec 0002 to enforce a self-checking habit when drafting specifications, preventing missing null-case and permitted-path definitions.

## How to read this PR?

The PR contains a single file: `specs/0002-spec-author-skill.delta-05.md`. Read the ADDED section to see the new requirement R18.

## How to test this PR?

1. Pull the branch `spec/0002-spec-author-skill-delta-05` locally.
2. Run `task spec:lint` to verify that the format adheres to the specification guidelines.

## Detailed description (for agents)

This delta adds the following requirement to spec 0002:
- R18: Enforces a mandatory self-check during the authoring phase. For each requirement, the `spec-author` skill must verify that the requirement explicitly answers the null/degenerate case and names a permitted path, revising it if it fails this check.

Related #703
