### PR TITLE
📝 Spec 0161: Reclassify harness transcript traffic (#866)

### DIFF
--- a/specs/0161-reclassify-harness-transcript-traffic.md
+++ b/specs/0161-reclassify-harness-transcript-traffic.md
@@ -1,7 +1,7 @@
 ---
 id: "0161"
 slug: reclassify-harness-transcript-traffic
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 866

--- a/specs/0161-reclassify-harness-transcript-traffic.md
+++ b/specs/0161-reclassify-harness-transcript-traffic.md
@@ -1,0 +1,74 @@
+---
+id: "0161"
+slug: reclassify-harness-transcript-traffic
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 866
+version: 1.0.0
+---
+
+# Reclassify harness transcript traffic
+
+## Intent
+
+The transcript hook distinguishes human user prompts from automated harness
+injections (such as background-task notifications, monitor events, and system
+reminders) on prompt submission events, recording machine chatter under a
+dedicated `[HARNESS]` prefix and `harness-injection` entry type rather than
+polluting the `[USER]` transcript stream.
+
+## Requirements
+
+1. `hooks/mempalace-transcript.sh` SHALL classify prompt submission events
+   (`UserPromptSubmit`, `BeforeAgent`, `userPromptSubmitted`) as
+   `harness-injection` with a `[HARNESS]` content prefix whenever the prompt
+   payload matches harness or system injection patterns (including
+   `<task-notification>`, `<system-reminder>`, `<system-message>`,
+   `<SYSTEM_MESSAGE>`, or related structural system wrapper tags).
+2. Genuine user prompts that do not match harness injection patterns SHALL
+   continue to be classified as `user-prompt` with the `[USER]` content prefix.
+3. The reclassified `harness-injection` entries SHALL be persisted to the
+   session transcript room using `ENTRY_TYPE="harness-injection"`, preserving the
+   forensic timeline of automated task events without allowing background
+   chatter to masquerade as human user requests.
+4. The test suite in `scripts/tests/test-mempalace-transcript-hook.sh` SHALL
+   assert that genuine user prompts and harness injections (including
+   `<task-notification>` and `<system-reminder>`) are distinctly classified and
+   formatted with their respective prefixes (`[USER]` vs `[HARNESS]`).
+5. `docs/cli-matrix.md` (row 8) SHALL document the prompt classification
+   behavior and multi-CLI parity across all supported CLIs.
+
+## Scenarios
+
+**Scenario:** human user prompt is recorded as user turn
+
+Given a prompt submission event containing a human prompt "Run the test suite"
+When  `hooks/mempalace-transcript.sh` processes the event
+Then  the persisted drawer content begins with `[USER]` and is classified as
+`user-prompt`
+
+**Scenario:** harness task notification is reclassified
+
+Given a prompt submission event containing `<task-notification><task-id>123</task-id><summary>CI pass</summary></task-notification>`
+When  `hooks/mempalace-transcript.sh` processes the event
+Then  the persisted drawer content begins with `[HARNESS]` and is classified as
+`harness-injection`
+
+**Scenario:** system reminder injection is reclassified
+
+Given a prompt submission event containing `<system-reminder>Remember to verify CI</system-reminder>`
+When  `hooks/mempalace-transcript.sh` processes the event
+Then  the persisted drawer content begins with `[HARNESS]` and is classified as
+`harness-injection`
+
+## Out of scope
+
+- Dropping harness traffic entirely at the door (the timeline is preserved via
+  reclassification for forensic value).
+- Extracting or truncating agent responses or tool call summaries (handled
+  separately in issue #757).
+- Modifying the transcript exclusion guidance in `artifacts/core/rules/60-tools.md`
+  for pre-existing raw transcript archives.
+
+## Open questions


### PR DESCRIPTION
This pull request introduces Specification 0161 qualifying the reclassification of automated harness injections on prompt submission events under a dedicated `[HARNESS]` prefix and `harness-injection` entry type. The implementation PR tracking issue #866 will close it on merge.

## How to read this PR?

Read `specs/0161-reclassify-harness-transcript-traffic.md` from frontmatter through requirements, scenarios, and out-of-scope clauses. It specifies distinguishing human user prompts (`[USER]`) from automated harness injections (`[HARNESS]`) to protect semantic memory search quality while preserving the forensic timeline.

## How to test this PR?

Run the spec linter:
```sh
task spec:lint
```

## Detailed description (for agents)

- Added `specs/0161-reclassify-harness-transcript-traffic.md` with id `0161`, slug `reclassify-harness-transcript-traffic`, complexity `small`, interaction-mode `INTERMEDIATE`, related-issue `866`.
- Specified requirements R1 through R5 covering detection of harness/system wrapper tags, reclassification to `[HARNESS]` / `ENTRY_TYPE="harness-injection"`, preservation of genuine user prompts under `[USER]`, unit test coverage in `test-mempalace-transcript-hook.sh`, and CLI matrix documentation (row 8).