### PR TITLE
✨ Bound plan artifacts and PLAN loops per complexity tier (spec 0138)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,8 +292,8 @@ document for any field-level question.
 
 See [`docs/plan-review-protocol.md`](docs/plan-review-protocol.md) for
 the authoring rule, the cold second-`architect` review rule, the
-finding-class taxonomy (`tech` / `arch` / `spec`), and the
-REQUEST-CHANGES-blocks-DEV rule.
+finding-class taxonomy (`tech` / `arch` / `spec`), the
+REQUEST-CHANGES-blocks-DEV rule, and the per-tier PLAN-loop cap.
 
 ## Retroactive review loop
 

--- a/docs/adr/0010-spec-plan-review-lifecycle.md
+++ b/docs/adr/0010-spec-plan-review-lifecycle.md
@@ -146,7 +146,9 @@ Normative transition rules:
    triggered by the loop.
 3. A SPECS or PLAN stage that produces no normative change MUST still
    emit an artifact (an "unchanged" delta spec, or a one-line plan
-   confirmation) so the audit trail records that the stage ran.
+   confirmation) so the audit trail records that the stage ran. At the
+   `trivial` tier, that one-line plan confirmation IS a sufficient
+   PLAN artifact (R2 of spec 0138).
 4. The lifecycle MUST be anchored to a logbook (per `AGENTS.md` →
    *Logbook Issues*). Stage transitions are journalled there.
 
@@ -266,12 +268,12 @@ The spec SHALL declare a complexity tier. The tier drives team
 composition for the DEV stage. The spec reviewer (whoever approves
 the spec PR) validates the tier.
 
-| Tier | Team for DEV | Notes |
-|---|---|---|
-| **trivial** | inline (orchestrator only) | No team spawn, no worktree, no logbook (the issue itself suffices). Reserved for single-file edits with no test surface. |
-| **small** | `developer` + `pr-logbook` + `pr-reviewer` | Worktree required. No architect, no tester. |
-| **standard** | Templates 1 / 2 / 3 from `AGENTS.md` → *Agent Team Protocol* | Current default. |
-| **large** | `architect`-led decomposition into sub-specs, then one standard team per sub-spec | Each sub-spec gets its own spec PR (chained via the delta mechanism). |
+| Tier | Team for DEV | PLAN-revision cap | Notes |
+|---|---|---|---|
+| **trivial** | inline (orchestrator only) | 1 | No team spawn, no worktree, no logbook (the issue itself suffices). Reserved for single-file edits with no test surface. |
+| **small** | `developer` + `pr-logbook` + `pr-reviewer` | 1 | Worktree required. No architect, no tester. |
+| **standard** | Templates 1 / 2 / 3 from `AGENTS.md` → *Agent Team Protocol* | 2 | Current default. |
+| **large** | `architect`-led decomposition into sub-specs, then one standard team per sub-spec | 5 | Each sub-spec gets its own spec PR (chained via the delta mechanism). |
 
 Normative rules:
 
@@ -282,6 +284,12 @@ Normative rules:
    routed through the PLAN loop with an updated team.
 3. Tier de-escalation (standard → small) is prohibited mid-lifecycle.
    The cost of running the larger team is already sunk.
+4. The PLAN-revision cap column above is the single source of truth
+   for those numbers; `docs/plan-review-protocol.md` defines the halt
+   semantics applied when a ticket's cap would be exceeded (R3–R4 of
+   spec 0138).
+
+These clauses bound the plan's size and the loop's length; they remove no item from the reviewer's checklist at any tier.
 
 ## REVIEW loop termination
 
@@ -382,7 +390,7 @@ These examples define expected artifacts so downstream tickets
 | Stage | Artifact | Content |
 |---|---|---|
 | SPECS | Spec id `2026-T-0001-readme-typo` | Single-line WHAT: "Fix spelling of 'receive' in README.md." Tier: `trivial`. Mode: INTERMEDIATE. |
