### PR TITLE
✨ Fold the spec approved→implemented transition into the implementation merge

### DIFF
--- a/.agents/skills/pr-logbook/SKILL.md
+++ b/.agents/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -123,6 +123,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 5b. Spec `approved` → `implemented` transition (when the PR implements a spec)
+
+When the PR implements a spec (its `related-issue` is a spec's issue), the
+spec's `approved` → `implemented` transition is folded into this PR's own
+merge — it is **not** recorded by a separate, post-merge, metadata-only PR
+(`docs/spec-format.md` → *Recording a status transition*). Before the PR
+merges, on the implementation feature branch:
+
+1. Edit the spec's frontmatter: `status: approved` → `status: implemented`.
+2. Touch nothing else — no body line, no `id`, no `slug`, no `version`. A
+   diff that alters any normative content under cover of the status bump is
+   a violation.
+3. Create a **new commit** — not `git commit --amend` — then `git push`. The
+   implementation PR squash-merges, so the transition rides the PR's own
+   squash commit and the spec lands on `main` already carrying
+   `status: implemented` at the moment its implementation lands.
+
+The spec-author skill writes `status: draft` on first write and records
+`draft` → `approved` in the spec-PR; this step is the `implemented` half of
+the same in-commit mechanic.
 
 ### 6. Pre-push sanity checks
 

--- a/.agents/skills/spec-author/SKILL.md
+++ b/.agents/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.5.0"
+    version: "1.6.0"
 ---
 
 
@@ -437,6 +437,14 @@ schema*:
 | `unsecured-id` | Omitted. Present, and copied verbatim from the tool's stdout, only on the exit-`3` path above. |
 
 The filename slug and the frontmatter slug SHALL match exactly.
+
+The `status` field is written `draft` on first write and flipped to
+`approved` in the spec-PR's own commit (the Merge mechanic). The subsequent
+`approved` → `implemented` transition is **not** this skill's job: it is
+recorded by the implementation team's `pr-logbook` on the implementation
+feature branch, folded into the implementation PR's own squash commit
+(`docs/spec-format.md` → *Recording a status transition*). This skill SHALL
+NOT open a separate, post-merge, metadata-only PR to record `implemented`.
 
 ### Body sections
 

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -127,6 +127,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 5b. Spec `approved` → `implemented` transition (when the PR implements a spec)
+
+When the PR implements a spec (its `related-issue` is a spec's issue), the
+spec's `approved` → `implemented` transition is folded into this PR's own
+merge — it is **not** recorded by a separate, post-merge, metadata-only PR
+(`docs/spec-format.md` → *Recording a status transition*). Before the PR
+merges, on the implementation feature branch:
+
+1. Edit the spec's frontmatter: `status: approved` → `status: implemented`.
+2. Touch nothing else — no body line, no `id`, no `slug`, no `version`. A
+   diff that alters any normative content under cover of the status bump is
+   a violation.
+3. Create a **new commit** — not `git commit --amend` — then `git push`. The
+   implementation PR squash-merges, so the transition rides the PR's own
+   squash commit and the spec lands on `main` already carrying
+   `status: implemented` at the moment its implementation lands.
+
+The spec-author skill writes `status: draft` on first write and records
+`draft` → `approved` in the spec-PR; this step is the `implemented` half of
+the same in-commit mechanic.
 
 ### 6. Pre-push sanity checks
 

--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.5.0"
+    version: "1.6.0"
 ---
 
 
@@ -443,6 +443,14 @@ schema*:
 | `unsecured-id` | Omitted. Present, and copied verbatim from the tool's stdout, only on the exit-`3` path above. |
 
 The filename slug and the frontmatter slug SHALL match exactly.
+
+The `status` field is written `draft` on first write and flipped to
+`approved` in the spec-PR's own commit (the Merge mechanic). The subsequent
+`approved` → `implemented` transition is **not** this skill's job: it is
+recorded by the implementation team's `pr-logbook` on the implementation
+feature branch, folded into the implementation PR's own squash commit
+(`docs/spec-format.md` → *Recording a status transition*). This skill SHALL
+NOT open a separate, post-merge, metadata-only PR to record `implemented`.
 
 ### Body sections
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -123,6 +123,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 5b. Spec `approved` → `implemented` transition (when the PR implements a spec)
+
+When the PR implements a spec (its `related-issue` is a spec's issue), the
+spec's `approved` → `implemented` transition is folded into this PR's own
+merge — it is **not** recorded by a separate, post-merge, metadata-only PR
+(`docs/spec-format.md` → *Recording a status transition*). Before the PR
+merges, on the implementation feature branch:
+
+1. Edit the spec's frontmatter: `status: approved` → `status: implemented`.
+2. Touch nothing else — no body line, no `id`, no `slug`, no `version`. A
+   diff that alters any normative content under cover of the status bump is
+   a violation.
+3. Create a **new commit** — not `git commit --amend` — then `git push`. The
+   implementation PR squash-merges, so the transition rides the PR's own
+   squash commit and the spec lands on `main` already carrying
+   `status: implemented` at the moment its implementation lands.
+
+The spec-author skill writes `status: draft` on first write and records
+`draft` → `approved` in the spec-PR; this step is the `implemented` half of
+the same in-commit mechanic.
 
 ### 6. Pre-push sanity checks
 

--- a/.gemini/skills/spec-author/SKILL.md
+++ b/.gemini/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.5.0"
+    version: "1.6.0"
 ---
 
 
@@ -437,6 +437,14 @@ schema*:
 | `unsecured-id` | Omitted. Present, and copied verbatim from the tool's stdout, only on the exit-`3` path above. |
 
 The filename slug and the frontmatter slug SHALL match exactly.
+
+The `status` field is written `draft` on first write and flipped to
+`approved` in the spec-PR's own commit (the Merge mechanic). The subsequent
+`approved` → `implemented` transition is **not** this skill's job: it is
+recorded by the implementation team's `pr-logbook` on the implementation
+feature branch, folded into the implementation PR's own squash commit
+(`docs/spec-format.md` → *Recording a status transition*). This skill SHALL
+NOT open a separate, post-merge, metadata-only PR to record `implemented`.
 
 ### Body sections
 

--- a/.github/skills/pr-logbook/SKILL.md
+++ b/.github/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -123,6 +123,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 5b. Spec `approved` → `implemented` transition (when the PR implements a spec)
+
+When the PR implements a spec (its `related-issue` is a spec's issue), the
+spec's `approved` → `implemented` transition is folded into this PR's own
+merge — it is **not** recorded by a separate, post-merge, metadata-only PR
+(`docs/spec-format.md` → *Recording a status transition*). Before the PR
+merges, on the implementation feature branch:
+
+1. Edit the spec's frontmatter: `status: approved` → `status: implemented`.
+2. Touch nothing else — no body line, no `id`, no `slug`, no `version`. A
+   diff that alters any normative content under cover of the status bump is
+   a violation.
+3. Create a **new commit** — not `git commit --amend` — then `git push`. The
+   implementation PR squash-merges, so the transition rides the PR's own
+   squash commit and the spec lands on `main` already carrying
+   `status: implemented` at the moment its implementation lands.
+
+The spec-author skill writes `status: draft` on first write and records
+`draft` → `approved` in the spec-PR; this step is the `implemented` half of
+the same in-commit mechanic.
 
 ### 6. Pre-push sanity checks
 

--- a/.github/skills/spec-author/SKILL.md
+++ b/.github/skills/spec-author/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.5.0"
+    version: "1.6.0"
 ---
 
 
@@ -437,6 +437,14 @@ schema*:
 | `unsecured-id` | Omitted. Present, and copied verbatim from the tool's stdout, only on the exit-`3` path above. |
 
 The filename slug and the frontmatter slug SHALL match exactly.
+
+The `status` field is written `draft` on first write and flipped to
+`approved` in the spec-PR's own commit (the Merge mechanic). The subsequent
+`approved` → `implemented` transition is **not** this skill's job: it is
+recorded by the implementation team's `pr-logbook` on the implementation
+feature branch, folded into the implementation PR's own squash commit
+(`docs/spec-format.md` → *Recording a status transition*). This skill SHALL
+NOT open a separate, post-merge, metadata-only PR to record `implemented`.
 
 ### Body sections
 

--- a/artifacts/core/skills/pr-logbook/SKILL.md
+++ b/artifacts/core/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.2.0"
+    version: "1.3.0"
 claude:
   allowed-tools:
     - Read
@@ -131,6 +131,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 5b. Spec `approved` → `implemented` transition (when the PR implements a spec)
+
+When the PR implements a spec (its `related-issue` is a spec's issue), the
+spec's `approved` → `implemented` transition is folded into this PR's own
+merge — it is **not** recorded by a separate, post-merge, metadata-only PR
+(`docs/spec-format.md` → *Recording a status transition*). Before the PR
+merges, on the implementation feature branch:
+
+1. Edit the spec's frontmatter: `status: approved` → `status: implemented`.
+2. Touch nothing else — no body line, no `id`, no `slug`, no `version`. A
+   diff that alters any normative content under cover of the status bump is
+   a violation.
+3. Create a **new commit** — not `git commit --amend` — then `git push`. The
+   implementation PR squash-merges, so the transition rides the PR's own
+   squash commit and the spec lands on `main` already carrying
+   `status: implemented` at the moment its implementation lands.
+
+The spec-author skill writes `status: draft` on first write and records
+`draft` → `approved` in the spec-PR; this step is the `implemented` half of
+the same in-commit mechanic.
 
 ### 6. Pre-push sanity checks
 

--- a/artifacts/core/skills/spec-author/SKILL.md
+++ b/artifacts/core/skills/spec-author/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.5.0"
+    version: "1.6.0"
 claude:
   allowed-tools:
     - Read
@@ -449,6 +449,14 @@ schema*:
 | `unsecured-id` | Omitted. Present, and copied verbatim from the tool's stdout, only on the exit-`3` path above. |
 
 The filename slug and the frontmatter slug SHALL match exactly.
+
+The `status` field is written `draft` on first write and flipped to
+`approved` in the spec-PR's own commit (the Merge mechanic). The subsequent
+`approved` → `implemented` transition is **not** this skill's job: it is
+recorded by the implementation team's `pr-logbook` on the implementation
+feature branch, folded into the implementation PR's own squash commit
+(`docs/spec-format.md` → *Recording a status transition*). This skill SHALL
+NOT open a separate, post-merge, metadata-only PR to record `implemented`.
 
 ### Body sections
 

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -194,7 +194,7 @@ table below is the contract.
 |---|---|---|---|
 | `draft` | Spec file opened in the working branch | Spec author (human or `spec-author` skill) | Spec file in the worktree, no PR yet |
 | `approved` | Spec PR merged on `main` | Spec reviewer (per the interaction mode declared in frontmatter) | Merged spec PR — its own (squash) commit already carries `status: approved`, so no separate status-transition PR is opened — plus a logbook comment recording the approval |
-| `implemented` | Implementation PR for `related-issue` merged on `main` | Implementation team's `pr-logbook` | Merged implementation PR + logbook closure comment |
+| `implemented` | Implementation PR for `related-issue` merged on `main` | Implementation team's `pr-logbook` | Merged implementation PR — its own (squash) commit already carries `status: implemented`, so no separate status-transition PR is opened — plus a logbook closure comment |
 | `archived` | Related issue closed without implementation (`won't fix`, duplicate, abandoned) | Ticket closer | Logbook comment explaining the archival |
 | `superseded` | A newer spec replaces this one (often through a `spec`-class loop that grows beyond a delta) | Author of the superseding spec | `superseded-by` field set; superseding spec exists with its own id |
 
@@ -248,12 +248,15 @@ lifecycle-tracking metadata: the `status` and `superseded-by` fields are
 *expected* to change, since the table above defines transitions the spec
 undergoes over its life.
 
-Those transitions divide into two kinds, recorded differently. The first,
+Those transitions divide into three kinds, recorded differently. The first,
 `draft` → `approved`, is recorded **inside the spec-PR's own commit**, so the
-spec lands on `main` already carrying `status: approved`. Every **later**
-transition — `approved` → `implemented`, `→ superseded`, `→ archived` — is
-recorded **after** the spec has merged, by a metadata-only edit to the merged
-spec's frontmatter. The two cases are defined in turn below.
+spec lands on `main` already carrying `status: approved`. The second,
+`approved` → `implemented`, is recorded **inside the implementation PR's own
+commit**, so the spec carries `status: implemented` the moment its
+implementation lands on `main`. Every **later** transition — `→ superseded`,
+`→ archived` — is recorded **after** the spec has merged, by a metadata-only
+edit to the merged spec's frontmatter. The three cases are defined in turn
+below.
 
 **Recording the initial `draft` → `approved` transition (in the spec-PR).**
 Every interaction mode has a real approval event whose grant the recorded
@@ -293,19 +296,34 @@ commit on `main` carrying `status: approved`; a new commit needs only a plain
 `git push`, whereas an amend would force `git push --force-with-lease` and
 risk clobbering a concurrent reviewer or CI push on the shared branch.
 
+**Recording the `approved` → `implemented` transition (in the implementation
+PR).** The `implemented` transition is triggered by the merge of the
+implementation PR for the spec's `related-issue` — a genuinely later, separate
+event that cannot be folded into the spec-PR that introduces the spec, but
+**can** be folded into the implementation PR itself. On the implementation
+feature branch, before the implementation PR merges, edit the spec's
+frontmatter (`status: approved` → `status: implemented`), create a **new
+commit** — not `git commit --amend` — then `git push`. The implementation PR
+squash-merges, so the transition rides the implementation PR's own squash
+commit and the spec lands on `main` already carrying `status: implemented` at
+the moment its implementation lands. The authority named in the table above
+(the implementation team's `pr-logbook`) performs the edit; it touches nothing
+else — no body line, no `id`, no `slug`, no `version`. A diff that alters any
+normative content under cover of the status bump is a violation. No separate,
+post-merge, metadata-only pull request is required to record the transition.
+
 **Recording a post-merge transition (every other transition).** Every
-transition other than `draft` → `approved` — `approved` → `implemented`,
+transition other than `draft` → `approved` and `approved` → `implemented` —
 `→ superseded`, `→ archived` — is triggered by a genuinely later, separate
-event (an implementation PR merging, a superseding spec landing, a ticket
-closed without implementation) that cannot be folded into the spec-PR that
-introduces the spec, and so is recorded **after** merge by a **metadata-only
-edit** to the merged spec's frontmatter. The authority named in the table
-above changes the `status` field (and sets `superseded-by` when moving to
-`superseded`) and touches nothing else — no body line, no `id`, no `slug`, no
-`version`. A diff that alters any normative content under cover of a status
-bump is a violation. The `version` field stays immutable on the original after
-merge; the cumulative version lives on the highest-numbered delta (per
-*Versioning*).
+event (a superseding spec landing, a ticket closed without implementation)
+that cannot be folded into the spec-PR that introduces the spec, and so is
+recorded **after** merge by a **metadata-only edit** to the merged spec's
+frontmatter. The authority named in the table above changes the `status` field
+(and sets `superseded-by` when moving to `superseded`) and touches nothing
+else — no body line, no `id`, no `slug`, no `version`. A diff that alters any
+normative content under cover of a status bump is a violation. The `version`
+field stays immutable on the original after merge; the cumulative version
+lives on the highest-numbered delta (per *Versioning*).
 
 This carve-out admits lifecycle metadata. A second, equally narrow carve-out
 admits meaning-preserving editorial edits to body prose; it is defined next.

--- a/specs/0135-implemented-transition-in-merge.md
+++ b/specs/0135-implemented-transition-in-merge.md
@@ -1,7 +1,7 @@
 ---
 id: "0135"
 slug: implemented-transition-in-merge
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 863


### PR DESCRIPTION
This PR folds the spec `approved` → `implemented` status transition into the implementation PR's own squash commit, symmetric to the existing `draft` → `approved` Merge mechanic. It eliminates the recurring post-merge "Record spec X as implemented" metadata-only PRs.

Closes #863

## How to read this PR?

Read `docs/spec-format.md` first — it is the normative contract for transition recording. Then `artifacts/core/skills/pr-logbook/SKILL.md` (section 5b) and `artifacts/core/skills/spec-author/SKILL.md` (the `implemented` note). `specs/0135-implemented-transition-in-merge.md` demonstrates the mechanic on its own spec: the `status: approved` → `status: implemented` edit rides this very PR's squash commit.

## How to test this PR?

1. Check the spec 0135 frontmatter reads `status: implemented` in this branch.
2. Run `bash scripts/build-components.sh` and confirm no new diff appears (the regenerated outputs are already staged).
3. Verify the version bumps — `pr-logbook` 1.3.0, `spec-author` 1.6.0 — in all four CLI skill surfaces.

## Detailed description (for agents)

- `docs/spec-format.md` — in *Lifecycle states*, the `implemented` row's accompanying-artifact cell now reads "its own (squash) commit already carries `status: implemented`". In *Recording a status transition*, the transitions now divide into three kinds: `draft` → `approved` (spec-PR commit), `approved` → `implemented` (implementation PR commit), and every later transition (post-merge metadata-only edit). A new subsection documents the `approved` → `implemented` in-commit mechanic.
- `artifacts/core/skills/pr-logbook/SKILL.md` — new section 5b "Spec `approved` → `implemented` transition" with the explicit pre-merge frontmatter edit step; version 1.2.0 → 1.3.0.
- `artifacts/core/skills/spec-author/SKILL.md` — note that `implemented` is recorded by the implementation team's `pr-logbook`, not this skill; version 1.5.0 → 1.6.0.
- `specs/0135-implemented-transition-in-merge.md` — metadata-only edit: `status: approved` → `status: implemented`, demonstrating the mechanic on this very PR.
- Regenerated build outputs for all four CLIs (`.claude/`, `.gemini/`, `.github/`, `.agents/`).
- `docs/cli-matrix.md` — consulted per CLI Matrix Maintenance; no update needed. `pr-logbook` and `spec-author` are not individual CLI integration points (they ship through the generic build mechanism, row 3), and the two most recent PRs touching these skills (#770, #831) made no matrix change either.
