### PR TITLE
✨ Add leaked tool scaffolding guard to spec-linter.js (#890)

### DIFF
--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -11,6 +11,8 @@ const INTERACTION_MODE_ENUM = ['FULL', 'INTERMEDIATE', 'MINIMAL', 'AUTO'];
 const ORIGINAL_HEADINGS = ['## Intent', '## Requirements', '## Scenarios', '## Out of scope', '## Open questions'];
 const DELTA_HEADINGS = ['## ADDED', '## MODIFIED', '## REMOVED'];
 
+const LEAKED_SCAFFOLDING_REGEX = /<\/?(?:content|invoke|tool_call|thought|tool_use|function_call|tool_result|tool_response)\b[^>]*>/i;
+
 function globSpecs(targetPath) {
     const result = [];
     if (fs.existsSync(targetPath)) {
@@ -449,13 +451,21 @@ function lintFile(filePath) {
     const lines = content.split('\n');
     const h2Headings = [];
     let inCodeBlock = false;
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
         if (line.trim().startsWith('```')) {
             inCodeBlock = !inCodeBlock;
             continue;
         }
-        if (!inCodeBlock && line.startsWith('## ')) {
-            h2Headings.push(line.trim());
+        if (!inCodeBlock) {
+            if (line.startsWith('## ')) {
+                h2Headings.push(line.trim());
+            }
+            const lineClean = line.replace(/`+[^`]+`+/g, '');
+            const match = lineClean.match(LEAKED_SCAFFOLDING_REGEX);
+            if (match) {
+                reportError(`Line ${i + 1}: Leaked tool scaffolding tag detected: "${match[0]}"`);
+            }
         }
     }
 

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -864,8 +864,33 @@ run_base_case "Case 40 — attribution stays root-anchored under diff.relative (
   "Non-delta specs present on the base branch" "[WARN]"
 
 # -------------------------------------------------------------------------
+# Case 41 — Leaked tool scaffolding tags outside code blocks → exit 1
+# -------------------------------------------------------------------------
+spec41="0041-leaked-scaffolding.md"
+headings41=$(printf "## Intent\n\n## Requirements\n\n## Scenarios\n\n## Out of scope\n\n## Open questions\n\n</content>\n</invoke>")
+render_spec "0041" "leaked-scaffolding" "draft" "standard" "" "$headings41" > "$TMP_ROOT/$spec41"
+run_case "Case 41 — leaked tool scaffolding fails" "$spec41" 1
+
+# -------------------------------------------------------------------------
+# Case 42 — Tool scaffolding tags inside fenced code block → exit 0
+# -------------------------------------------------------------------------
+spec42="0042-fenced-scaffolding.md"
+headings42=$(printf "## Intent\n\n\`\`\`text\n</content>\n</invoke>\n\`\`\`\n\n## Requirements\n\n## Scenarios\n\n## Out of scope\n\n## Open questions")
+render_spec "0042" "fenced-scaffolding" "draft" "standard" "" "$headings42" > "$TMP_ROOT/$spec42"
+run_case "Case 42 — tool scaffolding inside fenced code block passes" "$spec42" 0
+
+# -------------------------------------------------------------------------
+# Case 43 — Tool scaffolding tags in inline code spans → exit 0
+# -------------------------------------------------------------------------
+spec43="0043-inline-scaffolding.md"
+headings43=$(printf "## Intent\n\nRefers to \`</content>\` and \`</invoke>\` tags.\n\n## Requirements\n\n## Scenarios\n\n## Out of scope\n\n## Open questions")
+render_spec "0043" "inline-scaffolding" "draft" "standard" "" "$headings43" > "$TMP_ROOT/$spec43"
+run_case "Case 43 — tool scaffolding in inline code span passes" "$spec43" 0
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""
 echo "Results: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]
+


### PR DESCRIPTION
## Purpose

Extend `scripts/lib/spec-linter.js` to detect leaked LLM tool scaffolding tags (such as `</content>`, `</invoke>`, `<tool_call>`, `<thought>`, etc.) outside fenced code blocks and report a semantic lint failure causing the linter to exit with code 1.

Fixes #890. Closes #890.

## How to read this PR?

- Inspect `scripts/lib/spec-linter.js` for `LEAKED_SCAFFOLDING_REGEX` and the regex check in `lintFile`.
- Inspect `scripts/tests/test-spec-linter.sh` for Cases 41-43 covering leaked tags outside code blocks, inside fenced code blocks, and inside inline code spans.

## How to test this PR?

- Run `bash scripts/tests/test-spec-linter.sh`.
- Run `node scripts/lib/spec-linter.js specs`.

## Detailed description (for agents)

When LLM tool execution scaffolding (e.g. `</content>`, `</invoke>`, `<tool_call>`, `<thought>`) leaks into spec files, structural and heading lints previously passed with exit code 0 (`green-signal-certifies-adjacent-property`). This PR:
1. Adds `LEAKED_SCAFFOLDING_REGEX` to `scripts/lib/spec-linter.js` targeting raw LLM tool scaffolding tags outside markdown code fences.
2. Strips inline code spans before scanning to avoid false positives when tag names are mentioned in markdown text (e.g. `</content>`).
3. Adds automated test cases 41-43 in `scripts/tests/test-spec-linter.sh`.
