### PR TITLE
🔐 Harden the anti-argv guard and disclose the rotation recovery (spec 0149)

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -937,6 +937,7 @@ mcp_daemon_replace_process() {
   echo "           receives the newly minted token in the very next probe — this"
   echo "           one — and can then answer your agents with fabricated memory."
   echo "           Nothing below can tell that process from the real daemon."
+  echo "           Rotate the token again if the window may have been claimed."
   echo ""
 
   case "$(uname -s)" in

--- a/scripts/tests/test-mcp-daemon.sh
+++ b/scripts/tests/test-mcp-daemon.sh
@@ -270,27 +270,85 @@ grep -q "${tok}" "${launcher}" 2>/dev/null \
 # sampling the process table while a probe runs harvests the credential — the
 # reason both probes feed the header through a stdin curl config instead
 # (scripts/lib/common.sh `_mcp_daemon_probe_accepts`, and `_probe_code` in
-# section 16 below). The pattern's last syllable is concatenated at runtime so
-# THIS assertion cannot satisfy the search it performs. It deliberately admits
-# every spelling of the flag rather than the canonical one only: `--header` as
-# well as `-H`, `=` or nothing in place of the space (`--header=`, `-H'…'`,
-# `-HAuthorization:…`), an optional opening quote, and anything at all between
-# the colon and the scheme name — a cold review put all four variants past the
-# earlier `-(H|-header) ` form untouched. Over-matching is the right failure
-# direction here: a false positive costs a reader one glance, a false negative
-# ships the credential back into the process table. Comments are stripped
-# by matching grep -n's own `<line>:` prefix, NOT by leading whitespace —
-# the trap section 4 below documents; the filter is load-bearing here, since
-# common.sh's `register_mempalace_mcp` explains the hazard in prose that
-# quotes the very flag being banned. Scoped to the two files this spec
-# governs: scripts/tests/test-setup-org-mcp.sh asserts the org-MCP `--header`
-# argv shape on purpose, and sweeping that call site is the follow-up
-# specs/0139-token-rotation-revocation.delta-01.md defers.
-argv_bearer="Bea""rer"
-argv_bearer_hits="$(grep -nE -- "-(H|-header)[[:space:]=]*[\"']?Authorization:.*${argv_bearer}" \
+# section 16 below). BOTH halves of the banned string — the header name and
+# the scheme word — are concatenated at runtime (`argv_hdr`, `argv_scheme`) so
+# THIS assertion cannot satisfy the search it performs. Splitting the scheme
+# alone sufficed while the search was case-sensitive; it does not since spec
+# 0149 R1 made the match case-insensitive, because any line in this block that
+# spells the header name out then self-trips the pattern. It deliberately
+# admits every spelling of the flag rather than the canonical one only:
+# `--header` as well as `-H`, `=` or nothing in place of the space
+# (`--header=`, `-H'…'`, `-HAuthorization:…`), an optional opening quote, and
+# anything at all between the colon and the scheme name — a cold review put
+# all four variants past the earlier `-(H|-header) ` form untouched.
+# Over-matching is the right failure direction here: a false positive costs a
+# reader one glance, a false negative ships the credential back into the
+# process table.
+#
+# Comments are stripped by matching grep -n's own `<line>:` prefix ANCHORED
+# (spec 0149 R2), NOT by leading whitespace — the trap section 4 below
+# documents — and NOT unanchored, which used to swallow any genuine violation
+# whose line merely carried a trailing comment. The anchor is why the sweep
+# runs ONE FILE AT A TIME: hand `grep -n` two paths and every hit gains a
+# `<path>:` prefix, so `^[0-9]` never matches and the filter degenerates into
+# excluding nothing. The filter is load-bearing either way, since common.sh's
+# `register_mempalace_mcp` explains the hazard in prose that quotes the very
+# flag being banned.
+#
+# Scope: the two files this spec governs, swept through the same helper as the
+# fixture below — the executable witness that both mutations spec 0149 names
+# are caught and that a pure comment is still excluded. The one deliberate
+# occurrence in the repository, scripts/tests/test-setup-org-mcp.sh, asserts
+# the org-MCP argv shape on purpose and carries a comment saying so at its own
+# call site (spec 0149 R4); no other occurrence exists under scripts/.
+argv_scheme="Bea""rer"
+argv_hdr="Authoriz""ation"
+argv_pat="-(H|-header)[[:space:]=]*[\"']?${argv_hdr}:.*${argv_scheme}"
+# ONE pattern and ONE filter, shared by the self-test and the real sweep, so a
+# mutation cannot satisfy the witness while leaving the repository unguarded.
+_argv_bearer_hits() {
+  local f hits all=""
+  for f in "$@"; do
+    hits="$(grep -niE -- "${argv_pat}" "${f}" 2>/dev/null \
+      | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+    [ -n "${hits}" ] && all="${all}${f}:${hits}"$'\n'
+  done
+  printf '%s' "${all}"
+}
+
+# Self-test BEFORE the sweep: this guard is a static grep whose passing state
+# looks identical whether or not it can still catch a violation, so it has to
+# prove it can. Three fixture lines under ${TEST_HOME} (the cleanup trap at
+# :102-103 removes them): the lower-case shape R1 names, the trailing-comment
+# shape R2 names, and a pure comment that must stay excluded. The two words
+# are handed to printf at runtime for the same reason the pattern splits them.
+argv_fixture="${TEST_HOME}/argv-guard-fixture.txt"
+argv_hdr_lc="$(printf '%s' "${argv_hdr}" | tr '[:upper:]' '[:lower:]')"
+argv_scheme_lc="$(printf '%s' "${argv_scheme}" | tr '[:upper:]' '[:lower:]')"
+{ printf 'curl -H "%s: %s $t" http://x\n'              "${argv_hdr_lc}" "${argv_scheme_lc}"
+  printf 'curl -H "%s: %s $t" http://x  # ref: #913\n' "${argv_hdr}"    "${argv_scheme}"
+  printf '  # prose: NOT curl -H "%s: %s $t"\n'        "${argv_hdr}"    "${argv_scheme}"
+} > "${argv_fixture}"
+argv_self_hits="$(_argv_bearer_hits "${argv_fixture}")"
+argv_self_n="$(printf '%s' "${argv_self_hits}" | grep -c . || true)"
+case "${argv_self_hits}" in
+  *"${argv_hdr_lc}: ${argv_scheme_lc}"*) ok "the guard catches a violation spelled in lower case (R1)" ;;
+  *) nope "the guard missed the lower-case violation: ${argv_self_hits}" ;;
+esac
+case "${argv_self_hits}" in
+  *"# ref: #913"*) ok "the guard catches a violation carrying a trailing comment (R2)" ;;
+  *) nope "the comment filter swallowed a violation carrying a trailing comment: ${argv_self_hits}" ;;
+esac
+# The assertion that kills the degenerate "exclude nothing" filter, which would
+# satisfy both cases above while making the guard useless: exactly the two
+# violation lines are reported, and the pure comment is not.
+[ "${argv_self_n}" -eq 2 ] \
+  && ok "the anchored filter excludes the comment line and nothing else (R2)" \
+  || nope "expected exactly 2 fixture violations, got ${argv_self_n}: ${argv_self_hits}"
+
+argv_bearer_hits="$(_argv_bearer_hits \
   "${REPO_DIR}/scripts/lib/common.sh" \
-  "${REPO_DIR}/scripts/tests/test-mcp-daemon.sh" 2>/dev/null \
-  | grep -v ':[[:space:]]*#' || true)"
+  "${REPO_DIR}/scripts/tests/test-mcp-daemon.sh")"
 [ -z "${argv_bearer_hits}" ] \
   && ok "no bearer token is passed through an -H argv flag (R8)" \
   || nope "a bearer token reached argv via -H: ${argv_bearer_hits}"
