### PR TITLE
✨ Add reviewer-minted IDs and prior-finding audit protocol (#874)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ This section SHALL NOT duplicate that schema; consult the format
 document for any field-level question.
 
 See [`docs/plan-review-protocol.md`](docs/plan-review-protocol.md) for
-the authoring rule, the cold second-`architect` review rule, the
+the authoring rule, the cold second-`architect` review rule, reviewer-minted IDs (`v<N>-F<M>`), prior-finding audits, the
 finding-class taxonomy (`tech` / `arch` / `spec`), the
 REQUEST-CHANGES-blocks-DEV rule, and the per-tier PLAN-loop cap.
 

--- a/docs/plan-format.md
+++ b/docs/plan-format.md
@@ -124,24 +124,41 @@ acceptance note each. When present, the section SHALL appear **after**
 uncertainty SHOULD include it; plans whose blast radius is fully
 bounded MAY omit it.
 
+**`### Finding traceability`** (or `### Revision rationale & traceability`) —
+a Markdown table mapping every reviewer-minted ID (`v<N>-F<M>`) raised across
+prior review passes to its resolution or rationale in the revised plan comment.
+Mandatory when revising a plan in response to a `REQUEST CHANGES` verdict.
+The table SHALL carry the schema:
+
+```markdown
+| Plan Ver | Finding ID | Resolution / Rationale | Step |
+|---|---|---|---|
+| v1 | v1-F1 | Added preconditions step | Step 1 |
+| v1 | v1-F2 | Clarified scope boundary | Step 3 |
+```
+
+The row count of addressed reviewer-minted IDs SHALL equal the total number
+of findings raised across prior review passes (per `docs/plan-review-protocol.md`
+→ *Countable invariant*).
+
 ## Finding tag schema
 
-Every plan-review finding SHALL carry exactly one `class:` field
-whose value is one of `tech`, `arch`, or `spec` (R7). The class
-drives the loop target of the retroactive review loop; the routing
-matrix is defined once, in `AGENTS.md` → *Retroactive review loop*,
+Every plan-review finding SHALL carry a reviewer-minted identifier in its header
+(`v<N>-F<M>`) and exactly one `class:` field whose value is one of `tech`, `arch`,
+or `spec` (R7). The class drives the loop target of the retroactive review loop;
+the routing matrix is defined once, in `AGENTS.md` → *Retroactive review loop*,
 and SHALL NOT be duplicated here.
 
 A reviewer comment that lists multiple findings SHALL tag each
 finding individually:
 
 ```markdown
-**Finding 1**
+**Finding 1 (v1-F1)**
 
 class: tech
 <one-paragraph description and remediation pointer>
 
-**Finding 2**
+**Finding 2 (v1-F2)**
 
 class: arch
 <one-paragraph description and remediation pointer>

--- a/docs/plan-review-protocol.md
+++ b/docs/plan-review-protocol.md
@@ -19,6 +19,36 @@ identity, the shared-identity workaround from *Standard Team
 Templates → Template 1* applies (post the verdict as a regular
 comment).
 
+**Reviewer-minted identifiers.** Every finding emitted by a PLAN review
+pass SHALL carry a reviewer-minted identifier in the format `v<N>-F<M>`
+(e.g., `v1-F1`, `v1-F2` for pass 1 reviewing plan `v1`; `v2-F1` for pass
+2 reviewing plan `v2`). If a finding is later split by the author or
+reviewer, sub-findings SHALL retain the parent prefix (e.g., `v1-F2a`,
+`v1-F2b`). Reviewer-minted IDs stabilize finding identities across plan
+revisions and prevent renumbering drift.
+
+**Prior-finding traceability audit.** A PLAN review of a revised plan
+(`v<N+1>` for N ≥ 1) SHALL begin with a **Finding Traceability Audit**
+section before listing any new findings. The audit section SHALL
+enumerate every reviewer-minted ID (`v<N>-F<M>`) raised across all prior
+review passes and state its disposition in the revised plan: *addressed*,
+*superseded*, or *withdrawn with reason*. Any unaddressed prior finding
+SHALL cause the review pass to return a `### Verdict: REQUEST CHANGES`.
+
+**Countable invariant.** Reviewers and third parties MAY verify that all
+raised review findings are claimed in a revised plan's traceability
+table by asserting that the row count of addressed reviewer-minted IDs
+matches the total findings raised across prior review comments:
+
+```sh
+# Count findings raised across prior review comments
+for id in <review-comment-ids>; do
+  gh api repos/crewrig/crewrig/issues/comments/$id --jq .body | grep -c '^\*\*Finding '
+done
+# Count rows in the plan comment's traceability table
+grep -c '^| v[0-9]* | [0-9]' <plan-comment>
+```
+
 **Finding class taxonomy.** Every plan-review finding SHALL carry
 exactly one `class:` field whose value drives the loop target:
 


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0146 by establishing reviewer-minted finding identifiers (`v<N>-F<M>`), a mandatory reviewer prior-finding traceability audit obligation in `docs/plan-review-protocol.md`, a `### Finding traceability` subsection schema in `docs/plan-format.md`, and an updated reference summary in `AGENTS.md` (#874).

### How to read this PR?
1. Review `docs/plan-review-protocol.md` for the reviewer-minted identifier rules (`v<N>-F<M>`), prior-finding traceability audit requirement, and the countable invariant check command.
2. Review `docs/plan-format.md` for the `### Finding traceability` subsection schema and finding tag example.
3. Review `AGENTS.md` for the concise Plan review protocol reference update.

### How to test this PR?
1. `npx markdownlint docs/plan-review-protocol.md docs/plan-format.md AGENTS.md`
2. `bash scripts/check-agents-size.sh`
3. `bash scripts/check-markdown-links.sh`
4. `node scripts/lib/spec-linter.js specs`

### Detailed description (for agents)
- Implements Spec 0146 requirements R1–R4.
- Adds `Reviewer-minted identifiers`, `Prior-finding traceability audit`, and `Countable invariant` clauses to `docs/plan-review-protocol.md`.
- Documents `### Finding traceability` optional subsection and table schema (`| Plan Ver | Finding ID | Resolution / Rationale | Step |`) in `docs/plan-format.md`.
- Updates `AGENTS.md` Plan review protocol summary clause while maintaining file size under 22,000 bytes.