### PR TITLE
📝 Add spec 0129: the sync refusal names files, not their directory

### DIFF
--- a/specs/0129-dirty-report-names-files.md
+++ b/specs/0129-dirty-report-names-files.md
@@ -1,7 +1,7 @@
 ---
 id: "0129"
 slug: dirty-report-names-files
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 719

--- a/specs/0129-dirty-report-names-files.md
+++ b/specs/0129-dirty-report-names-files.md
@@ -1,0 +1,119 @@
+---
+id: "0129"
+slug: dirty-report-names-files
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 719
+version: 1.0.0
+---
+
+# The sync refusal names the files it found, never the directory holding them
+
+## Intent
+
+When `scripts/sync-from-upstream.sh` refuses to run because a downstream adopter has
+modified an upstream-owned path, it currently reports the manifest entry it was checking.
+For the 35 of 59 entries that name a directory, that means a single customized file is
+reported as `scripts` — and an adopter who is told `scripts` acts on `scripts`. They align
+the whole directory to upstream, run the sync, then restore the whole directory from their
+previous commit, and in doing so silently revert every file upstream added or changed in
+between. One reported case lost a launch-time version guard and an installer update, found
+much later through unrelated test failures. After this spec the refusal names the modified
+files themselves and states how to restore exactly those, so the destructive move has no
+occasion to be invented.
+
+## Requirements
+
+1. When the guard refuses, its report SHALL name each locally modified file individually,
+   at its full path relative to the repository root.
+2. For a manifest entry that resolves to a directory, the report SHALL NOT name that entry.
+   Only its modified members appear. An adopter restores what they are shown, so showing a
+   container is what produces the over-erasure this spec exists to end.
+3. The enumeration SHALL be complete: every modified member of every refusing entry is
+   reported, not the first one found. A partial list sends the adopter back for a second
+   refusal, and the second list is the one they act on hastily.
+4. The refusal SHALL state the restoration as a targeted operation over the named files, and
+   SHALL warn against restoring the containing directory. Requirement 2 removes the occasion
+   for the destructive move; this requirement removes the ambiguity for an adopter who
+   already knows the directory-level habit.
+5. A manifest entry that resolves to a single file SHALL be reported exactly as it is today.
+   Its report is already precise, and changing it would churn the one path that never had
+   this defect.
+6. Paths excluded under a refusing entry SHALL remain excluded from the report, unchanged
+   from current behaviour. An org-owned file is not the adopter's to revert.
+7. The exit status of a refusal SHALL remain unchanged.
+8. The cost of the non-refusing path SHALL NOT increase. The guard already visits every
+   member of every directory entry when nothing is modified, because the early exit it
+   performs is only reachable once something is; completeness is therefore free where it is
+   paid every run, and paid only where the adopter is already stopped.
+9. A regression case SHALL cover a manifest entry that resolves to a **directory** with
+   exactly one modified member, asserting that the report names that member and does not
+   name the directory. The existing suite covers the dirty guard only through a manifest
+   entry that resolves to a file, which is the shape that never exhibited the defect.
+10. A regression case SHALL cover a directory entry with **more than one** modified member,
+    asserting every one of them is named. Requirement 3 is the requirement a first-match
+    implementation satisfies by accident on a single-file fixture.
+
+## Scenarios
+
+**Scenario:** one customized file inside a directory entry
+
+```text
+Given a manifest entry naming a directory
+And   exactly one file inside it modified locally
+When  the adopter runs the sync
+Then  the refusal names that file at its full path
+And   the refusal does not name the directory
+And   the refusal states how to restore that file alone
+```
+
+**Scenario:** several customized files inside one directory entry
+
+```text
+Given a manifest entry naming a directory
+And   three files inside it modified locally
+When  the adopter runs the sync
+Then  the refusal names all three
+```
+
+**Scenario:** the precise entry is untouched
+
+```text
+Given a manifest entry naming a single file
+And   that file modified locally
+When  the adopter runs the sync
+Then  the refusal names that file exactly as before this spec
+```
+
+**Scenario:** nothing modified
+
+```text
+Given a manifest whose entries are all unmodified locally
+When  the adopter runs the sync
+Then  no refusal is raised
+And   the sync proceeds
+```
+
+## Out of scope
+
+- **Restoring the adopter's files on their behalf.** The alternative considered and declined
+  at the scoping gate: the script would set the modified files aside, sync, and put them
+  back, removing the manual move rather than guiding it. Declined because it changes what
+  this tool is — today it never touches what the adopter wrote, it refuses instead — and an
+  interruption mid-operation would leave the tree in an intermediate state. Adding a
+  silent-loss risk to the script whose subject is silent loss deserves its own ticket and
+  its own decision, not a clause in this one.
+- **The `adopt-on-edit` and `excluded` policies.** This spec changes what a `strict` refusal
+  reports. The reconciliation paths for the other two policies are untouched.
+- **The manifest format.** Whether an adopter should be able to declare a policy per file
+  inside a directory is a different question, and a real one; it is not this one. This spec
+  makes the existing shape report honestly rather than changing the shape.
+- **The wording of the guard's other diagnostics.** Only the refusal that lists modified
+  paths is in scope.
+
+## Open questions
+
+None. The scoping question the ticket left open — whether the fix informs the adopter or
+performs the restoration for them — was decided at the scoping gate in favour of informing,
+and the alternative is recorded above rather than left implicit.