-| PLAN | (skipped for trivial) | — |
+| PLAN | One-line confirmation on the ticket issue | "No design decisions beyond the spec; proceeding to DEV." |
 | DEV | Inline edit by orchestrator | One-line diff. |
 | REVIEW | Self-review by orchestrator | Expected classes: none. |
 

--- a/docs/interaction-modes.md
+++ b/docs/interaction-modes.md
@@ -85,6 +85,23 @@ every merge the carve-out does not cover — implementation-PRs, any
 delta-spec PR whose content changed after its own content-approval, and
 every non-spec-PR merge.
 
+**Feedback-conforming revision carve-out.** This carve-out is scoped
+explicitly to an **artifact-validation gate** (kind 1 above). When
+such a gate returned feedback and the artifact is revised, and every
+change in the revision is attributable to that gate's own feedback
+with no other normative change, the same gate SHALL NOT fire again on
+the revised artifact. When any change is not attributable to the
+feedback, or attribution is uncertain, the gate SHALL fire again on
+the full artifact — the conservative default (R6 of spec 0138). This
+carve-out does **not** reach the pre-merge merge-authorization gate
+(kind 2 above) — defined above as "a distinct action-authorization,
+NOT an artifact-validation gate" — so the *Notes on the matrix* claim
+that the one-file spec-PR discharge is "the sole exception" stays
+true, and *Branching Strategy* in `AGENTS.md` is neither weakened nor
+touched.
+
+These clauses bound the plan's size and the loop's length; they remove no item from the reviewer's checklist at any tier.
+
 ## Behavioral contract per (mode × stage) cell
 
 Each cell below names precisely the user gates the orchestrator SHALL

--- a/docs/plan-format.md
+++ b/docs/plan-format.md
@@ -9,8 +9,10 @@ the lifecycle introduced in
 satisfy and the schema that the plan reviewer (per `AGENTS.md` →
 *Plan review protocol*) and the retroactive routing engine
 (issue #172) will rely on. The format is mandated by
-[`specs/0004-plan-format-and-review.md`](../specs/0004-plan-format-and-review.md);
-every section below traces back to one of its requirements R1..R11.
+[`specs/0004-plan-format-and-review.md`](../specs/0004-plan-format-and-review.md)
+(R1..R11) and, for the tier-conditioned mandatory set below, by
+[`specs/0138-tier-bounded-plan-artifacts-and-loops.md`](../specs/0138-tier-bounded-plan-artifacts-and-loops.md)
+(R1); every section below traces back to one of these requirements.
 
 ## Not a file — a comment
 
@@ -45,8 +47,9 @@ alias for `## PLAN review of v1 — issue #<N>`.
 
 ## Mandatory body sections
 
-An initial or revised plan comment SHALL contain the following five
-level-3 headings, in this order, with their text matching verbatim
+An initial or revised plan comment SHALL contain the level-3 headings
+below that are mandatory at its complexity tier (see *Tier-conditioned
+mandatory set*), in this order, with their text matching verbatim
 (case-sensitive, no trailing punctuation). A future plan linter will
 rely on header presence and ordering to validate conformance.
 
@@ -84,6 +87,24 @@ rejected alternatives is rarely a plan that explored options.
 revert path (commit revert, configuration rollback, data migration
 reversal, etc.) and any coordination required with downstream tickets
 or deployed components.
+
+## Tier-conditioned mandatory set
+
+The complexity tier declared in the ticket's spec frontmatter (per
+[ADR-0010](adr/0010-spec-plan-review-lifecycle.md) → *Complexity tiers
+and team sizing*) determines which of the five sections above are
+mandatory:
+
+- At every tier — `trivial`, `small`, `standard`, and `large` —
+  `### Approach` and `### Steps` are mandatory.
+- At `trivial` and `small` tiers, `### Blast radius`,
+  `### Alternatives considered and rejected`, and `### Rollback
+  strategy` MAY be omitted; when present, they SHALL keep the format
+  defined above.
+- At `standard` and `large` tiers, all five sections remain mandatory
+  (R1 of spec 0138).
+
+These clauses bound the plan's size and the loop's length; they remove no item from the reviewer's checklist at any tier.
 
 ## Optional sections
 

