### PR TITLE
🔧 Bump pr-reviewer skill version to 1.3.0 for single-identity fallback (#692)

### DIFF
--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 

--- a/.claude/skills/pr-reviewer/SKILL.md
+++ b/.claude/skills/pr-reviewer/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 

--- a/.gemini/skills/pr-reviewer/SKILL.md
+++ b/.gemini/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 

--- a/.github/skills/pr-reviewer/SKILL.md
+++ b/.github/skills/pr-reviewer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 

--- a/artifacts/core/skills/pr-reviewer/SKILL.md
+++ b/artifacts/core/skills/pr-reviewer/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.2.0"
+    version: "1.3.0"
 claude:
   allowed-tools:
     - Read


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0151 by bumping `pr-reviewer` skill version to `1.3.0` in `artifacts/core/skills/pr-reviewer/SKILL.md` and compiling updated skill outputs across all supported CLIs (#692).

### How to read this PR?
1. Review `artifacts/core/skills/pr-reviewer/SKILL.md` version bump (`1.2.0` -> `1.3.0`).
2. Review compiled outputs under `.claude/`, `.gemini/`, `.github/`, and `.agents/`.

### How to test this PR?
1. `bash scripts/check-skill-versions.sh`
2. `node scripts/lib/spec-linter.js specs`