### PR TITLE
✨ Add spec 0136 — document the shared MemPalace MCP daemon

### DIFF
--- a/specs/0136-document-shared-mempalace-mcp-daemon.md
+++ b/specs/0136-document-shared-mempalace-mcp-daemon.md
@@ -1,7 +1,7 @@
 ---
 id: "0136"
 slug: document-shared-mempalace-mcp-daemon
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 751

--- a/specs/0136-document-shared-mempalace-mcp-daemon.md
+++ b/specs/0136-document-shared-mempalace-mcp-daemon.md
@@ -1,0 +1,119 @@
+---
+id: "0136"
+slug: document-shared-mempalace-mcp-daemon
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 751
+version: 1.0.0
+---
+
+# Document the shared MemPalace MCP daemon
+
+## Intent
+
+A reader who opens the project's entry documentation learns that shared memory
+has two coordinated layers, not one, and can operate the upper one: start it,
+check it, stop it, tell a collision from a healthy service, and replace its
+credential. The decision record behind that layer is reachable from the
+documentation rather than only from the directory that holds it, and no statement
+in it contradicts the code it depends on. An agent reading the memory rules
+understands that a refused write is now the rare case on a converted machine
+rather than the expected one.
+
+## Requirements
+
+1. Every factual claim this spec's implementation writes or corrects about
+   MemPalace's own behaviour SHALL be verified against the installed MemPalace
+   source at the pinned version, and the verifying file and line SHALL be cited
+   in the implementation's logbook comment. A claim that cannot be verified
+   SHALL NOT be written.
+2. `README.md` SHALL describe both memory coordination layers — the shared
+   ChromaDB daemon and the shared MCP daemon — and SHALL NOT state or imply that
+   the ChromaDB layer alone reduces write contention to a single process.
+3. `README.md` SHALL name the operator entry point that converts a machine to
+   the shared MCP daemon, and SHALL link the runbook of requirement 4.
+4. A runbook for the shared MCP daemon SHALL exist under `docs/runbooks/` and
+   SHALL cover: starting, stopping and checking the daemon; the distinction
+   between stopping it and uninstalling it, including that a stop under a
+   supervisor is a restart request; the location of its log; the diagnostic for a
+   port already in use; and the procedure for replacing the bearer token.
+5. The token-replacement procedure SHALL be recorded in the runbook of
+   requirement 4 in the order that leaves no daemon serving a superseded value,
+   and SHALL state that no automated path exists yet.
+6. The runbook of requirement 4 SHALL NOT describe any command-line flag,
+   option, or script that the repository does not ship at the time the
+   documentation merges.
+7. ADR 0016 SHALL be reachable by link from at least one document outside
+   `docs/adr/`.
+8. `docs/concepts.md` SHALL state that the agent-memory tier is served by a
+   shared process rather than by one process per session, and SHALL link ADR
+   0016.
+9. `artifacts/core/rules/60-tools.md` SHALL state that a peer-writer refusal is
+   the rare case on a machine converted to the shared MCP daemon, while keeping
+   the refusal documented as the degraded path an agent must still handle.
+10. Every statement in ADR 0016 asserting that MemPalace mints a bearer token on
+    a loopback bind SHALL be corrected, including any open question whose
+    premise rests on that assertion. The correction SHALL leave the ADR's
+    decision unchanged and SHALL be marked as a correction rather than silently
+    rewritten.
+11. This spec's implementation SHALL NOT restate the per-CLI integration facts
+    that `docs/cli-matrix.md` carries. Prose that needs them SHALL link the
+    matrix row.
+
+## Scenarios
+
+**Scenario:** An operator converts a machine and can then run it
+
+```text
+Given  a reader who has only read README.md
+When   they follow its memory section to the MCP daemon runbook
+Then   they can start the daemon, confirm it is serving, read its log,
+       recognise a port collision, and replace its token without reading
+       any script's source
+```
+
+**Scenario:** A reader is not told the contention problem is solved when it is not
+
+```text
+Given  a machine that has NOT been converted to the shared MCP daemon
+When   a reader consults README.md about concurrent sessions
+Then   the text distinguishes the layer that is active from the layer that
+       requires conversion, and does not present single-writer behaviour as
+       already in force
+```
+
+**Scenario:** A false claim is rejected rather than propagated
+
+```text
+Given  a statement in ADR 0016 that MemPalace mints a token on a loopback bind
+When   the implementation checks it against the installed MemPalace source
+Then   the statement is corrected in the ADR, the correction cites the source
+       line that refutes it, and every open question resting on the same
+       premise is corrected in the same change
+```
+
+**Scenario:** A documented procedure names a flag that does not exist
+
+```text
+Given  a draft runbook describing a --rotate flag for the token
+When   the repository ships no such flag
+Then   the draft is rejected and the manual procedure is documented instead,
+       stating that no automated path exists yet
+```
+
+## Out of scope
+
+- Building the token-rotation tooling itself. This spec documents the manual
+  procedure; the automated path is a separate ticket.
+- Any change to `docs/cli-matrix.md` rows 7c, 7d or 10, which already carry the
+  per-CLI facts and remain the machine-readable source of truth.
+- Repairing a machine left in an unrecognisable arrangement, and deciding the
+  transcript hook's write path. Both are separate derived specs of ADR 0016.
+- Correcting the content-coverage claim in `docs/cli-matrix.md` row 8, which
+  belongs to the transcript-fidelity work.
+- Any change to the daemon's behaviour, its supervisor units, or its scripts.
+
+## Open questions
+
+- None.