--- a/docs/plan-format.md
+++ b/docs/plan-format.md
@@ -96,7 +96,17 @@ and team sizing*) determines which of the five sections above are
 mandatory:
 
 - At every tier — `trivial`, `small`, `standard`, and `large` —
-  `### Approach` and `### Steps` are mandatory.
+  `### Approach` and `### Steps` are mandatory for a structured plan
+  comment; the sole exception is the `trivial`-tier one-line plan
+  confirmation admitted by spec 0138 R2 and by
+  [ADR-0010](adr/0010-spec-plan-review-lifecycle.md) → *Stage
+  definitions and transition rules* rule 3, which is a sufficient PLAN
+  artifact without either section. That confirmation still carries the
+  *Initial plan* header `## PLAN — issue #<N> (spec <NNNN>)` from
+  *Header conventions* above, so it stays discoverable under the
+  header patterns this document's preamble names and satisfies
+  `specs/0004-plan-format-and-review.md` R1; it is exempt from the
+  level-3 section set alone.
 - At `trivial` and `small` tiers, `### Blast radius`,
   `### Alternatives considered and rejected`, and `### Rollback
   strategy` MAY be omitted; when present, they SHALL keep the format

--- a/docs/plan-review-protocol.md
+++ b/docs/plan-review-protocol.md
@@ -38,6 +38,20 @@ list states the taxonomy, not the routing.
 REQUEST CHANGES` SHALL block the DEV stage from starting until a
 revised plan is posted and re-reviewed cold.
 
+**PLAN-loop cap.** The loop halts when a further plan revision would
+exceed the tier's cap (numbers per the ADR-0010 → *Complexity tiers
+and team sizing* table, not restated here). On halt, the orchestrator
+SHALL post a structured summary on the logbook issue and escalate to
+the user regardless of interaction mode; it SHALL NOT auto-approve the
+halted plan, and the loop resumes only on explicit user instruction,
+which MAY lift the cap for that ticket (R3–R4 of spec 0138). A review
+returned for retagging — a malformed verdict per `docs/plan-format.md`
+→ *Finding tag schema* and `docs/retroactive-loop.md` → *Class tagging
+discipline* — does not count as a revision (R5 of spec 0138). A plan
+approved on its first cold review consumes zero revisions.
+
+These clauses bound the plan's size and the loop's length; they remove no item from the reviewer's checklist at any tier.
+
 **Plan-validation gate.** In the modes that gate the PLAN stage (FULL
 and INTERMEDIATE per *Interaction modes → Behavioral contract per (mode
 × stage) cell*), the user gate that validates the plan comment before

--- a/specs/0004-plan-format-and-review.md
+++ b/specs/0004-plan-format-and-review.md
@@ -22,8 +22,13 @@ giving findings a stable shape that the retroactive review loop can route.
 1. The PLAN stage SHALL emit exactly one artifact: a Markdown comment
    posted on the logbook issue (per *Logbook Issues → Rule A*) whose
    first line is the header `## PLAN — issue #<N> (spec <NNNN>)`.
-2. Every plan comment SHALL contain, in order, the following five
-   mandatory sections, with their headings verbatim:
+2. Every plan comment SHALL contain, in order, the following mandatory
+   sections, with their headings verbatim. `### Approach` and
+   `### Steps` are mandatory at every complexity tier; `### Blast
+   radius`, `### Alternatives considered and rejected`, and
+   `### Rollback strategy` are mandatory at `standard` and `large`
+   tiers and MAY be omitted at `trivial` and `small` (R1 of spec
+   0138), keeping the format below whenever present:
    1. `### Approach` — one paragraph.
    2. `### Steps` — ordered list; each step SHALL name the concrete
       file path(s) it touches and a one-line description of the edit.
