### PR TITLE
✨ Enforce spec status transitions in CI and workflow (spec 0168, issue #974)

### DIFF
--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -211,15 +211,21 @@ to use `status` for the one question it exists to answer — "merged and in
 force" or "proposed but never landed".
 
 The rule is enforced mechanically rather than by recall. The spec linter
-(`scripts/lib/spec-linter.js`, run as `task spec:lint` in CI) names every
-non-delta spec that is **already present on the change's base branch** while
-carrying `status: draft`. Presence on the base branch is the discriminator for
-being named, so a spec the change under test *introduces* is not named at all:
-it is legitimately `draft` until the *Merge mechanic* below flips it.
-Delta-specs are exempt too — what `status` a delta should carry is deliberately
-unsettled, per
+(`scripts/lib/spec-linter.js`, run as `task spec:lint` in CI) enforces status
+invariants across all pull requests and on `main` (governed by
 [`specs/0109-spec-status-invariant-on-main.md`](../specs/0109-spec-status-invariant-on-main.md)
-→ *Out of scope*.
+and [`specs/0168-spec-status-transition-enforcement.md`](../specs/0168-spec-status-transition-enforcement.md)):
+
+- **Spec PRs (`spec/<NNNN>-*` or introducing a new spec):** CI fails (`[FAIL]`)
+  if an added or modified non-delta spec file carries `status: draft`. The spec
+  must transition to `status: approved` (and declare `interaction-mode`) before
+  merging to `main`.
+- **Implementation PRs (`(feat|fix|refactor|perf|chore)/<NNNN>-*`):** CI fails
+  (`[FAIL]`) if the corresponding specification file `specs/<NNNN>-*.md` does not
+  carry `status: implemented`.
+- **Base branch status check:** The linter names every non-delta spec already
+  present on the change's base branch that carries `status: draft`. Delta-specs
+  are exempt per Spec 0109.
 
 **Which build the violation fails, and which it only warns.** Being named and
 being failed are two different things, decided by two different questions. A

--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -234,6 +234,36 @@ function changedPaths(baseRef) {
     return new Set(diff.stdout.split('\0').filter(Boolean));
 }
 
+// resolveCurrentBranch() — resolve the branch name of the change under test.
+// Checks explicit test override (BRANCH_NAME), CI variables (GITHUB_HEAD_REF,
+// CI_MERGE_REQUEST_SOURCE_BRANCH_NAME), local git branch, and CI ref names.
+function resolveCurrentBranch() {
+    if (process.env.BRANCH_NAME && process.env.BRANCH_NAME.trim() !== '') {
+        return process.env.BRANCH_NAME.trim();
+    }
+    if (process.env.GITHUB_HEAD_REF && process.env.GITHUB_HEAD_REF.trim() !== '') {
+        return process.env.GITHUB_HEAD_REF.trim();
+    }
+    if (process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME && process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME.trim() !== '') {
+        return process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME.trim();
+    }
+    const gitBranch = gitCapture(['symbolic-ref', '--short', 'HEAD']);
+    if (gitBranch.status === 0 && gitBranch.stdout.trim() !== '') {
+        return gitBranch.stdout.trim();
+    }
+    const gitAbbrev = gitCapture(['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (gitAbbrev.status === 0 && gitAbbrev.stdout.trim() !== '' && gitAbbrev.stdout.trim() !== 'HEAD') {
+        return gitAbbrev.stdout.trim();
+    }
+    if (process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME.trim() !== '') {
+        return process.env.GITHUB_REF_NAME.trim();
+    }
+    if (process.env.CI_COMMIT_REF_NAME && process.env.CI_COMMIT_REF_NAME.trim() !== '') {
+        return process.env.CI_COMMIT_REF_NAME.trim();
+    }
+    return '';
+}
+
 // resolveBaseContext(files) — decide whether the base-branch status check runs,
 // and if so against which paths. Three outcomes, deliberately distinct:
 //
@@ -621,6 +651,48 @@ function run() {
                 console.error(`  branch rather than in this change and is not this change's to fix — it`);
                 console.error(`  does NOT fail this run. Correcting it is an edit to the named spec on the`);
                 console.error(`  base branch, whose own build fails on it (spec 0109 R1/R9/R10).`);
+            }
+        }
+
+        // Spec 0168 Requirement 1 — Spec-PR status validation:
+        // A pull request introducing a new non-delta specification file (or modifying one)
+        // SHALL NOT pass CI if it carries `status: draft`.
+        // It must carry `status: approved` (with `interaction-mode`) before merging to main.
+        if (baseContext.changed !== null) {
+            const newDraftOffenders = fileResults.filter(({ file, isDelta, status }) =>
+                !isDelta && status === 'draft' &&
+                baseContext.changed.has(baseContext.relPathByFile.get(file)) &&
+                !baseContext.basePaths.has(baseContext.relPathByFile.get(file))
+            );
+            if (newDraftOffenders.length > 0) {
+                console.error(`\n[FAIL] Non-delta specs added or modified by this change carry 'status: draft' (spec 0168 R1):`);
+                for (const { file } of newDraftOffenders) {
+                    console.error(`  - ${file}`);
+                }
+                console.error(`  A specification must be approved before merging to the base branch.`);
+                console.error(`  Transition 'status: draft' to 'status: approved' and declare 'interaction-mode'`);
+                console.error(`  in the frontmatter once review approval is secured.`);
+                totalErrors++;
+            }
+        }
+
+        // Spec 0168 Requirement 2 — Implementation PR status validation:
+        // A pull request operating on an implementation branch ((feat|fix|refactor|perf|chore)/<NNNN>-*)
+        // SHALL NOT pass CI if the corresponding specification file does not carry `status: implemented`.
+        const currentBranch = resolveCurrentBranch();
+        const implBranchMatch = currentBranch.match(/^(?:feat|fix|refactor|perf|chore)\/(\d{4})-.*$/);
+        if (implBranchMatch) {
+            const specId = implBranchMatch[1];
+            const matchingSpecs = fileResults.filter(({ id, isDelta }) => !isDelta && id === specId);
+            for (const { file, status } of matchingSpecs) {
+                if (status !== 'implemented') {
+                    console.error(`\n[FAIL] Implementation branch '${currentBranch}' matches spec id '${specId}', but specification`);
+                    console.error(`       file does not carry 'status: implemented' (spec 0168 R2):`);
+                    console.error(`  - ${file} (current status: '${status}')`);
+                    console.error(`  An implementation pull request must transition its corresponding specification`);
+                    console.error(`  frontmatter to 'status: implemented' before merging.`);
+                    totalErrors++;
+                }
             }
         }
     }

