### PR TITLE
📝 Mark spec 0134 as implemented

### DIFF
--- a/specs/0134-plannotator-detached-invocation-verified.md
+++ b/specs/0134-plannotator-detached-invocation-verified.md
@@ -1,7 +1,7 @@
 ---
 id: "0134"
 slug: plannotator-detached-invocation-verified
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 823


### PR DESCRIPTION
This PR transitions the status of spec 0134 to implemented after its successful implementation.

## How to read this PR?

Check the frontmatter of `specs/0134-plannotator-detached-invocation-verified.md`.

## How to test this PR?

Run the spec-linter:
```bash
node scripts/lib/spec-linter.js specs/0134-plannotator-detached-invocation-verified.md
```

## Detailed description (for agents)

- Updated `specs/0134-plannotator-detached-invocation-verified.md` frontmatter status to `implemented` (related-issue: #823).