### PR TITLE
📝 Spec 0156: Check figure labels in CI with OCR (#881)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,6 +258,32 @@ jobs:
       - name: Test Build Docs Index
         if: steps.filter.outputs.docs-index == 'true'
         run: bash scripts/ci-cache-guard.sh --cache-dir .ci-cache --key-files "scripts/build-docs-index.sh,scripts/tests/test-build-docs-index.sh,docs/**" --key-env "" -- bash scripts/tests/test-build-docs-index.sh
+  figure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            figure-labels:
+              - 'scripts/check-figure-labels.sh'
+              - 'scripts/lib/check-figure-labels.py'
+              - 'scripts/tests/test-check-figure-labels.sh'
+              - 'docs/assets/**/*.png'
+              - 'docs/assets/**/*.prompt.md'
+      - name: Install tesseract
+        if: steps.filter.outputs.figure-labels == 'true'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends tesseract-ocr
+      - name: Install python3
+        if: steps.filter.outputs.figure-labels == 'true'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends python3
+      - name: Check Figure Labels
+        if: steps.filter.outputs.figure-labels == 'true'
+        run: bash scripts/check-figure-labels.sh
+      - name: Test Check Figure Labels
+        if: steps.filter.outputs.figure-labels == 'true'
+        run: bash scripts/tests/test-check-figure-labels.sh
   mempalace:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,6 +278,30 @@ docs-index:
         - "scripts/tests/test-build-docs-index.sh"
         - "docs/**"
 
+figure-labels:
+  image: debian:stable-slim
+  before_script:
+    - apt-get update && apt-get install -y --no-install-recommends tesseract-ocr
+    - apt-get update && apt-get install -y --no-install-recommends python3
+  script:
+    - "bash scripts/check-figure-labels.sh"
+    - "bash scripts/tests/test-check-figure-labels.sh"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
+      changes:
+        - "scripts/check-figure-labels.sh"
+        - "scripts/lib/check-figure-labels.py"
+        - "scripts/tests/test-check-figure-labels.sh"
+        - "docs/assets/**/*.png"
+        - "docs/assets/**/*.prompt.md"
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'
+      changes:
+        - "scripts/check-figure-labels.sh"
+        - "scripts/lib/check-figure-labels.py"
+        - "scripts/tests/test-check-figure-labels.sh"
+        - "docs/assets/**/*.png"
+        - "docs/assets/**/*.prompt.md"
+
 mempalace:
   image: python:3.12
   before_script:

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -309,6 +309,33 @@ capabilities:
       - bash scripts/build-docs-index.sh --check
       - bash scripts/tests/test-build-docs-index.sh
 
+  - id: figure-labels
+    name: "Check figure labels with OCR"
+    trigger:
+      - on: pull-request
+        branches: [main, "release/**"]
+        paths:
+          - "scripts/check-figure-labels.sh"
+          - "scripts/lib/check-figure-labels.py"
+          - "scripts/tests/test-check-figure-labels.sh"
+          - "docs/assets/**/*.png"
+          - "docs/assets/**/*.prompt.md"
+      - on: push
+        branches: [main, "release/**"]
+        paths:
+          - "scripts/check-figure-labels.sh"
+          - "scripts/lib/check-figure-labels.py"
+          - "scripts/tests/test-check-figure-labels.sh"
+          - "docs/assets/**/*.png"
+          - "docs/assets/**/*.prompt.md"
+    portability: portable
+    changeset-gated: true
+    requires:
+      tools: [tesseract, python3]
+    command:
+      - bash scripts/check-figure-labels.sh
+      - bash scripts/tests/test-check-figure-labels.sh
+
   - id: mempalace
     name: "Test mempalace transcript, pin, and runtime guards"
     trigger:

--- a/scripts/build-ci.sh
+++ b/scripts/build-ci.sh
@@ -107,6 +107,12 @@ tool_install_lines() {
       # tool without re-deriving the install line.
       echo 'npm install -g markdownlint-cli'
       ;;
+    tesseract)
+      echo 'apt-get update && apt-get install -y --no-install-recommends tesseract-ocr'
+      ;;
+    python3)
+      echo 'apt-get update && apt-get install -y --no-install-recommends python3'
+      ;;
     *)
       echo "Error: unknown tool '$tool' — no GitLab install recipe (delta-02 Scenario 2)." >&2
       exit 1

--- a/scripts/check-ci-parity.sh
+++ b/scripts/check-ci-parity.sh
@@ -98,6 +98,8 @@ install_recipe_tool() {
     *yq_linux_amd64*|*mikefarah/yq*) echo yq ;;
     *taskfile.dev*)                  echo task ;;
     *markdownlint-cli*)              echo markdownlint-cli ;;
+    *tesseract*)                     echo tesseract ;;
+    *python3*)                       echo python3 ;;
     *apt-get*install*jq*|*install*-y*jq*) echo jq ;;
     *) echo "" ;;
   esac

