### PR TITLE
🐛 Fix symlinked palace token path canonicalization (#746)

### DIFF
--- a/docs/post-merge-flow.md
+++ b/docs/post-merge-flow.md
@@ -13,5 +13,5 @@ After any `gh pr merge`, the agent MUST verify the merge target before closing t
 3. **Open or propose the downstream PR** before considering the task complete. If the downstream PR can be created automatically (fast-forward or trivial rebase), open it. Otherwise, surface the need to the user with a clear explanation of what remains.
 
 > **Pre-merge up-to-date requirement.** Before executing `gh pr merge`, the agent MUST verify that the feature branch is up-to-date with `main` (`git fetch crewrig main`, `git rebase crewrig/main` or `gh pr update-branch`) and that all test suites pass on the rebased state (`AGENTS.md` → *Branching Strategy*).
-
+>
 > **Merge blocked before it ran (Claude Code).** This flow begins only after a `gh pr merge` command has already executed. If the merge command itself was denied before it could run — the Claude Code auto-mode permission classifier can block a solo-maintainer self-merge — see `AGENTS.md` → *Branching Strategy* → *On Claude Code CLI — solo-maintainer self-merge block* for how to respond.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1446,15 +1446,14 @@ uninstall_daemon_supervisor() {
 mcp_token_path() {
   local palace_path="${MEMPALACE_PALACE_PATH:-$HOME/.mempalace/palace}"
   local resolved key
-  # The parent must exist before resolving, or the key would depend on whether
-  # the directory happens to be there yet: `cd` fails on a missing parent, the
-  # path falls back to its unresolved form, and a later call — after some other
-  # step created the directory — resolves differently and computes a DIFFERENT
-  # key. That yields two token files for one palace, which reads as "the token
-  # keeps changing". Creating the parent first makes the key a function of the
-  # path alone.
-  mkdir -p "$(dirname "$palace_path")" 2>/dev/null || true
-  resolved="$(cd "$(dirname "$palace_path")" 2>/dev/null && pwd)/$(basename "$palace_path")" || resolved="$palace_path"
+  if [ -d "$palace_path" ]; then
+    resolved="$(cd -P "$palace_path" 2>/dev/null && pwd -P)"
+  else
+    # The parent must exist before resolving, or the key would depend on whether
+    # the directory happens to be there yet.
+    mkdir -p "$(dirname "$palace_path")" 2>/dev/null || true
+    resolved="$(cd -P "$(dirname "$palace_path")" 2>/dev/null && pwd -P)/$(basename "$palace_path")"
+  fi
   key="$(printf '%s' "$resolved" | shasum -a 256 2>/dev/null | cut -c1-24)"
   if [ -z "$key" ]; then
     key="$(printf '%s' "$resolved" | sha256sum | cut -c1-24)"

--- a/scripts/lib/mcp-daemon-launcher.sh
+++ b/scripts/lib/mcp-daemon-launcher.sh
@@ -59,15 +59,13 @@ die() { printf '%s ERROR: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >&2; exit 
 TOKEN_FILE="${MEMPALACE_MCP_TOKEN_FILE:-}"
 if [ -z "${TOKEN_FILE}" ]; then
   palace="${MEMPALACE_PALACE_PATH:-${HOME}/.mempalace/palace}"
-  # Derive the key exactly as mcp_token_path does (spec 0113 R8, spec 0133 R9).
-  # The parent must exist before resolving, or `cd` fails on a missing parent,
-  # the path falls back to its unresolved form, and a later call — after some
-  # other step created the directory — resolves differently and computes a
-  # DIFFERENT key. Two token files for one palace reads as "the token keeps
-  # changing". Creating the parent first makes the key a function of the path
-  # alone, and removes the dead `|| resolved=` fallback that masked the bug.
-  mkdir -p "$(dirname "${palace}")" 2>/dev/null || true
-  resolved="$(cd "$(dirname "${palace}")" 2>/dev/null && pwd)/$(basename "${palace}")"
+  # Derive the key exactly as mcp_token_path does (spec 0113 R8, spec 0133 R9, spec 0159).
+  if [ -d "${palace}" ]; then
+    resolved="$(cd -P "${palace}" 2>/dev/null && pwd -P)"
+  else
+    mkdir -p "$(dirname "${palace}")" 2>/dev/null || true
+    resolved="$(cd -P "$(dirname "${palace}")" 2>/dev/null && pwd -P)/$(basename "${palace}")"
+  fi
   if command -v shasum >/dev/null 2>&1; then
     key="$(printf '%s' "${resolved}" | shasum -a 256 | cut -c1-24)"
   else

--- a/scripts/tests/test-mcp-daemon.sh
+++ b/scripts/tests/test-mcp-daemon.sh
@@ -139,6 +139,16 @@ tok_file="$(mcp_token_path)"
 perms="$(stat -c '%a' "${tok_file}" 2>/dev/null || stat -f '%Lp' "${tok_file}" 2>/dev/null)"
 [ "${perms}" = "600" ] && ok "token file is mode 0600" || nope "token file is mode ${perms}, expected 600"
 
+# Symlinked palace directory canonicalization (spec 0159 / issue #746)
+real_palace="${TEST_HOME}/real_palace"
+sym_palace="${TEST_HOME}/sym_palace"
+mkdir -p "${real_palace}"
+ln -s "${real_palace}" "${sym_palace}"
+p_real="$(MEMPALACE_PALACE_PATH="${real_palace}" mcp_token_path)"
+p_sym="$(MEMPALACE_PALACE_PATH="${sym_palace}" mcp_token_path)"
+[ "${p_real}" = "${p_sym}" ] && ok "symlinked palace path resolves to identical token path as real directory (spec 0159)" \
+  || nope "symlinked palace path (${p_sym}) diverges from real directory (${p_real})"
+
 # --- 2. The launcher refuses to serve without a token ------------------------
 # This is the finding that would otherwise have shipped a daemon with
 # authentication silently disabled: MemPalace requires a token only on a

--- a/specs/0157-test-wiring-optimization.md
+++ b/specs/0157-test-wiring-optimization.md
@@ -3,6 +3,7 @@ id: "0157"
 slug: test-wiring-optimization
 status: approved
 complexity: standard
+interaction-mode: MINIMAL
 related-issue: 939
 version: 1.0.0
 ---

--- a/specs/0159-symlinked-palace-token-path-canonicalization.md
+++ b/specs/0159-symlinked-palace-token-path-canonicalization.md
@@ -1,7 +1,7 @@
 ---
 id: "0159"
 slug: symlinked-palace-token-path-canonicalization
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 746


### PR DESCRIPTION
### Purpose
This PR operationalises Spec 0159 by canonicalizing the complete physical palace path (including symlinked leaves) in `scripts/lib/common.sh` (`mcp_token_path()`) and `scripts/lib/mcp-daemon-launcher.sh` so that token path derivation converges with upstream MemPalace's `_server_token_path` (`os.path.realpath`) identically (#746).

### How to read this PR?
1. Review `scripts/lib/common.sh` (`mcp_token_path()`).
2. Review `scripts/lib/mcp-daemon-launcher.sh` token path derivation.
3. Review regression test in `scripts/tests/test-mcp-daemon.sh`.

### How to test this PR?
`bash scripts/tests/test-mcp-daemon.sh`