### PR TITLE
✨ Check figure labels in CI with OCR (#881)

### DIFF
--- a/specs/0156-check-figure-labels-ocr.md
+++ b/specs/0156-check-figure-labels-ocr.md
@@ -1,7 +1,7 @@
 ---
 id: "0156"
 slug: check-figure-labels-ocr
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 881


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0156 by adding `scripts/check-figure-labels.sh` and `scripts/lib/check-figure-labels.py` to mechanically verify PNG figure labels against sidecar prompt specifications using OCR (`tesseract`) in CI (#881).

### How to read this PR?
1. Review `scripts/check-figure-labels.sh` and `scripts/lib/check-figure-labels.py`.
2. Review `ci/ci-capabilities.yml` (`figure-labels` capability).
3. Review `scripts/tests/test-check-figure-labels.sh`.

### How to test this PR?
1. `bash scripts/check-figure-labels.sh`
2. `bash scripts/tests/test-check-figure-labels.sh`
3. `bash scripts/check-ci-parity.sh`