### PR TITLE
🐛 Fix CI lint failures on main — MD028 + spec 0157 interaction-mode

### DIFF
--- a/docs/post-merge-flow.md
+++ b/docs/post-merge-flow.md
@@ -13,5 +13,5 @@ After any `gh pr merge`, the agent MUST verify the merge target before closing t
 3. **Open or propose the downstream PR** before considering the task complete. If the downstream PR can be created automatically (fast-forward or trivial rebase), open it. Otherwise, surface the need to the user with a clear explanation of what remains.
 
 > **Pre-merge up-to-date requirement.** Before executing `gh pr merge`, the agent MUST verify that the feature branch is up-to-date with `main` (`git fetch crewrig main`, `git rebase crewrig/main` or `gh pr update-branch`) and that all test suites pass on the rebased state (`AGENTS.md` → *Branching Strategy*).
-
+>
 > **Merge blocked before it ran (Claude Code).** This flow begins only after a `gh pr merge` command has already executed. If the merge command itself was denied before it could run — the Claude Code auto-mode permission classifier can block a solo-maintainer self-merge — see `AGENTS.md` → *Branching Strategy* → *On Claude Code CLI — solo-maintainer self-merge block* for how to respond.

--- a/specs/0157-test-wiring-optimization.md
+++ b/specs/0157-test-wiring-optimization.md
@@ -3,6 +3,7 @@ id: "0157"
 slug: test-wiring-optimization
 status: approved
 complexity: standard
+interaction-mode: INTERMEDIATE
 related-issue: 939
 version: 1.0.0
 ---


### PR DESCRIPTION
## Purpose

Fixes two CI lint failures that are red on `main` (and on every PR branched from it), blocking all merges — issues #946.

1. `docs/post-merge-flow.md:16` — MD028 (blank line inside blockquote), introduced by PR #938 (`e0a60df`).
2. `specs/0157-test-wiring-optimization.md` — `status: approved` without `interaction-mode`, which the spec-linter requires for any non-draft spec.

## How to read this PR

Two one-line fixes:

- `docs/post-merge-flow.md` — the bare blank line separating two adjacent `>` blockquotes becomes a quoted blank line (`>`), so the two paragraphs parse inside a single blockquote (canonical MD028 resolution).
- `specs/0157-test-wiring-optimization.md` — `interaction-mode: INTERMEDIATE` added between `complexity` and `related-issue` (template field order; INTERMEDIATE matches the template default and the sibling CI specs 0145, 0147, 0155, 0156).

## How to test this PR

- `markdownlint docs/post-merge-flow.md` passes.
- `node scripts/lib/spec-linter.js specs/0157-test-wiring-optimization.md` passes.
- The `lint-markdown` and `lint-specs` CI jobs turn green on this branch (and on `main` after merge).

## Detailed description (for agents)

- **Root cause 1**: the pre-merge up-to-date requirement blockquote added by #938 sits directly above an existing Claude Code merge-block blockquote, separated by a bare empty line. markdownlint MD028 flags an unquoted blank line between adjacent blockquotes as ambiguous.
- **Root cause 2**: spec-PR #940 merged 0157 as `approved` without declaring `interaction-mode`; the linter's requirement (spec-linter.js:401) predates that merge, so the violation passed CI and reddened `main` retroactively.
- **Blocker lifted**: spec-PR #943 (and every other open branch) fails CI only because of these two files on the merged base.

Related #946