@@ -774,6 +832,14 @@ esac
 case "${out}" in
   *"receives the newly minted token"*) ok "the replacement window is disclosed before the stop is issued (R5)" ;;
   *) nope "no replacement-window disclosure: ${out}" ;;
+esac
+# Second half of the same witness: spec 0149 R3 makes a disclosure that names
+# the risk without naming the recovery non-conformant, so the risk substring
+# above cannot be the only thing asserted. `case` is case-sensitive, so this
+# substring tracks the copy in common.sh verbatim.
+case "${out}" in
+  *"Rotate the token again"*) ok "the disclosure names the recovery, not only the risk (0149 R3)" ;;
+  *) nope "the disclosure names the risk without the recovery action: ${out}" ;;
 esac
 
 # Behavioural half: probed skip on the prerequisites the launcher actually

--- a/scripts/tests/test-mcp-daemon.sh
+++ b/scripts/tests/test-mcp-daemon.sh
@@ -265,10 +265,11 @@ grep -q "${tok}" "${launcher}" 2>/dev/null \
   && nope "the token VALUE was substituted into the launcher" \
   || ok "no token value is baked into the launcher"
 
-# Reintroduction guard: no bearer may travel through an `-H`/`--header` argv
-# flag either. /proc/<pid>/cmdline is world-readable on Linux, so a local uid
-# sampling the process table while a probe runs harvests the credential — the
-# reason both probes feed the header through a stdin curl config instead
+# Reintroduction guard: no credential may travel through an argv flag either —
+# not the hand-built header, and not curl's own credential flags, which end up
+# in the same place. /proc/<pid>/cmdline is world-readable on Linux, so a local
+# uid sampling the process table while a probe runs harvests the credential —
+# the reason both probes feed the header through a stdin curl config instead
 # (scripts/lib/common.sh `_mcp_daemon_probe_accepts`, and `_probe_code` in
 # section 16 below). BOTH halves of the banned string — the header name and
 # the scheme word — are concatenated at runtime (`argv_hdr`, `argv_scheme`) so
