### PR TITLE
💚 Repair main's red markdown and spec lint (#971)

### DIFF
--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -33,19 +33,22 @@ Definitions of each class, canonical and borderline examples, and the disambigua
 
 ## Deferred-findings ledger
 
-Non-blocking findings MAY be routed to a persistent findings ledger rather than into the retroactive routing loop (see *Non-blocking conditional routing* below). 
+Non-blocking findings MAY be routed to a persistent findings ledger rather than into the retroactive routing loop (see *Non-blocking conditional routing* below).
 
 **Ledger shape and ownership.** The project maintains exactly one findings ledger: a pinned GitHub issue titled `📋 Findings ledger — deferred non-blocking findings` carrying the `deferred-findings-ledger` label. It serves as the single sink for all ledger-routed findings and SHALL never be closed. Each entry records the source PR number, source ticket number, finding class, a one-line summary, date routed, and the routing actor.
 
 **Journalling.** The orchestrator SHALL journal every ledger-route disposition on the active logbook issue (one line per finding: finding ref, disposition `ledger`, actor).
 
 **Drain protocol.** The project maintainer triggers a drain pass by posting a `DRAIN` comment on the ledger issue. Each open entry is evaluated as:
+
 - **Promote**: Finding is material; open a new ticket to address it.
 - **Accept**: Finding is noted but not actionable; close entry with rationale.
 - **Carry**: Finding is still relevant but not urgent; leave open.
+
 The maintainer is the sole decision-maker for each disposition.
 
 **Growth guardrail.** To prevent unbounded growth:
+
 - The orchestrator posts a warning on the logbook issue when open entries exceed **10**.
 - The orchestrator pages the user and blocks all further ledger-route operations when open entries exceed **20**, until a DRAIN comment is posted and at least one entry is disposed.
 

--- a/specs/0005-retroactive-routing-engine.delta-02.md
+++ b/specs/0005-retroactive-routing-engine.delta-02.md
@@ -21,6 +21,7 @@ Requirement 10 is replaced. Non-blocking routing now introduces the ledger-route
 
 Original R10 (as amended by delta-01):
 
+<!-- markdownlint-disable-next-line MD029 -->
 > 10. Non-blocking findings SHALL be routed conditionally by mode:
 >     - FULL — the orchestrator SHALL present every non-blocking finding
 >       to the user (Rule 4) and route only those the user accepts to the
@@ -32,6 +33,7 @@ Original R10 (as amended by delta-01):
 
 Replacement R10 (from spec 0162 R8):
 
+<!-- markdownlint-disable-next-line MD029 -->
 > 10. Non-blocking findings SHALL be routed conditionally by mode:
 >     - FULL — The orchestrator SHALL present every non-blocking finding to the user. The user SHALL choose per finding: **loop** (the finding SHALL be routed into the retroactive loop via the blocking matrix per spec 0005 R4), **ledger** (the finding SHALL be routed to the findings ledger), or **dismiss** (the finding SHALL be journalled in the logbook and left unactioned).
 >     - INTERMEDIATE / MINIMAL / AUTO — The orchestrator SHALL route every non-blocking finding to the **ledger** by default. No user gate SHALL fire.
@@ -40,12 +42,14 @@ Requirement 8 is replaced. The termination condition is narrowed to allow termin
 
 Original R8:
 
+<!-- markdownlint-disable-next-line MD029 -->
 > 8. The lifecycle SHALL terminate at MERGE iff a REVIEW pass produces
 >    verdict APPROVE, zero blocking findings of any class, and CI is
 >    green on the head commit reviewed (per ADR-0010 → *Termination*).
 
 Replacement R8 (from spec 0162 R9/R11):
 