--- a/specs/0136-document-shared-mempalace-mcp-daemon.md
+++ b/specs/0136-document-shared-mempalace-mcp-daemon.md
@@ -60,6 +60,17 @@ rather than the expected one.
 11. This spec's implementation SHALL NOT restate the per-CLI integration facts
     that `docs/cli-matrix.md` carries. Prose that needs them SHALL link the
     matrix row.
+12. The documentation SHALL carry a diagram of the two-layer coordination
+    topology, placed where a reader first meets that topology.
+13. Every operator procedure this spec requires whose steps have a
+    consequential order SHALL carry a diagram of that order. Converting a
+    machine and replacing the bearer token each qualify.
+14. Every diagram SHALL ship with a form that a later contributor can diff and
+    amend — either a text-based source rendered at read time, or a generated
+    image committed alongside the input that produced it. A diagram whose only
+    committed form is an opaque binary SHALL NOT be introduced.
+15. Every diagram SHALL remain legible on both a light and a dark reading
+    surface.
 
 ## Scenarios
 
@@ -100,6 +111,24 @@ Given  a draft runbook describing a --rotate flag for the token
 When   the repository ships no such flag
 Then   the draft is rejected and the manual procedure is documented instead,
        stating that no automated path exists yet
+```
+
+**Scenario:** A reader grasps the topology before reading a paragraph about it
+
+```text
+Given  a reader who has never heard of the two coordination layers
+When   they reach the section of README.md that introduces them
+Then   a diagram shows both layers, which one requires conversion, and where
+       the palace sits relative to them
+```
+
+**Scenario:** A diagram that cannot be amended is refused
+
+```text
+Given  a diagram contributed as an image file with no accompanying source
+When   a later contributor needs to correct one label in it
+Then   the contribution is refused, because nothing committed lets them
+       regenerate or diff it
 ```
 
 ## Out of scope


### PR DESCRIPTION
Spec 0136 is the SPECS-stage artifact for issue #751 — ADR 0016's derived spec
plan step 5, the narrative documentation the shared MemPalace MCP daemon shipped
without. It also binds the correction of a claim ADR 0016 makes about MemPalace's
code that turns out to be false.

## How to read this PR?

One new file, `specs/0136-document-shared-mempalace-mcp-daemon.md`. Read the
`## Requirements` section first, then the two non-obvious decisions behind it:

**Requirement 1 is the load-bearing one.** It makes verification-before-writing
binding for every factual claim the implementation touches, and requires the
verifying file and line in the logbook comment. This ticket exists partly because
a merged decision record asserts something the code refutes; a documentation spec
that does not guard against writing the next such claim would reproduce the
defect it is fixing.

**Requirement 10 covers two occurrences, not one.** Issue #751 names the false
claim at `docs/adr/0016-shared-mempalace-mcp-server.md:150-151`. Authoring found
a second one: the ADR's *Open questions* section asks whether to mint a token on
a loopback bind "matching `cmd_serve`'s own behaviour" — the same premise, so
correcting only the first would leave the ADR self-consistent about a false fact.
The requirement is therefore phrased over *every* statement resting on that
premise rather than over a line range.