@@ -296,38 +297,73 @@ grep -q "${tok}" "${launcher}" 2>/dev/null \
 # flag being banned.
 #
 # Scope: the two files this spec governs, swept through the same helper as the
-# fixture below — the executable witness that both mutations spec 0149 names
-# are caught and that a pure comment is still excluded. The one deliberate
-# occurrence in the repository, scripts/tests/test-setup-org-mcp.sh, asserts
-# the org-MCP argv shape on purpose and carries a comment saying so at its own
-# call site (spec 0149 R4); no other occurrence exists under scripts/.
+# fixture below — the executable witness that every shape the pattern claims to
+# catch is caught, that a pure comment is still excluded, and that the swept
+# paths were actually read. The one deliberate occurrence in the repository,
+# scripts/tests/test-setup-org-mcp.sh, asserts the org-MCP argv shape on
+# purpose and carries a comment saying so at its own call site (spec 0149 R4);
+# no other occurrence exists under scripts/.
 argv_scheme="Bea""rer"
 argv_hdr="Authoriz""ation"
+argv_hdr_lc="$(printf '%s' "${argv_hdr}" | tr '[:upper:]' '[:lower:]')"
+argv_scheme_lc="$(printf '%s' "${argv_scheme}" | tr '[:upper:]' '[:lower:]')"
+# Three shapes, one alternation. The header shape is the one the daemon probes
+# could regress into; the other two are the likelier INNOCENT reintroduction —
+# a contributor reaching for curl's own credential flags, which put the raw
+# token in argv just as plainly as a hand-built header does:
+#   A  -H/--header "<hdr>: <scheme> …"   the header shape
+#   B  --oauth2-bearer <token>           curl sends the same header from it
+#   C  curl … -u/--user "<user>:<pass>"  basic auth, credential in argv
+# C is anchored on `curl` on the same line and on the `user:password` colon,
+# unlike A and B: bare `-u` is far too common to match on its own (`shopt -u`,
+# `systemctl --user`, `date -u '+%H:%M'` — the last would match the colon rule
+# without the anchor). A and B need no anchor: both flags are unambiguous.
 argv_pat="-(H|-header)[[:space:]=]*[\"']?${argv_hdr}:.*${argv_scheme}"
-# ONE pattern and ONE filter, shared by the self-test and the real sweep, so a
-# mutation cannot satisfy the witness while leaving the repository unguarded.
+argv_pat="${argv_pat}|--oauth2-${argv_scheme_lc}[[:space:]=]"
+argv_pat="${argv_pat}|curl.*[[:space:]]-(u|-user)[[:space:]=]+[\"']?[^\"'[:space:]]*:"
+# ONE pattern and ONE filter, shared by the self-test and the real sweep.
+#
+# A path that does not exist is recorded as a violation, not skipped. This is
+# the difference between a guard and a guard-shaped no-op: `grep` on a missing
+# file yields no hits and `2>/dev/null` eats the diagnostic, so renaming either
+# swept file — `git mv`, a refactor — would otherwise disarm the sweep and
+# leave every assertion in this block green while the repository is searched
+# for nothing. Checking inside the helper, on exactly the paths it is about to
+# search, is what makes the property hold BY CONSTRUCTION: a second list at the
+# call site could drift from the first, this cannot.
 _argv_bearer_hits() {
-  local f hits all=""
+  local f line hits all=""
   for f in "$@"; do
+    if [ ! -f "${f}" ]; then
+      all="${all}${f}:0:MISSING — the guard swept a path that does not exist"$'\n'
+      continue
+    fi
     hits="$(grep -niE -- "${argv_pat}" "${f}" 2>/dev/null \
       | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
-    [ -n "${hits}" ] && all="${all}${f}:${hits}"$'\n'
+    [ -n "${hits}" ] || continue
+    # Per line, not per blob: prefixing the file to the whole blob left the
+    # second and later hits of a file carrying grep's bare `<line>:`, so a
+    # reader had to infer block boundaries to attribute them.
+    while IFS= read -r line; do
+      [ -n "${line}" ] && all="${all}${f}:${line}"$'\n'
+    done <<< "${hits}"
   done
   printf '%s' "${all}"
 }
 
 # Self-test BEFORE the sweep: this guard is a static grep whose passing state
 # looks identical whether or not it can still catch a violation, so it has to
