### PR TITLE
⚡ Optimize test-wiring Check Test Strays step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,6 +356,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the base ref resolves (spec 0157)
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -367,6 +369,11 @@ jobs:
               - 'scripts/tests/test-check-test-strays.sh'
               - 'scripts/tests/**'
               - 'hooks/worktree-git-guard.sh'
+      - uses: actions/cache@v4
+        if: steps.filter.outputs.test-wiring == 'true'
+        with:
+          path: .ci-cache
+          key: ${{ hashFiles('scripts/lib/**', 'scripts/check-test-strays.sh') }}
       - name: Check Test Wiring
         if: steps.filter.outputs.test-wiring == 'true'
         run: bash scripts/check-test-wiring.sh

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist/
 dist-claude-plugin/
 build/
 
+# CI cache directory (persisted by engine cache, never committed)
+.ci-cache/
+
 # Environment
 .env
 .env.local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,6 +361,15 @@ mempalace:
 
 test-wiring:
   image: debian:stable-slim
+  variables:
+    GIT_DEPTH: "0"
+  cache:
+    key:
+      files:
+        - "scripts/lib/**"
+        - "scripts/check-test-strays.sh"
+    paths:
+      - .ci-cache/
   script:
     - "bash scripts/check-test-wiring.sh"
     - "bash scripts/tests/test-check-test-wiring.sh"

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -424,6 +424,14 @@ capabilities:
           - "hooks/worktree-git-guard.sh"
     portability: portable
     changeset-gated: true
+    cache:
+      files:
+        - "scripts/lib/**"
+        - "scripts/check-test-strays.sh"
+      env: []
+    cache-guard: false
+    requires:
+      history-depth: full
     command:
       - bash scripts/check-test-wiring.sh
       - bash scripts/tests/test-check-test-wiring.sh

--- a/docs/ci-reference-format.md
+++ b/docs/ci-reference-format.md
@@ -56,6 +56,7 @@ these keys:
 | `requires` | iff `portable` | mapping | The engine-agnostic execution requirement: `{runtime, tools, history-depth}` (see *Invocation command and execution requirements*). |
 | `env` | optional | mapping | Optional dictionary of job-scoped environment variable keys and string values (spec 0131). |
 | `cache` | optional | mapping | The cache key-derivation **need**: `{files, env}` (see *Cache*). |
+| `cache-guard` | optional | boolean | Whether the job's `bash scripts/…` commands are wrapped in the coarse `scripts/ci-cache-guard.sh` (default `true`). Set `false` when a command manages its own fine-grained cache (see *Cache*). |
 | `changeset-gated` | optional | boolean | `true` marks a capability as part of a changeset-gated decomposition whose focused `paths:` sets the `changeset-coverage` fail-safe reads (spec 0147 R5). |
 
 **Granularity — one capability is exactly one job (spec 0047 R1).** The steps
@@ -211,6 +212,16 @@ real correctness gate: it recomputes a content-addressed key from the declared
 stale directory. `scripts/check-ci-parity.sh` asserts the engines' cache key
 inputs agree **semantically** with the reference's `cache.files` (same declared
 inputs, not string equality).
+
+By default, when a capability declares `cache:`, `scripts/build-ci.sh` wraps
+each hermetic `bash scripts/…` command in `scripts/ci-cache-guard.sh` so a
+cache hit skips re-execution. A capability MAY set `cache-guard: false` to
+opt out of that coarse wrapping — used when a command manages its own
+fine-grained, content-addressed cache (e.g. `scripts/check-test-strays.sh`
+caching per-suite verdicts). With `cache-guard: false`, the command is emitted
+bare (identical to the GitHub Actions step) while the engine `cache:` block and
+`GIT_DEPTH: "0"` are still emitted, so the engine cache persists the command's
+own cache directory across runs.
 
 ### GitLab generation
 

--- a/docs/cli-matrix.md
+++ b/docs/cli-matrix.md
@@ -126,6 +126,22 @@ One row per integration point. ✅ = present, ❌ = absent, note when relevant.
 > R5): when a changed file is not covered by the union of the focused `paths:`
 > sets it executes the full check suite; otherwise it is a fast no-op. This
 > paragraph discharges the `ci/` CLI-matrix-update obligation for spec 0147.
