### PR TITLE
🐛 Batch: four reviewer-seat documentation and dossier recipe refinements (spec 0188, issue #1054)

### DIFF
--- a/docs/reviewer-seat.md
+++ b/docs/reviewer-seat.md
@@ -134,17 +134,17 @@ surface — not only on `plan`:
 # every query below: a copy per query is a copy that can drift out of step.
 SEAT='(?m)^seat: (specs|plan|review)/[0-9]+(#[0-9]+)?[ \t]*\r?$'
 
-# every surface — the logbook issue
+# every surface — the logbook issue (guarded against unset SEAT)
 gh issue view <ticket> --json comments \
-  --jq "[.comments[] | select(.body | test(\"$SEAT\"))]"
+  --jq "[.comments[] | select(.body | test(\"${SEAT:-(?m)^seat: (specs|plan|review)/[0-9]+(#[0-9]+)?[ \\t]*\\r?$}\"))]"
 
 # a pull-request surface, additionally — both PR transports.
 # Mind the accessor: the reviews endpoint returns a top-level array, so
 # `.comments[]` errors against it.
 gh pr view <pr> --json comments \
-  --jq "[.comments[] | select(.body | test(\"$SEAT\"))]"
+  --jq "[.comments[] | select(.body | test(\"${SEAT:-(?m)^seat: (specs|plan|review)/[0-9]+(#[0-9]+)?[ \\t]*\\r?$}\"))]"
 gh api repos/<owner>/<repo>/pulls/<pr>/reviews \
-  --jq "[.[] | select(.body | test(\"$SEAT\"))]"
+  --jq "[.[] | select(.body | test(\"${SEAT:-(?m)^seat: (specs|plan|review)/[0-9]+(#[0-9]+)?[ \\t]*\\r?$}\"))]"
 ```
 
 **The filter belongs on every query, not just the first.** It is what makes
@@ -197,8 +197,10 @@ point, whereas a *valid* verdict whose seat line picked up a stray space or
 a `\r` would silently drop its seat's entire dossier and present as a false
 vacancy. So the pattern absorbs trailing blanks and an optional carriage
 return, and nothing else — an annotation still begins with a visible
-character and is still excluded. Where the orchestrator cannot edit the artifact — a distinct
-posting identity, or a permission refusal — the record described under
+character and is still excluded.
+
+Where the orchestrator cannot edit the artifact — a distinct posting
+identity, or a permission refusal — the record described under
 *Prior-finding disposition* names the voided verdict instead, and a
 reconstructing pass consults it before counting passes. Either way the
 discriminator is a forge artifact.
@@ -208,6 +210,13 @@ seat: the seat is unchanged and one of its passes is void. Generations
 replace a seat (*Retirement and generation*); they do not invalidate a
 single pass, and overloading them for that would make a seat key stop
 denoting a seat.
+
+**Pass ordinal on the `specs` surface.** On the `specs` surface, finding
+identifiers `s<N>-F<M>` key `<N>` to the seat's pass ordinal. When a
+single review pass emits multiple dossier comments (such as a primary
+verdict followed by an addendum or continuation comment on the same
+pass), those entries belong to that single pass and SHALL NOT inflate the
+pass ordinal for subsequent passes.
 
 ## Instantiating a seated pass
 
@@ -221,8 +230,11 @@ The brief that instantiates a seated pass carries **references only**:
   disposition*.
 
 It carries no diff, no summary, no assessment, no rationale, and no other
-content that originates in the authoring session. A seated pass retrieves
-every artifact it reads itself, from the forge's own command-line tool.
+content that originates in the authoring session. It SHALL NOT characterize,
+summarize, or interpret the contents, status, or relationships of the
+referenced records (e.g. asserting whether prior comments supersede each
+other or what a prior finding concluded). A seated pass retrieves every
+artifact it reads itself, from the forge's own command-line tool.
 
 **The cold-start independence guarantee is unchanged**
 ([`artifacts/core/agents/pr-reviewer/AGENT.md`](../artifacts/core/agents/pr-reviewer/AGENT.md)

--- a/specs/0188-reviewer-seat-refinements.md
+++ b/specs/0188-reviewer-seat-refinements.md
@@ -1,7 +1,7 @@
 ---
 id: "0188"
 slug: reviewer-seat-refinements
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 1054


### PR DESCRIPTION
Resolves the batch of four promoted findings from the findings ledger (#961) originating from ticket #970 qualifying spec 0188 (issue #1054). This isolates the non-editable artifact fallback rule in `docs/reviewer-seat.md` into its own paragraph, guards dossier query recipes against unset shell variables, clarifies pass ordinal counting across multi-entry passes on the `specs` surface, and formalizes that seated pass instantiation briefs shall not characterize referenced artifacts.

## How to read this PR?

1. Read `docs/reviewer-seat.md` around lines 134-235 to review the recipe guard and contract additions.
2. Verify `specs/0188-reviewer-seat-refinements.md` transitions to `status: implemented`.

## How to test this PR?

Run markdownlint on modified files:
```bash
npx markdownlint-cli "docs/reviewer-seat.md" "specs/0188-reviewer-seat-refinements.md"
```

## Detailed description (for agents)

- `docs/reviewer-seat.md`:
  - Splits the voiding paragraph into two distinct paragraphs, separating the whitespace tolerance rationale from the non-editable artifact fallback rule and re-wrapping under 80 chars.
  - Adds `${SEAT:-...}` default fallback expressions to the dossier reconstruction shell query recipes.
  - Clarifies that multiple dossier comments belonging to the same evaluation pass on the `specs` surface correspond to a single pass ordinal.
  - Explicitly prohibits characterization, summarization, or interpretation of referenced artifacts in seated pass briefs.
- `specs/0188-reviewer-seat-refinements.md`: Transitions status from `approved` to `implemented`.