### PR TITLE
✨ Support job-scoped env vars in CI reference and parity checks (#709)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,6 +136,7 @@ lint-specs:
   image: node:22
   variables:
     GIT_DEPTH: "0"
+    BASE_REF: "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
   before_script:
     - sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
   script:
@@ -160,6 +161,7 @@ check-skill-versions:
   image: debian:stable-slim
   variables:
     GIT_DEPTH: "0"
+    BASE_REF: "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
   script:
     - "bash scripts/check-skill-versions.sh"
   rules:
@@ -169,6 +171,7 @@ check-extension-version-bump:
   image: debian:stable-slim
   variables:
     GIT_DEPTH: "0"
+    BASE_REF: "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
   script:
     - "bash scripts/check-extension-version-bump.sh"
   rules:
@@ -178,6 +181,9 @@ check-spec-id-reserved:
   image: debian:stable-slim
   variables:
     GIT_DEPTH: "0"
+    BASE_REF: "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+    CREWRIG_PR_BASE_REPO: "$CI_PROJECT_PATH"
+    CREWRIG_PR_HEAD_REPO: "$CI_MERGE_REQUEST_SOURCE_PROJECT_PATH"
   script:
     - "command -v git >/dev/null || (apt-get update && apt-get install -y --no-install-recommends git ca-certificates)"
     - "bash scripts/check-spec-id-reserved.sh"

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -165,6 +165,8 @@ capabilities:
       runtime: node@22
       tools: [task]
       history-depth: full
+    env:
+      BASE_REF: "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
     command:
       - npm install
       - bash scripts/tests/test-spec-linter.sh
@@ -197,6 +199,8 @@ capabilities:
     portability: portable
     requires:
       history-depth: full
+    env:
+      BASE_REF: "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
     command:
       - bash scripts/check-skill-versions.sh
 
@@ -208,6 +212,8 @@ capabilities:
     portability: portable
     requires:
       history-depth: full
+    env:
+      BASE_REF: "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
     command:
       - bash scripts/check-extension-version-bump.sh
 
@@ -238,6 +244,10 @@ capabilities:
     portability: portable
     requires:
       history-depth: full
+    env:
+      BASE_REF: "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+      CREWRIG_PR_BASE_REPO: "$CI_PROJECT_PATH"
+      CREWRIG_PR_HEAD_REPO: "$CI_MERGE_REQUEST_SOURCE_PROJECT_PATH"
     command:
       - command -v git >/dev/null || (apt-get update && apt-get install -y --no-install-recommends git ca-certificates)
       - bash scripts/check-spec-id-reserved.sh

--- a/docs/ci-reference-format.md
+++ b/docs/ci-reference-format.md
@@ -54,6 +54,7 @@ these keys:
 | `exception` | iff `specific` | mapping | `{engine, evidence}` (see *Portability and exceptions*). |
 | `command` | iff `portable` | list of strings | The business invocation command(s) that realize the job (see *Invocation command and execution requirements*). |
 | `requires` | iff `portable` | mapping | The engine-agnostic execution requirement: `{runtime, tools, history-depth}` (see *Invocation command and execution requirements*). |
+| `env` | optional | mapping | Optional dictionary of job-scoped environment variable keys and string values (spec 0131). |
 
 **Granularity — one capability is exactly one job (spec 0047 R1).** The steps
 *inside* a job are an implementation detail of that one capability, **not**
@@ -175,6 +176,14 @@ or runtime it does not declare is rejected:
   before the capability is accepted as derivable (delta-02 Scenario 2).
 - A `specific` capability gains no `requires` (R12 scopes the obligation to
   portable capabilities, consistent with delta-01 R11).
+
+### `env` — job-scoped environment variables (spec 0131)
+
+`env` defines an optional mapping of environment variable keys to string values.
+When declared on a portable capability, `scripts/build-ci.sh` emits them into the
+job's `variables:` section in `.gitlab-ci.yml`, and `scripts/check-ci-parity.sh`
+verifies that the environment variables are exhibited by the attributed GitHub Actions
+job and matched on GitLab.
 
 ### GitLab generation
 

--- a/docs/cli-matrix.md
+++ b/docs/cli-matrix.md
@@ -78,7 +78,7 @@ One row per integration point. ✅ = present, ❌ = absent, note when relevant.
 > from that reference, not hand-authored: `scripts/build-ci.sh` reads
 > `ci/ci-capabilities.yml` and emits one GitLab job per *portable* capability
 > into [`.gitlab-ci.yml`](../.gitlab-ci.yml) at the repo root (job key ==
-> capability id; `requires:` → `image`/`before_script`/`GIT_DEPTH`; `command:`
+> capability id; `requires:` → `image`/`before_script`/`GIT_DEPTH`; `env:` → `variables:`; `command:`
 > → `script:`). Engine-specific capabilities are skipped with no placeholder
 > (spec 0048 R4); the GitHub Actions workflows under `.github/workflows/` are
 > **not** generated (spec 0048 R5). `scripts/build-ci.sh --check` runs in this

--- a/scripts/build-ci.sh
+++ b/scripts/build-ci.sh
@@ -232,9 +232,22 @@ emit_job() {
   # fetch-depth: 0) so base-ref diffing checks resolve their base.
   local history_depth
   history_depth=$(yq -r ".capabilities[] | select(.id == \"$id\") | .requires.history-depth // \"\"" "$REFERENCE")
-  if [ "$history_depth" = "full" ]; then
+  local env_keys
+  env_keys=$(yq -r ".capabilities[] | select(.id == \"$id\") | .env // {} | keys | .[]" "$REFERENCE")
+
+  if [ "$history_depth" = "full" ] || [ -n "$env_keys" ]; then
     echo "  variables:"
-    echo "    GIT_DEPTH: \"0\""
+    if [ "$history_depth" = "full" ]; then
+      echo "    GIT_DEPTH: \"0\""
+    fi
+    if [ -n "$env_keys" ]; then
+      local ek ev
+      while IFS= read -r ek; do
+        [ -z "$ek" ] && continue
+        ev=$(yq -r ".capabilities[] | select(.id == \"$id\") | .env.\"$ek\"" "$REFERENCE")
+        echo "    $ek: \"$(printf '%s' "$ev" | sed 's/\\/\\\\/g; s/"/\\"/g')\""
+      done <<< "$env_keys"
+    fi
   fi
 
   # before_script: tool installs satisfying requires.tools.

--- a/scripts/check-ci-parity.sh
+++ b/scripts/check-ci-parity.sh
@@ -214,6 +214,14 @@ for ((i = 0; i < cap_count; i++)); do
       done
     fi
   fi
+
+  # Check env mapping if present (spec 0131).
+  env_type=$(yq ".capabilities[$i].env | tag" "$REFERENCE")
+  if [ "$env_type" != "!!null" ] && [ -n "$env_type" ] && [ "$env_type" != "null" ]; then
+    if [ "$env_type" != "!!map" ]; then
+      verr "$label: env must be a key-value mapping (spec 0131)"
+    fi
+  fi
 done
 
 if [ "${#validity_errors[@]}" -gt 0 ]; then
@@ -398,6 +406,29 @@ check_gha_job() {
     [ "$prov_fetch" = "0" ] || \
       fail "capability '$id' (github-actions): requires full source history but checkout fetch-depth is '${prov_fetch:-unset}' (R4)"
   fi
+
+  # Spec 0131 — env parity check.
+  local req_env gha_env_job gha_env_steps gha_env_all
+  req_env=$(yq -r ".capabilities[] | select(.id == \"$id\") | .env // {} | keys | .[]" "$REFERENCE")
+  gha_env_job=$(yq -r ".jobs.\"$jk\".env // {} | keys | .[]" "$wf" 2>/dev/null || true)
+  gha_env_steps=$(yq -r ".jobs.\"$jk\".steps[].env // {} | keys | .[]" "$wf" 2>/dev/null || true)
+  gha_env_all=$(printf '%s\n%s' "$gha_env_job" "$gha_env_steps" | grep -v '^$' | sort -u || true)
+
+  local ek
+  while IFS= read -r ek; do
+    [ -z "$ek" ] && continue
+    if ! in_list "$ek" "$gha_env_all"; then
+      fail "capability '$id' (github-actions): requires env variable '$ek' but GHA job does not exhibit it (spec 0131)"
+    fi
+  done <<< "$req_env"
+
+  local gek
+  while IFS= read -r gek; do
+    [ -z "$gek" ] && continue
+    if ! in_list "$gek" "$req_env"; then
+      fail "capability '$id' (github-actions): GHA job defines env variable '$gek' not declared in reference env block (spec 0131)"
+    fi
+  done <<< "$gha_env_all"
 }
 
 if $GHA_PRESENT; then

--- a/scripts/tests/test-build-ci.sh
+++ b/scripts/tests/test-build-ci.sh
@@ -240,6 +240,26 @@ RC=0
 yq '.' "$tk/.gitlab-ci.yml" >/dev/null 2>&1 || RC=$?
 assert_eq "Case K1 — generated .gitlab-ci.yml parses as YAML" 0 "$RC"
 
+# Case L (spec 0131) — capability env mapping emits variables block in .gitlab-ci.yml.
+tl="$(new_tree)"
+cat > "$tl/ci/ci-capabilities.yml" <<'YML'
+capabilities:
+  - id: lint-specs
+    name: "Lint specs"
+    trigger:
+      - on: pull-request
+        branches: [main]
+    portability: portable
+    env:
+      BASE_REF: "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+    command:
+      - task spec:lint
+YML
+run_in "$tl"
+assert_eq "Case L0 — generate with env mapping succeeds" 0 "$RC"
+l_out="$(cat "$tl/.gitlab-ci.yml")"
+assert_contains "Case L1 — generated job contains env variable under variables" "$l_out" 'BASE_REF: "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"'
+
 # -------------------------------------------------------------------------
 echo ""
 echo "Results: $pass passed, $fail failed"

--- a/scripts/tests/test-check-ci-parity.sh
+++ b/scripts/tests/test-check-ci-parity.sh
@@ -404,6 +404,34 @@ refute_in() {
 }
 
 # ---------------------------------------------------------------------------
+# S10e — Reference validity: env must be a key-value mapping (spec 0131).
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '(.capabilities[] | select(.id == "build") | .env) = "invalid-string"' \
+    "$f/ci/ci-capabilities.yml"
+
+  run_check "$f"
+  expect_exit 1 "S10e: invalid env schema fails closed"
+  expect_in err "build" "S10e: names the capability"
+  expect_in err "env must be a key-value mapping" "S10e: names the env mapping violation"
+}
+
+# ---------------------------------------------------------------------------
+# S11 — Env block divergence (spec 0131): GHA defines an undeclared env variable.
+# ---------------------------------------------------------------------------
+{
+  f="$(make_fixture)"
+  yq -i '(.jobs.build.env.UNEXPECTED_VAR) = "val"' \
+    "$f/.github/workflows/build.yml"
+
+  run_check "$f"
+  expect_exit 1 "S11: GHA env block divergence fails closed"
+  expect_in err "capability 'build' (github-actions)" "S11: names capability + platform"
+  expect_in err "UNEXPECTED_VAR"                     "S11: names the divergent env variable"
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))