-# prove it can. Three fixture lines under ${TEST_HOME} (the cleanup trap at
+# prove it can. Five fixture lines under ${TEST_HOME} (the cleanup trap at
 # :102-103 removes them): the lower-case shape R1 names, the trailing-comment
-# shape R2 names, and a pure comment that must stay excluded. The two words
-# are handed to printf at runtime for the same reason the pattern splits them.
+# shape R2 names, a pure comment that must stay excluded, and one line per
+# credential-flag shape B and C. Every word the pattern searches for is handed
+# to printf at runtime, for the same reason the pattern itself splits them.
 argv_fixture="${TEST_HOME}/argv-guard-fixture.txt"
-argv_hdr_lc="$(printf '%s' "${argv_hdr}" | tr '[:upper:]' '[:lower:]')"
-argv_scheme_lc="$(printf '%s' "${argv_scheme}" | tr '[:upper:]' '[:lower:]')"
 { printf 'curl -H "%s: %s $t" http://x\n'              "${argv_hdr_lc}" "${argv_scheme_lc}"
   printf 'curl -H "%s: %s $t" http://x  # ref: #913\n' "${argv_hdr}"    "${argv_scheme}"
   printf '  # prose: NOT curl -H "%s: %s $t"\n'        "${argv_hdr}"    "${argv_scheme}"
+  printf 'curl --oauth2-%s "$t" http://x\n'            "${argv_scheme_lc}"
+  printf 'curl -sS -u "%s" http://x\n'                 'svc:$t'
 } > "${argv_fixture}"
 argv_self_hits="$(_argv_bearer_hits "${argv_fixture}")"
 argv_self_n="$(printf '%s' "${argv_self_hits}" | grep -c . || true)"
@@ -339,19 +375,34 @@ case "${argv_self_hits}" in
   *"# ref: #913"*) ok "the guard catches a violation carrying a trailing comment (R2)" ;;
   *) nope "the comment filter swallowed a violation carrying a trailing comment: ${argv_self_hits}" ;;
 esac
+case "${argv_self_hits}" in
+  *"--oauth2-${argv_scheme_lc}"*) ok "the guard catches curl's own token flag (shape B)" ;;
+  *) nope "the guard missed the credential-carrying curl flag: ${argv_self_hits}" ;;
+esac
+case "${argv_self_hits}" in
+  *'"svc:$t"'*) ok "the guard catches basic auth passed through argv (shape C)" ;;
+  *) nope "the guard missed the basic-auth credential in argv: ${argv_self_hits}" ;;
+esac
 # The assertion that kills the degenerate "exclude nothing" filter, which would
-# satisfy both cases above while making the guard useless: exactly the two
+# satisfy every case above while making the guard useless: exactly the four
 # violation lines are reported, and the pure comment is not.
-[ "${argv_self_n}" -eq 2 ] \
+[ "${argv_self_n}" -eq 4 ] \
   && ok "the anchored filter excludes the comment line and nothing else (R2)" \
-  || nope "expected exactly 2 fixture violations, got ${argv_self_n}: ${argv_self_hits}"
+  || nope "expected exactly 4 fixture violations, got ${argv_self_n}: ${argv_self_hits}"
 
 argv_bearer_hits="$(_argv_bearer_hits \
   "${REPO_DIR}/scripts/lib/common.sh" \
   "${REPO_DIR}/scripts/tests/test-mcp-daemon.sh")"
+# Asserted BEFORE the sweep verdict, and separately from it: a clean sweep and
+# a sweep that searched nothing are the same empty string, so the emptiness
+# below carries information only once the paths are known to have been read.
+case "${argv_bearer_hits}" in
+  *":0:MISSING"*) nope "the sweep is vacuous — a swept path does not exist: ${argv_bearer_hits}" ;;
+  *) ok "every swept path exists, so a clean sweep below means something" ;;
+esac
 [ -z "${argv_bearer_hits}" ] \
