### PR TITLE
🔐 Evict squatter before token provisioning on replacement (#951)

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -978,32 +978,29 @@ mcp_daemon_replace_process() {
   token="$(mcp_token_read_or_create)" || return 1
   deadline_s="${MCP_DAEMON_REPLACE_DEADLINE:-15}"
 
-  if _mcp_daemon_probe_accepts "$host" "$port" "$token"; then
-    return 0
+  local initial_listener initial_expected
+  initial_listener="$(mcp_listener_pid "$port")"
+  initial_expected="$(mcp_supervisor_pid)"
+
+  # Only accept immediately if the listener is NOT a squatter (i.e. if supervisor PID is
+  # known, listener PID must match it). If listener differs from supervisor PID, it is an
+  # impostor claiming the port and must NOT receive early acceptance even if it answers probes.
+  if [ -z "$initial_listener" ] || [ -z "$initial_expected" ] || [ "$initial_listener" = "$initial_expected" ]; then
+    if _mcp_daemon_probe_accepts "$host" "$port" "$token"; then
+      return 0
+    fi
   fi
 
-  # Disclose the replacement window before opening it (spec 0139 R5,
-  # delta-01). Placed in straight-line code between the accept-immediately
-  # early return above and the `case` below, so it prints on EVERY path that
-  # proceeds past that return — including the three that print it and then
-  # issue no stop at all (Darwin with no launchd unit listed, Linux with no
-  # active unit, and the unsupported-OS branch), where the port is never
-  # released and no window ever opens. That over-disclosure is deliberate and
-  # accepted: R5 is a floor on silence, not a ceiling, and this is the only
-  # placement the hermetic suite can witness — it loads no supervisor unit, so
-  # the two stop branches are unreachable there. What the placement guarantees
-  # is therefore: the disclosure precedes every replacement ATTEMPT, including
-  # the ones that find nothing to replace, and is silent only on the
-  # accept-immediately path R5 explicitly exempts (the window is never opened).
-  # Stdout, in the post-uninstall WARNING's voice; the helper's stderr lane
-  # stays reserved for error diagnostics.
+  # Disclose the replacement window and the evict-then-rotate recovery action
+  # before opening the window (spec 0139 R5 delta-01; spec 0149 R3 delta-01).
   echo ""
   echo "  WARNING: replacing the daemon frees ${host}:${port} between the stop and"
   echo "           the relaunch. Any local process that binds it in that window"
   echo "           receives the newly minted token in the very next probe — this"
   echo "           one — and can then answer your agents with fabricated memory."
   echo "           Nothing below can tell that process from the real daemon."
-  echo "           Rotate the token again if the window may have been claimed."
+  echo "           Evict any squatter process on ${host}:${port}, verify port"
+  echo "           release, and only then rotate the token."
   echo ""
 
   case "$(uname -s)" in
@@ -1029,8 +1026,41 @@ mcp_daemon_replace_process() {
 
   deadline=$((SECONDS + deadline_s))
   while [ "$SECONDS" -lt "$deadline" ]; do
-    if _mcp_daemon_probe_accepts "$host" "$port" "$token"; then
-      return 0
+    local cur_listener cur_expected
+    cur_listener="$(mcp_listener_pid "$port")"
+    cur_expected="$(mcp_supervisor_pid)"
+
+    # If an unauthorized squatter process is detected listening on the port:
+    if [ -n "$cur_listener" ] && [ -n "$cur_expected" ] && [ "$cur_listener" != "$cur_expected" ]; then
+      echo "  WARNING: squatter PID ${cur_listener} detected on ${host}:${port} (expected PID ${cur_expected}) — evicting." >&2
+      if [ -n "${MEMPALACE_MCP_EVICT_CMD+x}" ]; then
+        eval "${MEMPALACE_MCP_EVICT_CMD}"
+      else
+        kill -15 "$cur_listener" 2>/dev/null || true
+        sleep 0.2
+        if [ "$(mcp_listener_pid "$port")" = "$cur_listener" ]; then
+          kill -9 "$cur_listener" 2>/dev/null || true
+          sleep 0.2
+        fi
+      fi
+      cur_listener="$(mcp_listener_pid "$port")"
+      if [ -n "$cur_listener" ] && [ "$cur_listener" != "$cur_expected" ]; then
+        echo "  ERROR: failed to evict squatter PID ${cur_listener} from ${host}:${port}." >&2
+        return 1
+      fi
+    fi
+
+    # Only probe if the listener is verified (matches supervisor PID) or if supervisor PID is unknown
+    if [ -n "$cur_expected" ]; then
+      if [ "$cur_listener" = "$cur_expected" ]; then
+        if _mcp_daemon_probe_accepts "$host" "$port" "$token"; then
+          return 0
+        fi
+      fi
+    else
+      if _mcp_daemon_probe_accepts "$host" "$port" "$token"; then
+        return 0
+      fi
     fi
     sleep 0.3
   done

--- a/scripts/tests/test-mcp-daemon.sh
+++ b/scripts/tests/test-mcp-daemon.sh
@@ -965,13 +965,68 @@ case "${out}" in
   *"receives the newly minted token"*) ok "the replacement window is disclosed before the stop is issued (R5)" ;;
   *) nope "no replacement-window disclosure: ${out}" ;;
 esac
-# Second half of the same witness: spec 0149 R3 makes a disclosure that names
-# the risk without naming the recovery non-conformant, so the risk substring
-# above cannot be the only thing asserted. `case` is case-sensitive, so this
-# substring tracks the copy in common.sh verbatim.
+# Second half of the same witness: spec 0149 delta-01 R3 makes a disclosure that names
+# the risk without naming the evict-then-rotate recovery non-conformant, so the risk
+# substring above cannot be the only thing asserted.
 case "${out}" in
-  *"Rotate the token again"*) ok "the disclosure names the recovery, not only the risk (0149 R3)" ;;
-  *) nope "the disclosure names the risk without the recovery action: ${out}" ;;
+  *"Evict any squatter process"*"verify port"*"rotate the token"*) ok "the disclosure names the evict-then-rotate recovery (0149 delta-01 R3)" ;;
+  *) nope "the disclosure names the risk without the evict-then-rotate recovery action: ${out}" ;;
+esac
+
+# Squatter eviction during replacement (spec 0149 delta-01 R6, R7, R8):
+echo ""
+echo "mcp_daemon_replace_process — squatter eviction and port verification (0149 delta-01 R6, R7, R8):"
+
+# Test 1: Squatter answering 200 on the port does NOT trigger accept-immediately early return
+"${MEMPALACE_PYTHON}" "${TEST_HOME}/fake-mcp.py" "${HERMETIC_PORT}" 200 &
+fake_pid=$!
+sleep 1
+out="$(MCP_DAEMON_REPLACE_DEADLINE=1 MEMPALACE_MCP_PORT="${HERMETIC_PORT}" \
+  MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID=5678 \
+  MEMPALACE_MCP_EVICT_CMD="true" \
+  mcp_daemon_replace_process 2>&1)"; rc=$?
+kill "${fake_pid}" 2>/dev/null
+[ "${rc}" -ne 0 ] \
+  && ok "a squatter on the port is refused early accept-immediately even when answering 200" \
+  || nope "squatter was falsely accepted immediately"
+case "${out}" in
+  *"squatter PID 5678 detected"*|*"failed to evict squatter"*) ok "squatter detection is reported" ;;
+  *) nope "no squatter detection reported: ${out}" ;;
+esac
+
+# Test 2: Successful eviction allows verified daemon to be probed and succeed
+"${MEMPALACE_PYTHON}" "${TEST_HOME}/fake-mcp.py" "${HERMETIC_PORT}" 200 &
+fake_pid=$!
+sleep 1
+evict_flag="${TEST_HOME}/evicted.flag"
+rm -f "${evict_flag}"
+out="$(MCP_DAEMON_REPLACE_DEADLINE=2 MEMPALACE_MCP_PORT="${HERMETIC_PORT}" \
+  MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID=5678 \
+  MEMPALACE_MCP_EVICT_CMD="touch '${evict_flag}'; export MEMPALACE_MCP_LISTENER_PID=1234" \
+  mcp_daemon_replace_process 2>&1)"; rc=$?
+kill "${fake_pid}" 2>/dev/null
+[ "${rc}" -eq 0 ] \
+  && ok "evicting the squatter allows the verified daemon to succeed (R6)" \
+  || nope "replacement failed after eviction: ${out}"
+[ -f "${evict_flag}" ] \
+  && ok "eviction command was executed (R6)" \
+  || nope "eviction command was not executed"
+
+# Test 3: Non-evictable squatter fails visibly without transmitting the token (R7)
+"${MEMPALACE_PYTHON}" "${TEST_HOME}/fake-mcp.py" "${HERMETIC_PORT}" 200 &
+fake_pid=$!
+sleep 1
+out="$(MCP_DAEMON_REPLACE_DEADLINE=1 MEMPALACE_MCP_PORT="${HERMETIC_PORT}" \
+  MEMPALACE_MCP_EXPECTED_PID=1234 MEMPALACE_MCP_LISTENER_PID=9999 \
+  MEMPALACE_MCP_EVICT_CMD="true" \
+  mcp_daemon_replace_process 2>&1)"; rc=$?
+kill "${fake_pid}" 2>/dev/null
+[ "${rc}" -ne 0 ] \
+  && ok "failed eviction results in visible failure (R7)" \
+  || nope "failed eviction reported success: ${out}"
+case "${out}" in
+  *"failed to evict squatter"*) ok "failure diagnostic names failed squatter eviction" ;;
+  *) nope "missing eviction failure message: ${out}" ;;
 esac
 
 # Behavioural half: probed skip on the prerequisites the launcher actually

