### PR TITLE
📝 Add spec 0164 — transcript hook daemon routing (issue #753)

### DIFF
--- a/specs/0164-transcript-hook-daemon-routing.md
+++ b/specs/0164-transcript-hook-daemon-routing.md
@@ -12,29 +12,22 @@ version: 1.0.0
 
 ## Intent
 
-ADR-0016 established a single supervised MemPalace MCP HTTP daemon owning the
-palace writer lease and registered over HTTP across all four CLI surfaces (Claude
-Code, Gemini CLI, Copilot CLI, and Antigravity CLI). However, ADR-0016 left one
-architectural question open for Derived Spec 4 (issue #753): whether session
-transcript hooks (`hooks/mempalace-transcript.sh`) should continue writing
-directly via an out-of-process Python invocation under spec-0110 lock-bypass
-relief (Shape a), or route their writes through the shared MCP HTTP daemon
-(Shape b).
+Session transcript hook persistence routes to the shared MemPalace Model Context
+Protocol daemon instead of writing directly to the on-disk palace store. When an
+interactive session in any supported assistant interface completes a turn or
+lifecycle event, the transcript entry reaches the shared daemon over local
+network transport. Direct disk locks and temporary lock-bypass exceptions are
+retired, establishing a single-writer topology where the daemon manages all
+palace updates while transcript write latency stays within an order of magnitude
+of baseline execution.
 
-ADR-0016 mandated that this decision be decided by an empirical latency
-measurement campaign against a production-sized palace (~24,000+ drawers, 418 MB
-ChromaDB store), testing both baseline (133 bytes) and upper-bound (#757 / 4000
-bytes) payloads across all four session lifecycle events (`sessionStart`,
-`userPromptSubmitted`, `postToolUse`, `sessionEnd`). The pass criterion was that
-the p95 latency of the routed write must fit well within the hook's 5.0-second
-self-cap.
+### Empirical latency benchmark
 
-### Empirical Benchmark Campaign Results
+An empirical measurement campaign of 160 executions (N=20 per condition)
+conducted on the production palace (~24,000+ drawers, 418 MB store) produced
+the following wall-clock results:
 
-A benchmark campaign of 160 executions (N=20 per condition) on the production
-palace yielded the following wall-clock results:
-
-| Payload | Lifecycle Event | Direct Write (Shape a) p95 | Daemon Routed (Shape b) p95 | Daemon p50 | Speedup | Budget (<5.0s) |
+| Payload | Lifecycle Event | Direct Write p95 | Daemon Routed p95 | Daemon p50 | Speedup | Budget (<5.0s) |
 |---|---|---|---|---|---|---|
 | **133 B** | `sessionStart` | 0.675 s | **0.076 s** | 0.041 s | ~8.9× | PASS |
 | **133 B** | `userPromptSubmitted` | 0.696 s | **0.087 s** | 0.039 s | ~8.0× | PASS |
@@ -45,82 +38,70 @@ palace yielded the following wall-clock results:
 | **4000 B** | `postToolUse` | 0.823 s | **0.080 s** | 0.039 s | ~10.3× | PASS |
 | **4000 B** | `sessionEnd` | 0.812 s | **0.082 s** | 0.040 s | ~9.9× | PASS |
 
-### Decision Analysis
-
-The empirical measurements demonstrate that **Shape (b) (routing through the
-shared daemon)** decisively satisfies the pass criterion:
-1. **Latency Performance:** Daemon-routed writes achieve a p95 latency under
-   **0.17 seconds** in all cases (p50 ~40 ms), utilizing less than **3.5%** of
-   the 5.0-second budget and outperforming direct Python subprocess startup by
-   nearly an order of magnitude.
-2. **Single-Writer Topology:** Routing writes through the daemon eliminates
-   writer lease contention by construction. The daemon holds the sole writer
-   lease, and all four CLIs and their hooks write through the unified HTTP
-   interface.
-3. **Elimination of Fragile Lock Relief:** The in-memory monkey patch
-   (`_relieved_palace_lock` / spec 0110) becomes obsolete and is retired.
-
-This specification implements Shape (b), converting `hooks/mempalace-transcript.sh`
-to persist session exchanges via the shared MemPalace MCP HTTP daemon.
+Daemon-routed writes achieve a p95 latency under 0.17 seconds in all conditions,
+consuming less than 3.5% of the 5.0-second budget and satisfying the pass
+criterion defined in ADR-0016 Derived Spec 4.
 
 ## Requirements
 
-1. `hooks/mempalace-transcript.sh` SHALL persist session transcript drawers by
-   sending an HTTP JSON-RPC `tools/call` request for `mempalace_add_drawer` to
-   the shared MemPalace MCP HTTP daemon (`http://${MEMPALACE_MCP_HOST:-127.0.0.1}:${MEMPALACE_MCP_PORT:-41893}/mcp`).
-2. The transcript hook SHALL authenticate against the shared MemPalace MCP HTTP
-   daemon using the bearer token provisioned in the machine-local token store
-   (`~/.mempalace/server/<key>/token`).
-3. `hooks/mempalace-transcript.sh` SHALL retain its 5.0-second execution timeout
-   ceiling via the system timeout wrapper, ensuring that a hung network call
-   cannot stall the calling CLI session.
-4. If the shared MemPalace MCP HTTP daemon is unreachable, returns an HTTP error
-   status, or fails to respond within the timeout, the hook SHALL emit a
-   diagnostic message to stderr with exit code `4` (`DAEMON_UNREACHABLE`), SHALL
-   NOT write directly to disk, and SHALL exit 0 from the outer hook wrapper so
-   that the agent's turn is never blocked.
-5. The in-process lock bypass (`_relieved_palace_lock`) and direct in-process
-   `mempalace.mcp_server.tool_add_drawer` invocation in
-   `hooks/mempalace-transcript.sh` SHALL be removed.
-6. `docs/adr/0016-shared-mempalace-mcp-http-server.md` SHALL receive an addendum
-   recording the empirical latency measurement results and the resolution of
-   Derived Spec 4 in favor of daemon routing (Shape b).
-7. The hook JSON registrations (`hooks/*-transcript-hooks.json`) SHALL remain
-   structurally unchanged, preserving compatibility across Claude Code, Gemini
-   CLI, Copilot CLI, and Antigravity CLI.
+1. `hooks/mempalace-transcript.sh` SHALL forward session transcript drawer
+   records to the active MemPalace Model Context Protocol HTTP daemon endpoint.
+2. `hooks/mempalace-transcript.sh` SHALL provide the provisioned daemon bearer
+   token on all transcript write requests.
+3. `hooks/mempalace-transcript.sh` SHALL enforce a 5.0-second total execution
+   time ceiling.
+4. When the MemPalace Model Context Protocol HTTP daemon is unreachable or
+   returns an error response, `hooks/mempalace-transcript.sh` SHALL emit a
+   `DAEMON_UNREACHABLE` diagnostic to stderr and SHALL return a clean zero exit
+   status to the calling assistant interface.
+5. `hooks/mempalace-transcript.sh` SHALL NOT perform in-process lock bypasses or
+   direct database mutations.
+6. The palace write architecture SHALL maintain a single-writer topology with the
+   shared daemon holding the writer lease.
+7. `docs/adr/0016-shared-mempalace-mcp-http-server.md` SHALL contain an
+   addendum documenting the benchmark measurements and the selection of daemon
+   routing.
+8. The hook registration files (`hooks/*-transcript-hooks.json`) SHALL preserve
+   their format and interface compatibility across Claude Code, Gemini CLI,
+   GitHub Copilot CLI, and Antigravity CLI.
 
 ## Scenarios
 
-### Happy path — Transcript hook persists drawer through daemon
+**Scenario:** Transcript hook persists drawer through the shared daemon (happy path)
 
-Given a running session in any of the four supported CLIs  
-And the shared MemPalace MCP HTTP daemon is active on `127.0.0.1:41893`  
-When a session lifecycle event triggers `hooks/mempalace-transcript.sh`  
-Then the hook sends an authenticated `tools/call` request to the daemon  
-And the daemon persists the transcript drawer under the `transcripts` wing  
-And the hook completes execution in under 200 milliseconds.
+```text
+Given an active assistant session in any supported interface
+And the shared MemPalace Model Context Protocol HTTP daemon is running
+When a session lifecycle event triggers `hooks/mempalace-transcript.sh`
+Then the hook submits an authenticated tool call to the daemon
+And the transcript entry is recorded under the `transcripts` wing
+And the hook execution completes in under 200 milliseconds.
+```
 
-### Failure path — Daemon unreachable falls back to soft skip
+**Scenario:** Daemon unreachable triggers non-blocking soft skip (failure path)
 
-Given the shared MemPalace MCP HTTP daemon is stopped or unreachable  
-When a session lifecycle event triggers `hooks/mempalace-transcript.sh`  
-Then the hook attempts to reach the daemon endpoint  
-And the request fails with a connection refusal or timeout  
-And the hook logs `DAEMON_UNREACHABLE` to stderr  
-And the hook exits cleanly without blocking the interactive CLI session.
+```text
+Given the shared MemPalace Model Context Protocol HTTP daemon is stopped
+When a session lifecycle event triggers `hooks/mempalace-transcript.sh`
+Then the hook detects that the daemon is unavailable
+And logs a `DAEMON_UNREACHABLE` message to stderr
+And exits with status 0 without stalling the assistant session.
+```
 
-### Invariant check — Palace maintains single-writer lease
+**Scenario:** Palace maintains single-writer lease across concurrent events (audit)
 
-Given multiple concurrent CLI sessions executing hook events  
-When transcript writes are submitted concurrently  
-Then all writes route through the single shared MemPalace daemon process  
-And no process attempts to acquire an out-of-band disk lock.
+```text
+Given multiple concurrent assistant sessions executing lifecycle hooks
+When transcript records are submitted simultaneously
+Then all writes proceed through the single shared daemon process
+And no external process attempts to claim an on-disk lock.
+```
 
 ## Out of scope
 
-- Modifying the daemon's internal MCP tool implementations in `mempalace`.
-- Modifying the ChromaDB HTTP service daemon (managed separately under ADR-0006).
-- Altering the payload format or truncating cap (4000 characters) defined in `hooks/mempalace-transcript.sh`.
+- Modifying the internal tool schema of the MemPalace daemon.
+- Modifying the ChromaDB vector database daemon service.
+- Modifying the 4000-character content truncation limit in `hooks/mempalace-transcript.sh`.
 
 ## Open questions
 

--- a/specs/0164-transcript-hook-daemon-routing.md
+++ b/specs/0164-transcript-hook-daemon-routing.md
@@ -12,35 +12,12 @@ version: 1.0.0
 
 ## Intent
 
-Session transcript hook persistence routes to the shared MemPalace Model Context
-Protocol daemon instead of writing directly to the on-disk palace store. When an
-interactive session in any supported assistant interface completes a turn or
-lifecycle event, the transcript entry reaches the shared daemon over local
-network transport. Direct disk locks and temporary lock-bypass exceptions are
-retired, establishing a single-writer topology where the daemon manages all
-palace updates while transcript write latency stays within an order of magnitude
-of baseline execution.
-
-### Empirical latency benchmark
-
-An empirical measurement campaign of 160 executions (N=20 per condition)
-conducted on the production palace (~24,000+ drawers, 418 MB store) produced
-the following wall-clock results:
-
-| Payload | Lifecycle Event | Direct Write p95 | Daemon Routed p95 | Daemon p50 | Speedup | Budget (<5.0s) |
-|---|---|---|---|---|---|---|
-| **133 B** | `sessionStart` | 0.675 s | **0.076 s** | 0.041 s | ~8.9× | PASS |
-| **133 B** | `userPromptSubmitted` | 0.696 s | **0.087 s** | 0.039 s | ~8.0× | PASS |
-| **133 B** | `postToolUse` | 0.709 s | **0.081 s** | 0.040 s | ~8.8× | PASS |
-| **133 B** | `sessionEnd` | 0.712 s | **0.080 s** | 0.040 s | ~8.9× | PASS |
-| **4000 B** | `sessionStart` | 0.800 s | **0.069 s** | 0.040 s | ~11.6× | PASS |
-| **4000 B** | `userPromptSubmitted` | 0.804 s | **0.166 s** | 0.040 s | ~4.8× | PASS |
-| **4000 B** | `postToolUse` | 0.823 s | **0.080 s** | 0.039 s | ~10.3× | PASS |
-| **4000 B** | `sessionEnd` | 0.812 s | **0.082 s** | 0.040 s | ~9.9× | PASS |
-
-Daemon-routed writes achieve a p95 latency under 0.17 seconds in all conditions,
-consuming less than 3.5% of the 5.0-second budget and satisfying the pass
-criterion defined in ADR-0016 Derived Spec 4.
+Session transcript hook persistence forwards transcript records to the shared
+daemon instead of writing directly to the on-disk storage. Interactive sessions
+across all supported assistant interfaces deliver lifecycle records without
+contending for disk locks or relying on temporary lock-bypass exceptions,
+ensuring a single-writer topology while preserving sub-second persistence
+latencies.
 
 ## Requirements
 

--- a/specs/0164-transcript-hook-daemon-routing.md
+++ b/specs/0164-transcript-hook-daemon-routing.md
@@ -1,0 +1,127 @@
+---
+id: "0164"
+slug: transcript-hook-daemon-routing
+status: draft
+complexity: standard
+interaction-mode: INTERMEDIATE
+related-issue: 753
+version: 1.0.0
+---
+
+# Route session transcript hooks through the shared MemPalace MCP HTTP daemon
+
+## Intent
+
+ADR-0016 established a single supervised MemPalace MCP HTTP daemon owning the
+palace writer lease and registered over HTTP across all four CLI surfaces (Claude
+Code, Gemini CLI, Copilot CLI, and Antigravity CLI). However, ADR-0016 left one
+architectural question open for Derived Spec 4 (issue #753): whether session
+transcript hooks (`hooks/mempalace-transcript.sh`) should continue writing
+directly via an out-of-process Python invocation under spec-0110 lock-bypass
+relief (Shape a), or route their writes through the shared MCP HTTP daemon
+(Shape b).
+
+ADR-0016 mandated that this decision be decided by an empirical latency
+measurement campaign against a production-sized palace (~24,000+ drawers, 418 MB
+ChromaDB store), testing both baseline (133 bytes) and upper-bound (#757 / 4000
+bytes) payloads across all four session lifecycle events (`sessionStart`,
+`userPromptSubmitted`, `postToolUse`, `sessionEnd`). The pass criterion was that
+the p95 latency of the routed write must fit well within the hook's 5.0-second
+self-cap.
+
+### Empirical Benchmark Campaign Results
+
+A benchmark campaign of 160 executions (N=20 per condition) on the production
+palace yielded the following wall-clock results:
+
+| Payload | Lifecycle Event | Direct Write (Shape a) p95 | Daemon Routed (Shape b) p95 | Daemon p50 | Speedup | Budget (<5.0s) |
+|---|---|---|---|---|---|---|
+| **133 B** | `sessionStart` | 0.675 s | **0.076 s** | 0.041 s | ~8.9× | PASS |
+| **133 B** | `userPromptSubmitted` | 0.696 s | **0.087 s** | 0.039 s | ~8.0× | PASS |
+| **133 B** | `postToolUse` | 0.709 s | **0.081 s** | 0.040 s | ~8.8× | PASS |
+| **133 B** | `sessionEnd` | 0.712 s | **0.080 s** | 0.040 s | ~8.9× | PASS |
+| **4000 B** | `sessionStart` | 0.800 s | **0.069 s** | 0.040 s | ~11.6× | PASS |
+| **4000 B** | `userPromptSubmitted` | 0.804 s | **0.166 s** | 0.040 s | ~4.8× | PASS |
+| **4000 B** | `postToolUse` | 0.823 s | **0.080 s** | 0.039 s | ~10.3× | PASS |
+| **4000 B** | `sessionEnd` | 0.812 s | **0.082 s** | 0.040 s | ~9.9× | PASS |
+
+### Decision Analysis
+
+The empirical measurements demonstrate that **Shape (b) (routing through the
+shared daemon)** decisively satisfies the pass criterion:
+1. **Latency Performance:** Daemon-routed writes achieve a p95 latency under
+   **0.17 seconds** in all cases (p50 ~40 ms), utilizing less than **3.5%** of
+   the 5.0-second budget and outperforming direct Python subprocess startup by
+   nearly an order of magnitude.
+2. **Single-Writer Topology:** Routing writes through the daemon eliminates
+   writer lease contention by construction. The daemon holds the sole writer
+   lease, and all four CLIs and their hooks write through the unified HTTP
+   interface.
+3. **Elimination of Fragile Lock Relief:** The in-memory monkey patch
+   (`_relieved_palace_lock` / spec 0110) becomes obsolete and is retired.
+
+This specification implements Shape (b), converting `hooks/mempalace-transcript.sh`
+to persist session exchanges via the shared MemPalace MCP HTTP daemon.
+
+## Requirements
+
+1. `hooks/mempalace-transcript.sh` SHALL persist session transcript drawers by
+   sending an HTTP JSON-RPC `tools/call` request for `mempalace_add_drawer` to
+   the shared MemPalace MCP HTTP daemon (`http://${MEMPALACE_MCP_HOST:-127.0.0.1}:${MEMPALACE_MCP_PORT:-41893}/mcp`).
+2. The transcript hook SHALL authenticate against the shared MemPalace MCP HTTP
+   daemon using the bearer token provisioned in the machine-local token store
+   (`~/.mempalace/server/<key>/token`).
+3. `hooks/mempalace-transcript.sh` SHALL retain its 5.0-second execution timeout
+   ceiling via the system timeout wrapper, ensuring that a hung network call
+   cannot stall the calling CLI session.
+4. If the shared MemPalace MCP HTTP daemon is unreachable, returns an HTTP error
+   status, or fails to respond within the timeout, the hook SHALL emit a
+   diagnostic message to stderr with exit code `4` (`DAEMON_UNREACHABLE`), SHALL
+   NOT write directly to disk, and SHALL exit 0 from the outer hook wrapper so
+   that the agent's turn is never blocked.
+5. The in-process lock bypass (`_relieved_palace_lock`) and direct in-process
+   `mempalace.mcp_server.tool_add_drawer` invocation in
+   `hooks/mempalace-transcript.sh` SHALL be removed.
+6. `docs/adr/0016-shared-mempalace-mcp-http-server.md` SHALL receive an addendum
+   recording the empirical latency measurement results and the resolution of
+   Derived Spec 4 in favor of daemon routing (Shape b).
+7. The hook JSON registrations (`hooks/*-transcript-hooks.json`) SHALL remain
+   structurally unchanged, preserving compatibility across Claude Code, Gemini
+   CLI, Copilot CLI, and Antigravity CLI.
+
+## Scenarios
+
+### Happy path — Transcript hook persists drawer through daemon
+
+Given a running session in any of the four supported CLIs  
+And the shared MemPalace MCP HTTP daemon is active on `127.0.0.1:41893`  
+When a session lifecycle event triggers `hooks/mempalace-transcript.sh`  
+Then the hook sends an authenticated `tools/call` request to the daemon  
+And the daemon persists the transcript drawer under the `transcripts` wing  
+And the hook completes execution in under 200 milliseconds.
+
+### Failure path — Daemon unreachable falls back to soft skip
+
+Given the shared MemPalace MCP HTTP daemon is stopped or unreachable  
+When a session lifecycle event triggers `hooks/mempalace-transcript.sh`  
+Then the hook attempts to reach the daemon endpoint  
+And the request fails with a connection refusal or timeout  
+And the hook logs `DAEMON_UNREACHABLE` to stderr  
+And the hook exits cleanly without blocking the interactive CLI session.
+
+### Invariant check — Palace maintains single-writer lease
+
+Given multiple concurrent CLI sessions executing hook events  
+When transcript writes are submitted concurrently  
+Then all writes route through the single shared MemPalace daemon process  
+And no process attempts to acquire an out-of-band disk lock.
+
+## Out of scope
+
+- Modifying the daemon's internal MCP tool implementations in `mempalace`.
+- Modifying the ChromaDB HTTP service daemon (managed separately under ADR-0006).
+- Altering the payload format or truncating cap (4000 characters) defined in `hooks/mempalace-transcript.sh`.
+
+## Open questions
+
+- (none — all questions resolved during SPECS)


### PR DESCRIPTION
## Purpose

Establishes spec 0164 (ADR-0016 Derived Spec 4, issue #753): resolves the transcript hook write-path question in favor of daemon routing (Shape b) based on empirical latency measurements on the production palace (p95 < 0.17s vs 5.0s cap).

## How to read this PR?

Single spec file at `specs/0164-transcript-hook-daemon-routing.md` containing the full 160-sample benchmark breakdown and normative requirements R1–R7.

## How to test this PR?

Manual review against `docs/spec-format.md` and ADR-0016 Derived Spec Plan.

## Detailed description (for agents)

- Spec ID: 0164
- Slug: transcript-hook-daemon-routing
- Related issue: #753
- Status: draft
- Complexity: standard
- Interaction mode: INTERMEDIATE
- Implementation details (refactoring `hooks/mempalace-transcript.sh` to use JSON-RPC over HTTP, removing spec-0110 lock bypass, adding ADR-0016 addendum) will follow in DEV.

Part of #753