### PR TITLE
📝 Mark spec 0133 as implemented

### DIFF
--- a/specs/0133-close-mcp-daemon-coverage-gaps.md
+++ b/specs/0133-close-mcp-daemon-coverage-gaps.md
@@ -1,7 +1,7 @@
 ---
 id: "0133"
 slug: close-mcp-daemon-coverage-gaps
-status: draft
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 754


### PR DESCRIPTION
Marks spec 0133 (close-mcp-daemon-coverage-gaps) as `implemented` now that the implementation shipped via PR #861 (merge commit a75fa667).

Closes #754