### PR TITLE
📝 Add spec 0138 delta-01 mandating the spec 0004 alignment

### DIFF
--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0138"
 slug: tier-bounded-plan-artifacts-and-loops
-status: draft
+status: approved
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 884

--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md
@@ -1,0 +1,40 @@
+---
+id: "0138"
+slug: tier-bounded-plan-artifacts-and-loops
+status: draft
+complexity: small
+interaction-mode: MINIMAL
+related-issue: 884
+version: 1.1.0
+---
+
+# Tier-bounded plan artifacts and PLAN loops — delta 01
+
+## ADDED
+
+1. **New requirement (R8) — spec 0004 alignment.**
+   `specs/0004-plan-format-and-review.md` Requirement 2 and its scenarios
+   SHALL be updated to admit the tier-conditioned mandatory set of
+   Requirement 1 (sections `### Approach` and `### Steps` mandatory at
+   `trivial` and `small` tiers; all five sections at `standard` and `large`),
+   in the same implementation change that realizes Requirement 1.
+
+Scenario:
+
+**Scenario:** spec 0004 no longer contradicts the tier-conditioned set
+
+Given the implementation change for this spec has landed
+When  a reviewer checks a `small`-tier plan containing exactly `### Approach` and `### Steps` against `specs/0004-plan-format-and-review.md`
+Then  Requirement 2 of that spec admits the plan and no format finding arises
+
+Rationale (non-normative): the parent spec left `specs/0004-plan-format-and-review.md`
+Requirement 2 ("Every plan comment SHALL contain, in order, the following five
+mandatory sections") in force, so two merged normative artifacts contradicted
+each other at `trivial`/`small` tiers — the `class: spec` finding of the PLAN
+review of v1 on issue #884. The remediation follows the project precedent of
+spec 0128 Requirement 4, which mandated the equivalent update of spec 0004
+Requirement 6 and was carried by the implementation change of its own ticket.
+
+## MODIFIED
+
+## REMOVED


### PR DESCRIPTION
This spec-PR adds delta 0138.delta-01, resolving the merged-spec conflict surfaced by the cold PLAN review of issue #884 (finding 1, `class: spec`): spec 0004 R2 mandates five sections in every plan comment, contradicting spec 0138 R1's tier-conditioned set.

## How to read this PR?

One new file: `specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md`. A single ADDED requirement (R8) mandating that `specs/0004-plan-format-and-review.md` Requirement 2 and its scenarios be updated in the same implementation change that realizes R1, plus one scenario. MODIFIED and REMOVED are empty. The wording follows the spec 0128 R4 precedent (the prior mandated update of spec 0004, carried by PR #843).

## How to test this PR?

1. `task spec:lint` — passes.
2. Verify the delta carries the parent's id ("0138") and slug, with cumulative `version: 1.1.0` (MINOR: additive normative change).
3. Cross-check the conflict it resolves: spec 0004 R2 ("Every plan comment SHALL contain … five mandatory sections") vs spec 0138 R1.

## Detailed description (for agents)

- Added `specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md` — delta body sections `## ADDED` / `## MODIFIED` / `## REMOVED` per `docs/spec-format.md` → *Delta-spec convention*; ADDED carries new requirement R8 (spec 0004 alignment in the implementation change) and one Given/When/Then scenario; the other two sections are present and empty.
- Origin: PLAN review of v1 on issue #884 (REQUEST CHANGES; the `class: spec` finding routed this iteration to SPECS per the routing precedence). Remediation option chosen at the user escalation gate; content approved through the `user-validate` skill (plannotator backend, decision `approved`).
- The delta reuses the parent's reserved id 0138 — delta-specs secure nothing per the reservation contract.
- No close keyword for issue #884: the issue is the lifecycle logbook and stays open through PLAN v2, DEV, and REVIEW.