+<!-- markdownlint-disable-next-line MD029 -->
 > 8. The lifecycle SHALL terminate at MERGE iff a REVIEW pass produces
 >    verdict APPROVE, **zero blocking** findings of any class, CI is
 >    green on the head commit reviewed, and **every non-blocking finding** in the pass has been disposed as **ledger** or **dismiss** (FULL: per user triage; others: auto-ledger). Non-blocking findings loop-routed by the user in FULL mode count as blocking for this purpose.

--- a/specs/0162-deferred-findings-lane.md
+++ b/specs/0162-deferred-findings-lane.md
@@ -1,7 +1,7 @@
 ---
 id: "0162"
 slug: deferred-findings-lane
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: FULL
 related-issue: 885
@@ -73,9 +73,7 @@ would not be affected by this routing change.
 
 ## Requirements
 
-### Ledger shape and ownership
-
-1. The project SHALL maintain exactly one **findings ledger**, a pinned
+1. **Ledger shape and ownership.** The project SHALL maintain exactly one **findings ledger**, a pinned
    GitHub issue titled `📋 Findings ledger — deferred non-blocking
    findings` (Gitmoji convention: 📋). The issue SHALL be pinned on
    creation and SHALL never be closed; it SHALL serve as the sink for
@@ -89,9 +87,7 @@ would not be affected by this routing change.
 3. The ledger issue SHALL carry the label `deferred-findings-ledger`
    (created on first use). No other issue SHALL carry this label.
 
-### Drain trigger
-
-4. The ledger drain SHALL be triggered by the project maintainer at a
+4. **Drain trigger.** The ledger drain SHALL be triggered by the project maintainer at a
    cadence they own. The maintainer SHALL post a `DRAIN` command comment
    on the ledger issue to trigger a drain pass; the orchestrator SHALL
    treat the presence of this comment as the activation signal for the
@@ -119,9 +115,7 @@ would not be affected by this routing change.
    `DRAIN` comment on the ledger issue and at least one entry is
    disposed.
 
-### Routing rule amendments
-
-8. The non-blocking routing table (spec 0005 R10) SHALL be amended for
+8. **Routing rule amendments.** The non-blocking routing table (spec 0005 R10) SHALL be amended for
    all modes to introduce **ledger-route** as a third disposition
    alongside *loop-route* and *dismiss*:
 
@@ -145,9 +139,7 @@ would not be affected by this routing change.
       purposes and SHALL be routed through the blocking matrix per
       spec 0005 R4 using their `class:` tag.
 
-### Compatibility
-
-10. This spec SHALL NOT change the routing of **blocking** findings.
+10. **Compatibility.** This spec SHALL NOT change the routing of **blocking** findings.
     The routing matrix for blocking findings (tech → DEV, arch → PLAN,
     spec → SPECS) SHALL remain unchanged.
 
@@ -161,9 +153,7 @@ would not be affected by this routing change.
     dismiss disposition SHALL be recorded on the logbook issue, not on
     the findings ledger.
 
-### Documentation
-
-13. `docs/retroactive-loop.md` SHALL be amended to:
+13. **Documentation.** `docs/retroactive-loop.md` SHALL be amended to:
     - Add a *Deferred-findings ledger* section documenting R1–R7 of
       this spec (ledger shape, drain trigger, disposition table,
       growth guardrail).

--- a/specs/0163-drop-copilot-workspace-hook-merge.md
+++ b/specs/0163-drop-copilot-workspace-hook-merge.md
@@ -1,7 +1,7 @@
 ---
 id: "0163"
 slug: drop-copilot-workspace-hook-merge
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 959

--- a/specs/0164-transcript-hook-daemon-routing.md
+++ b/specs/0164-transcript-hook-daemon-routing.md
@@ -1,7 +1,7 @@
 ---
 id: "0164"
 slug: transcript-hook-daemon-routing
-status: draft
+status: implemented
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 753


### PR DESCRIPTION
`lint-markdown` and `lint-specs` both fail on `main`, so every open and future pull request inherits a red base branch it did not break. This repairs both jobs — 20 markdownlint errors and three merged specs still carrying `status: draft` — without changing a word of normative spec content.

