### PR TITLE
🐛 Name the modified files in the sync refusal, never their directory

### DIFF
--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -319,16 +319,26 @@ listed in `.crewrig/core-paths.txt` from the URL set in
 `config/TOOLS.md`, `crewrig.config.toml`, and `artifacts/community/`)
 untouched.
 
-**Most-likely error — dirty-core guard:** If at least one core-layer path
-has been locally modified, the script will list the offending paths and
-exit 1 with a message similar to:
+**Most-likely error — dirty-core guard:** If at least one core-layer file
+has been locally modified, the script will list the offending **files** — never
+the directory containing them — and exit 1 with a message similar to:
 
 ```text
 Error: the following core-layer paths have local modifications:
-  config/SOUL.md
+  scripts/sync-from-upstream.sh
   artifacts/core/skills/developer/SKILL.md
 Revert these changes before running sync, or promote them to overlay overrides.
+
+Restore ONLY the files listed above, one path at a time:
+  git checkout <your-ref> -- <path listed above>
+Never restore the containing directory. A directory-level checkout also
+reverts every file upstream added or changed in it, silently.
 ```
+
+Both example paths are *members* of directory entries in
+`.crewrig/core-paths.txt` (`scripts` and `artifacts/core`). The guard names the
+member rather than the entry precisely so that the restoration below can be
+targeted: told `scripts`, an adopter restores `scripts`.
 
 Resolution: see [Troubleshooting — dirty-core refusal](#dirty-core-refusal) below.
 
@@ -468,22 +478,30 @@ missing directories, re-run `bash scripts/build-components.sh`.
 
 ### Dirty-core refusal during sync {#dirty-core-refusal}
 
-**Cause:** At least one path listed in `.crewrig/core-paths.txt` has been
-locally modified. The sync script enforces a dirty-core guard to prevent
-upstream changes from silently overwriting local modifications to core-layer
-files.
+**Cause:** At least one **file** governed by `.crewrig/core-paths.txt` has been
+locally modified — either because it is listed there itself, or because it sits
+inside a directory that is. The sync script enforces a dirty-core guard to
+prevent upstream changes from silently overwriting local modifications to
+core-layer files.
 
 **Effect:** `bash scripts/sync-from-upstream.sh` exits 1 and lists the
-offending paths.
+offending **files**, each at its full path. A directory listed in the manifest
+is never itself reported: what you see is what you modified.
 
 **Resolution:** Choose one of two paths for each offending file:
 
 1. **Revert the modification** — if the change was experimental or
-   unintended, restore the file to its committed state:
+   unintended, restore that file, and only that file, to its committed state:
 
    ```bash
    git checkout -- <path/to/core-file>
    ```
+
+   **Restore file by file, never the containing directory.** A directory-level
+   checkout — `git checkout -- scripts` — also reverts every file upstream
+   added or changed inside it, with no message and no error. That is how an
+   adopter loses a new upstream guard and discovers it later through unrelated
+   test failures; it is why the guard lists files rather than directories.
 
    Then re-run `bash scripts/sync-from-upstream.sh`.
 

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -432,8 +432,16 @@ for i in "${!PATHS[@]}"; do
   resolves_at_fetch_head "$path" || continue
 
   if [ "$(git cat-file -t "FETCH_HEAD:$path" 2>/dev/null)" = "tree" ]; then
-    # Directory entry: check each upstream member individually.
-    dir_dirty=0
+    # Directory entry: report the MEMBERS, never the entry (spec 0129 R1/R2).
+    # An adopter restores what they are shown. Reporting `scripts` is what makes
+    # them run `git checkout <ref> -- scripts` afterwards, reverting every file
+    # upstream added in between — the silent over-erasure of issue #719.
+    #
+    # No `break` (spec 0129 R3): a partial list sends the adopter back for a
+    # second refusal, and the second list is the one they act on in a hurry.
+    # This costs nothing on the path that runs every time — when nothing is
+    # modified the loop already visits every member, because the early exit was
+    # only ever reachable once something was dirty (spec 0129 R8).
     while IFS= read -r member; do
       [ -n "$member" ] || continue
       skip=0
@@ -441,17 +449,45 @@ for i in "${!PATHS[@]}"; do
         case "$member" in "$excl"/*|"$excl") skip=1; break ;; esac
       done < <(excluded_children_of "$path")
       [ "$skip" -eq 1 ] && continue
-      if strict_blob_is_dirty "$member"; then
-        dir_dirty=1
-        break
-      fi
+      strict_blob_is_dirty "$member" && DIRTY+=("$member")
     done < <(git ls-tree -r --name-only FETCH_HEAD -- "$path/" 2>/dev/null)
-    [ "$dir_dirty" -eq 1 ] && DIRTY+=("$path")
   else
-    # Blob entry: upstream-history membership check.
+    # Blob entry: upstream-history membership check. Untouched by spec 0129 —
+    # for a file entry the entry IS the file, so this already reports precisely
+    # (R5).
     strict_blob_is_dirty "$path" && DIRTY+=("$path")
   fi
 done
+
+# One file can be governed by two strict entries — the manifest ships
+# `docs` + `docs/index.json` and `artifacts/core` + `artifacts/core/system-context`
+# — and would then be appended twice, putting a duplicated line in the list the
+# adopter is asked to copy. Dedup HERE, in one pass after the loop, and not at
+# append time: the `docs` pair is produced by one append from the tree branch and
+# one from the blob branch, so an append-time filter inside either branch cannot
+# see it. Order-preserving, first occurrence wins — the duplicates are identical
+# strings, so what this preserves is manifest order, which is the order the
+# refusal already prints.
+#
+# Delimited by NEWLINE, not by a space: a space-delimited membership test reports
+# a false hit for any probe that is a space-separated fragment of a stored value
+# (with `docs/a b.md` stored, both `docs/a` and `b.md` read as already-seen), and
+# a false hit here silently DROPS a modified file from the refusal — this
+# ticket's own defect, reached through its fix. `git ls-tree` prints a space in a
+# path verbatim but C-quotes control characters, so a member string can contain a
+# space and can never contain a newline.
+UNIQ=()
+seen=""
+NL='
+'
+for p in ${DIRTY[@]+"${DIRTY[@]}"}; do
+  case "$NL$seen$NL" in
+    *"$NL$p$NL"*) continue ;;
+  esac
+  seen="$seen$NL$p"
+  UNIQ+=("$p")
+done
+DIRTY=(${UNIQ[@]+"${UNIQ[@]}"})
 
 if [ ${#DIRTY[@]} -gt 0 ]; then
   echo "Error: the following core-layer paths have local modifications:" >&2
@@ -459,6 +495,11 @@ if [ ${#DIRTY[@]} -gt 0 ]; then
     echo "  $p" >&2
   done
   echo "Revert these changes before running sync, or promote them to overlay overrides." >&2
+  echo "" >&2
+  echo "Restore ONLY the files listed above, one path at a time:" >&2
+  echo "  git checkout <your-ref> -- <path listed above>" >&2
+  echo "Never restore the containing directory. A directory-level checkout also" >&2
+  echo "reverts every file upstream added or changed in it, silently." >&2
   exit 1
 fi
 

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -459,10 +459,13 @@ for i in "${!PATHS[@]}"; do
   fi
 done
 
-# One file can be governed by two strict entries — the manifest ships
-# `docs` + `docs/index.json` and `artifacts/core` + `artifacts/core/system-context`
-# — and would then be appended twice, putting a duplicated line in the list the
-# adopter is asked to copy. Dedup HERE, in one pass after the loop, and not at
+# One file can be governed by two strict entries and would then be appended
+# twice, putting a duplicated line in the list the adopter is asked to copy. The
+# manifest ships FOUR such pairs today — `docs` + `docs/index.json`,
+# `artifacts/core` + `artifacts/core/system-context`, and `scripts` with each of
+# `scripts/sync-from-upstream.sh` and `scripts/build-docs-index.sh` — but the
+# dedup is placement-general and does not depend on that count. Dedup HERE, in
+# one pass after the loop, and not at
 # append time: the `docs` pair is produced by one append from the tree branch and
 # one from the blob branch, so an append-time filter inside either branch cannot
 # see it. Order-preserving, first occurrence wins — the duplicates are identical

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -258,6 +258,61 @@ run_case_stderr() {
   fi
 }
 
+# run_case_dirty_report <name> <repo> <present-path>… -- <absent-line>…
+#
+# Spec 0129's report assertions, and the reason this helper exists rather than a
+# second `run_case_stderr` call: R2 is an ABSENCE requirement, and the string
+# that must be absent (`scripts`) is a substring of the string that must be
+# present (`scripts/sync-from-upstream.sh`). A substring absence check therefore
+# fails whether or not the defect is fixed — a test that can never go green —
+# while a substring PRESENCE check on the directory name passes with the defect
+# fully present, because the pre-0129 refusal prints `  scripts`. Only a
+# WHOLE-LINE comparison discriminates, and the refusal prints each path as two
+# spaces followed by the path.
+#
+# Present paths are matched with the same two-space prefix, for symmetry and
+# because a bare substring would match a sibling path that contains this one.
+run_case_dirty_report() {
+  local name="$1" repo="$2"
+  shift 2
+  local present=() absent=() bucket="present"
+  local a
+  for a in "$@"; do
+    if [ "$a" = "--" ]; then bucket="absent"; continue; fi
+    if [ "$bucket" = "present" ]; then present+=("$a"); else absent+=("$a"); fi
+  done
+
+  local actual_exit=0 stderr_out
+  stderr_out="$(cd "$repo" && CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" 2>&1 >/dev/null)" || actual_exit=$?
+
+  local ok=1 p n
+  if [ "$actual_exit" -ne 1 ]; then
+    echo "FAIL  $name (expected exit 1, got $actual_exit)"
+    ok=0
+  fi
+  for p in ${present[@]+"${present[@]}"}; do
+    n="$(printf '%s\n' "$stderr_out" | grep -cxF "  $p" || true)"
+    if [ "$n" -ne 1 ]; then
+      echo "FAIL  $name (expected the line '  $p' exactly once, saw $n)"
+      ok=0
+    fi
+  done
+  for p in ${absent[@]+"${absent[@]}"}; do
+    if printf '%s\n' "$stderr_out" | grep -qxF "  $p"; then
+      echo "FAIL  $name (stderr names '$p' as its own line, which it must not)"
+      ok=0
+    fi
+  done
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  $name"
+    pass=$((pass + 1))
+  else
+    echo "      actual stderr: $stderr_out"
+    fail=$((fail + 1))
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Case 1 — Clean-core sync: all paths clean → exit 0
 # ---------------------------------------------------------------------------
@@ -2327,6 +2382,124 @@ STUB
   else
     fail=$((fail + 1))
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Case kk — spec 0129 R9: a directory manifest entry with ONE modified member
+# reports the MEMBER, and never the entry.
+#
+# The suite's pre-0129 coverage of the dirty guard runs through a manifest entry
+# that resolves to a FILE (`dirty-core refusal`, and case-d), which is the shape
+# that never exhibited issue #719 — for a file entry the entry IS the file. This
+# is the first case to drive a directory entry through the refusal.
+#
+# The assertions are whole-line, via run_case_dirty_report, and that is
+# load-bearing rather than tidy: asserting the presence of `scripts` as a
+# substring passes against the PRE-fix script, which printed exactly that.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "tools/alpha.sh" "upstream alpha" \
+    "tools/beta.sh" "upstream beta"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'tools\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "tools/alpha.sh" "upstream alpha" \
+    "tools/beta.sh" "upstream beta"
+
+  printf 'locally customised alpha' > "$adopter/tools/alpha.sh"
+
+  run_case_dirty_report \
+    "case-kk: a directory entry reports the modified member, not the directory" \
+    "$adopter" \
+    "tools/alpha.sh" \
+    -- \
+    "tools"
+}
+
+# ---------------------------------------------------------------------------
+# Case ll — spec 0129 R10: every modified member is reported, not the first.
+#
+# This is the case that discriminates R3. On case-kk's single-member fixture an
+# implementation that keeps the original `break` passes by accident: it reports
+# the one member there is. Only a fixture with several modified members can tell
+# "reports the members" from "reports the first member it finds".
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "tools/alpha.sh" "upstream alpha" \
+    "tools/beta.sh" "upstream beta" \
+    "tools/nested/gamma.sh" "upstream gamma"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'tools\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "tools/alpha.sh" "upstream alpha" \
+    "tools/beta.sh" "upstream beta" \
+    "tools/nested/gamma.sh" "upstream gamma"
+
+  printf 'locally customised alpha' > "$adopter/tools/alpha.sh"
+  printf 'locally customised beta'  > "$adopter/tools/beta.sh"
+  printf 'locally customised gamma' > "$adopter/tools/nested/gamma.sh"
+
+  run_case_dirty_report \
+    "case-ll: every modified member is reported, not just the first" \
+    "$adopter" \
+    "tools/alpha.sh" "tools/beta.sh" "tools/nested/gamma.sh" \
+    -- \
+    "tools"
+}
+
+# ---------------------------------------------------------------------------
+# Case mm — spec 0129 R1 via the deduplication: a file governed by BOTH a
+# directory entry and a nested strict entry is reported exactly once.
+#
+# The manifest ships two shapes of this, and they fail differently. This fixture
+# pins the NESTED-FILE shape (`docs` + `docs/index.json`), where the duplicate is
+# produced by one append from the tree branch and one from the blob branch — so a
+# deduplication installed at append time inside the tree branch cannot see it.
+# The nested-DIRECTORY shape (`artifacts/core` + `artifacts/core/system-context`)
+# also answers "governed by two entries" but goes green against that wrong
+# placement, which is why the fixture here is the file shape and not that one.
+#
+# `grep -cxF` equal to 1 is the whole point: a substring count would silently
+# absorb any sibling path containing this one.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "papers/index.json" '{"upstream": true}' \
+    "papers/other.md" "upstream other"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'papers\npapers/index.json\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "papers/index.json" '{"upstream": true}' \
+    "papers/other.md" "upstream other"
+
+  printf '{"locally": "customised"}' > "$adopter/papers/index.json"
+
+  run_case_dirty_report \
+    "case-mm: a file governed by two strict entries is reported exactly once" \
+    "$adopter" \
+    "papers/index.json" \
+    -- \
+    "papers"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test-sync-from-upstream.sh
+++ b/scripts/tests/test-sync-from-upstream.sh
@@ -2503,6 +2503,94 @@ STUB
 }
 
 # ---------------------------------------------------------------------------
+# Case nn — the dedup's seen-string is delimited by a NEWLINE, and a space
+# delimiter silently drops a modified file from the refusal.
+#
+# Without this case the delimiter is defended by a comment and nothing else:
+# reverting the newline to a space leaves the rest of the suite fully green, so
+# the guard reads as protected while being unprotected. That gap is what the cold
+# review of this PR found, and it is the same shape as the defect the whole ticket
+# is about — a claim made in prose with no signal behind it.
+#
+# The fixture is built so a space-delimited membership test produces a FALSE HIT.
+# The `container` entry is processed first and stores the member `container/name b`;
+# the separate `b` entry probes the string "b", which is a space-separated
+# fragment of what is stored. Under a space delimiter that probe reads as
+# already-seen and `b` never reaches the report — a modified file, silently
+# missing. Under a newline delimiter it cannot: git prints a space in a path
+# verbatim but C-quotes control characters, so a member can hold a space and can
+# never hold a newline.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "container/name b" "upstream spaced" \
+    "b" "upstream b"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'container\nb\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "container/name b" "upstream spaced" \
+    "b" "upstream b"
+
+  printf 'locally customised spaced' > "$adopter/container/name b"
+  printf 'locally customised b'      > "$adopter/b"
+
+  run_case_dirty_report \
+    "case-nn: a space-bearing member does not mask a separate modified file" \
+    "$adopter" \
+    "container/name b" "b" \
+    -- \
+    "container"
+}
+
+# ---------------------------------------------------------------------------
+# Case oo — spec 0129 R4: the refusal states the targeted restoration and warns
+# against the directory-level move.
+#
+# R4 is the half of this spec that reaches the adopter who already knows the
+# directory-level habit and would reproduce it from memory. Deleting all four
+# guidance lines left the suite green before this case existed, so the
+# requirement shipped with no signal behind it.
+#
+# Asserted on the sentence that carries the warning rather than on the whole
+# block: the wording may be improved, but a refusal that stops warning against
+# the directory-level checkout has lost the requirement.
+# ---------------------------------------------------------------------------
+{
+  upstream="$(mktemp -d "$TMP_ROOT/upstream.XXXXXX")"
+  init_git_repo "$upstream"
+  make_initial_commit "$upstream" \
+    "tools/alpha.sh" "upstream alpha"
+
+  adopter="$(mktemp -d "$TMP_ROOT/adopter.XXXXXX")"
+  init_git_repo "$adopter"
+  printf 'canonical_repo = "%s"\n' "$upstream" > "$adopter/crewrig.config.toml"
+  mkdir -p "$adopter/.crewrig"
+  printf 'tools\n' > "$adopter/.crewrig/core-paths.txt"
+  make_initial_commit "$adopter" \
+    "tools/alpha.sh" "upstream alpha"
+
+  printf 'locally customised alpha' > "$adopter/tools/alpha.sh"
+
+  run_case_stderr \
+    "case-oo: the refusal warns against restoring the containing directory" \
+    "$adopter" \
+    1 \
+    "Never restore the containing directory"
+
+  run_case_stderr \
+    "case-oo: the refusal states the targeted restoration command" \
+    "$adopter" \
+    1 \
+    "Restore ONLY the files listed above"
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))


### PR DESCRIPTION
Realizes [spec 0129](https://github.com/crewrig/crewrig/blob/main/specs/0129-dirty-report-names-files.md): when the dirty guard refuses a sync, it names the modified **files** rather than the manifest entry containing them, so a downstream adopter restores what they modified instead of the directory holding it. Three files, +250/−18.

Here is the whole ticket in one screen. Before, with one file customized inside the `tools` directory entry:

```text
Error: the following core-layer paths have local modifications:
  tools
```

After, with two:

```text
Error: the following core-layer paths have local modifications:
  tools/alpha.sh
  tools/nested/gamma.sh
Revert these changes before running sync, or promote them to overlay overrides.

Restore ONLY the files listed above, one path at a time:
  git checkout <your-ref> -- <path listed above>
Never restore the containing directory. A directory-level checkout also
reverts every file upstream added or changed in it, silently.
```

## How to read this PR?

**1. `scripts/sync-from-upstream.sh`, the detection loop.** The change is small and the comment above it is not, because two of the three decisions it records were wrong in earlier drafts and were only caught by measuring.

The detection was *already* per-file — `strict_blob_is_dirty` runs on each member. The knowledge was discarded by a `break` on the first hit and an append of the entry rather than the member. Both are gone.

**2. The deduplication, and why it sits after the loop rather than at append time.** A file can be governed by two strict entries at once, and the manifest ships two such pairs. They fail *differently*:

| pair | duplicate produced by | append-time dedup in the tree branch | post-loop pass |
|---|---|---|---|
| `docs` + `docs/index.json` | one append from **each** branch | still duplicated | fixed |
| `artifacts/core` + `artifacts/core/system-context` | two appends from the **tree** branch | fixed | fixed |

Spec R5 keeps the blob branch out of scope, so an append-time filter can only live in the tree branch — where it cannot see the first pair. Only the post-loop pass closes both. `case-mm` is pinned to the nested-**file** shape for that reason: the nested-directory shape goes green against the wrong placement and would not discriminate.

**3. The newline delimiter.** The seen-string membership test is `case "$NL$seen$NL" in *"$NL$p$NL"*`. With a space delimiter and `docs/a b.md` stored, the probes `docs/a` and `b.md` both report as already-seen — and a false hit there **drops a genuinely modified file from the refusal**, which is this ticket's own defect reached through its fix. `git ls-tree` prints a space in a path verbatim but C-quotes control characters, so a member can contain a space and can never contain a newline.

**4. `docs/adoption-guide.md`.** Not adjacent to the work — part of it. The guide reproduced the refusal verbatim and its troubleshooting entry taught the recovery this change alters, so a fix landing without it would ship a guide describing a message the script no longer prints, next to guidance for the move the script now warns against. The example's `config/SOUL.md` also goes: `.crewrig/core-paths.txt` has no `config` entry and no `config/SOUL.md` entry, so the guard could never emit it. It is replaced by `scripts/sync-from-upstream.sh` — a real member of a strict directory entry, and the file the reporting adopter had actually customized.

**5. The three cases, and why every assertion is whole-line.** The string that must be absent (`tools`) is a substring of the string that must be present (`tools/alpha.sh`). So a substring **absence** check fails whether or not the fix is in — a test that can never go green — and a substring **presence** check on the directory name passes with the defect fully present, because the pre-fix refusal printed exactly `  tools`. `run_case_dirty_report` compares whole lines with `grep -cxF` and requires a count of exactly 1, which is also what pins the deduplication.

## How to test this PR?

```sh
bash scripts/tests/test-sync-from-upstream.sh    # expect: Results: 68/68 passed
bash scripts/check-bash32-portability.sh         # expect: OK
```

**To confirm the three new cases actually discriminate**, run the new suite against the unmodified script. Stay inside the repository while doing it — `case-bb` resolves its subject with `git -C "$SCRIPT_DIR" rev-parse --show-toplevel`, which from a `mktemp` copy falls through to the process cwd and reports a spurious failure if you have wandered out:

```sh
git fetch crewrig main
d="$(mktemp -d)"; mkdir -p "$d/scripts/tests"
git show crewrig/main:scripts/sync-from-upstream.sh > "$d/scripts/sync-from-upstream.sh"
/bin/cp -f scripts/tests/test-sync-from-upstream.sh "$d/scripts/tests/"
bash "$d/scripts/tests/test-sync-from-upstream.sh"
```

Expected `Results: 65/68 passed` — every pre-existing case still green, and the three new ones failing **at their own mutation assertions**:

```text
FAIL  case-kk … (expected the line '  tools/alpha.sh' exactly once, saw 0)
FAIL  case-kk … (stderr names 'tools' as its own line, which it must not)
FAIL  case-ll … (expected the line '  tools/beta.sh' exactly once, saw 0)
FAIL  case-mm … (stderr names 'papers' as its own line, which it must not)
```

That distinction is the acceptance criterion: a case that reds because its fixture never built would satisfy a bare "it failed". Write the ref literally as shown — parameterized, `:s` is a zsh history modifier that corrupts the path — and note `cp` is aliased interactive in this environment, hence `/bin/cp -f`.

## Detailed description (for agents)

**`scripts/sync-from-upstream.sh`** — the tree branch of the dirty-core detection loop appends each modified `$member` and nothing for the entry; the `break` is removed (R1/R2/R3). The `excluded_children_of` skip is untouched (R6) — **`case-z` is its sentinel**, verified by deleting the skip and observing which case reds; `case-aa` cannot fail on that mutation because its `settings.json` is byte-identical to upstream, and `case-a`/`case-e` cannot either because their excluded children are adopter-only and never appear in `git ls-tree FETCH_HEAD`. The blob branch is untouched (R5). A deduplication pass follows the loop, order-preserving, first occurrence wins — the duplicates are identical strings, so what that preserves is manifest order, which is the order the refusal already printed. The write-back is `DIRTY=(${UNIQ[@]+"${UNIQ[@]}"})`, the guarded form spec 0124 R2 requires. The refusal gains the targeted-restoration guidance (R4); its exit status is unchanged (R7).

**R8 is satisfied by construction and required nothing:** the removed `break` was unreachable when nothing is modified, so a clean run already visited every member and the non-refusing path pays nothing new.

**`scripts/tests/test-sync-from-upstream.sh`** — `run_case_dirty_report` added, taking present-paths and absent-lines around a `--` separator, asserting exit 1, `grep -cxF "  $p"` equal to 1 for each present path, and no whole-line match for each absent one. Cases `kk` (R9, one modified member), `ll` (R10, three modified members including a nested one), and `mm` (the deduplication, pinned to the nested-file shape). Case `ll` is what discriminates R3: on `kk`'s single-member fixture an implementation that keeps the `break` passes by accident.

**`docs/adoption-guide.md`** — three edits: the fenced example block, the `git checkout` resolution step, and the cause/effect pair above it, which described a listed path as a manifest entry. That vocabulary is what spec R2 corrects.

**Not touched, and why:** no `artifacts/` source, so no component rebuild and no `metadata.provenance.version` bump. No `docs/cli-matrix.md` row — the file carries no occurrence of `sync-from-upstream` and the script matches none of the `{build,install,setup,import,manage}-*.sh` trigger prefixes. `.crewrig/core-paths.txt` is read, not modified; its format is out of scope per spec 0129, so no manifest co-maintenance obligation arises. The consumer set for the refusal text is exactly two files — `git grep -ln "have local modifications"` returns the script and the guide — and both are in this diff.

**Process record:** the PLAN went through three revisions and three cold-review passes. The reviews caught two defects that would have shipped — the deduplication placed where it cannot see half the duplicates, and a membership test that would have silently dropped modified files — plus a blast-radius claim of mine asserting no in-repo consumer of the refusal text existed, which a three-second `grep` refutes, and one finding I recorded as resolved without making the edit. None was reachable by reading; each came from applying the change in a scratch copy and measuring. The trail is on #719.

Closes #719
