### PR TITLE
✨ Verify the MCP daemon listener's owner (spec 0158)

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -725,6 +725,72 @@ MCP_DAEMON_PORT_DEFAULT="41893"
 MCP_DAEMON_LABEL_DEFAULT="com.mempalace.mcp-server"
 MCP_DAEMON_UNIT_DEFAULT="mempalace-mcp-server"
 
+# mcp_listener_pid <port> — the PID of the process listening on <port>, or
+# empty when none can be identified. lsof on macOS, ss on Linux.
+#
+# MEMPALACE_MCP_LISTENER_PID fixes the listener side for a hermetic suite
+# (spec 0158 R3). The set-but-empty contract is load-bearing: an explicitly
+# empty value forces the lookup to report undeterminable, while an unset one
+# falls through to the real lookup. `${VAR+x}` is what distinguishes the two —
+# `:-` would collapse both to the fallback.
+mcp_listener_pid() {
+  local port="$1"
+  if [ -n "${MEMPALACE_MCP_LISTENER_PID+x}" ]; then
+    printf '%s\n' "${MEMPALACE_MCP_LISTENER_PID}"
+    return 0
+  fi
+  local pid=""
+  case "$(uname -s)" in
+    Darwin)
+      pid="$(lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null | head -n1)"
+      ;;
+    Linux)
+      pid="$(ss -H -tlnp "sport = :${port}" 2>/dev/null \
+        | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | head -n1)"
+      ;;
+    *)
+      pid=""
+      ;;
+  esac
+  printf '%s\n' "${pid}"
+}
+
+# mcp_supervisor_pid — the PID the OS supervisor reports for the daemon unit,
+# or empty when the unit is not loaded or reports no running process. The
+# expected process comes from the OS supervisor — launchctl print
+# gui/<uid>/<label> on macOS, systemctl --user show -p MainPID on Linux — never
+# from a file a same-uid local process could write (spec 0158 R2).
+#
+# MEMPALACE_MCP_EXPECTED_PID fixes the supervisor side for a hermetic suite
+# (spec 0158 R3); set-but-empty forces undeterminable, unset falls through to
+# the real supervisor lookup.
+mcp_supervisor_pid() {
+  if [ -n "${MEMPALACE_MCP_EXPECTED_PID+x}" ]; then
+    printf '%s\n' "${MEMPALACE_MCP_EXPECTED_PID}"
+    return 0
+  fi
+  local label unit pid=""
+  label="${MEMPALACE_MCP_LABEL:-$MCP_DAEMON_LABEL_DEFAULT}"
+  unit="${MEMPALACE_MCP_UNIT:-$MCP_DAEMON_UNIT_DEFAULT}"
+  case "$(uname -s)" in
+    Darwin)
+      pid="$(launchctl print "gui/$(id -u)/${label}" 2>/dev/null \
+        | sed -n 's/^[[:space:]]*pid = \([0-9][0-9]*\)[[:space:]]*$/\1/p' \
+        | head -n1)"
+      ;;
+    Linux)
+      pid="$(systemctl --user show -p MainPID --value "${unit}" 2>/dev/null)"
+      # systemctl reports MainPID=0 when the unit is loaded but no process
+      # runs; that is undeterminable, not a PID.
+      [ "${pid}" = "0" ] && pid=""
+      ;;
+    *)
+      pid=""
+      ;;
+  esac
+  printf '%s\n' "${pid}"
+}
+
 mcp_launcher_installed_path() {
   printf '%s\n' "${MEMPALACE_MCP_LAUNCHER_PATH:-$HOME/.crewrig/mcp-daemon-launcher.sh}"
 }

--- a/scripts/status-mcp-server.sh
+++ b/scripts/status-mcp-server.sh
@@ -69,7 +69,33 @@ if [ "${rc}" -eq 0 ]; then
   fi
 fi
 
-# --- 3. Launcher drift -------------------------------------------------------
+# --- 3. Listener owner (spec 0158) -------------------------------------------
+# Only meaningful while serving: a dead daemon has no listener to verify, and
+# the NOT SERVING verdict already carries the failure. Runs BEFORE the launcher
+# drift check so a drifted launcher cannot hide a usurped listener — the two are
+# independent problems and both must be reported.
+if [ "${rc}" -eq 0 ]; then
+  listener_pid="$(mcp_listener_pid "${PORT}")"
+  expected_pid="$(mcp_supervisor_pid)"
+  if [ -n "${listener_pid}" ] && [ -n "${expected_pid}" ]; then
+    if [ "${listener_pid}" = "${expected_pid}" ]; then
+      echo "  owner:    VERIFIED (listener PID ${listener_pid} is the supervised daemon)"
+    else
+      echo "  owner:    *** USURPED LISTENER ***"
+      echo "            PID ${listener_pid} is answering on ${HOST}:${PORT}, but the"
+      echo "            supervisor runs PID ${expected_pid}. A process that claimed"
+      echo "            the port first may have received the bearer token."
+      echo "            Rotate the token: rm -f $(mcp_token_path), then re-run"
+      echo "            bash scripts/switch-mempalace-http.sh"
+      rc=1
+    fi
+  else
+    echo "  owner:    UNVERIFIABLE (listener PID ${listener_pid:-unknown}, expected PID ${expected_pid:-unknown})"
+    rc=1
+  fi
+fi
+
+# --- 4. Launcher drift -------------------------------------------------------
 launcher="$(mcp_launcher_installed_path)"
 if [ -f "${launcher}" ]; then
   recorded="$(grep -m1 '^LAUNCHER_SOURCE_SHA=' "${launcher}" 2>/dev/null | cut -d'"' -f2)"
