### PR TITLE
📝 Record spec 0129 as implemented

### DIFF
--- a/specs/0129-dirty-report-names-files.md
+++ b/specs/0129-dirty-report-names-files.md
@@ -1,7 +1,7 @@
 ---
 id: "0129"
 slug: dirty-report-names-files
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 719


### PR DESCRIPTION
Closes the lifecycle of #719. `specs/0129-dirty-report-names-files.md` read `status: approved` while its implementation merged at `3bb770e` (PR #856).

## How to read this PR?

One line in the frontmatter: `status: approved` → `status: implemented`.

## How to test this PR?

```sh
task spec:lint
```

Expected: `Linting passed!`.

## Detailed description (for agents)

**Modified:** `specs/0129-dirty-report-names-files.md`, `status` field only.

**Presence of the implementation verified at content level**, not by ancestry — #856 was squash-merged, so an ancestry check reports the work absent and is misleading. Extracted `scripts/sync-from-upstream.sh` from `crewrig/main` and read the detection loop: the tree branch appends each modified member and nothing for the entry; the first-match `break` is gone (the one remaining `break` is the exclusion loop's, untouched by design); the post-loop deduplication is present with the guarded write-back; the R4 guidance appears in the refusal and in `docs/adoption-guide.md`; the suite carries the five new case markers.

**No version bump.** The spec's `version` stays `1.0.0` — the body is what the SPECS gate approved and what merged. Same treatment as specs 0109, 0114, 0126 and 0128.

Closes #859