### PR TITLE
📝 Document subagent idle notification non-completion protocol (#730)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,7 @@ See [`docs/agent-team-protocol.md`](docs/agent-team-protocol.md) for the full pr
 - **Whole-tree git ops.** `git reset --hard`, `git stash`, `git clean` require an exclusive claim + empty `git status`. See [`docs/agent-team-protocol.md`](docs/agent-team-protocol.md) → *Worktree Isolation*.
 - **Built components.** Any commit touching `artifacts/` MUST also run `bash scripts/build-components.sh` and stage the regenerated outputs in the same commit.
 - **Complexity tier.** Read the spec frontmatter `complexity` field at ticket pickup: `trivial` = inline, `small` = developer + pr-logbook + pr-reviewer, `standard` = full Template 1/2/3, `large` = architect-led sub-spec decomposition.
+- **Idle notification non-completion.** `idle_notification` events indicate thread status at event emission time and are NOT request completion signals; never abandon subagents on an idle event while a request is pending.
 
 ```sh
 git worktree add -b <branch-name> .worktrees/<ticket-id> crewrig/main

--- a/docs/agent-team-protocol.md
+++ b/docs/agent-team-protocol.md
@@ -406,12 +406,12 @@ can resume rather than restart from scratch. Direct `Agent` spawns (without team
 reliably complete and return results; `SendMessage` to a stuck idle
 agent does not.
 
-**Rule 3 — Idle notifications can race result messages.** When the
+**Rule 3 — Idle notifications can race result messages.** An `idle_notification` event indicates subagent process/thread idleness at the time of event emission and SHALL NOT be interpreted as a completion signal for a pending `SendMessage` request. When the
 team-lead receives an `idle_notification` for a teammate, that signal
 does NOT prove the teammate skipped Rule 1. Result messages and idle
 notifications travel as separate events on the harness bus, and the
 idle notification can arrive first even when the teammate sent its
-result correctly. Before treating an apparent silence as a Rule 1
+result correctly. The team-lead SHALL NOT abandon, replace, or terminate an active subagent on the basis of an `idle_notification` alone while a request is pending. Before treating an apparent silence as a Rule 1
 violation, the team-lead MUST:
 
 1. **Let the channel drain.** Do not send anything to the idle


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0150 by updating `docs/agent-team-protocol.md` and `AGENTS.md` to formalize that subagent `idle_notification` events carry process/thread idleness status at event emission time and MUST NOT be interpreted as completion signals for pending requests (#730).

### How to read this PR?
1. Review `docs/agent-team-protocol.md` under `Rule 3` for the non-completion semantics clause.
2. Review `AGENTS.md` under `## Agent Team Protocol` for the summary bullet.

### How to test this PR?
1. `npx markdownlint docs/agent-team-protocol.md AGENTS.md`
2. `bash scripts/check-markdown-links.sh`
3. `bash scripts/check-agents-size.sh`