### PR TITLE
✨ Implement coverage and CI guards deferred from spec 0112

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,12 @@ jobs:
       - name: Test check-test-wiring regression (spec 0076)
         run: bash scripts/tests/test-check-test-wiring.sh
 
+      - name: Enforce test suites runtime stray guard (issue #738)
+        run: bash scripts/check-test-strays.sh
+
+      - name: Test check-test-strays regression (issue #738)
+        run: bash scripts/tests/test-check-test-strays.sh
+
       - name: Test build-ci regression (spec 0076 wiring)
         run: bash scripts/tests/test-build-ci.sh
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,8 @@ check-components:
     - "bash scripts/tests/test-system-context-store.sh"
     - "bash scripts/check-test-wiring.sh"
     - "bash scripts/tests/test-check-test-wiring.sh"
+    - "bash scripts/check-test-strays.sh"
+    - "bash scripts/tests/test-check-test-strays.sh"
     - "bash scripts/tests/test-build-ci.sh"
     - "bash scripts/tests/test-chroma-fd-limits.sh"
     - "bash scripts/tests/test-chroma-health-race.sh"

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -92,6 +92,8 @@ capabilities:
       - bash scripts/tests/test-system-context-store.sh
       - bash scripts/check-test-wiring.sh
       - bash scripts/tests/test-check-test-wiring.sh
+      - bash scripts/check-test-strays.sh
+      - bash scripts/tests/test-check-test-strays.sh
       - bash scripts/tests/test-build-ci.sh
       - bash scripts/tests/test-chroma-fd-limits.sh
       - bash scripts/tests/test-chroma-health-race.sh

--- a/scripts/check-test-strays.sh
+++ b/scripts/check-test-strays.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# check-test-strays.sh — CI guard for stray commands in test suites (issue #738).
+#
+# A script with a stray command line (e.g. `some-bogus-command`) will print
+# `some-bogus-command: command not found` to stderr and, unless `set -e` is
+# active, continue executing. Because tests are wired as `bash <suite>`, a
+# stray command inside one fails without anything consuming its status.
+#
+# The check here uses the runtime form: executing the suites and grepping for
+# the error message. This avoids the ambiguity of parsing bash syntax statically.
+#
+# Usage:
+#   bash scripts/check-test-strays.sh
+#
+
+set -euo pipefail
+
+REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
+TESTS_DIR="$REPO_DIR/scripts/tests"
+
+if [ ! -d "$TESTS_DIR" ]; then
+  echo "Error: tests directory not found: $TESTS_DIR" >&2
+  exit 2
+fi
+
+failed=0
+
+for suite in "$TESTS_DIR"/test-*.sh; do
+  [ -f "$suite" ] || continue
+  
+  # Execute the suite and count occurrences of "command not found"
+  count=$(LC_ALL=C bash "$suite" 2>&1 | grep -c "command not found" || true)
+  if [ "$count" -ne 0 ]; then
+    echo "FAILED: $(basename "$suite") has $count stray 'command not found' errors" >&2
+    failed=1
+  fi
+done
+
+if [ "$failed" -eq 0 ]; then
+  echo "OK: zero runtime strays across all test suites."
+fi
+exit "$failed"

--- a/scripts/tests/test-check-spec-id-reserved.sh
+++ b/scripts/tests/test-check-spec-id-reserved.sh
@@ -561,9 +561,9 @@ expect_fail_verdict "Case 9 — a rename onto an unsecured id fails"
 # The unsecured-id mark (requirement 9) and its removal (requirement 10)
 # ---------------------------------------------------------------------------
 # The mark is the reservation tool's OUTPUT and this check's INPUT, and nothing
-# in PLAN v9 drew the line between them — which is how the invariant at
-# docs/spec-format.md:34, "a merged spec never carries it", reached `main`
-# enforced by nothing. The linter type-checks the boolean; this check compared
+# in PLAN v9 drew the line between them — which is how the invariant in the
+# `unsecured-id` row of the frontmatter schema table, "a merged spec never
+# carries it", reached `main` enforced by nothing. The linter type-checks the boolean; this check compared
 # holder against ticket and logged OK without ever reading the mark.
 #
 # One case is not enough here, and the reason is structural rather than
@@ -741,6 +741,8 @@ expect_log_matches "Case 12 — and says so, rather than exiting green in silenc
   '\[REPORT\].*could not be read'
 expect_log_matches "Case 12 — and says why it is not treated as a finding" \
   'indistinguishable from an empty'
+expect_log_not_matching "Case 12 — the namespace-unreadable report names no spec" \
+  'specs/0212-unreadable[.]md'
 
 # Case 12b — the third degradation, between Case 12's unreadable namespace and a
 # clean record: the namespace reads, the ref for this id is there, and the
@@ -782,6 +784,20 @@ expect_log_matches "Case 12b — and the spec is named rather than silently acce
 # wrong when written: it is the note reporting the count, not the end of the
 # loop.
 expect_log_matches "Case 12b — and it is reported through the non-blocking channel" '\[REPORT\]'
+
+# Case 12c — the second route to recorded_issue returning empty: the object is
+# fetchable but its message names no ticket. The calling loop cannot distinguish
+# this from an unreadable object, so it reports without failing exactly as Case 12b
+# does. If recorded_issue later failed loudly on a non-conformant message instead
+# of returning empty, this is the case that catches the regression.
+new_fixture c12c
+scratch_work="$(fixture_work c12c)"
+obj="$(git -C "$scratch_work" commit-tree -m "no ticket here" "$EMPTY_TREE")"
+git -C "$scratch_work" push -q crewrig "${obj}:refs/spec-ids/0401"
+add_spec c12c specs/0401-no-ticket.md 0401 no-ticket 911
+run_check_same_repo c12c
+expect_pass_verdict "Case 12c — a fetchable reservation lacking a ticket reports without failing"
+expect_log_matches "Case 12c — and it is reported through the non-blocking channel" '\[REPORT\]'
 
 # ---------------------------------------------------------------------------
 # Base-ref resolution

--- a/scripts/tests/test-check-test-strays.sh
+++ b/scripts/tests/test-check-test-strays.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# test-check-test-strays.sh — Regression tests for scripts/check-test-strays.sh
+# (issue #738)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-test-strays.sh"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: cannot find $SCRIPT_UNDER_TEST" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+mk_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts/tests"
+}
+
+run_check() {
+  local repo="$1" out_file err_file
+  out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
+  err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
+  CHECK_EXIT=0
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  CHECK_STDOUT="$(cat "$out_file")"
+  CHECK_STDERR="$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+}
+
+# ---------------------------------------------------------------------------
+# Case a — Clean suite passes.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Everything is fine"
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-a: a clean suite passes the check (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-a: expected exit 0, got $CHECK_EXIT"
+    echo "      stderr: $CHECK_STDERR"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDOUT" | grep -qF "zero runtime strays across all test suites"; then
+    echo "PASS  case-a: OK line emitted on stdout"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-a: missing OK line (stdout: $CHECK_STDOUT)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case b — Stray command fails.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-stray.sh" << 'EOF'
+#!/bin/bash
+some-bogus-command
+EOF
+  chmod +x "$repo/scripts/tests/test-stray.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-b: a stray command fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-b: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  if echo "$CHECK_STDERR" | grep -q "test-stray.sh has 1 stray.*errors"; then
+    echo "PASS  case-b: stderr names the suite and count"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-b: stderr did not name test-stray.sh and count correctly (stderr: $CHECK_STDERR)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+echo "Results: $pass/$total passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/test-reserve-spec-id.sh
+++ b/scripts/tests/test-reserve-spec-id.sh
@@ -37,8 +37,9 @@
 #   Reference remote Resolved by NAME, never by a flag and never hard-coded:
 #                    the first remote matching `crewrig|origin`, else the first
 #                    remote at all. This is the existing repository idiom
-#                    (scripts/lib/spec-linter.js:114-131, aligned with
-#                    scripts/check-skill-versions.sh:24-33 "so the repository has
+#                    (the `getRemoteName` function in scripts/lib/spec-linter.js,
+#                    aligned with the remote resolution block in
+#                    scripts/check-skill-versions.sh "so the repository has
 #                    one idiom rather than two"). Fixtures carry both a `crewrig`
 #                    and an `origin` remote; Case 23 covers the fallback arm.
 #


### PR DESCRIPTION
Resolves #738 by implementing the coverage assertions and CI runtime guards deferred from spec 0112.

## How to read this PR?

- `scripts/check-test-strays.sh` and its test `scripts/tests/test-check-test-strays.sh` are the main additions, fulfilling the runtime guard for test suites.
- `.github/workflows/build.yml` and `ci/ci-capabilities.yml` contain the wiring of this new guard.
- `scripts/tests/test-check-spec-id-reserved.sh` contains the new assertions for the unreadable namespace (Case 12) and the ticketless fetchable object (Case 12c).
- `scripts/tests/test-reserve-spec-id.sh` has the updated semantic anchors for the context citations.

## How to test this PR?

1. Run the CI parity check to ensure the generated pipelines are aligned:
   `bash scripts/check-ci-parity.sh`
2. Run the test suite for the new guard:
   `bash scripts/tests/test-check-test-strays.sh`
3. Run the spec-id reserve checks test suite:
   `bash scripts/tests/test-check-spec-id-reserved.sh`

## Detailed description (for agents)

This PR resolves the four items listed in #738:
1. **Case 12c Assertion**: Added `test-check-spec-id-reserved.sh` Case 12c to verify that a fetchable reservation lacking a ticket is reported via the non-blocking channel exactly like an unfetchable reservation (Case 12b).
2. **Case 12 Assertion**: Added `expect_log_not_matching` to `test-check-spec-id-reserved.sh` Case 12 to assert that an unreadable-namespace report names no spec, ensuring the invariant holds.
3. **Runtime stray guard**: Created `scripts/check-test-strays.sh` to explicitly run `LC_ALL=C bash <suite> 2>&1 | grep -c "command not found"` across all wired test suites. Added its test `scripts/tests/test-check-test-strays.sh` and wired both into `ci-capabilities.yml` and `build.yml`.
4. **Context Citations**: Replaced brittle line-number citations in `test-check-spec-id-reserved.sh` and `test-reserve-spec-id.sh` with stable, semantic anchors (e.g. naming the invariant row in the schema table, or the function name).