Closes #971

## Scope — issue #971 scoped three items, this diff carries five files

Stated up front rather than left for a reviewer to discover. Issue #971 named the 17 `MD029` violations and one `status: draft` spec. Measuring the two CI jobs on a pristine `crewrig/main` worktree showed that fixing exactly those leaves both jobs red, so two items were added. Each is load-bearing:

| # | File | Scoped by #971? | Why it is required |
|---|---|---|---|
| 1 | `specs/0162-deferred-findings-lane.md` | yes | 13 × MD029, and `status: draft` |
| 2 | `specs/0005-retroactive-routing-engine.delta-02.md` | yes | 4 × MD029 |
| 3 | `docs/retroactive-loop.md` | **no — added** | `lint-markdown` fails on **20** tracked-file errors, not 17; without these 3 the job stays red |
| 4 | `specs/0163-drop-copilot-workspace-hook-merge.md` | **no — added** | same `status: draft` defect; without it `lint-specs` stays red on `main` |
| 5 | `specs/0164-transcript-hook-daemon-routing.md` | **no — added** | same |

Items 4 and 5 are invisible from a pull request: there the linter reports them as a non-blocking `[WARN]`, which is exactly how they survived. On `main`'s own build they are `[FAIL]`. Test 3 below reproduces that.

## Why this ships without a spec-PR

The Spec-PR workflow requires a spec-PR to merge before any implementation branch for the same ticket opens. Applying it here is impossible, not merely inconvenient: a spec-PR adds a file under `specs/` and does not touch either offending file, so it inherits the red `lint-specs` from its base branch and cannot merge. This repair PR, by contrast, makes both linters green on its own head. Ordering the repair behind a spec-PR would deadlock every ticket in the project, including the spec-PR itself.

Recorded here as a reasoned exception, not a skipped step.

## How to read this PR?

Five files, in this order.

1. `specs/0005-retroactive-routing-engine.delta-02.md` — the smallest and least obvious change. The four blockquotes are **verbatim quotations** of requirements 10 and 8 of spec 0005. Their numbers are the requirements' identities, not list ordinals, so `MD029/ol-prefix` ("a list must start at 1") is a false positive: renumbering to `1.` would corrupt the quote. The rule is disabled per quote rather than obeyed.

   Two alternatives were tried and rejected on measured evidence, not taste:
   - Escaping the ordinal (`> 10\. …`) lints clean but degrades the rendering — GitHub's `/markdown` endpoint returns a plain `<p>` instead of `<ol start="10">`, and the sub-bullets lose their nesting.
   - Removing the blank line before the quote (the shape `specs/0149-daemon-credential-hardening.delta-01.md` already uses) silences MD029 only because `markdownlint` then fails to see a list at all — and it immediately trips 3 × `MD027/no-multiple-space-blockquote` in its place. GitHub still renders `<ol start="10">` there, so that shape is a parser divergence, not a fix.

