### PR TITLE
✨ Mandate up-to-date branch merge precondition (#934)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ rule takes over.
 - **NEVER merge a Pull Request (PR/MR)** without asking for the user's formal permission JUST BEFORE executing the merge.
   - Narrow one-file spec-PR exception: [`docs/interaction-modes.md`](docs/interaction-modes.md) → *User-gate definition*.
 - The `import/gitlab` branch tracks the legacy GitLab project (`gitlab` remote) and serves as inspiration only.
+- **Up-to-date merge precondition:** BEFORE executing `gh pr merge`, the agent MUST verify that the branch is up-to-date with `main` (`git fetch crewrig main`, `git rebase crewrig/main` or `gh pr update-branch`). If `main` has advanced since the branch was created/rebased, the agent MUST update the branch and re-verify all test suites pass on the rebased state prior to merging.
 - Non-trivial tickets follow the **Spec-PR workflow** (see below).
 
 ### On Claude Code CLI — solo-maintainer self-merge block

--- a/docs/post-merge-flow.md
+++ b/docs/post-merge-flow.md
@@ -12,4 +12,6 @@ After any `gh pr merge`, the agent MUST verify the merge target before closing t
    - The merge target is an intermediate integration branch that must eventually reach `main`.
 3. **Open or propose the downstream PR** before considering the task complete. If the downstream PR can be created automatically (fast-forward or trivial rebase), open it. Otherwise, surface the need to the user with a clear explanation of what remains.
 
+> **Pre-merge up-to-date requirement.** Before executing `gh pr merge`, the agent MUST verify that the feature branch is up-to-date with `main` (`git fetch crewrig main`, `git rebase crewrig/main` or `gh pr update-branch`) and that all test suites pass on the rebased state (`AGENTS.md` → *Branching Strategy*).
+
 > **Merge blocked before it ran (Claude Code).** This flow begins only after a `gh pr merge` command has already executed. If the merge command itself was denied before it could run — the Claude Code auto-mode permission classifier can block a solo-maintainer self-merge — see `AGENTS.md` → *Branching Strategy* → *On Claude Code CLI — solo-maintainer self-merge block* for how to respond.


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0155 by updating `AGENTS.md` → `## Branching Strategy` and `docs/post-merge-flow.md` to mandate that an agent MUST verify a feature branch is up-to-date with current `main` and re-verify all test suites pass on the rebased state before executing `gh pr merge` (#934).

### How to read this PR?
1. Review `AGENTS.md` → `## Branching Strategy` clause.
2. Review `docs/post-merge-flow.md` pre-merge note.

### How to test this PR?
1. `bash scripts/check-agents-size.sh`
2. `node scripts/lib/spec-linter.js specs`
3. `npx markdownlint docs/agent-team-protocol.md AGENTS.md`
4. `bash scripts/check-markdown-links.sh`