### PR TITLE
📝 Define multi-pass plan review header conventions

### DIFF
--- a/docs/plan-format.md
+++ b/docs/plan-format.md
@@ -33,12 +33,15 @@ matching exactly one of the patterns below.
 |---|---|---|
 | Initial plan | `## PLAN — issue #<N> (spec <NNNN>)` | R1 |
 | Revision | `## PLAN v<N+1> — issue #<N> (spec <NNNN>) — revision after <trigger>` | R9 |
-| Review | `## PLAN review — issue #<N>` followed by `### Verdict: APPROVE` or `### Verdict: REQUEST CHANGES` on the next non-empty line | R6 |
+| Review (pass 1) | `## PLAN review — issue #<N>` (or `## PLAN review of v1 — issue #<N>`) followed by `### Verdict: APPROVE` or `### Verdict: REQUEST CHANGES` on the next non-empty line | R6 |
+| Review (pass M ≥ 2) | `## PLAN review of v<M> — issue #<N>` followed by `### Verdict: APPROVE` or `### Verdict: REQUEST CHANGES` on the next non-empty line | R6 |
 
 `<N>` is the logbook issue number, `<NNNN>` the zero-padded spec id,
+`<M>` the plan revision ordinal being judged (`v1`, `v2`, etc.),
 and `<trigger>` is a short noun phrase describing why the revision
 exists (`DEV finding`, `user request`, `REQUEST CHANGES review`,
-etc.).
+etc.). `## PLAN review — issue #<N>` is accepted as a backward-compatible
+alias for `## PLAN review of v1 — issue #<N>`.
 
 ## Mandatory body sections
 

--- a/specs/0004-plan-format-and-review.md
+++ b/specs/0004-plan-format-and-review.md
@@ -44,7 +44,8 @@ giving findings a stable shape that the retroactive review loop can route.
 6. Plan review SHALL be performed by a second `architect` agent spawned
    cold (no authoring context), posting the review as a follow-up
    comment on the same logbook issue whose first line is the header
-   `## PLAN review — issue #<N>` followed by a verdict line
+   `## PLAN review of v<M> — issue #<N>` (or `## PLAN review — issue #<N>`
+   for pass 1) followed by a verdict line
    (`### Verdict: APPROVE` or `### Verdict: REQUEST CHANGES`).
 7. Every plan-review finding SHALL be tagged with exactly one `class:`
    field (`tech` / `arch` / `spec`) so the retroactive routing engine


### PR DESCRIPTION
## Purpose
Defines normative header conventions for multi-pass plan reviews (`## PLAN review of v<M> — issue #<N>`), closing the gap where reviewers invent ad-hoc headers.
Closes #833.

## How to read this PR?
- `docs/plan-format.md`: Header conventions table updated with `## PLAN review of v<M> — issue #<N>`.
- `specs/0004-plan-format-and-review.md`: Requirement 6 updated.

## How to test this PR?
Review the documentation and spec updates.

## Detailed description (for agents)
This implementation satisfies Spec 0128 for issue #833 under the ADR-0010 lifecycle.