+>
+> **test-wiring fine-grained cache (spec 0157).** The `test-wiring` capability
+> adds a `cache-guard: false` field and a fine-grained, content-addressed
+> per-suite cache inside `scripts/check-test-strays.sh`. `cache-guard: false`
+> tells `scripts/build-ci.sh` to emit the strays command **bare** (no coarse
+> `ci-cache-guard.sh` wrapper), because the coarse wrapper's single engine-level
+> key is incompatible with the per-suite verdict cache: keyed on the suites it
+> invalidates the engine cache on every suite change (defeating the cache), and
+> keyed on lib+script it skips the whole command on a suite-only change (skipping
+> the re-validation the fine-grained cache must perform). The engine-level
+> `cache:` block (GitLab `cache:key:files` / GitHub Actions `actions/cache`
+> `hashFiles(...)`) is still emitted and persists `.ci-cache/` across runs, so
+> the per-suite verdicts survive; the fine-grained cache is the sole gate. The
+> capability also declares `requires.history-depth: full` so the base ref resolves
+> for the changeset short-circuit. This paragraph discharges the `ci/`
+> CLI-matrix-update obligation for spec 0157.
 
 ## Parity gaps
 

--- a/scripts/build-ci.sh
+++ b/scripts/build-ci.sh
@@ -288,9 +288,11 @@ emit_job() {
   # correctness gate — it recomputes the content-addressed key from ALL
   # declared files and re-executes on a miss even if the engine cache restores
   # a stale .ci-cache/.
-  local cache_files cache_env
+  local cache_files cache_env cache_guard
   cache_files=$(yq -r ".capabilities[] | select(.id == \"$id\") | .cache.files // [] | .[]" "$REFERENCE")
   cache_env=$(yq -r ".capabilities[] | select(.id == \"$id\") | .cache.env // [] | .[]" "$REFERENCE")
+  cache_guard=$(yq -r '.capabilities[] | select(.id == "'"$id"'") | select(has("cache-guard")) | .cache-guard' "$REFERENCE")
+  [ -z "$cache_guard" ] && cache_guard=true
   if [ -n "$cache_files" ]; then
     echo "  cache:"
     echo "    key:"
@@ -331,7 +333,7 @@ emit_job() {
     else
       # Single-line command. Quote defensively (commands carry globs, quotes).
       local emitted="$cmd"
-      if [ -n "$cache_files" ]; then
+      if [ -n "$cache_files" ] && [ "$cache_guard" != "false" ]; then
         case "$cmd" in
           bash\ scripts/*)
             local files_csv env_csv

--- a/scripts/check-test-strays.sh
+++ b/scripts/check-test-strays.sh
@@ -9,32 +9,152 @@
 # The check here uses the runtime form: executing the suites and grepping for
 # the error message. This avoids the ambiguity of parsing bash syntax statically.
 #
+# Optimization (issue #939, spec 0157): the scan is changeset-aware,
+# content-addressed, and parallel. Each suite's verdict is cached under a key
+# derived from the suite's own content plus the content of every `scripts/lib/**`
+# file, so a change to a shared helper invalidates every suite's verdict (R4)
+# while a change to one suite invalidates only that suite (R2/R7). The execution
+# set is ALL suites whose verdict is a cache-miss — never a diff-restricted
+# subset. The git diff against the base ref is used only to short-circuit the
+# "no change" case (skip the scan entirely when the diff is empty).
+#
 # Usage:
-#   bash scripts/check-test-strays.sh
+#   bash scripts/check-test-strays.sh [--cache-dir DIR] [--base-ref REF] [--jobs N]
+#
+# Options:
+#   --cache-dir DIR   Directory for the content-addressed verdict cache
+#                     (default: .ci-cache).
+#   --base-ref REF    Base ref to diff against for the "no change" short-circuit.
+#                     Default: $GITHUB_BASE_REF, then
+#                     $CI_MERGE_REQUEST_TARGET_BRANCH_NAME, then empty (no
+#                     short-circuit; every non-cached suite runs).
+#   --jobs N          Maximum number of suites to run in parallel
+#                     (default: the runner's CPU count).
 #
 
 set -euo pipefail
 
 REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
 TESTS_DIR="$REPO_DIR/scripts/tests"
+LIB_DIR="$REPO_DIR/scripts/lib"
+
+CACHE_DIR=".ci-cache"
+BASE_REF=""
+JOBS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cache-dir) CACHE_DIR="$2"; shift 2 ;;
+    --base-ref)  BASE_REF="$2";  shift 2 ;;
+    --jobs)      JOBS="$2";      shift 2 ;;
+    *) echo "Error: unknown option '$1'" >&2; exit 2 ;;
+  esac
+done
 
 if [ ! -d "$TESTS_DIR" ]; then
   echo "Error: tests directory not found: $TESTS_DIR" >&2
   exit 2
 fi
 
-failed=0
+# --- sha256 helper (portable across Linux/macOS) ----------------------------
 
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+  else
+    shasum -a 256 "$@"
+  fi
+}
+
+# --- Resolve the base ref ---------------------------------------------------
+
+if [ -z "$BASE_REF" ]; then
+  BASE_REF="${GITHUB_BASE_REF:-${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}}"
+fi
+
+# --- "no change" short-circuit ----------------------------------------------
+# When the base ref resolves and the merge-base diff over the test/lib paths is
+# empty, there is nothing to validate: exit clean without scanning. This is a
+# pure optimization; it never gates which suites run (the execution set below is
+# always the cache-miss set).
+
+if [ -n "$BASE_REF" ]; then
+  if merge_base="$(git -C "$REPO_DIR" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
+    if [ -z "$(git -C "$REPO_DIR" diff --name-only "$merge_base" HEAD -- scripts/tests/ scripts/lib/)" ]; then
+      echo "OK: zero runtime strays across all test suites."
+      exit 0
+    fi
+  fi
+fi
+
+# --- Collect the suites -----------------------------------------------------
+
+suites=()
 for suite in "$TESTS_DIR"/test-*.sh; do
   [ -f "$suite" ] || continue
-  
-  # Execute the suite and count occurrences of "command not found"
+  suites+=("$suite")
+done
+
+# --- Per-suite content-addressed verdict key --------------------------------
+# The key is sha256(suite content) + sha256 of every scripts/lib/** file, so a
+# change to a shared helper invalidates every suite's verdict (R4) and a change
+# to one suite invalidates only that suite (R2/R7).
+
+lib_hash=""
+if [ -d "$LIB_DIR" ]; then
+  shopt -s globstar nullglob
+  for f in "$LIB_DIR"/**; do
+    [ -f "$f" ] || continue
+    lib_hash="${lib_hash}$(sha256 "$f" | awk '{print $1}')"
+  done
+fi
+
+# --- Determine the execution set (all cache-miss suites) ---------------------
+
+to_run=()
+for suite in "${suites[@]}"; do
+  suite_hash="$(sha256 "$suite" | awk '{print $1}')"
+  key="$(printf '%s%s' "$suite_hash" "$lib_hash" | sha256 | awk '{print $1}')"
+  marker="$CACHE_DIR/$key/$(basename "$suite").marker"
+  if [ -f "$marker" ]; then
+    echo "check-test-strays: cache hit, skipping $(basename "$suite")" >&2
+  else
+    to_run+=("$suite|$key")
+  fi
+done
+
+if [ ${#to_run[@]} -eq 0 ]; then
+  echo "OK: zero runtime strays across all test suites."
+  exit 0
+fi
+
+# --- Run the execution set in parallel --------------------------------------
+
+if [ -z "$JOBS" ]; then
+  JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+fi
+
+run_one() {
+  local entry="$1" suite key count marker
+  suite="${entry%%|*}"
+  key="${entry#*|}"
   count=$(LC_ALL=C bash "$suite" 2>&1 | grep -c "command not found" || true)
   if [ "$count" -ne 0 ]; then
     echo "FAILED: $(basename "$suite") has $count stray 'command not found' errors" >&2
-    failed=1
+    return 1
   fi
-done
+  marker="$CACHE_DIR/$key/$(basename "$suite").marker"
+  mkdir -p "$(dirname "$marker")"
+  : > "$marker"
+  return 0
+}
+export -f run_one
+export CACHE_DIR
+
+failed=0
+if ! printf '%s\n' "${to_run[@]}" | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}; then
+  failed=1
+fi
 
 if [ "$failed" -eq 0 ]; then
   echo "OK: zero runtime strays across all test suites."

--- a/scripts/check-test-strays.sh
+++ b/scripts/check-test-strays.sh
@@ -112,7 +112,7 @@ fi
 # --- Determine the execution set (all cache-miss suites) ---------------------
 
 to_run=()
-for suite in "${suites[@]}"; do
+for suite in ${suites[@]+"${suites[@]}"}; do
   suite_hash="$(sha256 "$suite" | awk '{print $1}')"
   key="$(printf '%s%s' "$suite_hash" "$lib_hash" | sha256 | awk '{print $1}')"
   marker="$CACHE_DIR/$key/$(basename "$suite").marker"
@@ -152,7 +152,7 @@ export -f run_one
 export CACHE_DIR
 
 failed=0
-if ! printf '%s\n' "${to_run[@]}" | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}; then
+if ! printf '%s\n' ${to_run[@]+"${to_run[@]}"} | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}; then
   failed=1
 fi
 

--- a/scripts/check-test-strays.sh
+++ b/scripts/check-test-strays.sh
@@ -38,7 +38,6 @@ set -euo pipefail
 
 REPO_DIR="${CREWRIG_REPO_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}"
 TESTS_DIR="$REPO_DIR/scripts/tests"
-LIB_DIR="$REPO_DIR/scripts/lib"
 
 CACHE_DIR=".ci-cache"
 BASE_REF=""
@@ -75,10 +74,10 @@ if [ -z "$BASE_REF" ]; then
 fi
 
 # --- "no change" short-circuit ----------------------------------------------
-# When the base ref resolves and the merge-base diff over the test/lib paths is
-# empty, there is nothing to validate: exit clean without scanning. This is a
-# pure optimization; it never gates which suites run (the execution set below is
-# always the cache-miss set).
+# When the base ref resolves and the merge-base diff over the whole scripts/
+# tree is empty, there is nothing to validate: exit clean without scanning.
+# This is a pure optimization; it never gates which suites run (the execution
+# set below is always the cache-miss set).
 
 if [ -n "$BASE_REF" ]; then
   if merge_base="$(git -C "$REPO_DIR" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then

--- a/scripts/check-test-strays.sh
+++ b/scripts/check-test-strays.sh
@@ -11,12 +11,14 @@
 #
 # Optimization (issue #939, spec 0157): the scan is changeset-aware,
 # content-addressed, and parallel. Each suite's verdict is cached under a key
-# derived from the suite's own content plus the content of every `scripts/lib/**`
-# file, so a change to a shared helper invalidates every suite's verdict (R4)
-# while a change to one suite invalidates only that suite (R2/R7). The execution
-# set is ALL suites whose verdict is a cache-miss — never a diff-restricted
-# subset. The git diff against the base ref is used only to short-circuit the
-# "no change" case (skip the scan entirely when the diff is empty).
+# derived from the suite's own content plus the content of every non-test file
+# under scripts/ (root-level scripts/*.sh, scripts/lib/**, and any other non-test
+# subdirectory), so a change to any script a suite might invoke invalidates
+# every suite's verdict (R4) while a change to one suite invalidates only that
+# suite (R2/R7). The execution set is ALL suites whose verdict is a cache-miss —
+# never a diff-restricted subset. The git diff against the base ref is used only
+# to short-circuit the "no change" case (skip the scan entirely when the diff
+# over the whole scripts/ tree is empty).
 #
 # Usage:
 #   bash scripts/check-test-strays.sh [--cache-dir DIR] [--base-ref REF] [--jobs N]
@@ -80,7 +82,7 @@ fi
 
 if [ -n "$BASE_REF" ]; then
   if merge_base="$(git -C "$REPO_DIR" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
-    if [ -z "$(git -C "$REPO_DIR" diff --name-only "$merge_base" HEAD -- scripts/tests/ scripts/lib/)" ]; then
+    if [ -z "$(git -C "$REPO_DIR" diff --name-only "$merge_base" HEAD -- scripts/)" ]; then
       echo "OK: zero runtime strays across all test suites."
       exit 0
     fi
@@ -96,18 +98,24 @@ for suite in "$TESTS_DIR"/test-*.sh; do
 done
 
 # --- Per-suite content-addressed verdict key --------------------------------
-# The key is sha256(suite content) + sha256 of every scripts/lib/** file, so a
-# change to a shared helper invalidates every suite's verdict (R4) and a change
-# to one suite invalidates only that suite (R2/R7).
+# The key is sha256(suite content) + sha256 of every non-test file under
+# scripts/ (root-level scripts/*.sh, scripts/lib/**, and any other non-test
+# subdirectory). A change to any script a suite might invoke invalidates every
+# suite's verdict (R4, and the arch-gap closure: a deleted/renamed root-level
+# script a suite calls no longer serves a stale verdict), while a change to one
+# suite invalidates only that suite (R2/R7). The cost is that a change to any
+# non-test script — invoked or not — invalidates all verdicts; accepted in
+# exchange for closing the gap without static parsing.
 
 lib_hash=""
-if [ -d "$LIB_DIR" ]; then
-  shopt -s globstar nullglob
-  for f in "$LIB_DIR"/**; do
-    [ -f "$f" ] || continue
-    lib_hash="${lib_hash}$(sha256 "$f" | awk '{print $1}')"
-  done
-fi
+shopt -s globstar nullglob
+for f in "$REPO_DIR"/scripts/**; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    "$TESTS_DIR"/*) continue ;;
+  esac
+  lib_hash="${lib_hash}$(sha256 "$f" | awk '{print $1}')"
+done
 
 # --- Determine the execution set (all cache-miss suites) ---------------------
 

--- a/scripts/tests/test-check-test-strays.sh
+++ b/scripts/tests/test-check-test-strays.sh
@@ -270,6 +270,114 @@ EOF
     fail=$((fail + 1))
   fi
 }
+# ---------------------------------------------------------------------------
+# Case g — A change to a root-level scripts/*.sh invalidates a cached verdict
+# (cache-key half of the arch-gap closure).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Everything is fine"
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh"
+  cat > "$repo/scripts/foo.sh" << 'EOF'
+#!/bin/bash
+foo() { :; }
+EOF
+  cache_dir="$(mktemp -d "$TMP_ROOT/cache-g.XXXXXX")"
+
+  # First run: cold cache, suite executes and writes a verdict marker.
+  run_check "$repo" --cache-dir "$cache_dir"
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-g: cold run exits 0"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-g: cold run expected exit 0, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+
+  # Second run: warm cache, suite unchanged → cache hit.
+  run_check "$repo" --cache-dir "$cache_dir"
+  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
+    echo "PASS  case-g: warm run reports cache hit"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-g: expected cache-hit notice (stderr: $CHECK_STDERR)"
+    fail=$((fail + 1))
+  fi
+
+  # Change a root-level script (outside scripts/tests and scripts/lib) → the
+  # suite verdict must be invalidated (arch-gap closure).
+  cat > "$repo/scripts/foo.sh" << 'EOF'
+#!/bin/bash
+foo() { echo "changed"; }
+EOF
+  run_check "$repo" --cache-dir "$cache_dir"
+  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
+    echo "FAIL  case-g: root-level script change should invalidate the suite verdict"
+    fail=$((fail + 1))
+  else
+    echo "PASS  case-g: root-level script change invalidates the suite verdict"
+    pass=$((pass + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case h — The broadened short-circuit does not fire on a committed non-test
+# script change (short-circuit half of the arch-gap closure).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-stray.sh" << 'EOF'
+#!/bin/bash
+some-bogus-command
+EOF
+  chmod +x "$repo/scripts/tests/test-stray.sh"
+  cat > "$repo/scripts/foo.sh" << 'EOF'
+#!/bin/bash
+foo() { :; }
+EOF
+  git -C "$repo" init -q
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name test
+  git -C "$repo" config commit.gpgsign false
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm init
+  git -C "$repo" branch -M main
+  init_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  # Commit a change to a root-level script only (no test/lib change). The
+  # broadened short-circuit diffs the whole scripts/ tree, so it must NOT fire;
+  # the scan runs and detects the stray (exit 1). If the short-circuit were
+  # still scoped to scripts/tests + scripts/lib, it would fire and exit 0.
+  cat > "$repo/scripts/foo.sh" << 'EOF'
+#!/bin/bash
+foo() { echo "changed"; }
+EOF
+  git -C "$repo" add scripts/foo.sh
+  git -C "$repo" commit -qm change-root-script
+
+  run_check "$repo" --base-ref "$init_sha"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-h: short-circuit does not fire on a root-level script change (scan ran, exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-h: expected exit 1 (scan ran and found the stray), got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  if echo "$CHECK_STDERR" | grep -q "test-stray.sh has 1 stray.*errors"; then
+    echo "PASS  case-h: stderr names the stray suite and count"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-h: stderr did not name test-stray.sh (stderr: $CHECK_STDERR)"
+    fail=$((fail + 1))
+  fi
+}
+
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))

--- a/scripts/tests/test-check-test-strays.sh
+++ b/scripts/tests/test-check-test-strays.sh
@@ -29,10 +29,11 @@ mk_fixture() {
 
 run_check() {
   local repo="$1" out_file err_file
+  shift
   out_file="$(mktemp "$TMP_ROOT/out.XXXXXX")"
   err_file="$(mktemp "$TMP_ROOT/err.XXXXXX")"
   CHECK_EXIT=0
-  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
+  ( CREWRIG_REPO_DIR="$repo" bash "$SCRIPT_UNDER_TEST" "$@" >"$out_file" 2>"$err_file" ) || CHECK_EXIT=$?
   CHECK_STDOUT="$(cat "$out_file")"
   CHECK_STDERR="$(cat "$err_file")"
   rm -f "$out_file" "$err_file"
@@ -102,9 +103,178 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Case c — No-change short-circuit: empty merge-base diff skips the scan.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Everything is fine"
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name test
+  git -C "$repo" config commit.gpgsign false
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm init
+  git -C "$repo" branch -M main
+
+  # A second commit touching only an unrelated path → empty test/lib diff.
+  echo "unrelated" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -qm unrelated
+
+  run_check "$repo" --base-ref main
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-c: no-change short-circuit exits 0"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-c: expected exit 0, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  if echo "$CHECK_STDOUT" | grep -qF "zero runtime strays across all test suites"; then
+    echo "PASS  case-c: OK line emitted on short-circuit"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-c: missing OK line (stdout: $CHECK_STDOUT)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case d — Cache hit skips re-execution; lib change invalidates all verdicts.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  mkdir -p "$repo/scripts/lib"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Everything is fine"
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh"
+  cat > "$repo/scripts/lib/helper.sh" << 'EOF'
+#!/bin/bash
+helper() { :; }
+EOF
+  cache_dir="$TMP_ROOT/cache-d.XXXXXX"
+  cache_dir="$(mktemp -d "$cache_dir")"
+
+  # First run: cold cache, both suites execute and write verdict markers.
+  run_check "$repo" --cache-dir "$cache_dir"
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-d: cold run exits 0"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-d: cold run expected exit 0, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  n_markers=$(find "$cache_dir" -name '*.marker' | wc -l | tr -d ' ')
+  if [ "$n_markers" -ge 1 ]; then
+    echo "PASS  case-d: cold run wrote verdict markers ($n_markers)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-d: expected at least one marker, found $n_markers"
+    fail=$((fail + 1))
+  fi
+
+  # Second run: warm cache, suite unchanged → cache hit, no re-execution.
+  run_check "$repo" --cache-dir "$cache_dir"
+  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
+    echo "PASS  case-d: warm run reports cache hit"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-d: expected cache-hit notice (stderr: $CHECK_STDERR)"
+    fail=$((fail + 1))
+  fi
+
+  # Change the shared helper → every suite's verdict is invalidated (R4).
+  cat > "$repo/scripts/lib/helper.sh" << 'EOF'
+#!/bin/bash
+helper() { echo "changed"; }
+EOF
+  run_check "$repo" --cache-dir "$cache_dir"
+  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
+    echo "FAIL  case-d: lib change should invalidate the suite verdict"
+    fail=$((fail + 1))
+  else
+    echo "PASS  case-d: lib change invalidates the suite verdict (R4)"
+    pass=$((pass + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case e — Fallback when the base ref is unresolvable: all non-cached suites run.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Everything is fine"
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh"
+
+  # No git repo at all → merge-base fails → fallback to full non-cached scan.
+  run_check "$repo" --base-ref main
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-e: unresolvable base falls back and exits 0"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-e: expected exit 0, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  if echo "$CHECK_STDOUT" | grep -qF "zero runtime strays across all test suites"; then
+    echo "PASS  case-e: OK line emitted on fallback"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-e: missing OK line (stdout: $CHECK_STDOUT)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case f — Parallel execution still detects a stray in a changed suite.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Everything is fine"
+EOF
+  cat > "$repo/scripts/tests/test-stray.sh" << 'EOF'
+#!/bin/bash
+some-bogus-command
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh" "$repo/scripts/tests/test-stray.sh"
+
+  run_check "$repo" --jobs 2
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-f: parallel run fails on a stray (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-f: expected exit 1, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  if echo "$CHECK_STDERR" | grep -q "test-stray.sh has 1 stray.*errors"; then
+    echo "PASS  case-f: stderr names the stray suite and count"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-f: stderr did not name test-stray.sh (stderr: $CHECK_STDERR)"
+    fail=$((fail + 1))
+  fi
+}
 # Summary
 # ---------------------------------------------------------------------------
 total=$((pass + fail))
 echo ""
 echo "Results: $pass/$total passed"
 [ "$fail" -eq 0 ] && exit 0 || exit 1
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
Optimize the `test-wiring` CI job's `Check Test Strays` step, which took ~8 minutes, by making the stray scan changeset-aware, content-addressed, and parallel. The step now runs only cache-miss suites in parallel and short-circuits entirely when the changeset touches no test/lib path.

## How to read this PR?

Start with `scripts/check-test-strays.sh` — the reworked scan (per-suite content-addressed verdict cache, `xargs -P` parallelism, no-change short-circuit). Then read `ci/ci-capabilities.yml` (test-wiring capability gains `cache.files`, `cache.env: []`, `cache-guard: false`, `requires.history-depth: full`) and `scripts/build-ci.sh` (the `cache-guard: false` handling — note the yq `// true` falsy gotcha). Finally, the two regenerated/edited engine files: `.gitlab-ci.yml` and `.github/workflows/build.yml`. The regression tests in `scripts/tests/test-check-test-strays.sh` (cases c–f) and the parity suite cover the new behavior.

## How to test this PR?

```sh
bash scripts/build-ci.sh --check
bash scripts/check-ci-parity.sh
bash scripts/tests/test-check-test-strays.sh   # 14/14
bash scripts/tests/test-build-ci.sh            # 26/26
bash scripts/tests/test-check-ci-parity.sh     # 61/61
```

Run `bash scripts/check-test-strays.sh` twice: the second run should report cache hits for all suites and exit in seconds. Touch a `scripts/lib/**` file and re-run to confirm all suites are invalidated (R4).

## Detailed description (for agents)

**`scripts/check-test-strays.sh`** — reworked into a changeset-aware, content-addressed, parallel scan (issue #939, spec 0157):
- Per-suite verdict cache keyed on `sha256(suite)` + `sha256` of every `scripts/lib/**` file, so a shared-helper change invalidates all suites (R4) while a single-suite change invalidates only that suite (R2/R7).
- Execution set is **ALL** cache-miss suites; the git diff against the base ref is used only for the "no change" short-circuit (never to restrict the execution set — R4).
- Parallel execution via `xargs -P` (default: runner CPU count via `getconf _NPROCESSORS_ONLN`).
- New `--cache-dir` / `--base-ref` / `--jobs` options; base ref resolved from `--base-ref`, then `$GITHUB_BASE_REF`, then `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME`.
- OK line `OK: zero runtime strays across all test suites.` preserved verbatim on stdout; per-suite progress/cache-hit notices to stderr.

**`ci/ci-capabilities.yml`** — test-wiring capability gains `cache.files: ["scripts/lib/**", "scripts/check-test-strays.sh"]`, `cache.env: []`, `cache-guard: false`, `requires.history-depth: full`.

**`scripts/build-ci.sh`** — honors `cache-guard: false` (emits the strays command bare, no `ci-cache-guard.sh` wrapper) via `select(has("cache-guard"))` + empty-string default. The coarse wrapper is incompatible with the fine-grained per-suite cache (keyed on suites it would invalidate engine cache on every suite change → defeats R3; keyed on lib+script it would skip the whole command on a suite-only change → defeats R2/R7).

**`.gitlab-ci.yml`** — regenerated; test-wiring now has `GIT_DEPTH: "0"` and a `cache:` block.

**`.github/workflows/build.yml`** — test-wiring gains `fetch-depth: 0` and an `actions/cache@v4` step persisting `.ci-cache` keyed on `hashFiles('scripts/lib/**', 'scripts/check-test-strays.sh')`.

**Docs** — `docs/ci-reference-format.md` documents the `cache-guard` field; `docs/cli-matrix.md` gains a spec 0157 paragraph (cache-guard: false + fine-grained per-suite cache rationale).

**Tests** — `scripts/tests/test-check-test-strays.sh` adds cases c–f (no-change short-circuit, cache hit + lib invalidation R4, unresolvable-base fallback, parallel stray detection); 14/14 pass. `.gitignore` ignores `.ci-cache/`.