-  && ok "no bearer token is passed through an -H argv flag (R8)" \
-  || nope "a bearer token reached argv via -H: ${argv_bearer_hits}"
+  && ok "no credential is passed through an argv flag (R8)" \
+  || nope "a credential reached argv: ${argv_bearer_hits}"
 
 # --- 4. Unit files never carry the token -------------------------------------
 echo ""

--- a/scripts/tests/test-setup-org-mcp.sh
+++ b/scripts/tests/test-setup-org-mcp.sh
@@ -196,6 +196,15 @@ while IFS= read -r line || [ -n "$line" ]; do ARGV_HTTP+=("$line"); done \
 HTTP_STR="${ARGV_HTTP[*]:-}"
 [[ "$HTTP_STR" == *"--transport http"* ]] && ok "http argv: --transport http" || bad "http argv missing --transport http ($HTTP_STR)"
 [[ "$HTTP_STR" == *"atlassian https://mcp.atlassian.example/mcp"* ]] && ok "http argv: <name> <url>" || bad "http argv name/url wrong ($HTTP_STR)"
+# DELIBERATE bearer-in-argv occurrence, and the only one under scripts/ (spec
+# 0149 R4). What follows asserts the SHAPE of the argv the Claude adapter
+# builds from an org declaration — the flag plus the header name it emits —
+# not a live credential: the value comes from the ORG_HTTP fixture at :58,
+# whose token is the literal placeholder `${ATLASSIAN_TOKEN}`. The reader
+# sweeping the repository for this pattern is meant to land here and stop. The
+# credential-bearing surface is elsewhere and guarded elsewhere: the MemPalace
+# daemon probes feed their header through a stdin curl config, enforced by the
+# reintroduction guard in scripts/tests/test-mcp-daemon.sh section 3.
 [[ "$HTTP_STR" == *"--header Authorization: Bearer"* ]] && ok "http argv: --header \"K: V\"" || bad "http argv missing --header ($HTTP_STR)"
 
 # ---------------------------------------------------------------------------

--- a/specs/0149-daemon-credential-hardening.md
+++ b/specs/0149-daemon-credential-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: "0149"
 slug: daemon-credential-hardening
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 913


### PR DESCRIPTION
The anti-argv guard in the daemon suite was a static grep whose passing state looked identical whether or not it could still catch a violation, and spec 0149 names two mutations it let through. This PR closes those, closes a third vacuity the review found underneath them — a sweep pointed at a path that no longer exists — widens the guard to the credential flags `curl` supplies itself, and adds the recovery action to the rotation-window disclosure.