@@ -89,7 +115,7 @@ else
   rc=1
 fi
 
-# --- 4. Per-assistant arrangement (R16) --------------------------------------
+# --- 5. Per-assistant arrangement (R16) --------------------------------------
 echo ""
 echo "Assistant registrations:"
 mcp_report_assistant_arrangements || true

--- a/scripts/tests/test-mcp-daemon.sh
+++ b/scripts/tests/test-mcp-daemon.sh
@@ -666,6 +666,77 @@ case "${out}" in
   *) nope "no DRIFTED report: ${out}" ;;
 esac
 
+# --- 13d. Listener owner (spec 0158) -----------------------------------------
+# The owner check compares the process listening on the MCP port against the
+# process the OS supervisor runs for the daemon. Both sides are fixed via
+# environment so the branch under test is the ONLY difference from a healthy
+# run (R3): MEMPALACE_MCP_EXPECTED_PID fixes the supervisor side,
+# MEMPALACE_MCP_LISTENER_PID fixes the listener side. The launcher is
+# re-installed first because 13c left its hash corrupted to deadbeef — the
+# healthy-match case asserts exit 0, which requires EVERY probe check to pass,
+# including the drift check (v2-F1).
+install_mcp_launcher >/dev/null 2>&1
+launcher="$(mcp_launcher_installed_path)"
+"${MEMPALACE_PYTHON}" "${TEST_HOME}/fake-mcp.py" "${MEMPALACE_MCP_PORT}" 401 &
+fake_pid=$!
+sleep 1
+
+# Healthy match: listener PID == expected PID -> verified, exit 0.
+out="$(MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID=1234 \
+  bash "${REPO_DIR}/scripts/status-mcp-server.sh" 2>&1)"; rc=$?
+[ "${rc}" -eq 0 ] \
+  && ok "a listener matching the supervised process exits 0" \
+  || nope "healthy owner exited ${rc}: ${out}"
+case "${out}" in
+  *"VERIFIED"*) ok "the matching owner is reported as VERIFIED" ;;
+  *) nope "no VERIFIED report: ${out}" ;;
+esac
+
+# Usurped mismatch: listener PID != expected PID -> non-zero, naming both PIDs
+# and the recovery action (R1, R5).
+out="$(MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID=5678 \
+  bash "${REPO_DIR}/scripts/status-mcp-server.sh" 2>&1)"; rc=$?
+[ "${rc}" -ne 0 ] \
+  && ok "a mismatched listener exits non-zero" \
+  || nope "usurped owner exited ${rc}"
+case "${out}" in
+  *"USURPED"*) ok "a mismatched listener is reported as USURPED" ;;
+  *) nope "no USURPED report: ${out}" ;;
+esac
+case "${out}" in
+  *"PID 5678"*"PID 1234"*) ok "the usurped report names both PIDs" ;;
+  *) nope "the usurped report does not name both PIDs: ${out}" ;;
+esac
+case "${out}" in
+  *"Rotate"*) ok "the usurped report names the recovery action (rotate the token)" ;;
+  *) nope "no recovery action named: ${out}" ;;
+esac
+
+# Unverifiable: expected process undeterminable (no supervisor unit loaded).
+out="$(MEMPALACE_MCP_EXPECTED_PID='' MEMPALACE_MCP_LISTENER_PID=5678 \
+  bash "${REPO_DIR}/scripts/status-mcp-server.sh" 2>&1)"; rc=$?
+[ "${rc}" -ne 0 ] \
+  && ok "an undeterminable expected process exits non-zero" \
+  || nope "unverifiable (no supervisor) exited ${rc}"
+case "${out}" in
+  *"UNVERIFIABLE"*) ok "an undeterminable expected process is reported as UNVERIFIABLE" ;;
+  *) nope "no UNVERIFIABLE report: ${out}" ;;
+esac
+
+# Unverifiable: listener unidentifiable (forced by an empty
+# MEMPALACE_MCP_LISTENER_PID — set-but-empty, not unset).
+out="$(MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID='' \
+  bash "${REPO_DIR}/scripts/status-mcp-server.sh" 2>&1)"; rc=$?
+[ "${rc}" -ne 0 ] \
+  && ok "an unidentifiable listener exits non-zero" \
+  || nope "unverifiable (no listener) exited ${rc}"
+case "${out}" in
+  *"UNVERIFIABLE"*) ok "an unidentifiable listener is reported as UNVERIFIABLE" ;;
+  *) nope "no UNVERIFIABLE report: ${out}" ;;
+esac
+
+kill "${fake_pid}" 2>/dev/null
+
 # --- 14. _materialise_mcp_unit refuses unsubstituted placeholders (R7) -------
 echo ""
 echo "Unit materialisation refuses an unsubstituted placeholder (R7):"