2. `specs/0162-deferred-findings-lane.md` — 13 × MD029 plus the status line. The `## Requirements` section is one 1..16 sequence that five level-3 headings split into five separate lists, each of which `markdownlint` then expects to restart at 1. Flattened into a single continuous list, each group label carried as a bold lead-in on its first item. That is the shape `specs/0166-stable-reviewer-seat.md` (PR #972) and `docs/retroactive-loop.md` already use.

   The R-numbers are load-bearing — `specs/0005-…delta-02.md` cites 0162 R8, R9/R11 and R16 by number — and are preserved exactly. Rendered numbering is unchanged too: GitHub previously emitted `<ol start="4">`, `<ol start="8">`, `<ol start="10">`, `<ol start="13">` for the split lists, so the visible numbers were already 1..16.

3. `docs/retroactive-loop.md` — one trailing space (MD009) and two lists not surrounded by blank lines (MD032), landed by PR #962. Not named in issue #971, but `lint-markdown` on a pristine `crewrig/main` worktree fails on **20** tracked-file errors, not 17; these are the other three. Fixing only the 17 would leave the job red.

4. `specs/0163-drop-copilot-workspace-hook-merge.md` and `specs/0164-transcript-hook-daemon-routing.md` — one frontmatter line each, for the same reason as 0162 (see below).

### Why `implemented` and not `approved`

`docs/spec-format.md` → *Lifecycle states* assigns `approved` to the merge of the spec-PR and `implemented` to the merge of the implementation PR for `related-issue`. All three specs have had both, so `approved` would understate the truth:

| Spec | spec-PR | implementation PR | `related-issue` |
|---|---|---|---|
| 0162 | #960 merged | #962 merged 2026-08-16T18:34:25Z | #885 closed 18:34:35Z |
| 0163 | #964 merged | #965 merged 2026-08-16T21:25:59Z | #959 closed 21:26:00Z |
| 0164 | #966 merged | #967 merged 2026-08-16T21:50:32Z | #753 closed 21:50:43Z |

Corroborating for 0162: `docs/retroactive-loop.md` carries the `## Deferred-findings ledger` section (spec 0162 R13) and issue #961 `📋 Findings ledger — deferred non-blocking findings` is live with the `deferred-findings-ledger` label (R1/R15).

### Why all three, not only 0162

Issue #971 names only 0162, but fixing it alone does **not** turn `lint-specs` green on `main`. `scripts/lib/spec-linter.js` computes `blockEveryOffender = changed === null || changed.size === 0`; on `main`'s own build the changed-file set is empty, so *every* draft spec is `[FAIL]`, never the `[WARN]` a pull request sees. Measured, not assumed — see the third test below.

`specs/0005-retroactive-routing-engine.delta-02.md` is deliberately left at `status: draft`: the linter exempts delta-specs (`!isDelta && status === 'draft' && …`), and `docs/spec-format.md` records that what status a delta should carry is still unsettled.

## How to test this PR?

Prerequisites: `task`, `node`, `markdownlint-cli`, and `npm install` in the checkout.

**1 — both linters are green on this branch.**

```sh
task lint-markdown   # exit 0
task spec:lint       # exit 0, "Linting passed!"
```

**2 — both linters are red on the base, so the contrast is measured rather than assumed.** Use a pristine worktree so untracked local files (`config/SOUL.md`, `tests/e2e/reports/**`) cannot pollute the result — neither exists in a CI checkout.

```sh
git worktree add --detach /tmp/971-base crewrig/main
cd /tmp/971-base && npm install
task lint-markdown   # exit 1: 20 errors (17 MD029 + 3 in docs/retroactive-loop.md)
task spec:lint       # exit 1: markdownlint stage fails first
```

**3 — the status flips are load-bearing.** Reproduce `main`'s own build, where the linter's changed-file set is empty, with only the formatting fixed:

```sh
cd /tmp/971-base
git apply <(cd - >/dev/null && git diff crewrig/main -- specs/0005-retroactive-routing-engine.delta-02.md specs/0162-deferred-findings-lane.md)
# revert 0162's frontmatter to `status: draft`, then commit so the tree is clean
BASE_REF=HEAD task spec:lint
```

Expected: exit 1, with all three specs named as blocking.

```text
[FAIL] Non-delta specs present on the base branch (HEAD) carry 'status: draft':
  - specs/0162-deferred-findings-lane.md
  - specs/0163-drop-copilot-workspace-hook-merge.md
  - specs/0164-transcript-hook-daemon-routing.md
```

**4 — the same condition is green on this branch.**

```sh
BASE_REF=HEAD task spec:lint   # exit 0
```

**5 — no normative wording changed.** Read `git diff` and check every hunk is numbering, indentation, a bold lead-in, a lint directive, a blank line, a trailing space, or one frontmatter line. Mechanically: strip the five `### ` headings from the base copy of 0162 and the five `**Label.** ` prefixes from this branch's copy, normalise the `status:` line, drop blank lines — the two are then identical. Same for `0005…delta-02` with the four directive lines removed, and for `docs/retroactive-loop.md` modulo blank lines and trailing whitespace.

## Detailed description (for agents)

### Modified — `specs/0162-deferred-findings-lane.md`

- Frontmatter: `status: draft` → `status: implemented`. Metadata-only, permitted by `docs/spec-format.md` → *Recording a status transition*. No body line, `id`, `slug` or `version` touched.
- `## Requirements`: removed the five level-3 headings `Ledger shape and ownership`, `Drain trigger`, `Routing rule amendments`, `Compatibility`, `Documentation`, and re-attached each as a bold lead-in (`**Ledger shape and ownership.** `) on the first item of its group — items 1, 4, 8, 10, 13 respectively. Requirements 1..16 are now one continuous ordered list, which is what MD029 requires.
- No requirement text, table cell, scenario or out-of-scope item altered. No R-number altered.

### Modified — `specs/0005-retroactive-routing-engine.delta-02.md`

- Inserted `<!-- markdownlint-disable-next-line MD029 -->` on its own line before each of the four blockquoted requirement quotations (original R10, replacement R10, original R8, replacement R8). Four added lines, nothing else.
- The directive is invisible in rendered output; GitHub's `/markdown` endpoint returns the identical `<blockquote><ol start="10">…` DOM with and without it.
- `status: draft` deliberately untouched — delta-specs are exempt from the base-branch draft check.

### Modified — `docs/retroactive-loop.md`

- Stripped one trailing space at the end of the `Non-blocking findings MAY be routed…` line (MD009).
- Inserted a blank line before the *Drain protocol* disposition list, after it (before `The maintainer is the sole decision-maker…`), and before the *Growth guardrail* list (MD032). Four lines touched, no prose altered.

### Modified — `specs/0163-drop-copilot-workspace-hook-merge.md`, `specs/0164-transcript-hook-daemon-routing.md`

- `status: draft` → `status: implemented`. One line each; the files are otherwise byte-identical to `crewrig/main`.

### Deliberately not done

- **The linter's base-branch blind spot is untouched.** `scripts/lib/spec-linter.js` checks the `status: draft` contradiction only for files present in the PR diff, and says so in its own output — which is why 0162's violation survived a whole merge unnoticed, and why 0163 and 0164 then repeated it. Issue #971 defers it explicitly and this PR respects that.

  It does warrant its own ticket, and a wider one than the blind spot alone: **three consecutive spec/implementation PR pairs (0162, 0163, 0164) all failed to record the `draft → approved → implemented` transitions the *Merge mechanic* mandates.** That is a process failure rather than three accidents, and it compounds with the blind spot — the mechanism that should have caught it is the one that cannot see it. One follow-up ticket should cover both halves.

- **No `artifacts/` change**, so `scripts/build-components.sh` was not run and no `metadata.provenance.version` bump applies.
- **No CLI-matrix-governed path touched**, so `docs/cli-matrix.md` needs no update.

### Verification performed

| Command | Where | Exit |
|---|---|---|
| `task lint-markdown` | this branch | 0 |
| `task spec:lint` | this branch | 0 |
| `BASE_REF=HEAD task spec:lint` | this branch (simulates `main`'s own build) | 0 |
| `task lint-markdown` | pristine `crewrig/main` worktree | 201 (20 errors) |
| `task spec:lint` | pristine `crewrig/main` worktree | 201 |
| `BASE_REF=HEAD task spec:lint` | `crewrig/main` + formatting fix only, clean tree | 201, three specs `[FAIL]` |
| `bash scripts/check-markdown-links.sh` | this branch | 0 |
| `bash scripts/build-docs-index.sh --check` | this branch | 0 |

`bash scripts/ci-changeset-coverage.sh` was started locally but had not returned when this PR was opened; it is left to CI.