--- a/scripts/check-figure-labels.sh
+++ b/scripts/check-figure-labels.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# check-figure-labels.sh — Verify figure PNG labels against sidecar prompt expectations using OCR (spec 0156 / issue #881).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+if ! command -v tesseract >/dev/null 2>&1; then
+  echo "[SKIP] tesseract is not installed. Skipping figure label OCR check."
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[SKIP] python3 is not installed. Skipping figure label OCR check."
+  exit 0
+fi
+
+python3 "$SCRIPT_DIR/lib/check-figure-labels.py" "$@"

--- a/scripts/lib/check-figure-labels.py
+++ b/scripts/lib/check-figure-labels.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+check-figure-labels.py — Verify figure labels against sidecar prompts using OCR (spec 0156 / issue #881).
+"""
+
+import sys
+import os
+import glob
+import re
+import subprocess
+import difflib
+
+def normalize(text):
+    text = text.replace("’", "'").replace("“", '"').replace("”", '"').replace("—", "-").replace("–", "-")
+    text = re.sub(r"-\s+", "-", text)
+    text = re.sub(r"[^\w\s-]", " ", text)
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+def extract_labels(prompt_path):
+    with open(prompt_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    
+    # 1. Look for Box text: "..."
+    box_matches = re.findall(r'Box text:\s*"([^"]+)"', content)
+    if box_matches:
+        return box_matches
+    
+    # 2. Look for numbered list of quoted strings e.g. 1. "Claude Code"
+    quoted_matches = re.findall(r'^\s*(?:\d+\.\s*)?"([^"]+)"\s*$', content, re.MULTILINE)
+    if quoted_matches:
+        return quoted_matches
+    
+    return []
+
+def get_clusters(png_path):
+    cmd = ["tesseract", png_path, "stdout", "tsv"]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        return []
+    
+    lines = res.stdout.splitlines()
+    words = []
+    for line in lines[1:]:
+        parts = line.split("\t")
+        if len(parts) >= 12 and parts[0] == "5" and parts[11].strip():
+            left, top, width, height, text = int(parts[6]), int(parts[7]), int(parts[8]), int(parts[9]), parts[11]
+            words.append({
+                "left": left, "top": top, "right": left + width, "bottom": top + height, "text": text
+            })
+            
+    if not words:
+        return []
+
+    words_by_x = sorted(words, key=lambda w: w["left"])
+    clusters = []
+    for w in words_by_x:
+        merged = False
+        for c in clusters:
+            if not (w["right"] < c["left"] - 40 or w["left"] > c["right"] + 40):
+                c["words"].append(w)
+                c["left"] = min(c["left"], w["left"])
+                c["right"] = max(c["right"], w["right"])
+                c["top"] = min(c["top"], w["top"])
+                c["bottom"] = max(c["bottom"], w["bottom"])
+                merged = True
+                break
+        if not merged:
+            clusters.append({
+                "left": w["left"], "right": w["right"], "top": w["top"], "bottom": w["bottom"],
+                "words": [w]
+            })
+            
+    clusters.sort(key=lambda c: (c["left"], c["top"]))
+    
+    res_clusters = []
+    for c in clusters:
+        c_words = sorted(c["words"], key=lambda w: (w["top"] // 20, w["left"]))
+        raw_txt = " ".join(w["text"] for w in c_words)
+        res_clusters.append((c["left"], c["top"], raw_txt, normalize(raw_txt)))
+        
+    return res_clusters
+
+def is_word_matched(word, ocr_words):
+    for ow in ocr_words:
+        if word == ow or difflib.SequenceMatcher(None, word, ow).ratio() >= 0.75:
+            return True
+    return False
+
+def match_label_in_text(label, text):
+    norm_lbl = normalize(label)
+    norm_txt = normalize(text)
+
+    if norm_lbl in norm_txt:
+        return True
+
+    lbl_words = [w for w in norm_lbl.split() if len(w) > 1]
+    txt_words = norm_txt.split()
+
+    if not lbl_words:
+        return False
+
+    matched_count = sum(1 for lw in lbl_words if is_word_matched(lw, txt_words))
+    return (matched_count / len(lbl_words)) >= 0.5
+
+def match_label(label, clusters, full_raw_text):
+    # 1. Try spatial clusters first
+    for idx, (left, top, raw_txt, norm_txt) in enumerate(clusters):
+        if match_label_in_text(label, raw_txt):
+            return idx, left, top
+
+    # 2. Fallback to full OCR text stream
+    if match_label_in_text(label, full_raw_text):
+        return 0, 0, 0
+
+    return None
+
+def main():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    sidecars = sorted(glob.glob(os.path.join(repo_root, "docs", "assets", "**", "*.prompt.md"), recursive=True))
+    
+    if not sidecars:
+        print("[INFO] No figure prompt sidecars found in docs/assets.")
+        sys.exit(0)
+
+    total_figures = 0
+    failed_figures = 0
+
+    for sidecar in sidecars:
+        png = sidecar[:-10] + ".png"
+        if not os.path.exists(png):
+            continue
+        
+        total_figures += 1
+        rel_png = os.path.relpath(png, repo_root)
+        labels = extract_labels(sidecar)
+        clusters = get_clusters(png)
+        full_ocr = " ".join(c[2] for c in clusters)
+
+        print(f"Checking {rel_png} ({len(labels)} expected labels)...")
+        
+        if not labels:
+            print(f"  [WARN] No labels extracted from sidecar {os.path.relpath(sidecar, repo_root)}")
+            continue
+
+        last_idx = -1
+        figure_ok = True
+
+        for lbl in labels:
+            res = match_label(lbl, clusters, full_ocr)
+            if res is None:
+                print(f"  ❌ [FAIL] Missing label: '{lbl}'")
+                figure_ok = False
+            else:
+                c_idx, left, top = res
+                if c_idx < last_idx:
+                    print(f"  ❌ [FAIL] Label out of order: '{lbl}' found at cluster {c_idx} (x={left}px), expected after cluster {last_idx}")
+                    figure_ok = False
+                else:
+                    print(f"  ✓ [PASS] Label: '{lbl}'")
+                    last_idx = c_idx
+
+        if not figure_ok:
+            failed_figures += 1
+            print(f"  RESULT: FAIL for {rel_png}\n")
+        else:
+            print(f"  RESULT: PASS for {rel_png}\n")
+
+    if failed_figures > 0:
+        print(f"[FAIL] {failed_figures}/{total_figures} figure(s) failed label OCR verification.")
+        sys.exit(1)
+    else:
+        print(f"[PASS] All {total_figures} figure(s) passed label OCR verification.")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test-check-figure-labels.sh
+++ b/scripts/tests/test-check-figure-labels.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# test-check-figure-labels.sh — Unit test suite for scripts/check-figure-labels.sh (spec 0156 / issue #881).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+CHECK_SCRIPT="$SCRIPT_DIR/scripts/check-figure-labels.sh"
+
+pass=0
+fail=0
+
+run_test() {
+  local name="$1"
+  local actual_exit=0
+  local output
+  output=$(bash "$CHECK_SCRIPT" 2>&1) || actual_exit=$?
+
+  if [ "$actual_exit" -eq 0 ]; then
+    echo "PASS  $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $name (expected exit 0, got $actual_exit)"
+    echo "      output: $output"
+    fail=$((fail + 1))
+  fi
+}
+
+run_test "case-1: check-figure-labels.sh passes on repository figures"
+
+echo ""
+echo "Results: $pass/$((pass + fail)) passed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/specs/0156-check-figure-labels-ocr.md
+++ b/specs/0156-check-figure-labels-ocr.md
@@ -1,0 +1,50 @@
+---
+id: "0156"
+slug: check-figure-labels-ocr
+status: approved
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 881
+version: 1.0.0
+---
+
+# Check Figure Labels in CI with OCR Protocol
+
+## Intent
+
+Mechanically verify PNG figure labels against sidecar prompt specifications using OCR (`tesseract`) in CI to prevent diagram text defects and ordering regressions.
+
+## Requirements
+
+1. **OCR Checker Script.** A script `scripts/check-figure-labels.sh` (delegating to `scripts/lib/check-figure-labels.py`) SHALL inspect every PNG in `docs/assets/` that has a sibling `.prompt.md` sidecar.
+2. **Label Extraction and Order Verification.** The script SHALL parse expected box/diagram labels from sidecar prompts (such as `Box text: "..."` or quoted prompt lists), run OCR (`tesseract`), and verify that every expected label is present in the image and appears in the defined left-to-right / step sequence.
+3. **Graceful Degradation.** If `tesseract` is absent from `$PATH`, `scripts/check-figure-labels.sh` SHALL print a `[SKIP]` notice and exit `0` to avoid blocking environments without OCR tooling.
+4. **CI Integration.** A portable capability `figure-labels` SHALL be registered in `ci/ci-capabilities.yml` and wired into `.github/workflows/build.yml` and `.gitlab-ci.yml`.
+
+## Scenarios
+
+### Scenario 1: Figures match sidecar prompt labels in defined order
+
+- **GIVEN** a PNG figure whose text labels match all expected sidecar `Box text:` strings in sequence
+- **WHEN** `scripts/check-figure-labels.sh` is executed
+- **THEN** all label checks pass and the script exits `0`.
+
+### Scenario 2: Figure has missing or out-of-order text labels
+
+- **GIVEN** a PNG figure with a missing or inverted label order
+- **WHEN** `scripts/check-figure-labels.sh` is executed
+- **THEN** the script reports `[FAIL]` detailing the missing/misordered label and exits `1`.
+
+### Scenario 3: Tesseract is not installed
+
+- **GIVEN** an environment where `tesseract` binary is missing
+- **WHEN** `scripts/check-figure-labels.sh` is executed
+- **THEN** the script outputs `[SKIP]` notice and exits `0`.
+
+## Out of scope
+
+- Converting raster PNG diagrams to Mermaid or SVG vector format.
+
+## Open questions
+
+- None.


### PR DESCRIPTION
### Purpose
This spec PR introduces Spec 0156 (`specs/0156-check-figure-labels-ocr.md`) establishing a mechanical CI check (`scripts/check-figure-labels.sh`) that uses OCR (`tesseract`) to verify figure PNG labels against their sidecar prompt expectations (#881).

### Related issue
- #881