@@ -71,8 +76,8 @@ giving findings a stable shape that the retroactive review loop can route.
 ### Happy path — single review pass
 
 Given a non-trivial ticket #N whose spec-PR has merged on `main`
-When the architect drafts a PLAN comment on the logbook with the five
-  mandatory sections and posts it
+When the architect drafts a PLAN comment on the logbook with the
+  mandatory sections for its complexity tier and posts it
 And a second architect is spawned cold to review the plan
 Then the reviewer posts a `## PLAN review` comment with verdict
   `### Verdict: APPROVE` and zero findings of any class

--- a/specs/0004-plan-format-and-review.md
+++ b/specs/0004-plan-format-and-review.md
@@ -24,8 +24,11 @@ giving findings a stable shape that the retroactive review loop can route.
    first line is the header `## PLAN — issue #<N> (spec <NNNN>)`.
 2. Every plan comment SHALL contain, in order, the following mandatory
    sections, with their headings verbatim. `### Approach` and
-   `### Steps` are mandatory at every complexity tier; `### Blast
-   radius`, `### Alternatives considered and rejected`, and
+   `### Steps` are mandatory at every complexity tier, except for the
+   `trivial`-tier one-line plan confirmation admitted by spec 0138 R2,
+   which is a sufficient PLAN artifact without either section (R1 of
+   spec 0138, as amended by delta-02); `### Blast radius`,
+   `### Alternatives considered and rejected`, and
    `### Rollback strategy` are mandatory at `standard` and `large`
    tiers and MAY be omitted at `trivial` and `small` (R1 of spec
    0138), keeping the format below whenever present:

--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0138"
 slug: tier-bounded-plan-artifacts-and-loops
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 884

--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md
@@ -1,7 +1,7 @@
 ---
 id: "0138"
 slug: tier-bounded-plan-artifacts-and-loops
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 884

--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.md
@@ -1,7 +1,7 @@
 ---
 id: "0138"
 slug: tier-bounded-plan-artifacts-and-loops
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 884


### PR DESCRIPTION
This PR implements spec 0138 (cumulative 1.1.0): plan artifacts and PLAN review loops become bounded by the ticket's complexity tier, and an artifact-validation gate no longer re-fires on an amendment that implements its own feedback. It realizes requirements R1–R8 across four contract documents plus the mandated spec 0004 alignment.

## How to read this PR?

