### PR TITLE
📝 Clarify spec status transition in discharge carve-out (#849)

### DIFF
--- a/docs/interaction-modes.md
+++ b/docs/interaction-modes.md
@@ -74,8 +74,8 @@ pre-merge merge-authorization gate for that spec-PR. The orchestrator SHALL
 NOT fire a second merge-authorization request for such a spec-PR, because
 the artifact merged to `main` is the identical, unchanged artifact the
 content-approval already approved. The lifecycle-metadata transition
-(`status` and `interaction-mode`) mandated by `docs/spec-format.md` is
-explicitly NOT a content change and does NOT forfeit this
+(`status: draft` to `status: approved` and `interaction-mode`) mandated by `docs/spec-format.md` is
+explicitly NOT a content change (which covers the spec body and non-status frontmatter) and does NOT forfeit this
 merge-authorization discharge. This discharge is deliberately narrow —
 it is not a general waiver of the gate. It does **not** apply in `AUTO`,
 where no SPECS-stage content-approval gate runs to discharge it, so the


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0154 by updating `docs/interaction-modes.md` to state explicitly that the frontmatter status transition from `status: draft` to `status: approved` does not forfeit the one-file spec-PR merge-authorization discharge (#849).

### How to read this PR?
1. Review `docs/interaction-modes.md` under `Narrow discharge carve-out` clause.

### How to test this PR?
1. `node scripts/lib/spec-linter.js specs`
2. `npx markdownlint docs/agent-team-protocol.md AGENTS.md`
3. `bash scripts/check-markdown-links.sh`