### PR TITLE
🐛 Drop redundant jq install step in test-harness-curate CI job (#979)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -748,9 +748,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Smoke-test harness curator
         run: bash artifacts/library/skills/harness-curator/scripts/test.sh
 

--- a/scripts/check-ci-parity.sh
+++ b/scripts/check-ci-parity.sh
@@ -442,6 +442,8 @@ check_gha_job() {
   esac
   while IFS= read -r rt; do
     [ -z "$rt" ] && continue
+    # jq is preinstalled on GitHub Actions ubuntu-latest runners; GitLab CI installs it via tool_install_lines.
+    [ "$rt" = "jq" ] && continue
     in_list "$rt" "$prov_tools" || \
       fail "capability '$id' (github-actions): requires tool '$rt' but no setup step installs it (R4)"
   done <<< "$req_tools"


### PR DESCRIPTION
## Purpose
This PR removes the redundant `sudo apt-get update && sudo apt-get install -y jq` step from the `test-harness-curate` GitHub Actions job, which caused intermittent 6-hour CI hangs during transient Ubuntu mirror stalls (issue #979).

## How to read this PR?
1. Inspect `.github/workflows/build.yml` to see the removal of the redundant `Install jq` step from `test-harness-curate`.
2. Inspect `scripts/check-ci-parity.sh` to see that `jq` is recognized as ambiently preinstalled on GitHub Actions `ubuntu-latest` runners while remaining automatically provisioned on GitLab CI's `debian:stable-slim`.

## How to test this PR?
```bash
bash scripts/check-ci-parity.sh
bash scripts/tests/test-check-ci-parity.sh
bash scripts/build-ci.sh --check
```

## Detailed description (for agents)
`jq` is preinstalled by default on GitHub Actions `ubuntu-latest` runner images. The explicit `apt-get` install step in `test-harness-curate` was the only such step in `build.yml` and exposed the workflow to 6-hour runner timeouts when external package mirrors stalled. Updating `check-ci-parity.sh` ensures CI parity checks pass without requiring a redundant install step on GitHub Actions while preserving automated provisioning in GitLab CI.

Closes #979