1. `specs/0004-plan-format-and-review.md` — start here: the merged-spec alignment mandated by delta-01 R8 (R2 and its happy-path scenario now admit the tier-conditioned set).
2. `docs/plan-format.md` — the tier-conditioned mandatory set (R1): `### Approach` + `### Steps` at `trivial`/`small`; all five sections at `standard`/`large`; preamble provenance extended to spec 0138.
3. `docs/adr/0010-spec-plan-review-lifecycle.md` — the PLAN-revision cap column on the tier table (R3: 1/1/2/5) with its normative rule, transition rule 3 extended (one-line confirmation at `trivial`, R2), and Appendix Example 1 reconciled with rule 1.
4. `docs/plan-review-protocol.md` — the PLAN-loop cap paragraph (R3–R5: halt, escalate to the user, never auto-approve; malformed verdicts do not count).
5. `docs/interaction-modes.md` — the feedback-conforming revision carve-out, scoped to the artifact-validation gate (kind 1) and explicitly not reaching the pre-merge merge-authorization gate (R6).
6. `AGENTS.md` — pointer wording only, no normative change.
7. `specs/0138-*.md` and `.delta-01.md` — frontmatter `approved` → `implemented` (the transition rides this PR's squash commit per `docs/spec-format.md` → *Recording a status transition*).

The R7 boundary sentence lands verbatim in each of the four amended contracts: "These clauses bound the plan's size and the loop's length; they remove no item from the reviewer's checklist at any tier."

## How to test this PR?

1. `task spec:lint` — passes.
2. `npx markdownlint-cli "docs/**/*.md" "specs/**/*.md"` — clean.
3. `bash scripts/check-agents-size.sh` — `OK: AGENTS.md is 18864 bytes (threshold: 22000 bytes)`.
4. `bash scripts/build-docs-index.sh --check` — index up to date.
5. `grep -c "they remove no item from the reviewer" docs/plan-format.md docs/adr/0010-spec-plan-review-lifecycle.md docs/plan-review-protocol.md docs/interaction-modes.md AGENTS.md` — expect `1,1,1,1,0` (each occurrence kept on a single physical line so the check stays grep-readable).

## Detailed description (for agents)

- **Realizes spec 0138 R1–R8** (base spec merged in PR #886, delta-01 in PR #887; plan v2 approved cold with zero findings on issue #884).
- `specs/0004-plan-format-and-review.md`: R2 rewritten to condition the five-section set on the declared tier; its happy-path scenario line updated accordingly. Substantive text minimal, frontmatter untouched (shape precedent: commit 689b3be, spec 0128 R4).
- `docs/plan-format.md`: preamble provenance sentence now names spec 0138 alongside spec 0004; *Mandatory body sections* opening clause tier-conditioned; new `## Tier-conditioned mandatory set` section closing on the R7 sentence.
- `docs/adr/0010-spec-plan-review-lifecycle.md`: complexity-tier table gains a *PLAN-revision cap* column (trivial 1, small 1, standard 2, large 5) as the single source for the numbers; new normative rule references the table; transition rule 3 extended for the trivial one-line confirmation; Appendix Example 1's PLAN row no longer contradicts transition rule 1.
- `docs/plan-review-protocol.md`: new bold-lead paragraph — the PLAN loop halts at the tier cap; on halt the orchestrator posts a structured summary on the logbook, escalates to the user regardless of mode, never auto-approves; retag round-trips do not count as revisions.
- `docs/interaction-modes.md`: new `**Feedback-conforming revision carve-out.**` paragraph beside the existing narrow discharge — scoped to artifact-validation gates only; conservative default (any non-attributable change, or uncertain attribution, re-fires the gate); states explicitly that it does not reach the pre-merge merge-authorization gate.
- `AGENTS.md`: pointer enumeration updated (protocol-only change; byte size 18864 vs 22000 threshold).
- Status transitions: `specs/0138-*` and its delta-01 flipped `approved` → `implemented` in commit 8134866 by the pr-logbook authority; metadata-only.
- Exemptions verified: no version bump (no `artifacts/**` or `extensions/**` files touched); no `docs/cli-matrix.md` update (docs-only paths are off the trigger surface; the `AGENTS.md` touch is protocol-only).
- Commits: 3b287e8 (implementation, developer) + 8134866 (0138/delta-01 status flips, pr-logbook) + 135cae5 (merge of main absorbing delta-02) + d3a1277 (delta-02 reconciliation: structured-plan scoping + trivial one-line exception in `docs/plan-format.md` and `specs/0004` R2, developer) + c8edd0a (delta-02 status flip, pr-logbook).
- REVIEW loop trail: iteration 1 (REQUEST_CHANGES, `class: spec` — spec 0138 R1/R2 self-contradiction) routed to SPECS, resolved by merged delta-02 (PR #893); PLAN v3 → REQUEST CHANGES (1 arch, 1 tech) → cap escalation (user lifted the small-tier cap) → PLAN v4 cold-APPROVED zero findings; this head is iteration 2.
- Issue #884 is the lifecycle logbook and must stay open until after merge (manual close per Logbook Rule C) — no close keyword anywhere in this PR by design.