### PR DESCRIPTION
Qualifies the WHAT for issue #719: when `scripts/sync-from-upstream.sh` refuses a sync because a downstream adopter modified an upstream-owned path, the refusal names the modified files rather than the manifest entry containing them.

## How to read this PR?

One file, `specs/0129-dirty-report-names-files.md`. Two commits, deliberately: the spec, then the `draft` → `approved` transition that `docs/spec-format.md` requires **inside** the spec-PR before the squash. That second commit is not ceremony — omitting it is the defect tracked in #766, and this session produced its third occurrence a few hours ago (PR #824 put a draft spec on `main` and failed `lint-specs` repository-wide until #827 repaired it).

Read in this order:

1. **`## Intent`** — the failure, end to end. 35 of the manifest's 59 entries name a directory, so one customized file is reported as `scripts`. An adopter told `scripts` aligns the whole directory to upstream, syncs, then restores the whole directory from their previous commit — silently reverting everything upstream added in between. The reported case lost a launch-time version guard (spec 0108) and an installer update (spec 0096), discovered later through unrelated CI failures.

2. **Requirements 2 and 3** — the two that carry the fix. R2 forbids naming the directory at all, rather than merely preferring the files: the destructive move exists because of what the script shows, so ceasing to show a container removes the cause instead of routing around it. R3 requires the enumeration to be complete, because a partial list produces a second refusal and the second list is the one an adopter acts on hastily.

3. **Requirement 8** — the cost claim, with its reason rather than a promise. Completeness is free on the path that runs every time: the guard already visits every member of every directory entry when nothing is modified, since the early exit is only reachable once something is. It costs only where the adopter is already stopped, which is where the information is wanted.

4. **Requirements 9 and 10** — the coverage, and why it is two cases and not one. The existing suite exercises the dirty guard through a manifest entry that resolves to a *file* — the shape that never exhibited this defect. R10 exists because a first-match implementation satisfies a single-modified-file fixture by accident.

5. **`## Out of scope`, first bullet** — the alternative declined at the scoping gate: having the script set the files aside, sync, and restore them. Declined because it would change what the tool is (today it never touches what the adopter wrote) and an interruption mid-operation would leave the tree in an intermediate state — adding a silent-loss risk to the script whose subject is silent loss. Recorded so a later reader sees a decision rather than an oversight.

## How to test this PR?

Specification only, no executable change. The checks are conformance checks.

```sh
task spec:lint
```

Expected: `Linting passed!` across the corpus.

To confirm the linter actually inspects the new file rather than passing over it:

```sh
cp specs/0129-dirty-report-names-files.md /tmp/0129.bak
sed -i '' 's/^## Out of scope$/## Scope/' specs/0129-dirty-report-names-files.md
node scripts/lib/spec-linter.js   # expect: [FAIL] … 0129 … Heading #4 MUST be "## Out of scope"
/bin/cp -f /tmp/0129.bak specs/0129-dirty-report-names-files.md
diff -q /tmp/0129.bak specs/0129-dirty-report-names-files.md
```

Confirm the id is secured for this ticket:

```sh
CREWRIG_SPEC_ID_ORIGIN=same bash scripts/check-spec-id-reserved.sh
```

Expected: `1` spec added, `id '0129' secured for issue #719`. This check diffs against `crewrig/main`, so it reports `0` and passes vacuously while the file is uncommitted — run it against the commit.

Confirm the status transition landed on the branch rather than in a working tree:

```sh
git show "spec/0129-dirty-report-names-files:specs/0129-dirty-report-names-files.md" | sed -n 4p
```

Expected: `status: approved`.

## Detailed description (for agents)

**Added:** `specs/0129-dirty-report-names-files.md` (id `0129`, status `approved`, complexity `small`, interaction-mode `INTERMEDIATE`, related-issue `719`, version `1.0.0`). No other file touched.

**The diagnosis differs from the ticket's, and the spec records the corrected one.** #719 asks to "modify the script to evaluate and report dirty status per-file rather than per-directory". Evaluation is *already* per-file: `strict_blob_is_dirty` is called on each member of a directory entry. The defect is in two adjacent lines of the reporting loop — a `break` on the first modified member, which discards knowledge of the rest, and an append of the *entry* rather than the member. The correction is therefore narrower than the ticket implies, and the spec's requirements are written against the real mechanism.

**Design decision taken at the scoping gate, recorded so PLAN does not reopen it:** the script informs, it does not perform the restoration. Both options were put to the user with their costs; the informing option was chosen.

**Scope boundaries.** No `docs/cli-matrix.md` row — the file carries no `sync-from-upstream` integration row and the script matches none of the `{build,install,setup,import,manage}-*.sh` trigger prefixes. No `artifacts/` source, so no component rebuild and no `metadata.provenance.version` bump. `.crewrig/core-paths.txt` is *read* by the script under specification but its format is explicitly out of scope, so no manifest co-maintenance obligation arises.

**Gate record.** SPECS-stage content-approval via the `user-validate` skill, `plannotator` backend, `{"decision":"approved"}`, exit 0. Per `docs/interaction-modes.md` → *User-gate definition*, that approval discharges the merge-authorization gate for this one-file spec-PR, provided the content merges unchanged.

Refs #719
