### PR TITLE
🐛 Check copy success in backup_file before setting LAST_BACKUP_PATH (#982)

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -18,21 +18,26 @@ MEMPALACE_MAX_VERSION_EXCLUSIVE="3.7"
 # LAST_BACKUP_PATH — set by every backup_file call so a caller can name the
 # backup it just produced (spec 0089 R9 warning). Deterministic on ALL paths:
 # the path of the backup when one was made, the empty string when the target
-# was absent and no backup was made. Initialising it unconditionally means a
-# caller reading it after a no-backup call never sees a prior call's value and
-# never trips `set -u` (spec 0089 review F2).
+# was absent, or when backup creation failed. Initialising it unconditionally
+# means a caller reading it after a no-backup call never sees a prior call's
+# value, never sees a nonexistent backup path, and never trips `set -u`
+# (spec 0089 review F2, issue #982).
 LAST_BACKUP_PATH=""
 
 backup_file() {
   local target="$1"
   LAST_BACKUP_PATH=""
   if [ -f "$target" ] || [ -L "$target" ]; then
-    local stamp
+    local stamp bak
     stamp="$(date +%Y%m%d-%H%M%S)"
-    cp -P "$target" "${target}.bak.${stamp}"
-    # shellcheck disable=SC2034  # read by scripts that source this lib (R9 warning), not here
-    LAST_BACKUP_PATH="${target}.bak.${stamp}"
-    echo "  Backed up: ${target##*/} -> ${target##*/}.bak.${stamp}"
+    bak="${target}.bak.${stamp}"
+    if cp -P "$target" "$bak" 2>/dev/null && [ -e "$bak" ]; then
+      # shellcheck disable=SC2034  # read by scripts that source this lib (R9 warning), not here
+      LAST_BACKUP_PATH="$bak"
+      echo "  Backed up: ${target##*/} -> ${target##*/}.bak.${stamp}"
+    else
+      echo "  WARNING: Failed to back up ${target##*/} (could not create ${bak##*/})" >&2
+    fi
   fi
 }
 

--- a/scripts/tests/test-setup-mcp-merge.sh
+++ b/scripts/tests/test-setup-mcp-merge.sh
@@ -238,6 +238,83 @@ for s in setup-gemini-interactive.sh setup-copilot-interactive.sh \
 done
 
 # ---------------------------------------------------------------------------
+echo "5. backup_file helper behaviour (spec 0089 R9/R10, issue #982)"
+# ---------------------------------------------------------------------------
+
+# 5a. Existing regular file is backed up, sets LAST_BACKUP_PATH, announces success
+src_file="$TMP_ROOT/valid_src.json"
+echo '{"hello":"world"}' > "$src_file"
+out_5a_file="$TMP_ROOT/out_5a.txt"
+backup_file "$src_file" > "$out_5a_file" 2>&1
+out_5a="$(cat "$out_5a_file")"
+if [ -n "$LAST_BACKUP_PATH" ] && [ -f "$LAST_BACKUP_PATH" ]; then
+  ok "backup_file sets LAST_BACKUP_PATH to existing file on success"
+else
+  bad "backup_file failed to set valid LAST_BACKUP_PATH (got: '$LAST_BACKUP_PATH')"
+fi
+if printf '%s' "$out_5a" | grep -q "Backed up: valid_src.json ->"; then
+  ok "backup_file reports success on stdout"
+else
+  bad "backup_file missing success message on stdout (got: '$out_5a')"
+fi
+
+# 5b. Absent target leaves LAST_BACKUP_PATH empty and emits no output
+absent_file="$TMP_ROOT/nonexistent.json"
+out_5b_file="$TMP_ROOT/out_5b.txt"
+backup_file "$absent_file" > "$out_5b_file" 2>&1
+out_5b="$(cat "$out_5b_file")"
+if [ -z "$LAST_BACKUP_PATH" ]; then
+  ok "backup_file leaves LAST_BACKUP_PATH empty on absent file"
+else
+  bad "backup_file set LAST_BACKUP_PATH on absent file (got: '$LAST_BACKUP_PATH')"
+fi
+if [ -z "$out_5b" ]; then
+  ok "backup_file produces no output for absent target"
+else
+  bad "backup_file produced unexpected output for absent target: '$out_5b'"
+fi
+
+# 5c. Target cannot be copied (forcing cp failure when writing backup next to target)
+no_write_dir="$TMP_ROOT/nowrite_dir"
+mkdir -p "$no_write_dir"
+unwritable_target="$no_write_dir/src.json"
+echo '{"test":1}' > "$unwritable_target"
+chmod 555 "$no_write_dir"
+out_5c_file="$TMP_ROOT/out_5c.txt"
+backup_file "$unwritable_target" > "$out_5c_file" 2>&1
+out_5c="$(cat "$out_5c_file")"
+chmod 755 "$no_write_dir"
+if [ -z "$LAST_BACKUP_PATH" ]; then
+  ok "backup_file leaves LAST_BACKUP_PATH empty when cp fails (issue #982)"
+else
+  bad "backup_file published nonexistent LAST_BACKUP_PATH on failure (got: '$LAST_BACKUP_PATH')"
+fi
+if printf '%s' "$out_5c" | grep -q "WARNING: Failed to back up src.json"; then
+  ok "backup_file emits warning on stderr when backup fails"
+else
+  bad "backup_file missing failure warning (got: '$out_5c')"
+fi
+if printf '%s' "$out_5c" | grep -q "Backed up:"; then
+  bad "backup_file falsely reported success when copy failed"
+else
+  ok "backup_file does not falsely report success when copy fails"
+fi
+
+# 5d. Symlink target is backed up with -P (preserves symlink)
+link_target="$TMP_ROOT/link_src.json"
+echo '{"link":true}' > "$link_target"
+symlink_path="$TMP_ROOT/symlink.json"
+ln -s "$link_target" "$symlink_path"
+out_5d_file="$TMP_ROOT/out_5d.txt"
+backup_file "$symlink_path" > "$out_5d_file" 2>&1
+out_5d="$(cat "$out_5d_file")"
+if [ -n "$LAST_BACKUP_PATH" ] && [ -L "$LAST_BACKUP_PATH" ]; then
+  ok "backup_file preserves symlink on backup (-P)"
+else
+  bad "backup_file failed to preserve symlink as backup (got: '$LAST_BACKUP_PATH')"
+fi
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "RESULT: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Purpose
This PR fixes `backup_file()` in `scripts/lib/common.sh` to verify that `cp -P` succeeded and that the backup file exists before publishing `LAST_BACKUP_PATH` and announcing success on stdout, preventing phantom backup paths when copies fail (issue #982).

## How to read this PR?
1. Inspect `scripts/lib/common.sh` (`backup_file`) to review the exit status and file existence check.
2. Review `scripts/tests/test-setup-mcp-merge.sh` (section 5) for unit test coverage across normal backups, absent targets, copy failures, and symlinks.

## How to test this PR?
```bash
bash scripts/tests/test-setup-mcp-merge.sh
```

## Detailed description (for agents)
When `cp -P` fails in `backup_file()`, `LAST_BACKUP_PATH` was previously assigned unconditionally and a `Backed up: ...` success message was printed on stdout. Callers relying on `LAST_BACKUP_PATH` (e.g. MCP setup merge routines) then referenced nonexistent backup paths. The helper now validates copy completion, leaves `LAST_BACKUP_PATH` empty on failure, suppresses false success output, and emits a diagnostic warning on stderr.

Closes #982