### PR TITLE
💚 Add the missing H1 to spec 0137 to unbreak main

### DIFF
--- a/specs/0137-antigravity-agent-allowed-tools.md
+++ b/specs/0137-antigravity-agent-allowed-tools.md
@@ -8,6 +8,8 @@ related-issue: 835
 version: 1.0.0
 ---
 
+# Preserve tool capabilities for Antigravity agents
+
 ## Intent
 
 Ensure that agents compiled for the Antigravity CLI target preserve their tool capabilities so that they do not fail to execute required commands or access necessary capabilities.
@@ -39,4 +41,4 @@ Then the compiled agent's frontmatter SHALL contain `enable_mcp_tools: true`
 
 ## Open questions
 
-*(none)*
+- None.


### PR DESCRIPTION
`specs/0137-antigravity-agent-allowed-tools.md` merged without an H1 title, which
has been failing both `lint-specs` and `lint-markdown` on `main` since `a2c314d`.
Two meaning-preserving edits restore green.

## How to read this PR?

One file, two lines added and one replaced. Read the diff first — it is the whole
change — then the justification below, which is the only part that needs thought.

**Why this is admissible on a merged spec.** `docs/spec-format.md` →
*Editorial edits* permits meaning-preserving surface corrections to a merged spec
and forbids any change to the substance of a requirement, scenario, intent or
out-of-scope item. Neither edit here touches a normative section:

- The H1 is the document's **title**, not one of the five mandatory body sections.
  Its form follows the template and its siblings — a prose rendering of the slug,
  the way `spec-pr-draft-approved-guard` reads as *"Pre-merge guard for spec-PR
  draft→approved flip"*.
- `- None.` says exactly what `*(none)*` said, in the form `specs/0132` and
  `specs/0134` already use.

No requirement, scenario or boundary changes; `id`, `slug` and `version` are
untouched. **The carve-out's wording names orthography and typos and does not
explicitly name a missing structural element**, so if the maintainers judge that
this exceeds it, the alternative is a delta-spec — that reading is recorded in
#878 rather than assumed away.

**Why a separate PR rather than folding it in.** The file belongs to ticket #835,
whose implementation PR #875 is open. Filing separately lets `main` go green
without waiting on that PR, and keeps an unrelated repair out of #877 (which
currently inherits both reds). The owning session has been notified to avoid a
write race.

**Why no SPECS → PLAN cycle.** Two surface corrections to one file is the
`trivial` tier, which `AGENTS.md` → *Agent Team Protocol* handles inline. The
pre-edit guard is satisfied: issue #878, branch `fix/878-spec-0137-missing-h1`,
worktree `.worktrees/878`.

## How to test this PR?

```sh
# The file alone — was 2 errors, now clean
markdownlint specs/0137-antigravity-agent-allowed-tools.md

# The two jobs that were red on main
task spec:lint
markdownlint "**/*.md" --ignore node_modules --ignore extension-skeleton \
  --ignore communication --ignore 'extensions/**/commands/*.md'
```

Expected: all three exit 0. On `main` at `374dd64` the first reports:

```
specs/0137-antigravity-agent-allowed-tools.md:11 error MD041/first-line-heading/first-line-h1
  First line in a file should be a top-level heading [Context: "## Intent"]
specs/0137-antigravity-agent-allowed-tools.md:42 error MD036/no-emphasis-as-heading
  Emphasis used instead of a heading [Context: "(none)"]
```

**The red was measured on `main` itself, not inferred from a PR:**

| Run | Commit | `lint-specs` | `lint-markdown` |
|---|---|---|---|
| 31586662517 | `7c8fc91` | failure | failure |
| 31586717103 | `374dd64` | failure | failure |

Both predate every branch currently open, which is what establishes that this is
a defect on `main` rather than a PR's own regression.

## Detailed description (for agents)

### Modified

`specs/0137-antigravity-agent-allowed-tools.md`:

1. Inserted `# Preserve tool capabilities for Antigravity agents` between the
   frontmatter fence and `## Intent`. Clears `MD041/first-line-heading`.
2. Replaced `*(none)*` with `- None.` under `## Open questions`. Clears
   `MD036/no-emphasis-as-heading`.

### Not changed

Everything else. No frontmatter field, no requirement, no scenario, no
out-of-scope item, no other file. `version` stays `1.0.0` — the version-bump
convention governs skill and agent sources carrying
`metadata.provenance.version`, which a spec file does not.

### Why one missing `#` reddened two jobs

`markdownlint` runs over `**/*.md` at `.github/workflows/build.yml:318` — that is
`lint-markdown`. The spec linter shells out to markdownlint as its first stage —
that is `lint-specs`. A single violation anywhere in the corpus therefore fails
both, repo-wide, and every open PR inherits two reds it did not cause.

### The failure class worth noting

The defect is invisible to its author at authoring time: nothing about writing
`## Intent` first looks wrong, and the local signal only appears if you run the
corpus linter rather than editing and pushing. `specs/_template.md` does carry the
H1, so the guard that exists is the template — which helps only an author who
starts from it.

Closes #878