--- a/scripts/lib/spec-linter.js
+++ b/scripts/lib/spec-linter.js
@@ -235,17 +235,11 @@ function changedPaths(baseRef) {
 }
 
 // resolveCurrentBranch() — resolve the branch name of the change under test.
-// Checks explicit test override (BRANCH_NAME), CI variables (GITHUB_HEAD_REF,
-// CI_MERGE_REQUEST_SOURCE_BRANCH_NAME), local git branch, and CI ref names.
+// Checks explicit test override (BRANCH_NAME), local git branch, and CI variables
+// (GITHUB_HEAD_REF, CI_MERGE_REQUEST_SOURCE_BRANCH_NAME, GITHUB_REF_NAME, etc.).
 function resolveCurrentBranch() {
     if (process.env.BRANCH_NAME && process.env.BRANCH_NAME.trim() !== '') {
         return process.env.BRANCH_NAME.trim();
-    }
-    if (process.env.GITHUB_HEAD_REF && process.env.GITHUB_HEAD_REF.trim() !== '') {
-        return process.env.GITHUB_HEAD_REF.trim();
-    }
-    if (process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME && process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME.trim() !== '') {
-        return process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME.trim();
     }
     const gitBranch = gitCapture(['symbolic-ref', '--short', 'HEAD']);
     if (gitBranch.status === 0 && gitBranch.stdout.trim() !== '') {
@@ -254,6 +248,12 @@ function resolveCurrentBranch() {
     const gitAbbrev = gitCapture(['rev-parse', '--abbrev-ref', 'HEAD']);
     if (gitAbbrev.status === 0 && gitAbbrev.stdout.trim() !== '' && gitAbbrev.stdout.trim() !== 'HEAD') {
         return gitAbbrev.stdout.trim();
+    }
+    if (process.env.GITHUB_HEAD_REF && process.env.GITHUB_HEAD_REF.trim() !== '') {
+        return process.env.GITHUB_HEAD_REF.trim();
+    }
+    if (process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME && process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME.trim() !== '') {
+        return process.env.CI_MERGE_REQUEST_SOURCE_BRANCH_NAME.trim();
     }
     if (process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME.trim() !== '') {
         return process.env.GITHUB_REF_NAME.trim();

--- a/scripts/tests/test-spec-linter.sh
+++ b/scripts/tests/test-spec-linter.sh
@@ -888,9 +888,93 @@ render_spec "0043" "inline-scaffolding" "draft" "standard" "" "$headings43" > "$
 run_case "Case 43 — tool scaffolding in inline code span passes" "$spec43" 0
 
 # -------------------------------------------------------------------------
+# Cases 44-48 (spec 0168 R1, R2) — AUTOMATED STATUS TRANSITION ENFORCEMENT
+# -------------------------------------------------------------------------
+GITFIX5="$TMP_ROOT/gitfix5"
+mkdir -p "$GITFIX5/specs" "$GITFIX5/docs"
+cp "$ROOT_DIR/.markdownlintrc" "$GITFIX5/"
+ln -s "$ROOT_DIR/node_modules" "$GITFIX5/node_modules"
+render_spec "0300" "base-feature" "implemented" "standard" "interaction-mode: AUTO" > "$GITFIX5/specs/0300-base-feature.md"
+(
+  cd "$GITFIX5" || exit 1
+  git init -q
+  git symbolic-ref HEAD refs/heads/main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+  git add specs
+  git commit -q -m "initial main branch"
+)
+
+# -------------------------------------------------------------------------
+# Case 44 (Spec 0168 R1) — A new spec PR introducing a spec carrying `status: draft`
+# fails CI when targeting the base branch.
+# -------------------------------------------------------------------------
+git -C "$GITFIX5" checkout -q -b spec/0301-new-feature
+render_spec "0301" "new-feature" "draft" "standard" "" > "$GITFIX5/specs/0301-new-feature.md"
+git -C "$GITFIX5" add specs/0301-new-feature.md
+git -C "$GITFIX5" commit -q -m "add spec in draft"
+run_base_case "Case 44 — new spec PR carrying draft status fails CI (spec 0168 R1)" \
+  "$GITFIX5" "specs" 1 "main" \
+  "Non-delta specs added or modified by this change carry 'status: draft'" "-"
+
+# -------------------------------------------------------------------------
+# Case 45 (Spec 0168 R1) — Transitioning the new spec to `status: approved` (with
+# interaction-mode) passes CI on the spec PR.
+# -------------------------------------------------------------------------
+render_spec "0301" "new-feature" "approved" "standard" "interaction-mode: AUTO" > "$GITFIX5/specs/0301-new-feature.md"
+git -C "$GITFIX5" add specs/0301-new-feature.md
+git -C "$GITFIX5" commit -q -m "transition spec to approved"
+run_base_case "Case 45 — new spec PR carrying approved status passes CI (spec 0168 R1)" \
+  "$GITFIX5" "specs" 0 "main" \
+  "-" "Non-delta specs added or modified by this change carry 'status: draft'"
+
+# -------------------------------------------------------------------------
+# Case 46 (Spec 0168 R2) — An implementation PR on branch feat/0302-cool-feature
+# whose spec still carries `status: approved` fails CI.
+# -------------------------------------------------------------------------
+git -C "$GITFIX5" checkout -q main
+render_spec "0302" "cool-feature" "approved" "standard" "interaction-mode: AUTO" > "$GITFIX5/specs/0302-cool-feature.md"
+git -C "$GITFIX5" add specs/0302-cool-feature.md
+git -C "$GITFIX5" commit -q -m "merge spec 0302 to main"
+git -C "$GITFIX5" checkout -q -b feat/0302-cool-feature
+printf 'console.log("implemented");\n' > "$GITFIX5/docs/feature.js"
+git -C "$GITFIX5" add docs/feature.js
+git -C "$GITFIX5" commit -q -m "implement feature without updating spec status"
+run_base_case "Case 46 — implementation PR without status: implemented fails CI (spec 0168 R2)" \
+  "$GITFIX5" "specs" 1 "main" \
+  "matches spec id '0302', but specification" "-"
+
+# -------------------------------------------------------------------------
+# Case 47 (Spec 0168 R2) — An implementation PR that transitions the spec to
+# `status: implemented` passes CI.
+# -------------------------------------------------------------------------
+render_spec "0302" "cool-feature" "implemented" "standard" "interaction-mode: AUTO" > "$GITFIX5/specs/0302-cool-feature.md"
+git -C "$GITFIX5" add specs/0302-cool-feature.md
+git -C "$GITFIX5" commit -q -m "transition spec 0302 to implemented"
+run_base_case "Case 47 — implementation PR with status: implemented passes CI (spec 0168 R2)" \
+  "$GITFIX5" "specs" 0 "main" \
+  "-" "matches spec id '0302'"
+
+# -------------------------------------------------------------------------
+# Case 48 (Spec 0168 R2) — An implementation branch for a ticket that has no
+# matching spec file in specs/ (e.g. non-spec bug fix) is a clean pass.
+# -------------------------------------------------------------------------
+git -C "$GITFIX5" checkout -q main
+git -C "$GITFIX5" checkout -q -b fix/0999-no-such-spec
+mkdir -p "$GITFIX5/docs"
+printf 'console.log("fix");\n' > "$GITFIX5/docs/fix.js"
+git -C "$GITFIX5" add docs/fix.js
+git -C "$GITFIX5" commit -q -m "fix non-spec issue"
+run_base_case "Case 48 — implementation branch with no matching spec file passes (spec 0168 R2)" \
+  "$GITFIX5" "specs" 0 "main" \
+  "-" "matches spec id"
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo ""
 echo "Results: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]
+
 

--- a/specs/0168-spec-status-transition-enforcement.md
+++ b/specs/0168-spec-status-transition-enforcement.md
@@ -1,7 +1,7 @@
 ---
 id: "0168"
 slug: spec-status-transition-enforcement
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 974


### PR DESCRIPTION
## Purpose
This PR implements automated CI and workflow enforcement for specification lifecycle status transitions (`draft` → `approved` on spec-PRs, and `approved` → `implemented` on implementation PRs) per Spec 0168, preventing unrecorded or stale spec statuses from merging into `main`.

## How to read this PR?
1. Start with `scripts/lib/spec-linter.js` to inspect the branch resolution and status transition enforcement logic.
2. Read `scripts/tests/test-spec-linter.sh` for the regression test cases 44 to 48.
3. Review `docs/spec-format.md` for the documented CI enforcement rules.

## How to test this PR?
```bash
bash scripts/tests/test-spec-linter.sh
task spec:lint
```

## Detailed description (for agents)
- Added branch name resolution in `scripts/lib/spec-linter.js` checking CI environment variables (`GITHUB_HEAD_REF`, `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`), local git branches, and explicit override `BRANCH_NAME`.
- Enforces that non-delta specs added or modified on a PR targeting the base branch must not carry `status: draft` (spec 0168 R1).
- Enforces that PRs on implementation branches (`(feat|fix|refactor|perf|chore)/<NNNN>-*`) must transition matching `specs/<NNNN>-*.md` files to `status: implemented` (spec 0168 R2).
- Preserves the Spec 0109 Delta-02 bystander warning rule for untouched base-branch draft specs.
- Added regression test cases 44 to 48 covering all transitions and edge cases in `scripts/tests/test-spec-linter.sh`.
- Updated `specs/0168-spec-status-transition-enforcement.md` frontmatter to `status: implemented`.

Closes #974