### PR TITLE
⚡ Scope test strays check to changeset and add static syntax validation (spec 0170, #993)

### DIFF
--- a/scripts/check-test-strays.sh
+++ b/scripts/check-test-strays.sh
@@ -1,24 +1,18 @@
 #!/bin/bash
-# check-test-strays.sh — CI guard for stray commands in test suites (issue #738).
+# check-test-strays.sh — CI guard for stray commands in test suites (issue #738, spec 0170).
 #
 # A script with a stray command line (e.g. `some-bogus-command`) will print
 # `some-bogus-command: command not found` to stderr and, unless `set -e` is
 # active, continue executing. Because tests are wired as `bash <suite>`, a
 # stray command inside one fails without anything consuming its status.
 #
-# The check here uses the runtime form: executing the suites and grepping for
-# the error message. This avoids the ambiguity of parsing bash syntax statically.
-#
-# Optimization (issue #939, spec 0157): the scan is changeset-aware,
-# content-addressed, and parallel. Each suite's verdict is cached under a key
-# derived from the suite's own content plus the content of every non-test file
-# under scripts/ (root-level scripts/*.sh, scripts/lib/**, and any other non-test
-# subdirectory), so a change to any script a suite might invoke invalidates
-# every suite's verdict (R4) while a change to one suite invalidates only that
-# suite (R2/R7). The execution set is ALL suites whose verdict is a cache-miss —
-# never a diff-restricted subset. The git diff against the base ref is used only
-# to short-circuit the "no change" case (skip the scan entirely when the diff
-# over the whole scripts/ tree is empty).
+# Fast validation strategy (spec 0170):
+# 1. Static syntax check (`bash -n`) is run across all test suites in milliseconds.
+# 2. Runtime execution for stray command detection is strictly scoped to the
+#    suites modified or added in the changeset (git diff --name-only <base> HEAD -- scripts/tests/test-*.sh).
+# 3. When no test suites are modified, zero suites are executed at runtime.
+# 4. Changes to non-test scripts under scripts/ do NOT trigger runtime execution
+#    of unchanged test suites.
 #
 # Usage:
 #   bash scripts/check-test-strays.sh [--cache-dir DIR] [--base-ref REF] [--jobs N]
@@ -26,10 +20,9 @@
 # Options:
 #   --cache-dir DIR   Directory for the content-addressed verdict cache
 #                     (default: .ci-cache).
-#   --base-ref REF    Base ref to diff against for the "no change" short-circuit.
+#   --base-ref REF    Base ref to diff against for changeset detection.
 #                     Default: $GITHUB_BASE_REF, then
-#                     $CI_MERGE_REQUEST_TARGET_BRANCH_NAME, then empty (no
-#                     short-circuit; every non-cached suite runs).
+#                     $CI_MERGE_REQUEST_TARGET_BRANCH_NAME.
 #   --jobs N          Maximum number of suites to run in parallel
 #                     (default: the runner's CPU count).
 #
@@ -57,6 +50,24 @@ if [ ! -d "$TESTS_DIR" ]; then
   exit 2
 fi
 
+# --- Collect all test suites ------------------------------------------------
+
+all_suites=()
+for suite in "$TESTS_DIR"/test-*.sh; do
+  [ -f "$suite" ] || continue
+  all_suites+=("$suite")
+done
+
+# --- 1. Static syntax validation across all test suites (spec 0170 R1) -------
+
+for suite in ${all_suites[@]+"${all_suites[@]}"}; do
+  if ! err_out="$(bash -n "$suite" 2>&1)"; then
+    echo "FAILED: $(basename "$suite") has syntax errors:" >&2
+    echo "$err_out" >&2
+    exit 1
+  fi
+done
+
 # --- sha256 helper (portable across Linux/macOS) ----------------------------
 
 sha256() {
@@ -73,55 +84,40 @@ if [ -z "$BASE_REF" ]; then
   BASE_REF="${GITHUB_BASE_REF:-${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}}"
 fi
 
-# --- "no change" short-circuit ----------------------------------------------
-# When the base ref resolves and the merge-base diff over the whole scripts/
-# tree is empty, there is nothing to validate: exit clean without scanning.
-# This is a pure optimization; it never gates which suites run (the execution
-# set below is always the cache-miss set).
+# --- 2. Scope execution to changeset-modified suites (spec 0170 R2-R5) ------
 
+suites=()
 if [ -n "$BASE_REF" ]; then
   if merge_base="$(git -C "$REPO_DIR" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
-    if [ -z "$(git -C "$REPO_DIR" diff --name-only "$merge_base" HEAD -- scripts/)" ]; then
+    changed_files="$(git -C "$REPO_DIR" diff --name-only "$merge_base" HEAD -- scripts/tests/ 2>/dev/null || true)"
+    if [ -z "$changed_files" ]; then
       echo "OK: zero runtime strays across all test suites."
       exit 0
     fi
+    for rel in $changed_files; do
+      abs="$REPO_DIR/$rel"
+      if [ -f "$abs" ] && [[ "$(basename "$abs")" == test-*.sh ]]; then
+        suites+=("$abs")
+      fi
+    done
+    if [ ${#suites[@]} -eq 0 ]; then
+      echo "OK: zero runtime strays across all test suites."
+      exit 0
+    fi
+  else
+    # Fallback if merge-base fails
+    suites=(${all_suites[@]+"${all_suites[@]}"})
   fi
+else
+  # Fallback when no base-ref is provided
+  suites=(${all_suites[@]+"${all_suites[@]}"})
 fi
 
-# --- Collect the suites -----------------------------------------------------
-
-suites=()
-for suite in "$TESTS_DIR"/test-*.sh; do
-  [ -f "$suite" ] || continue
-  suites+=("$suite")
-done
-
-# --- Per-suite content-addressed verdict key --------------------------------
-# The key is sha256(suite content) + sha256 of every non-test file under
-# scripts/ (root-level scripts/*.sh, scripts/lib/**, and any other non-test
-# subdirectory). A change to any script a suite might invoke invalidates every
-# suite's verdict (R4, and the arch-gap closure: a deleted/renamed root-level
-# script a suite calls no longer serves a stale verdict), while a change to one
-# suite invalidates only that suite (R2/R7). The cost is that a change to any
-# non-test script — invoked or not — invalidates all verdicts; accepted in
-# exchange for closing the gap without static parsing.
-
-lib_hash=""
-shopt -s globstar nullglob
-for f in "$REPO_DIR"/scripts/**; do
-  [ -f "$f" ] || continue
-  case "$f" in
-    "$TESTS_DIR"/*) continue ;;
-  esac
-  lib_hash="${lib_hash}$(sha256 "$f" | awk '{print $1}')"
-done
-
-# --- Determine the execution set (all cache-miss suites) ---------------------
+# --- Determine execution set from content-addressed cache -------------------
 
 to_run=()
 for suite in ${suites[@]+"${suites[@]}"}; do
-  suite_hash="$(sha256 "$suite" | awk '{print $1}')"
-  key="$(printf '%s%s' "$suite_hash" "$lib_hash" | sha256 | awk '{print $1}')"
+  key="$(sha256 "$suite" | awk '{print $1}')"
   marker="$CACHE_DIR/$key/$(basename "$suite").marker"
   if [ -f "$marker" ]; then
     echo "check-test-strays: cache hit, skipping $(basename "$suite")" >&2

--- a/scripts/tests/test-check-test-strays.sh
+++ b/scripts/tests/test-check-test-strays.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # test-check-test-strays.sh — Regression tests for scripts/check-test-strays.sh
-# (issue #738)
+# (issue #738, spec 0170)
 
 set -uo pipefail
 
@@ -121,7 +121,7 @@ EOF
   git -C "$repo" commit -qm init
   git -C "$repo" branch -M main
 
-  # A second commit touching only an unrelated path → empty test/lib diff.
+  # A second commit touching only an unrelated path → empty test diff.
   echo "unrelated" > "$repo/README.md"
   git -C "$repo" add README.md
   git -C "$repo" commit -qm unrelated
@@ -145,25 +145,19 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Case d — Cache hit skips re-execution; lib change invalidates all verdicts.
+# Case d — Cache hit skips re-execution on warm cache.
 # ---------------------------------------------------------------------------
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   mk_fixture "$repo"
-  mkdir -p "$repo/scripts/lib"
   cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
 #!/bin/bash
 echo "Everything is fine"
 EOF
   chmod +x "$repo/scripts/tests/test-clean.sh"
-  cat > "$repo/scripts/lib/helper.sh" << 'EOF'
-#!/bin/bash
-helper() { :; }
-EOF
-  cache_dir="$TMP_ROOT/cache-d.XXXXXX"
-  cache_dir="$(mktemp -d "$cache_dir")"
+  cache_dir="$(mktemp -d "$TMP_ROOT/cache-d.XXXXXX")"
 
-  # First run: cold cache, both suites execute and write verdict markers.
+  # First run: cold cache, suite executes and writes verdict marker.
   run_check "$repo" --cache-dir "$cache_dir"
   if [ "$CHECK_EXIT" -eq 0 ]; then
     echo "PASS  case-d: cold run exits 0"
@@ -190,20 +184,6 @@ EOF
     echo "FAIL  case-d: expected cache-hit notice (stderr: $CHECK_STDERR)"
     fail=$((fail + 1))
   fi
-
-  # Change the shared helper → every suite's verdict is invalidated (R4).
-  cat > "$repo/scripts/lib/helper.sh" << 'EOF'
-#!/bin/bash
-helper() { echo "changed"; }
-EOF
-  run_check "$repo" --cache-dir "$cache_dir"
-  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
-    echo "FAIL  case-d: lib change should invalidate the suite verdict"
-    fail=$((fail + 1))
-  else
-    echo "PASS  case-d: lib change invalidates the suite verdict (R4)"
-    pass=$((pass + 1))
-  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -218,7 +198,7 @@ echo "Everything is fine"
 EOF
   chmod +x "$repo/scripts/tests/test-clean.sh"
 
-  # No git repo at all → merge-base fails → fallback to full non-cached scan.
+  # No git repo at all → merge-base fails → fallback to non-cached scan.
   run_check "$repo" --base-ref main
 
   if [ "$CHECK_EXIT" -eq 0 ]; then
@@ -270,75 +250,53 @@ EOF
     fail=$((fail + 1))
   fi
 }
+
 # ---------------------------------------------------------------------------
-# Case g — A change to a root-level scripts/*.sh invalidates a cached verdict
-# (cache-key half of the arch-gap closure).
+# Case g — Static syntax error fails immediately (spec 0170 R1).
 # ---------------------------------------------------------------------------
 {
   repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
   mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-syntax-err.sh" << 'EOF'
+#!/bin/bash
+if [ -f "foo" ; then
+  echo "broken"
+EOF
+  chmod +x "$repo/scripts/tests/test-syntax-err.sh"
+
+  run_check "$repo"
+
+  if [ "$CHECK_EXIT" -eq 1 ]; then
+    echo "PASS  case-g: syntax error fails the check (exit 1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-g: expected exit 1 on syntax error, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  if echo "$CHECK_STDERR" | grep -q "test-syntax-err.sh has syntax errors"; then
+    echo "PASS  case-g: stderr reports syntax error"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-g: stderr did not report syntax error (stderr: $CHECK_STDERR)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case h — Non-test script/helper changes do NOT re-execute unchanged test suites (spec 0170 R4, R5).
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  mkdir -p "$repo/scripts/lib"
   cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
 #!/bin/bash
 echo "Everything is fine"
 EOF
   chmod +x "$repo/scripts/tests/test-clean.sh"
-  cat > "$repo/scripts/foo.sh" << 'EOF'
+  cat > "$repo/scripts/lib/helper.sh" << 'EOF'
 #!/bin/bash
-foo() { :; }
-EOF
-  cache_dir="$(mktemp -d "$TMP_ROOT/cache-g.XXXXXX")"
-
-  # First run: cold cache, suite executes and writes a verdict marker.
-  run_check "$repo" --cache-dir "$cache_dir"
-  if [ "$CHECK_EXIT" -eq 0 ]; then
-    echo "PASS  case-g: cold run exits 0"
-    pass=$((pass + 1))
-  else
-    echo "FAIL  case-g: cold run expected exit 0, got $CHECK_EXIT"
-    fail=$((fail + 1))
-  fi
-
-  # Second run: warm cache, suite unchanged → cache hit.
-  run_check "$repo" --cache-dir "$cache_dir"
-  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
-    echo "PASS  case-g: warm run reports cache hit"
-    pass=$((pass + 1))
-  else
-    echo "FAIL  case-g: expected cache-hit notice (stderr: $CHECK_STDERR)"
-    fail=$((fail + 1))
-  fi
-
-  # Change a root-level script (outside scripts/tests and scripts/lib) → the
-  # suite verdict must be invalidated (arch-gap closure).
-  cat > "$repo/scripts/foo.sh" << 'EOF'
-#!/bin/bash
-foo() { echo "changed"; }
-EOF
-  run_check "$repo" --cache-dir "$cache_dir"
-  if echo "$CHECK_STDERR" | grep -q "cache hit, skipping test-clean.sh"; then
-    echo "FAIL  case-g: root-level script change should invalidate the suite verdict"
-    fail=$((fail + 1))
-  else
-    echo "PASS  case-g: root-level script change invalidates the suite verdict"
-    pass=$((pass + 1))
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# Case h — The broadened short-circuit does not fire on a committed non-test
-# script change (short-circuit half of the arch-gap closure).
-# ---------------------------------------------------------------------------
-{
-  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
-  mk_fixture "$repo"
-  cat > "$repo/scripts/tests/test-stray.sh" << 'EOF'
-#!/bin/bash
-some-bogus-command
-EOF
-  chmod +x "$repo/scripts/tests/test-stray.sh"
-  cat > "$repo/scripts/foo.sh" << 'EOF'
-#!/bin/bash
-foo() { :; }
+helper() { :; }
 EOF
   git -C "$repo" init -q
   git -C "$repo" config user.email test@example.com
@@ -349,31 +307,78 @@ EOF
   git -C "$repo" branch -M main
   init_sha="$(git -C "$repo" rev-parse HEAD)"
 
-  # Commit a change to a root-level script only (no test/lib change). The
-  # broadened short-circuit diffs the whole scripts/ tree, so it must NOT fire;
-  # the scan runs and detects the stray (exit 1). If the short-circuit were
-  # still scoped to scripts/tests + scripts/lib, it would fire and exit 0.
-  cat > "$repo/scripts/foo.sh" << 'EOF'
+  # Modify helper script only (no changes under scripts/tests/).
+  cat > "$repo/scripts/lib/helper.sh" << 'EOF'
 #!/bin/bash
-foo() { echo "changed"; }
+helper() { echo "updated"; }
 EOF
-  git -C "$repo" add scripts/foo.sh
-  git -C "$repo" commit -qm change-root-script
+  git -C "$repo" add scripts/lib/helper.sh
+  git -C "$repo" commit -qm change-helper
+
+  run_check "$repo" --base-ref "$init_sha"
+
+  if [ "$CHECK_EXIT" -eq 0 ]; then
+    echo "PASS  case-h: non-test helper change does not execute test suites (exit 0)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-h: expected exit 0, got $CHECK_EXIT"
+    fail=$((fail + 1))
+  fi
+  if echo "$CHECK_STDOUT" | grep -qF "zero runtime strays across all test suites"; then
+    echo "PASS  case-h: OK line emitted"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  case-h: missing OK line (stdout: $CHECK_STDOUT)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case i — Changeset-scoped execution runs only the modified test suite.
+# ---------------------------------------------------------------------------
+{
+  repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+  mk_fixture "$repo"
+  cat > "$repo/scripts/tests/test-clean.sh" << 'EOF'
+#!/bin/bash
+echo "Clean suite"
+EOF
+  cat > "$repo/scripts/tests/test-stray.sh" << 'EOF'
+#!/bin/bash
+echo "Old clean suite"
+EOF
+  chmod +x "$repo/scripts/tests/test-clean.sh" "$repo/scripts/tests/test-stray.sh"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name test
+  git -C "$repo" config commit.gpgsign false
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm init
+  git -C "$repo" branch -M main
+  init_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  # Introduce a stray into test-stray.sh ONLY
+  cat > "$repo/scripts/tests/test-stray.sh" << 'EOF'
+#!/bin/bash
+some-bogus-command
+EOF
+  git -C "$repo" add scripts/tests/test-stray.sh
+  git -C "$repo" commit -qm add-stray
 
   run_check "$repo" --base-ref "$init_sha"
 
   if [ "$CHECK_EXIT" -eq 1 ]; then
-    echo "PASS  case-h: short-circuit does not fire on a root-level script change (scan ran, exit 1)"
+    echo "PASS  case-i: modified suite with stray fails the check (exit 1)"
     pass=$((pass + 1))
   else
-    echo "FAIL  case-h: expected exit 1 (scan ran and found the stray), got $CHECK_EXIT"
+    echo "FAIL  case-i: expected exit 1, got $CHECK_EXIT"
     fail=$((fail + 1))
   fi
   if echo "$CHECK_STDERR" | grep -q "test-stray.sh has 1 stray.*errors"; then
-    echo "PASS  case-h: stderr names the stray suite and count"
+    echo "PASS  case-i: stderr names the modified stray suite"
     pass=$((pass + 1))
   else
-    echo "FAIL  case-h: stderr did not name test-stray.sh (stderr: $CHECK_STDERR)"
+    echo "FAIL  case-i: stderr did not name test-stray.sh (stderr: $CHECK_STDERR)"
     fail=$((fail + 1))
   fi
 }
@@ -384,5 +389,3 @@ total=$((pass + fail))
 echo ""
 echo "Results: $pass/$total passed"
 [ "$fail" -eq 0 ] && exit 0 || exit 1
-
-# ---------------------------------------------------------------------------

--- a/specs/0170-efficient-test-strays-guard.md
+++ b/specs/0170-efficient-test-strays-guard.md
@@ -1,7 +1,7 @@
 ---
 id: "0170"
 slug: efficient-test-strays-guard
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 993


### PR DESCRIPTION
Resolves #993. Implements specification [0170](specs/0170-efficient-test-strays-guard.md).

The `test-wiring` CI job's `Check Test Strays` step (`scripts/check-test-strays.sh`) previously executed all 75+ test suites at runtime whenever any non-test file under `scripts/` changed, causing nearly 4 minutes of redundant execution on 2-vCPU CI runners even though test suites are already executed in their dedicated capability jobs. This PR refactors `scripts/check-test-strays.sh` to perform fast static syntax validation (`bash -n`) across all test suites in milliseconds, while strictly scoping runtime execution (`command not found` check) to test suites modified or added in the changeset (`scripts/tests/test-*.sh`). Modifications to non-test scripts and shared libraries under `scripts/` no longer invalidate unchanged test suites, reducing standard PR run times from ~4 minutes to ~2 seconds.

## How to read this PR?
1. `scripts/check-test-strays.sh`: Adds static syntax validation (`bash -n`) across all test suites, scopes runtime execution to changeset-modified suites (`scripts/tests/test-*.sh`), and removes global `lib_hash` invalidation.
2. `scripts/tests/test-check-test-strays.sh`: Updates regression test cases to verify static syntax check on broken scripts, short-circuit on non-test file changes, and changeset-scoped stray detection.
3. `specs/0170-efficient-test-strays-guard.md`: Transitions status from `approved` to `implemented`.

## How to test this PR?
```bash
bash scripts/tests/test-check-test-strays.sh
bash scripts/check-test-strays.sh --base-ref crewrig/main
bash scripts/check-bash32-portability.sh
bash scripts/check-test-wiring.sh
bash scripts/check-ci-parity.sh
```

## Detailed description (for agents)
- Implemented static syntax pass `bash -n` across all test suites under `scripts/tests/test-*.sh` in `scripts/check-test-strays.sh`.
- Scoped changeset detection to `scripts/tests/test-*.sh`, running runtime checks only on modified/added test suites.
- Verified 19/19 test cases pass in `scripts/tests/test-check-test-strays.sh`.
- Verified Bash 3.2 portability.