**Requirements 6 and 11 are boundary guards.** Requirement 6 forbids documenting
a flag the repository does not ship, because the token-rotation tooling is a
separate ticket (#744) and the runbook must describe today's manual procedure
without promising tomorrow's `--rotate`. Requirement 11 keeps the prose from
restating `docs/cli-matrix.md`, which stays the machine-readable source of truth
for the per-CLI facts.

## How to test this PR?

```sh
# 1. Spec corpus lint — markdownlint plus the semantic validator
task spec:lint

# 2. Spec-id reservation guard
CREWRIG_SPEC_ID_ORIGIN=same BASE_REF=crewrig/main \
  bash scripts/check-spec-id-reserved.sh
```

Expected: both exit 0. The second prints
`OK specs/0136-document-shared-mempalace-mcp-daemon.md — id '0136' secured for
issue #751 at refs/spec-ids/0136 (no stale mark)`.

**The linter's green was proven, not assumed.** Two mutations were injected
against this file and both reddened it, so the passing run carries information:

| Mutation | Result |
|---|---|
| `id: "0136"` → `id: "9999"` | `[FAIL] … Frontmatter 'id' ("9999") does not match filename prefix ("0136")` |
| `## Open questions` section deleted | `MD012/no-multiple-blanks` at the truncation point |

Both were reverted and the file was confirmed byte-identical to its pre-mutation
state before committing.

The claim the spec's requirement 10 targets is independently checkable against
the pinned MemPalace version:

```sh
grep -n 'allow_insecure\|non-loopback' \
  ~/.local/pipx/venvs/mempalace/lib/python*/site-packages/mempalace/cli.py
```

Expected on mempalace 3.6.0: `cli.py:1421` documents "auto-generating a strong
one for **non-loopback** binds", and `cli.py:1450` reads
`if not token and not loopback and not args.allow_insecure:`. Both refute the
ADR's "on loopback … `cmd_serve` mints one anyway".

## Detailed description (for agents)

### Added

`specs/0136-document-shared-mempalace-mcp-daemon.md` — one file, per the
spec-PR one-file rule. Frontmatter: `id: "0136"`, `slug:
document-shared-mempalace-mcp-daemon`, `status: draft`, `complexity: small`,
`interaction-mode: INTERMEDIATE`, `related-issue: 751`, `version: 1.0.0`.

Eleven requirements, grouped by what they bind:

- **1** — verification obligation over every factual claim about MemPalace
  behaviour, with the verifying file and line cited in the logbook.
- **2, 3** — `README.md` must describe both coordination layers and must stop
  implying the ChromaDB layer alone reduces contention to one process; it must
  name the conversion entry point and link the runbook.
- **4, 5, 6** — a runbook under `docs/runbooks/` covering start/stop/status, the
  stop-versus-uninstall distinction, log location, port-collision diagnosis and
  token replacement; the replacement procedure recorded in an order that leaves
  no daemon serving a superseded value, stating no automated path exists yet; and
  a prohibition on documenting unshipped flags.
- **7, 8** — ADR 0016 reachable from outside `docs/adr/`; `docs/concepts.md`
  stating that the agent-memory tier is served by a shared process.
- **9** — `artifacts/core/rules/60-tools.md` presenting a peer-writer refusal as
  the rare case on a converted machine while keeping it documented as the
  degraded path.
- **10** — every statement resting on the loopback-token premise corrected,
  marked as a correction, with the ADR's decision left unchanged.
- **11** — no restatement of `docs/cli-matrix.md`.

Four scenarios: two happy-path (an operator can run the daemon from the entry
documentation; a reader is not told the contention problem is solved on an
unconverted machine) and two failure-path (a false claim is rejected rather than
propagated; a runbook naming an unshipped flag is rejected).

`## Out of scope` excludes building the rotation tooling (#744), the cli-matrix
rows that already carry the per-CLI facts, the two sibling derived specs (#752,
#753), the row-8 content-coverage correction that belongs to the
transcript-fidelity work (#757), and any behavioural change to the daemon.

`## Open questions` is empty — nothing was left unresolved at authoring.

### Not changed

No other file. No behavioural change, no script, no built component.

### Process notes

- Spec id secured on the reference repository before the file existed, per spec
  0112: `refs/spec-ids/0136` for issue #751.
- An earlier reservation of `0135` was **released** during authoring: a sibling
  session holds an untracked `specs/0135-implemented-transition-in-merge.md` in
  `.worktrees/0135` plus a branch and worktree named for that id, and had not
  secured it. Ceding cost one push; making it renumber would have cost three
  artifacts.
- Authored inline rather than delegated to the `spec-author` agent. The session's
  operating instructions prohibit spawning subagents unless the user requests
  them, which overrides the *Solo work prohibition* of `AGENTS.md` → *Agent Team
  Protocol* for this session. Recorded here rather than left for a REVIEW pass to
  discover.

Refs #751, ADR 0016 derived spec plan step 5.
