### PR TITLE
🚑 Hotfix: Update spec 0128 status from draft to approved on main

### DIFF
--- a/specs/0128-plan-review-header-convention.md
+++ b/specs/0128-plan-review-header-convention.md
@@ -1,7 +1,7 @@
 ---
 id: "0128"
 slug: plan-review-header-convention
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 833


### PR DESCRIPTION
## Purpose
Hotfix to transition spec 0128 status from  to  on main per spec 0109 invariant.

## How to read this PR?
Inspect specs/0128-plan-review-header-convention.md frontmatter.

## How to test this PR?
Run  or 
> crewrig@1.0.0 test
> npm run test --workspaces.