Spec: [`specs/0149-daemon-credential-hardening.md`](https://github.com/crewrig/crewrig/blob/main/specs/0149-daemon-credential-hardening.md) · Logbook: issue #913 · Interaction mode: MINIMAL · Complexity: small · **Review iteration 2**

Branch is up to date with `main` at `bfb320e`. All line anchors below are at `9d7ee5a`, re-derived after the refresh — `main`'s `7deb998` inserted an assertion at `:142` of the same suite, so every anchor in this file moved by +10 since iteration 1.

## How to read this PR?

Four commits, four files. Read in this order.

**1. `specs/0149-daemon-credential-hardening.md`** — the contract everything traces to (R1–R5). The only change is the frontmatter `status: approved` → `status: implemented`, in its own commit (`87dd7b3`); no body line, no `id`, no `slug`, no `version` (`docs/spec-format.md` → *Recording a status transition*).

**2. `scripts/tests/test-mcp-daemon.sh` §3 (`:258-415`)** — the load-bearing file, and the only one iteration 2 changed. Four design decisions, in the order they appear:

- **A missing swept path is a violation, not a silent skip** (`:347-350`). This is the review's blocking finding and the reason for iteration 2. `grep` on a missing file yields no hits and `2>/dev/null` ate the diagnostic, so renaming either swept file left every assertion green while the repository was searched for nothing — byte-identical to the shipped green state. The check lives **inside** `_argv_bearer_hits`, on exactly the paths it is about to search, rather than in a second list at the call site: a second list can drift from the first as the swept set grows, this cannot. A missing path is recorded as a violation-shaped entry (`<path>:0:MISSING …`), so no caller can skip past it, and the call site asserts the absence of that marker at `:409-412` **separately from and before** the sweep verdict at `:413-415`. That separation is the point: a clean sweep and a sweep that read nothing are the same empty string, so emptiness carries information only once the paths are known to have been read.
- **Three argv shapes, one alternation** (`:331-333`). The header shape is the one the daemon probes could regress into; the other two are the likelier *innocent* reintroduction, a contributor reaching for curl's own credential flags, which put the raw token in argv just as plainly as a hand-built header does — `--oauth2-bearer <token>` (shape B, `:332`) and `curl … -u/--user "<user>:<pass>"` (shape C, `:333`).
- **Shape C alone is anchored** on `curl` appearing on the same line and on the `user:password` colon, because bare `-u` is common in ordinary shell. That anchor is *defensive rather than currently load-bearing*, and the distinction is measured, not assumed: removing it leaves this suite green at `81/0`, because neither swept file contains a matching line. Its value shows up one directory wider — over all of `scripts/`, the unanchored form produces exactly one false positive, `scripts/worktree-claim.sh:493` (`now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }`), while the anchored form produces none. The anchor is what would let this shape survive a widened sweep; today it costs nothing and buys that.
- **The guard proves it can still catch a violation** (`:364-401`). Five fixture lines are written under `${TEST_HOME}` (`:371-377`, removed by the existing `cleanup()` trap at `:102-103`) and swept through the *same* helper as the real files: the lower-case shape R1 names, the trailing-comment shape R2 names, a pure comment that must stay excluded, and one line per credential-flag shape. Both halves of the banned string are still assembled at runtime (`:316-319`) — once R1 makes the match `-i`, any line here that spells the header name out self-trips the pattern. The hit-count assertion at `:399-401` (now `-eq 4`) remains the one that kills the degenerate "exclude nothing" filter, which would satisfy every named requirement while leaving the guard useless.

  One diagnostic fix rides along (`:354-359`): hits are prefixed with their file **per line** rather than per blob, so the second and later violations of a file no longer carry `grep`'s bare `<line>:` for the reader to attribute by inference.

**3. `scripts/lib/common.sh:940`** — one added `echo` (from `a1a0600`, untouched by iteration 2), inside the existing unconditional stdout block of `mcp_daemon_replace_process`, in the surrounding WARNING's voice and column alignment. It satisfies spec 0149 R3, which makes a disclosure that names the risk without naming a recovery non-conformant. **The security pass then found that the recovery it names does not actually recover** — rotating again re-runs the same vulnerable path and hands the squatter the new token too. That is a behaviour change (identify the process holding the port, evict it, verify the port is free), not a copy edit, so it is routed to **#951** by user decision at the REVIEW gate rather than fixed here. This line ships as the literal R3 requirement; #951 tracks making it true.

**4. `scripts/tests/test-mcp-daemon.sh` §16 (`:902`)** — the witness that makes the line above falsifiable. `:894` already asserted the risk half; `:902` adds the recovery half. `case` is case-sensitive, so the asserted substring tracks `common.sh:940` verbatim.

**5. `scripts/tests/test-setup-org-mcp.sh:199-207`** — the R4 deliberate-exception marker, immediately above the assertion it explains at `:208`. Note what the comment deliberately does *not* do: it never quotes the banned argv shape, because a third occurrence would break R4's own "no other occurrence in `scripts/`" clause that the sweep below verifies.

## How to test this PR?

Prerequisites: `bash`, `git`, and `task` (for `spec:lint`). No MemPalace venv is needed — the daemon suite skips the probes that require one.

**1. The two suites this diff touches.**

```sh
bash scripts/tests/test-mcp-daemon.sh       # exit 0 — "passed: 81   failed: 0"
bash scripts/tests/test-setup-org-mcp.sh    # exit 0 — "RESULT: 41 passed, 0 failed"
```

`81`, not the `80` measured before the branch refresh: `main`'s `7deb998` (spec 0159, symlinked palace token path) added one assertion to this same suite, which the merge brought in.

Seven assertions in §3 belong to this guard:

```
  ok   the guard catches a violation spelled in lower case (R1)
  ok   the guard catches a violation carrying a trailing comment (R2)
  ok   the guard catches curl's own token flag (shape B)
  ok   the guard catches basic auth passed through argv (shape C)
  ok   the anchored filter excludes the comment line and nothing else (R2)
  ok   every swept path exists, so a clean sweep below means something
  ok   no credential is passed through an argv flag (R8)
```

plus `ok   the disclosure names the recovery, not only the risk (0149 R3)` in §16.

**2. Spec lint and Bash 3.2 portability.**

```sh
task spec:lint                          # exit 0 — "Linting passed!" (212 files)
bash scripts/check-bash32-portability.sh
# exit 0 — "OK: no forbidden Bash 4+ construct and no unguarded array value
# expansion in scripts hooks (3 declared construct(s), 171 file(s) scanned,
# 157 .sh file(s) array-scanned)."
```

**3. R4's sweep clause — exactly two matches under `scripts/`, and exactly the two named.**

```sh
B="Bea""rer"; grep -rniE -- "-(H|-header)[[:space:]=]*[\"']?Authorization:.*${B}" scripts/
```

```
scripts/tests/test-setup-org-mcp.sh:208:[[ "$HTTP_STR" == *"--header Authorization: Bearer"* ]] && ok "http argv: --header \"K: V\"" || bad …
scripts/lib/common.sh:1040:      # NOT `claude mcp add --header "Authorization: Bearer $token"`: on Linux
```

The first is the deliberate exception this PR marks (a fixture-driven *shape* assertion, whose token is the literal placeholder `${ATLASSIAN_TOKEN}` from the `ORG_HTTP` fixture at `:58`); the second is prose explaining the hazard.

**Failure modes — mutate the guard and watch it redden.** This is the check worth running, because a green state that carries no information is the exact defect this PR exists to remove. Every row below was produced at `9d7ee5a` by mutating `scripts/tests/test-mcp-daemon.sh` in place and running the **whole** suite; each restores with `git checkout -- scripts/tests/test-mcp-daemon.sh`.

| Mutation | Suite | Exit | Assertions that redden |
|---|---|---|---|
| **as shipped** | `81 / 0` | 0 | — |
| `:404` swept path renamed to a nonexistent file | `79 / 2` | 1 | `every swept path exists`; the sweep verdict (`a credential reached argv: …common-RENAMED.sh:0:MISSING`) |
| `:351` `grep -niE` → `grep -nE` (drop `-i`) | `79 / 2` | 1 | R1 lower-case; hit count (`got 3`) |
| `:332` shape B removed from the alternation | `79 / 2` | 1 | shape B; hit count (`got 3`) |
| `:333` shape C removed from the alternation | `79 / 2` | 1 | shape C; hit count (`got 3`) |
| `:333` shape C's `curl` anchor removed | `81 / 0` | 0 | none — see the anchoring note in *How to read this PR?* |

Row 2 is the one iteration 2 exists for: before this change that same mutation left the suite at `77 / 0`, exit 0, indistinguishable from a clean run.

## Detailed description (for agents)

### Requirement traceability

| Req | Change | Executable witness |
|---|---|---|
| **R1** — match case-insensitively | `:351` carries `grep -niE`; `argv_hdr` (`:317`) joins `argv_scheme` (`:316`) as a runtime-assembled half, because `-i` makes any line spelling the header name self-trip the pattern | `:380-383` — fixture line 1, lower-case `authorization: bearer`; killed by dropping `-i` |
| **R2** — comment filter excludes only comments | `:352` anchors on `^[0-9]+:`; the sweep is per-file (`:344-362`) so the anchor can match at all | `:384-387` — fixture line 2, a violation carrying `# ref: #913`; plus the hit-count assertion at `:399-401` |
| **R3** — disclosure names the recovery | `common.sh:940` — `Rotate the token again if the window may have been claimed.` | `:902`, paired with the pre-existing risk witness at `:894`. **Sufficiency of the named recovery is tracked in #951**, not resolved here |
| **R4** — deliberate occurrence marked at its site | `test-setup-org-mcp.sh:199-207` — 9 comment lines above `:208`, naming it deliberate, citing spec 0149 R4, recording that the asserted string is the org-MCP argv *shape*, not a live credential | The sweep in *How to test* §3: exactly 2 matches, exactly the two named |
| **R5** — structural fix requested upstream | No code change — the replacement-window bind race lives inside the upstream `mempalace` package, so no local change can hold the socket across a process replacement | **MemPalace/mempalace#2257** — recorded on #913 in [comment 5294787144](https://github.com/crewrig/crewrig/issues/913#issuecomment-5294787144) before the issue closes, per R5's scenario |

R5's `SHALL` is discharged by publication, not by this diff. Until upstream ships the capability, spec 0139 delta-01's R5 disclosure remains the in-force local treatment and no local proxy component is introduced (spec 0149 → *Out of scope*).

### Review findings from iteration 1

| Finding | Class | Status |
|---|---|---|
| **F1** — the sweep passed vacuously when a swept path did not exist | `tech` (blocking) | **Fixed** in `e38180e`, by construction rather than at the call site. The shipped comment claiming "a mutation cannot satisfy the witness while leaving the repository unguarded" was false as written when the review found it; it is true now, and row 2 of the failure-mode table is its witness |
| **LOW** (security pass) — the guard was `-H`-shaped only, so curl's own credential flags escaped it | `tech` | **Fixed** in `e38180e` — two shapes added to the alternation, each with its own fixture line and its own mutation-locked assertion |
| **F2** — the failure message attributed only a file's first hit to that file | `tech` (non-blocking) | **Fixed** in `e38180e` — per-line prefixing at `:354-359` |
| **F3** — two shipped comments assert a repository-wide property nothing verifies | `spec` (non-blocking) | **Open, accepted.** `class: spec`, not routed to this pass. The claim is true today (the sweep above returns exactly the two named matches) but is unqualified present tense, and nothing in CI reads a comment |
| Recovery advice does not evict the squatter | security | **Routed to #951** by user decision at the REVIEW gate — a behaviour change, not a copy edit |

### Deviation from the approved plan

**One, flagged since iteration 1.** Plan step 2 specified `tr 'A-Z' 'a-z'`; the shipped code at `:318-319` uses `tr '[:upper:]' '[:lower:]'`. Verified rather than asserted: `shellcheck` emits `SC2019`/`SC2018` on the bracket-less form, and neither code appears in this repository's baseline for these three files. Behaviour is identical for the ASCII-only literals being folded.

### Shell-lint delta

This repository runs no `shellcheck` CI job; the available linter is `.github/skills/pr-reviewer/scripts/lint-shell.sh`, which has pre-existing findings on all three touched scripts, so it was run on both sides and compared rather than read as a gate. Counting **every** `SCnnnn (level)` occurrence — including the two-code `^---^` form that a `grep -cE -- '-- SC[0-9]+'` one-liner misses:

- Baseline (the three files at `crewrig/main` = `bfb320e`): **89** findings — `SC1091` ×2, `SC2015` ×77, `SC2016` ×8, `SC2034` ×1, `SC2088` ×1.
- At `9d7ee5a`: **96** findings, same five codes. No new category.
- 8 new, 1 gone; the one that disappeared is the R8 assertion, reworded from `no bearer token is passed through an -H argv flag` to `no credential is passed through an argv flag`, so it is the same finding on new text.
- Net `+1 SC2015` (the hit-count assertion) and `+6 SC2016`, all `(info)`. The `SC2016`s are the five fixture `printf` lines and the shape-C `case` pattern: single quotes are load-bearing there, since the `$t` must reach the fixture unexpanded — it stands in for a token variable in the shape being matched.

(Iteration 1's body reported `83 → 87` against the old merge-base using the narrower `grep -cE` method the reviewer also used; the same method gives `84 → 89` here. The figures above use the fuller count and the current merge-base.)

### Convention triggers — none fires

- **Version bump — not triggered.** `docs/version-bump-convention.md`'s affected-path list covers component sources under `artifacts/**` and `extensions/**`; none of the four touched paths matches, and no `scripts/**` file carries a `provenance.version`.
- **CLI matrix — not triggered.** The trigger surface names `scripts/build-components.sh` and `scripts/{build,install,setup,import,manage}-*.sh`. None of the three touched scripts matches — `test-setup-org-mcp.sh` sits under `scripts/tests/`, not `scripts/setup-*.sh`. The change is one shared helper plus its tests, uniform across all four CLIs, so no parity cell shifts.
- **Test wiring — not triggered.** No test file is added or removed.
- **Exec bits preserved.** `100755` on both test scripts, `100644` on `common.sh` — identical to `crewrig/main`.

### Lifecycle state

SPECS → spec-PR #916 merged. PLAN → posted on #913, cold `architect` review APPROVE with zero findings; both non-blocking observations applied. DEV → `a1a0600`, `87dd7b3`. REVIEW iteration 1 → REQUEST CHANGES (F1 blocking, F2/F3 non-blocking) plus a security pass. DEV iteration 2 → `e38180e`. Branch refreshed onto `main` at `bfb320e` via `9d7ee5a`. REVIEW iteration 2 → next.

This PR carries **no close keyword** for #913: R5 makes the recorded upstream URL a precondition for closing it, and the issue is the ticket's logbook (`docs/logbook-issues.md` → Rule A), closed under Rule C after merge.

**Writer:** `pr-logbook` owns this PR body for ticket #913.
