### PR TITLE
✨ Implement spec-PR draft-approved guard

### DIFF
--- a/docs/interaction-modes.md
+++ b/docs/interaction-modes.md
@@ -73,7 +73,10 @@ new file, no other edits) merging that content **unchanged** discharges the
 pre-merge merge-authorization gate for that spec-PR. The orchestrator SHALL
 NOT fire a second merge-authorization request for such a spec-PR, because
 the artifact merged to `main` is the identical, unchanged artifact the
-content-approval already approved. This discharge is deliberately narrow —
+content-approval already approved. The lifecycle-metadata transition
+(`status` and `interaction-mode`) mandated by `docs/spec-format.md` is
+explicitly NOT a content change and does NOT forfeit this
+merge-authorization discharge. This discharge is deliberately narrow —
 it is not a general waiver of the gate. It does **not** apply in `AUTO`,
 where no SPECS-stage content-approval gate runs to discharge it, so the
 merge-authorization request there still fires and remains the sole approval

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -283,11 +283,11 @@ spec is never at once merged and still `draft` — and **no** separate,
 post-merge, metadata-only pull request is required to record the approval.
 
 *Merge mechanic.* Strictly **after** the approval event has been secured
-and strictly **before** running `gh pr merge --squash`, on the spec-PR branch
+and strictly **before** running `bash scripts/merge-spec-pr.sh`, on the spec-PR branch
 (`spec/<NNNN>-<slug>`) edit the spec's frontmatter (`status: draft` →
 `status: approved`, adding `interaction-mode` if it was omitted during
 `draft`), create a **new commit** — not `git commit --amend` — then `git push`
-and only then `gh pr merge --squash`. A new commit rather than an amend
+and only then `bash scripts/merge-spec-pr.sh`. A new commit rather than an amend
 because the spec-PR squash-merges, so both routes collapse to the same single
 commit on `main` carrying `status: approved`; a new commit needs only a plain
 `git push`, whereas an amend would force `git push --force-with-lease` and

--- a/scripts/merge-spec-pr.sh
+++ b/scripts/merge-spec-pr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/merge-spec-pr.sh — exclusive merge mechanism for spec-PRs.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ -f "scripts/lib/common.sh" ]; then
+  . scripts/lib/common.sh
+fi
+
+BRANCH_NAME="$(git branch --show-current)"
+
+if [[ "$BRANCH_NAME" != spec/* ]]; then
+    echo "  Not on a spec/ branch. Delegating to gh pr merge."
+    exec gh pr merge --squash "$@"
+fi
+
+SPEC_SLUG="${BRANCH_NAME#spec/}"
+SPEC_FILE="specs/${SPEC_SLUG}.md"
+
+if [ ! -f "$SPEC_FILE" ]; then
+    echo "  WARNING: Spec file $SPEC_FILE not found on branch $BRANCH_NAME. Delegating to gh pr merge."
+    exec gh pr merge --squash "$@"
+fi
+
+STATUS=$(awk '/^---$/{ c++ } c==1 && /^status:/{ print $2; exit }' "$SPEC_FILE")
+
+if [ "$STATUS" = "draft" ]; then
+    echo "ERROR: Spec file $SPEC_FILE has 'status: draft' in its frontmatter." >&2
+    echo "       A draft spec cannot be merged. Please approve it first." >&2
+    exit 1
+fi
+
+echo "  Spec file $SPEC_FILE is not draft. Delegating to gh pr merge."
+exec gh pr merge --squash "$@"

--- a/scripts/merge-spec-pr.sh
+++ b/scripts/merge-spec-pr.sh
@@ -18,6 +18,7 @@ if [[ "$BRANCH_NAME" != spec/* ]]; then
 fi
 
 SPEC_SLUG="${BRANCH_NAME#spec/}"
+SPEC_SLUG="$(echo "$SPEC_SLUG" | sed 's/-delta-\([0-9][0-9]*\)$/.delta-\1/')"
 SPEC_FILE="specs/${SPEC_SLUG}.md"
 
 if [ ! -f "$SPEC_FILE" ]; then


### PR DESCRIPTION
✨ Implement spec-PR draft-approved guard

Implements the spec-PR guard defined in spec 0132 to prevent accidental merging of `draft` specs.

## How to read this PR?
- `scripts/merge-spec-pr.sh` contains the bash script blocking the merge.
- `docs/spec-format.md` is updated to mandate the script.
- `docs/interaction-modes.md` is clarified regarding lifecycle metadata transitions.

## How to test this PR?
To test the guard on a draft spec:
1. `git checkout -b spec/9999-test-draft`
2. `mkdir -p specs && echo -e "---\nstatus: draft\n---\n" > specs/9999-test-draft.md`
3. `./scripts/merge-spec-pr.sh` (it should exit 1 with an error)
4. Clean up: `git checkout - && git branch -D spec/9999-test-draft && rm specs/9999-test-draft.md`

## Detailed description (for agents)
Added `scripts/merge-spec-pr.sh` to extract `status` from spec-PR branches and block `gh pr merge` if the status is `draft`. Delegating to `gh pr merge` otherwise. Minor doc amends included for `docs/spec-format.md` and `docs/interaction-modes.md` per spec 0132 requirements.

