### PR TITLE
📝 Add spec 0139 for token rotation revoking the old token

### DIFF
--- a/specs/0139-token-rotation-revocation.md
+++ b/specs/0139-token-rotation-revocation.md
@@ -1,7 +1,7 @@
 ---
 id: "0139"
 slug: token-rotation-revocation
-status: draft
+status: approved
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 880

--- a/specs/0139-token-rotation-revocation.md
+++ b/specs/0139-token-rotation-revocation.md
@@ -1,0 +1,80 @@
+---
+id: "0139"
+slug: token-rotation-revocation
+status: draft
+complexity: small
+interaction-mode: MINIMAL
+related-issue: 880
+version: 1.0.0
+---
+
+# Token rotation revokes the old token
+
+## Intent
+
+An operator who follows the printed token-rotation procedure ends up with a
+daemon that actually refuses the superseded token — the procedure's whole
+purpose. Today the printed step 2 claims the switch script "restarts" the
+daemon while the running process keeps honouring the old token until something
+replaces it; the operator believes a suspected-leaked credential is dead while
+it still works.
+
+## Requirements
+
+1. After the printed rotation procedure completes, the running MemPalace MCP
+   daemon SHALL refuse the superseded bearer token and SHALL accept the newly
+   minted one. A rotation that leaves the old token honoured is a failure of
+   the procedure, not an operator error.
+2. `scripts/switch-mempalace-http.sh` SHALL leave the running daemon honouring
+   the current value of the token file when it exits successfully — including
+   when the supervisor unit was already loaded before the run (the case where
+   the daemon installation currently skips any process replacement). When the
+   daemon process cannot be replaced, the script SHALL fail visibly rather
+   than report success over a stale credential.
+3. Every behaviour claim in the printed rotation procedure
+   (`scripts/uninstall-mcp-daemon.sh`) SHALL be true of the scripts it names
+   at the moment it ships: the procedure SHALL state when the new token takes
+   effect (only once the daemon process has been replaced), and the inline
+   description of each step SHALL NOT assert a behaviour the named script
+   does not have.
+4. An automated test SHALL assert the rotation contract end to end — provision
+   a daemon, capture the token, rotate, then probe the daemon and require the
+   old token refused and the new one accepted. The test SHALL follow the
+   repository's behavioural-test conventions (isolated `HOME`, non-production
+   port, clean skip when prerequisites are absent) and SHALL NOT mutate the
+   machine's real supervisor state or live palace.
+
+## Scenarios
+
+**Scenario:** rotation revokes the superseded token
+
+Given a running daemon serving bearer token A
+When  the operator performs the printed rotation procedure and it mints token B
+Then  a probe presenting token A is refused and a probe presenting token B is accepted
+
+**Scenario:** switch over an already-loaded supervisor unit takes effect
+
+Given the supervisor unit is already loaded and the daemon process holds token A
+When  `scripts/switch-mempalace-http.sh` completes successfully after token B was minted
+Then  the running daemon honours token B and no longer honours token A
+
+**Scenario:** the daemon cannot be replaced
+
+Given the supervisor refuses or fails to replace the daemon process during a switch
+When  `scripts/switch-mempalace-http.sh` reaches its end
+Then  the script fails visibly and does not report a completed switch over the stale credential
+
+## Out of scope
+
+- A `--rotate` command-line flag or any new rotation tooling — tracked as
+  issue #744, which must not inherit this defect but is not implemented here.
+- Automatic token-file watching or hot reload (a supervisor `WatchPaths`-style
+  mechanism); replacement of the daemon process is the accepted revocation
+  boundary.
+- Rotation or cleanup of the timestamped `.bak` files named by the printed
+  procedure's step 3 (the wording stays; the mechanism is unchanged).
+- The spec-0136 runbook prose that inherited the false claim — it cites the
+  scripts, and the scripts becoming truthful is what this spec fixes; a
+  runbook wording refresh, if needed, is a documentation follow-up.
+
+## Open questions


### PR DESCRIPTION
This spec-PR adds spec 0139, qualifying the fix for issue #880: the printed token-rotation procedure never revokes the old token. It is the SPECS-stage artifact and carries no implementation.

## How to read this PR?

One new file: `specs/0139-token-rotation-revocation.md`. Read `## Intent`, then the four requirements: R1 (the observable goal — after rotation the old token is refused), R2 (the design decision, resolved: `switch-mempalace-http.sh` leaves the daemon honouring the current token file value, including over an already-loaded supervisor unit, failing visibly otherwise), R3 (every behaviour claim in the printed procedure must be true of the scripts it names), R4 (an automated rotation test per the repository's behavioural-test conventions, no real supervisor mutation). The full defect chain was re-verified first-hand against the shipped scripts before authoring (see issue #880 for the trace).

## How to test this PR?

1. `task spec:lint` — passes.
2. Verify the id reservation: `git ls-remote origin 'refs/spec-ids/0139'` shows the ref secured for issue #880.
3. Frontmatter consistency: filename slug equals frontmatter `slug`; `related-issue: 880`; `complexity: small`; `interaction-mode: MINIMAL`.

## Detailed description (for agents)

- Added `specs/0139-token-rotation-revocation.md` (status `draft` at PR open; flipped to `approved` in a follow-up commit on this branch per `docs/spec-format.md` → *Merge mechanic*, after the SPECS-stage content-approval was secured through the `user-validate` skill, plannotator backend, decision `approved`).
- The spec resolves issue #880's open design question in-spec (R2: restart-on-already-loaded rather than a manual procedure step) and scopes out #744 (`--rotate` tooling), hot reload, `.bak` cleanup, and the 0136 runbook prose.
- This is the first ticket qualified under the spec-0138 contract (merged 40be4af) and serves as its measurement ticket against the #751 baseline — gating issue #885.
- No close keyword for issue #880 anywhere in this PR: the issue is the lifecycle logbook and stays open through PLAN, DEV, and REVIEW.
