### PR TITLE
📝 Spec 0182: Transition status approved -> implemented

### DIFF
--- a/specs/0182-test-mcp-daemon-fake-server-readiness.md
+++ b/specs/0182-test-mcp-daemon-fake-server-readiness.md
@@ -1,7 +1,7 @@
 ---
 id: "0182"
 slug: test-mcp-daemon-fake-server-readiness
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 983


### PR DESCRIPTION
Transitions `specs/0182-test-mcp-daemon-fake-server-readiness.md` from `status: approved` to `status: implemented` following the merge of implementation PR #1039 (resolving issue #983).

## How to read this PR?

Inspect the frontmatter of `specs/0182-test-mcp-daemon-fake-server-readiness.md` where `status` is transitioned to `implemented`.

## How to test this PR?

Run `node scripts/lib/spec-linter.js specs/0182-test-mcp-daemon-fake-server-readiness.md`.

## Detailed description (for agents)

- Transition metadata-only: `status: approved` -> `status: implemented` for spec 0182.
