### PR TITLE
📝 Add per-command cwd anchoring rule to worktree isolation

### DIFF
--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -113,6 +113,12 @@ All file edits performed by the team — by every specialist, without exception 
 
 This is a distinct, actionable check from the "treat the main directory as read-only" expectation above: that sentence states the constraint, this is the step that catches a session whose working directory silently defaulted to the main checkout before any file lands there.
 
+**Per-command cwd anchoring.** Every Bash command that operates on worktree content, or names a repository-relative path, SHALL begin with `cd <abs-worktree> &&`; no repository-relative path SHALL be used without that prefix. The rule binds every agent issuing Bash commands against a ticket worktree — every specialist and the orchestrating session alike; the failure it closes was observed in both roles in the originating incident (the developer session and the team-lead's DEV brief). The Tier 1 ref-based inspection recipes above (`git fetch` / `git log` / `git show` / `git diff` against `crewrig/<branch>`) are exempt: they deliberately run from the shared checkout on ref-scoped paths, not repository-relative filesystem paths. Embed the following instruction verbatim in every spawned sub-agent brief that targets a worktree:
+
+> Begin every Bash command that operates on worktree content, or names a repository-relative path, with `cd <abs-worktree> &&` — never use a repository-relative path without that prefix.
+
+This complements — does not replace — the cwd-verification check above: the check covers the session's first mutating call, the rule covers the whole session, including a Bash-tool cwd reset that occurs after the check has passed.
+
 **Stray-file discovery — no unilateral action.** Discovering a file on the main repository checkout that appears misplaced from a worktree-scoped ticket — whether the discoverer is the orchestrator or a sibling sub-agent — does NOT trigger deletion of that file, on sight or by any other means. A file's location does not establish its provenance: a sibling agent's own in-flight write may be transiting through that same path at the moment of discovery, and location alone cannot distinguish an abandoned stray from a write still in progress. Instead:
 
 1. **Flag, don't act.** The discoverer flags the file to the orchestrator (or `team-lead`) for adjudication.

--- a/specs/0141-worktree-cwd-reset-guard.md
+++ b/specs/0141-worktree-cwd-reset-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0141"
 slug: worktree-cwd-reset-guard
-status: approved
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 889


### PR DESCRIPTION
This PR hardens `docs/agent-team-protocol.md` → *Worktree Isolation* against mid-session Bash-tool cwd resets by stating the per-command `cd <abs-worktree> &&` anchoring rule, per spec 0141. It is a documentation-only change: one new paragraph, no harness change, no enforcement tooling.

## How to read this PR?

- Read the single changed file: `docs/agent-team-protocol.md` → *Worktree Isolation*.
- The new "Per-command cwd anchoring" paragraph sits immediately after the existing "Cwd verification (every spawned role)" paragraph, its verbatim instruction blockquote, and its closing note — the placement mandated by the validated plan (PLAN v2 on issue #889). It states the `cd <abs-worktree> &&` prefix rule, the no-repository-relative-path-without-prefix constraint, the Tier 1 ref-based-inspection carve-out (`git fetch` / `git log` / `git show` / `git diff` against `crewrig/<branch>`), the every-role binding, and a verbatim-embeddable instruction for spawned sub-agent briefs.
- The non-obvious design decision: the paragraph is framed as a complement to — not a replacement of — the one-time cwd-verification check. The check covers the session's first mutating call; the rule covers the whole session, including a Bash-tool cwd reset that occurs after the check has passed.

## How to test this PR?

1. Read the new paragraph in `docs/agent-team-protocol.md` → *Worktree Isolation* (the "Per-command cwd anchoring" paragraph, inserted after the cwd-verification block): confirm it states the `cd <abs-worktree> &&` prefix rule, the no-repository-relative-path-without-prefix constraint, the Tier 1 ref-based-inspection carve-out, the every-role binding, and the verbatim-embeddable instruction blockquote.
2. Confirm the pre-existing "Cwd verification (every spawned role)" paragraph, its verbatim instruction blockquote, and its closing note ("This is a distinct, actionable check from the 'treat the main directory as read-only' expectation above…") are intact and unmodified.
3. Confirm the new paragraph's closing note ("This complements — does not replace — the cwd-verification check above…") is present.
4. Confirm `AGENTS.md` is unchanged by this PR: the diff touches only `docs/agent-team-protocol.md`; `AGENTS.md` remains at 19 080 bytes, within the 22 000-byte CI budget enforced by `scripts/check-agents-size.sh`.

## Detailed description (for agents)

- **Added** — one paragraph (+6 lines) in `docs/agent-team-protocol.md` → *Worktree Isolation*, inserted after the "Cwd verification (every spawned role)" paragraph, its blockquote, and its closing note, and before "Stray-file discovery — no unilateral action." The paragraph:
  - States the operational rule: every Bash command operating on worktree content, or naming a repository-relative path, SHALL begin with `cd <abs-worktree> &&`; no repository-relative path SHALL be used without that prefix (spec 0141 Requirement 2).
  - Scopes the rule to worktree-content commands and exempts the section's Tier 1 ref-based inspection recipes, which deliberately run from the shared checkout on ref-scoped paths (Requirement 3).
  - Carries a verbatim-embeddable instruction for spawned sub-agent briefs (Requirement 4).
  - States the rule binds every agent issuing Bash commands against a ticket worktree — specialists and orchestrator alike — and notes the failure mode was observed in both roles in the originating incident (Requirement 5).
  - Frames the rule as a complement to, not an alternative of, the one-time cwd-verification check (Requirement 6).
- **Unchanged** — every other subsection of *Worktree Isolation* (whole-tree operations, stray-file discovery, verification recipes) and every other section of `docs/agent-team-protocol.md`; `AGENTS.md` is untouched (Requirement 7).
- **Out of scope, per spec 0141** — any harness-level Bash-tool change (Requirement 8) and any mechanical enforcement tooling (Requirement 9).
- No `artifacts/` change, so `scripts/build-components.sh` is not run; no skill/agent source carries a version bump; no CLI-matrix trigger surface is touched.
