### PR TITLE
🐛 Fix CI parity drift from spec 0145 markdown-link steps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,8 @@ check-components:
     - "bash scripts/tests/test-sync-from-upstream.sh"
     - "bash scripts/check-core-paths.sh"
     - "bash scripts/tests/test-check-core-paths.sh"
+    - "bash scripts/check-markdown-links.sh"
+    - "bash scripts/tests/test-check-markdown-links.sh"
     - "bash scripts/tests/test-check-ci-parity.sh"
     - "bash scripts/tests/test-assembly-verification.sh"
     - "bash scripts/tests/test-artifact-build-install-scope.sh"

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -67,6 +67,8 @@ capabilities:
       - bash scripts/tests/test-sync-from-upstream.sh
       - bash scripts/check-core-paths.sh
       - bash scripts/tests/test-check-core-paths.sh
+      - bash scripts/check-markdown-links.sh
+      - bash scripts/tests/test-check-markdown-links.sh
       - bash scripts/tests/test-check-ci-parity.sh
       - bash scripts/tests/test-assembly-verification.sh
       - bash scripts/tests/test-artifact-build-install-scope.sh

--- a/specs/0145-ci-relative-markdown-link-checker.md
+++ b/specs/0145-ci-relative-markdown-link-checker.md
@@ -1,7 +1,7 @@
 ---
 id: "0145"
 slug: ci-relative-markdown-link-checker
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 872


### PR DESCRIPTION
Restores CI parity on `main` by declaring the spec 0145 markdown-link steps in the `check-components` capability reference, and records spec 0145 as `implemented`.

## How to read this PR?

- `ci/ci-capabilities.yml` — the load-bearing file. Declares `bash scripts/check-markdown-links.sh` and `bash scripts/tests/test-check-markdown-links.sh` in the `command` list of capability `check-components`, between `test-check-core-paths.sh` and `test-check-ci-parity.sh`. This is what unblocks `check-ci-parity` (spec 0049) and `check-components` on `main`.
- `.gitlab-ci.yml` — regenerated via `bash scripts/build-ci.sh` so the GitLab arm mirrors the same two lines in the same position (drift-free by construction).
- `specs/0145-ci-relative-markdown-link-checker.md` — frontmatter-only transition `status: approved` → `status: implemented` (spec 0135 R2). PR #905's squash commit did not carry it, so it rides this PR's merge.

## How to test this PR?

```sh
bash scripts/build-ci.sh --check           # GitLab CI matches the regenerated reference; exit 0
bash scripts/check-ci-parity.sh            # no parity drift (spec 0049); exit 0
bash scripts/check-markdown-links.sh       # link checker runs; exit 0
bash scripts/tests/test-check-markdown-links.sh
bash scripts/tests/test-check-ci-parity.sh # 58/58 assertions
task spec:lint                             # spec frontmatter stays valid
```

All six were re-run on `41c4fe1` just before this PR was opened and exit 0.

## Detailed description (for agents)

PR #905 (implementation of spec 0145 `ci-relative-markdown-link-checker`, `related-issue: 872`) added two steps to `.github/workflows/build.yml` — "Check relative Markdown link integrity (#872)" and "Test check-markdown-links regression (#872)" — but never declared them in the CI-parity reference. `scripts/check-ci-parity.sh` (spec 0049) therefore flagged them as unexpected steps (parity R3) and both required checks, `check-ci-parity` and `check-components`, went red on `main` for every PR.

This PR applies the resolution from issue #910:

- `ci/ci-capabilities.yml` (capability `check-components`, `command` list): inserts the two missing steps between `bash scripts/tests/test-check-core-paths.sh` and `bash scripts/tests/test-check-ci-parity.sh`, matching the step order in `.github/workflows/build.yml`.
- `.gitlab-ci.yml`: same two lines, same position, regenerated with `bash scripts/build-ci.sh` so the GitLab arm mirrors the GitHub declaration.
- `specs/0145-ci-relative-markdown-link-checker.md`: metadata-only `status: approved` → `status: implemented`. No body line, no `id`/`slug`/`version` touched (spec 0135 R2).

No CLI-matrix or skill-version-bump obligations apply: the changed paths (`ci/`, `.gitlab-ci.yml`, `specs/`) are outside the scopes of both `docs/cli-matrix-maintenance.md` and the version-bump convention.

Closes #910