--- a/specs/0149-daemon-credential-hardening.delta-01.md
+++ b/specs/0149-daemon-credential-hardening.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0149"
 slug: daemon-credential-hardening
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 951


### PR DESCRIPTION
### Purpose
Evict squatter processes from the MCP port and verify port release before probing with newly rotated tokens to prevent handing credentials to impostors.

### How to read this PR?
- `scripts/lib/common.sh`: update `mcp_daemon_replace_process` to verify listener PID against expected supervisor PID, evict squatters via `MEMPALACE_MCP_EVICT_CMD` or SIGTERM/SIGKILL, verify port release, and update replacement-window warning copy to specify evict-then-rotate recovery.
- `scripts/tests/test-mcp-daemon.sh`: update warning disclosure assertions and add hermetic unit tests verifying squatter eviction, safe failure on non-evictable squatters, and refusal of early accept-immediately on impostor listeners.
- `specs/0149-daemon-credential-hardening.delta-01.md`: mark delta spec 0149 as implemented.

### How to test this PR?
```bash
bash scripts/tests/test-mcp-daemon.sh
node scripts/lib/spec-linter.js
```

### Detailed description (for agents)
Implements Spec 0149 Delta-01 (Requirements 6, 7, 8, and modified Requirement 3) addressing Issue #951. When rotating tokens or replacing the daemon process via `mcp_daemon_replace_process`, any process holding `host:port` is inspected. If it does not match the supervisor PID, it is identified as a squatter, prevented from receiving early probe acceptance, evicted, and verified to have released the port before fresh token probes are dispatched.

Closes #951