### PR TITLE
📝 Add spec 0138 delta-02 reconciling R1 with the trivial one-line artifact

### DIFF
--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md
@@ -1,0 +1,40 @@
+---
+id: "0138"
+slug: tier-bounded-plan-artifacts-and-loops
+status: draft
+complexity: small
+interaction-mode: MINIMAL
+related-issue: 884
+version: 1.2.0
+---
+
+# Tier-bounded plan artifacts and PLAN loops — delta 02
+
+## ADDED
+
+## MODIFIED
+
+1. **Requirement 1, last-but-one sentence — reconciled with Requirement 2.**
+   Original line:
+
+   > A plan omitting `### Approach` or `### Steps` SHALL remain non-conformant
+   > at every tier.
+
+   Replacement:
+
+   > A structured plan comment omitting `### Approach` or `### Steps` SHALL be
+   > non-conformant at every tier; the sole exception is the `trivial`-tier
+   > one-line plan confirmation admitted by Requirement 2, which is a
+   > sufficient PLAN artifact without either section.
+
+   Rationale (non-normative): as merged, Requirement 1 and Requirement 2
+   contradicted each other — the one-line confirmation carries no headings,
+   so Requirement 1's "at every tier" declared non-conformant the very
+   artifact Requirement 2 declares sufficient. The cold REVIEW pass on the
+   implementation PR (#888, iteration 1, `class: spec`) surfaced the
+   contradiction after the implementation faithfully carried both horns into
+   `docs/plan-format.md` and ADR-0010. This delta keeps the floor for
+   structured plans and names the one-line confirmation as the single
+   explicit exception.
+
+## REMOVED

--- a/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md
+++ b/specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md
@@ -1,7 +1,7 @@
 ---
 id: "0138"
 slug: tier-bounded-plan-artifacts-and-loops
-status: draft
+status: approved
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 884


### PR DESCRIPTION
This spec-PR adds delta 0138.delta-02, resolving the self-contradiction surfaced by the cold REVIEW pass on implementation PR #888 (iteration 1, `class: spec`): R1's "non-conformant at every tier" sentence collided with R2's trivial-tier one-line plan confirmation.

## How to read this PR?

One new file: `specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md`. A single MODIFIED entry quoting R1's original last-but-one sentence and replacing it — the floor stays for structured plan comments at every tier; the trivial-tier one-line confirmation admitted by R2 becomes the sole explicit exception. ADDED and REMOVED are empty. Cumulative version 1.2.0.

## How to test this PR?

1. `task spec:lint` — passes.
2. Cross-check the contradiction it resolves: spec 0138 R1 last-but-one sentence vs R2, and their faithful carriers `docs/plan-format.md` ("At every tier … mandatory") and ADR-0010 transition rule 3 as amended by PR #888.

## Detailed description (for agents)

- Added `specs/0138-tier-bounded-plan-artifacts-and-loops.delta-02.md` — `## MODIFIED` quotes the original R1 sentence and supplies the replacement with the explicit R2 exception; `## ADDED` and `## REMOVED` present and empty per the delta convention.
- Origin: cold `pr-reviewer` verdict on PR #888 (REQUEST_CHANGES, one `class: spec` finding), re-verified first-hand before routing. Content approved through the `user-validate` skill (plannotator backend, decision `approved`).
- Downstream (not in this PR): PLAN v3 targeted revision + cold re-review, then a one-line adjustment of `docs/plan-format.md` on the #888 feature branch, then PR #888 resumes its loop at `iter:2`.
- No close keyword for issue #884: the lifecycle logbook stays open.