### PR DESCRIPTION
## Purpose
Support job-scoped environment variables (`env:`) in `ci/ci-capabilities.yml`, propagate them to `.gitlab-ci.yml` `variables:`, and enforce bi-directional parity verification across GitHub Actions and GitLab pipelines.

## How to read this PR?
Start by reading `docs/ci-reference-format.md` for the normative schema update, then examine `ci/ci-capabilities.yml`, `scripts/build-ci.sh`, and `scripts/check-ci-parity.sh`. Finally, inspect the test suites in `scripts/tests/test-build-ci.sh` and `scripts/tests/test-check-ci-parity.sh`.

## How to test this PR?
Run `bash scripts/build-ci.sh --check`, `bash scripts/check-ci-parity.sh`, `bash scripts/tests/test-build-ci.sh`, and `bash scripts/tests/test-check-ci-parity.sh`.

## Detailed description (for agents)
- Updated `ci/ci-capabilities.yml` schema with `env:` mapping support and declared job-scoped variables for `lint-specs`, `check-skill-versions`, `check-extension-version-bump`, and `check-spec-id-reserved`.
- Updated `scripts/build-ci.sh` generator to parse `env:` capability mappings and emit `variables:` entries into `.gitlab-ci.yml`.
- Updated `scripts/check-ci-parity.sh` validator to verify `env:` schema validity, harvest GHA job-level and step-level env vars, and fail closed on any divergence.
- Added comprehensive unit tests (Case L in `test-build-ci.sh`, S10e & S11 in `test-check-ci-parity.sh`).
- Updated `docs/ci-reference-format.md` and `docs/cli-matrix.md`.