--- a/specs/0158-verify-mcp-listener-owner.md
+++ b/specs/0158-verify-mcp-listener-owner.md
@@ -1,7 +1,7 @@
 ---
 id: "0158"
 slug: verify-mcp-listener-owner
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 745


### PR DESCRIPTION
The status probe `scripts/status-mcp-server.sh` now verifies the process listening on the MCP port against the process the OS supervisor runs for the daemon, reporting a usurped listener or an unverifiable owner with a non-zero exit instead of silent health. The hermetic suite exercises every served-port branch with the branch under test as the only difference from a healthy run.

## How to read this PR?

Read in this order:

1. `scripts/lib/common.sh:736-793` — the two new helpers. `mcp_listener_pid <port>` resolves the PID listening on the port (lsof on macOS, ss on Linux); `mcp_supervisor_pid` resolves the PID the OS supervisor reports for the daemon unit (launchctl print `gui/<uid>/<label>` on macOS, `systemctl --user show -p MainPID` on Linux). Both honour the existing `MEMPALACE_MCP_LABEL` / `MEMPALACE_MCP_UNIT` overrides and add two test overrides, `MEMPALACE_MCP_EXPECTED_PID` and `MEMPALACE_MCP_LISTENER_PID`. The set-but-empty contract (`${VAR+x}`) is load-bearing: an explicitly empty value forces the lookup to report undeterminable, while an unset one falls through to the real lookup.
2. `scripts/status-mcp-server.sh:72-96` — the new section 3 "Listener owner (spec 0158)". It runs only in the serving state (`rc -eq 0`, after liveness and auth) and BEFORE the launcher drift check, so a drifted launcher cannot hide a usurped listener. Three outcomes: VERIFIED (exit unchanged), USURPED (names both PIDs plus the token-rotation recovery, `rc=1`), UNVERIFIABLE (either side undeterminable, `rc=1`).
3. `scripts/tests/test-mcp-daemon.sh` — section 13d, four hermetic cases fixing both sides via the overrides.

## How to test this PR?

Run the hermetic suite:

```sh
bash scripts/tests/test-mcp-daemon.sh
```

Expected: `passed: 84   failed: 0`, exit 0. Section 13d covers the four served-port branches: healthy match (exit 0, VERIFIED), usurped mismatch (non-zero, USURPED, both PIDs named, recovery action named), unverifiable-no-supervisor (non-zero, UNVERIFIABLE), unverifiable-no-listener (non-zero, UNVERIFIABLE, forced by an empty `MEMPALACE_MCP_LISTENER_PID`).

Failure mode to try: with a serving daemon on the MCP port, run the probe with `MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID=5678 bash scripts/status-mcp-server.sh` — it must exit non-zero and report `*** USURPED LISTENER ***` naming both PIDs.

## Detailed description (for agents)

- **Owner check (spec 0158 R1, R4).** When the probe is in the serving state, it compares the listener PID against the supervisor PID. A mismatch reports a usurped listener naming both PIDs and the token-rotation recovery (`rm -f $(mcp_token_path)`, then re-run `bash scripts/switch-mempalace-http.sh`), mirroring the uninstall disclosure (R5). When either side cannot be determined, the owner is reported as unverifiable. Both cases exit non-zero.
- **Expected process from the supervisor, not a file (R2).** The expected PID comes from launchd/systemd, never from a file a same-uid local process could write.
- **Hermetic reachability (R3).** `MEMPALACE_MCP_EXPECTED_PID` pins the supervisor side, `MEMPALACE_MCP_LISTENER_PID` pins the listener side; set-but-empty forces undeterminable. Each served-port branch differs from a healthy run by exactly one override.
- **v2-F1 (launcher-sync precondition).** Section 13d re-installs the launcher first because section 13c left its hash corrupted to `deadbeef`; the healthy-match case asserts exit 0, which requires every probe check to pass, including the drift check.
- **v2-F2 (downstream consumer).** `scripts/switch-mempalace-http.sh:62` consumes the probe's exit code as the transaction's final gate. A usurped or unverifiable owner now fails that transaction after registration — spec-aligned and desirable, since the switch installs the supervisor unit first and the owner check passes in the normal flow.
- **Spec status transition.** The PR also flips spec 0158 `status: approved` → `status: implemented` (metadata-only, per `docs/spec-format.md` → *Recording a status transition*), so the spec lands on `main` already carrying `implemented` at the moment its implementation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
