### PR TITLE
🐛 Batch: incidental lifecycle findings (spec 0186, issue #1028)

### DIFF
--- a/.github/workflows/release-monorepo.yml
+++ b/.github/workflows/release-monorepo.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags-ignore:
       - "**"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/docs/plan-review-protocol.md
+++ b/docs/plan-review-protocol.md
@@ -39,7 +39,12 @@ section before listing any new findings. The audit section SHALL
 enumerate every reviewer-minted ID (`v<N>-F<M>`) raised across all prior
 review passes and state its disposition in the revised plan: *addressed*,
 *superseded*, or *withdrawn with reason*. Any unaddressed prior finding
-SHALL cause the review pass to return a `### Verdict: REQUEST CHANGES`.
+whose class or severity warrants a plan revision SHALL cause the review
+pass to return a `### Verdict: REQUEST CHANGES`. Non-blocking prior-finding
+residue (e.g. wording corrections or mechanical adjustments that do not
+alter the architectural approach) MAY instead be disposed as DEV-routed named
+edits recorded directly in the review verdict without consuming a revision
+iteration.
 
 **On this surface the two clauses above already discharge the seat
 contract's finding-identifier, disposition-record and audit obligations.**
@@ -59,7 +64,7 @@ for id in <review-comment-ids>; do
   gh api repos/crewrig/crewrig/issues/comments/$id --jq .body | grep -c '^\*\*Finding '
 done
 # Count rows in the plan comment's traceability table
-grep -c '^| v[0-9]* | [0-9]' <plan-comment>
+grep -c '^| v[0-9]* | v[0-9]*-F[0-9]*' <plan-comment>
 ```
 
 **Finding class taxonomy.** Every plan-review finding SHALL carry
@@ -92,11 +97,20 @@ and team sizing* table, not restated here). On halt, the orchestrator
 SHALL post a structured summary on the logbook issue and escalate to
 the user regardless of interaction mode; it SHALL NOT auto-approve the
 halted plan, and the loop resumes only on explicit user instruction,
-which MAY lift the cap for that ticket (R3–R4 of spec 0138). A review
-returned for retagging — a malformed verdict per `docs/plan-format.md`
-→ *Finding tag schema* and `docs/retroactive-loop.md` → *Class tagging
-discipline* — does not count as a revision (R5 of spec 0138). A plan
-approved on its first cold review consumes zero revisions.
+which MAY lift the cap for that ticket (R3–R4 of spec 0138).
+
+The cap counts verdicts that send a plan back for revision; arbitration
+folds, message-crossing splits, and reviews returned for retagging — a
+malformed verdict per `docs/plan-format.md` → *Finding tag schema* and
+`docs/retroactive-loop.md` → *Class tagging discipline* — do not count as
+revisions (R5 of spec 0138). A plan approved on its first cold review
+consumes zero revisions.
+
+When a plan review routes an iteration out to the SPECS stage for
+delta-spec authoring (via a `class: spec` finding), the resulting approved
+delta-spec establishes a new specification baseline. Returning to the PLAN
+stage initiates a fresh planning cycle against that revised baseline and
+resets the PLAN-revision counter to zero for the new iteration.
 
 These clauses bound the plan's size and the loop's length; they remove no item from the reviewer's checklist at any tier.
 

--- a/docs/pr-format.md
+++ b/docs/pr-format.md
@@ -31,3 +31,17 @@ Include prerequisites, commands to run, and expected outcomes.>
 This section is intended for AI agents that will analyze the PR.
 Be explicit about what was added, modified, or removed and why.>
 ```
+
+## Continuous Integration directives
+
+GitHub concatenates all branch commit bodies into the default squash commit
+message when merging a PR. Continuous integration platforms (including GitHub
+Actions) honor skip directives (such as `[skip ci]`, `[ci skip]`, `[skip actions]`)
+appearing **anywhere** within a push commit message on `main`.
+
+**Rule — never write unescaped CI skip directives.** Branch commit messages and
+PR bodies SHALL NOT contain literal unescaped CI skip directives (e.g. `[skip ci]`).
+When referring to CI skip behaviors in prose, documentation, or commit descriptions,
+always use an escaped or descriptive form (such as `skip-ci` or `[skip-ci]`) to
+prevent accidental suppression of build, test, analysis, and release pipelines
+on `main`.

--- a/docs/retroactive-loop.md
+++ b/docs/retroactive-loop.md
@@ -120,6 +120,12 @@ The re-spawn columns are minimums. Every re-spawn SHALL apply the
 Security rule* if the touched surface qualifies; the engine does not
 override the rule, it inherits it.
 
+**Delta-spec baseline reset.** When a `spec`-class iteration produces
+and merges a new delta-spec PR, the return to the PLAN stage initiates a
+fresh planning baseline against the amended specification: the PLAN-revision
+counter resets to zero for that subsequent iteration (per
+[`docs/plan-review-protocol.md`](plan-review-protocol.md) → *PLAN-loop cap*).
+
 ## Class tagging discipline
 
 Every reviewer finding SHALL carry exactly one `class:` field whose

--- a/scripts/check-bash32-portability.sh
+++ b/scripts/check-bash32-portability.sh
@@ -253,7 +253,7 @@ HITS="$( printf '%s\n' "$RAW" \
          | grep -v 'acknowledged-exception:' || true )"
 
 if [ -n "$HITS" ]; then
-  hits_count="$(printf '%s\n' "$HITS" | wc -l | tr -d '[:space:]')"
+  hits_count="$(printf '%s\n' "$HITS" | grep -c . | tr -d '[:space:]')"
   echo "FAILED: $hits_count line(s) use a forbidden Bash 4+ construct:" >&2
   echo "" >&2
   printf '%s\n' "$HITS" >&2
@@ -279,7 +279,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 array_guard_scan "$REPO_DIR"
 if [ -n "$ARRAY_GUARD_HITS" ]; then
-  ag_hits_count="$(printf '%s\n' "$ARRAY_GUARD_HITS" | wc -l | tr -d '[:space:]')"
+  ag_hits_count="$(printf '%s\n' "$ARRAY_GUARD_HITS" | grep -c . | tr -d '[:space:]')"
   echo "FAILED: $ag_hits_count array value expansion(s) are unguarded:" >&2
   echo "" >&2
   printf '%s\n' "$ARRAY_GUARD_HITS" >&2

--- a/scripts/tests/test-palace-path-propagation.sh
+++ b/scripts/tests/test-palace-path-propagation.sh
@@ -32,7 +32,10 @@ assert_eq() {
 assert_contains() {
   local haystack="$1" needle="$2" label="$3"
   TESTS_RUN=$((TESTS_RUN + 1))
-  if echo "$haystack" | grep -Fq -e "$needle"; then
+  # Pure-bash containment: `echo | grep -Fq` under pipefail turns an EARLY
+  # match into a false FAIL — grep exits on match, echo takes SIGPIPE (141),
+  # and pipefail reports the pipeline failed.
+  if [[ "$haystack" == *"$needle"* ]]; then
     echo "  PASS: $label"
     TESTS_PASSED=$((TESTS_PASSED + 1))
   else
@@ -45,7 +48,7 @@ assert_contains() {
 assert_not_contains() {
   local haystack="$1" needle="$2" label="$3"
   TESTS_RUN=$((TESTS_RUN + 1))
-  if ! echo "$haystack" | grep -Fq -e "$needle"; then
+  if [[ "$haystack" != *"$needle"* ]]; then
     echo "  PASS: $label"
     TESTS_PASSED=$((TESTS_PASSED + 1))
   else

--- a/specs/0186-incidental-lifecycle-findings-batch.md
+++ b/specs/0186-incidental-lifecycle-findings-batch.md
@@ -1,7 +1,7 @@
 ---
 id: "0186"
 slug: incidental-lifecycle-findings-batch
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 1028


### PR DESCRIPTION
Resolves the batch of incidental findings from recent lifecycle executions qualifying spec 0186 (issue #1028). This corrects failure counts in the Bash 3.2 portability checker, aligns the plan review countable invariant grep pattern, fixes broken pipe risks in Palace test assertions, documents lifecycle loop cap resets across delta-spec excursions and non-blocking residue handling, adds a manual workflow dispatch trigger to the monorepo release workflow, and formalizes CI skip directive escaping conventions.

## How to read this PR?

1. Start with `scripts/check-bash32-portability.sh` and `scripts/tests/test-palace-path-propagation.sh` for the test and tooling improvements.
2. Read `docs/plan-review-protocol.md`, `docs/retroactive-loop.md`, and `docs/pr-format.md` for the lifecycle and contribution rule clarifications.
3. Check `.github/workflows/release-monorepo.yml` for the `workflow_dispatch` trigger.
4. Verify `specs/0186-incidental-lifecycle-findings-batch.md` transitions to `status: implemented`.

## How to test this PR?

Run the test suite and portability check:
```bash
bash scripts/tests/test-palace-path-propagation.sh
bash scripts/check-bash32-portability.sh
```

Run markdownlint:
```bash
npx markdownlint-cli "docs/plan-review-protocol.md" "docs/retroactive-loop.md" "docs/pr-format.md"
```

## Detailed description (for agents)

- `scripts/check-bash32-portability.sh`: Uses `grep -c .` instead of `wc -l` to count non-empty lines accurately for `hits_count` and `ag_hits_count`.
- `scripts/tests/test-palace-path-propagation.sh`: Replaces `echo "$haystack" | grep -Fq` in `assert_contains` and `assert_not_contains` with pure-bash substring containment `[[ "$haystack" == *"$needle"* ]]` to prevent SIGPIPE termination under `set -o pipefail`.
- `docs/plan-review-protocol.md`: Updates the countable invariant grep command to match `v<N>-F<M>` finding IDs (`grep -c '^| v[0-9]* | v[0-9]*-F[0-9]*'`), reconciles the prior-finding traceability rule with DEV-routed named edits for non-blocking residue, and documents that returning from a delta-spec excursion resets the PLAN-revision counter.
- `docs/retroactive-loop.md`: Adds the delta-spec baseline reset note explaining that a delta-spec merge establishes a fresh planning baseline with a reset revision counter.
- `.github/workflows/release-monorepo.yml`: Adds `workflow_dispatch:` trigger under `on:` to enable manual release workflow execution.
- `docs/pr-format.md`: Adds the Continuous Integration directives section prohibiting unescaped CI skip markers (e.g. `[skip-ci]`) in branch commit messages and PR bodies.
- `specs/0186-incidental-lifecycle-findings-batch.md`: Updates status to `implemented`.