### PR TITLE
✨ Add null-case self-check to spec-author skill

### DIFF
--- a/.agents/skills/spec-author/SKILL.md
+++ b/.agents/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.0"
+    version: "1.5.0"
 ---
 
 
@@ -472,6 +472,13 @@ locally that: (a) all five headings are present in order, (b)
 frontmatter parses as YAML, (c) every required field has a value of the
 right type. Enforcement of the format is the spec linter's job; this
 self-check is a courtesy, not a substitute.
+
+In addition, per R18 of spec 0002, the skill SHALL enforce a mandatory
+null-case and permitted-path self-check during the authoring phase. For
+each drafted requirement, verify that the requirement explicitly answers
+the null/degenerate case and names a permitted path, rather than solely
+stating what is forbidden or describing only the happy path. If a
+requirement fails this check, revise it before finalizing the draft.
 
 ## Open-questions discipline
 

--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.0"
+    version: "1.5.0"
 ---
 
 
@@ -478,6 +478,13 @@ locally that: (a) all five headings are present in order, (b)
 frontmatter parses as YAML, (c) every required field has a value of the
 right type. Enforcement of the format is the spec linter's job; this
 self-check is a courtesy, not a substitute.
+
+In addition, per R18 of spec 0002, the skill SHALL enforce a mandatory
+null-case and permitted-path self-check during the authoring phase. For
+each drafted requirement, verify that the requirement explicitly answers
+the null/degenerate case and names a permitted path, rather than solely
+stating what is forbidden or describing only the happy path. If a
+requirement fails this check, revise it before finalizing the draft.
 
 ## Open-questions discipline
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.0"
+    version: "1.5.0"
 ---
 
 
@@ -472,6 +472,13 @@ locally that: (a) all five headings are present in order, (b)
 frontmatter parses as YAML, (c) every required field has a value of the
 right type. Enforcement of the format is the spec linter's job; this
 self-check is a courtesy, not a substitute.
+
+In addition, per R18 of spec 0002, the skill SHALL enforce a mandatory
+null-case and permitted-path self-check during the authoring phase. For
+each drafted requirement, verify that the requirement explicitly answers
+the null/degenerate case and names a permitted path, rather than solely
+stating what is forbidden or describing only the happy path. If a
+requirement fails this check, revise it before finalizing the draft.
 
 ## Open-questions discipline
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.4.0"
+    version: "1.5.0"
 ---
 
 
@@ -472,6 +472,13 @@ locally that: (a) all five headings are present in order, (b)
 frontmatter parses as YAML, (c) every required field has a value of the
 right type. Enforcement of the format is the spec linter's job; this
 self-check is a courtesy, not a substitute.
+
+In addition, per R18 of spec 0002, the skill SHALL enforce a mandatory
+null-case and permitted-path self-check during the authoring phase. For
+each drafted requirement, verify that the requirement explicitly answers
+the null/degenerate case and names a permitted path, rather than solely
+stating what is forbidden or describing only the happy path. If a
+requirement fails this check, revise it before finalizing the draft.
 
 ## Open-questions discipline
 

--- a/artifacts/core/skills/spec-author/SKILL.md
+++ b/artifacts/core/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.4.0"
+    version: "1.5.0"
 claude:
   allowed-tools:
     - Read
@@ -484,6 +484,13 @@ locally that: (a) all five headings are present in order, (b)
 frontmatter parses as YAML, (c) every required field has a value of the
 right type. Enforcement of the format is the spec linter's job; this
 self-check is a courtesy, not a substitute.
+
+In addition, per R18 of spec 0002, the skill SHALL enforce a mandatory
+null-case and permitted-path self-check during the authoring phase. For
+each drafted requirement, verify that the requirement explicitly answers
+the null/degenerate case and names a permitted path, rather than solely
+stating what is forbidden or describing only the happy path. If a
+requirement fails this check, revise it before finalizing the draft.
 
 ## Open-questions discipline
 


### PR DESCRIPTION
This PR adds the null-case and permitted-path self-check to the `spec-author` skill, enforcing R18 of spec 0002.

## How to read this PR?

The PR updates `artifacts/core/skills/spec-author/SKILL.md` to add a new checklist item under the `### Self-validation (best-effort)` section. It also includes the regenerated skill and agent files.

## How to test this PR?

1. Pull the branch `fix/703-spec-author-null-case-check` locally.
2. Read `artifacts/core/skills/spec-author/SKILL.md` to verify the new check is in place.
3. Check the built artifacts in `.agents/`, `.gemini/`, `.claude/`, and `.github/` to ensure the change propagated correctly.

## Detailed description (for agents)

- Modified `artifacts/core/skills/spec-author/SKILL.md`: Added enforcement of R18 (null-case and permitted-path check) to the self-validation section.
- Bumped the `spec-author` version to `1.5.0` in the frontmatter.
- Ran `scripts/build-components.sh` to update the downstream files.

Related #703
