### PR TITLE
✨ Scope logbook label to dedicated logbook issues in pr-logbook (spec 0190, issue #1063)

### DIFF
--- a/.agents/skills/pr-logbook/SKILL.md
+++ b/.agents/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.3.0"
+    version: "1.3.1"
 ---
 
 
@@ -80,12 +80,13 @@ an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
    (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
    server, so a host-provided one is an optional convenience, not the
    default.
-2. Ensure the issue carries the `logbook` label — add it with
-   `gh issue edit <N> --add-label logbook` if absent.
+2. The feature issue **IS** the logbook (`AGENTS.md` → *Logbook Issues → Rule A*).
+   Do not add the `logbook` label to a pre-existing feature issue.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
 
 A standalone logbook issue is only warranted when the PR has no upstream
 feature ticket (hotfix, dependency bump, automation run with no prior ticket).
+A dedicated logbook issue uses the `logbook` label (`gh issue create ... --label logbook`).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimize for that reader.

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.3.0"
+    version: "1.3.1"
 ---
 
 
@@ -84,12 +84,13 @@ an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
    (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
    server, so a host-provided one is an optional convenience, not the
    default.
-2. Ensure the issue carries the `logbook` label — add it with
-   `gh issue edit <N> --add-label logbook` if absent.
+2. The feature issue **IS** the logbook (`AGENTS.md` → *Logbook Issues → Rule A*).
+   Do not add the `logbook` label to a pre-existing feature issue.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
 
 A standalone logbook issue is only warranted when the PR has no upstream
 feature ticket (hotfix, dependency bump, automation run with no prior ticket).
+A dedicated logbook issue uses the `logbook` label (`gh issue create ... --label logbook`).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimize for that reader.

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.3.0"
+    version: "1.3.1"
 ---
 
 
@@ -80,12 +80,13 @@ an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
    (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
    server, so a host-provided one is an optional convenience, not the
    default.
-2. Ensure the issue carries the `logbook` label — add it with
-   `gh issue edit <N> --add-label logbook` if absent.
+2. The feature issue **IS** the logbook (`AGENTS.md` → *Logbook Issues → Rule A*).
+   Do not add the `logbook` label to a pre-existing feature issue.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
 
 A standalone logbook issue is only warranted when the PR has no upstream
 feature ticket (hotfix, dependency bump, automation run with no prior ticket).
+A dedicated logbook issue uses the `logbook` label (`gh issue create ... --label logbook`).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimize for that reader.

--- a/.github/skills/pr-logbook/SKILL.md
+++ b/.github/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"
     feedback: "https://github.com/crewrig/crewrig"
-    version: "1.3.0"
+    version: "1.3.1"
 ---
 
 
@@ -80,12 +80,13 @@ an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
    (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
    server, so a host-provided one is an optional convenience, not the
    default.
-2. Ensure the issue carries the `logbook` label — add it with
-   `gh issue edit <N> --add-label logbook` if absent.
+2. The feature issue **IS** the logbook (`AGENTS.md` → *Logbook Issues → Rule A*).
+   Do not add the `logbook` label to a pre-existing feature issue.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
 
 A standalone logbook issue is only warranted when the PR has no upstream
 feature ticket (hotfix, dependency bump, automation run with no prior ticket).
+A dedicated logbook issue uses the `logbook` label (`gh issue create ... --label logbook`).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimize for that reader.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -699,6 +699,7 @@ jobs:
               - 'scripts/tests/test-assembly-verification.sh'
               - 'scripts/tests/test-artifact-build-install-scope.sh'
               - 'scripts/tests/test-component-tier-resolution.sh'
+              - 'scripts/tests/test-pr-logbook-label-scope.sh'
               - 'scripts/lib/**'
               - 'artifacts/**'
       - name: Install yq
@@ -724,6 +725,9 @@ jobs:
       - name: Test Component Tier Resolution
         if: steps.filter.outputs.frontmatter == 'true'
         run: bash scripts/tests/test-component-tier-resolution.sh
+      - name: Test PR Logbook Label Scope
+        if: steps.filter.outputs.frontmatter == 'true'
+        run: bash scripts/tests/test-pr-logbook-label-scope.sh
   markdown-links:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -649,6 +649,7 @@ frontmatter:
     - "bash scripts/tests/test-assembly-verification.sh"
     - "bash scripts/tests/test-artifact-build-install-scope.sh"
     - "bash scripts/tests/test-component-tier-resolution.sh"
+    - "bash scripts/tests/test-pr-logbook-label-scope.sh"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main$|^release\//'
       changes:
@@ -658,6 +659,7 @@ frontmatter:
         - "scripts/tests/test-assembly-verification.sh"
         - "scripts/tests/test-artifact-build-install-scope.sh"
         - "scripts/tests/test-component-tier-resolution.sh"
+        - "scripts/tests/test-pr-logbook-label-scope.sh"
         - "scripts/lib/**"
         - "artifacts/**"
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^main$|^release\//'
@@ -668,6 +670,7 @@ frontmatter:
         - "scripts/tests/test-assembly-verification.sh"
         - "scripts/tests/test-artifact-build-install-scope.sh"
         - "scripts/tests/test-component-tier-resolution.sh"
+        - "scripts/tests/test-pr-logbook-label-scope.sh"
         - "scripts/lib/**"
         - "artifacts/**"
 

--- a/artifacts/core/skills/pr-logbook/SKILL.md
+++ b/artifacts/core/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${CANONICAL_REPO}"
-    version: "1.3.0"
+    version: "1.3.1"
 claude:
   allowed-tools:
     - Read
@@ -88,12 +88,13 @@ an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
    (`AGENTS.md` → *Forge Access*); the framework ships no forge MCP
    server, so a host-provided one is an optional convenience, not the
    default.
-2. Ensure the issue carries the `logbook` label — add it with
-   `gh issue edit <N> --add-label logbook` if absent.
+2. The feature issue **IS** the logbook (`AGENTS.md` → *Logbook Issues → Rule A*).
+   Do not add the `logbook` label to a pre-existing feature issue.
 3. Do **not** create a new logbook issue. The feature ticket is the logbook.
 
 A standalone logbook issue is only warranted when the PR has no upstream
 feature ticket (hotfix, dependency bump, automation run with no prior ticket).
+A dedicated logbook issue uses the `logbook` label (`gh issue create ... --label logbook`).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimize for that reader.

--- a/ci/ci-capabilities.yml
+++ b/ci/ci-capabilities.yml
@@ -707,6 +707,7 @@ capabilities:
           - "scripts/tests/test-assembly-verification.sh"
           - "scripts/tests/test-artifact-build-install-scope.sh"
           - "scripts/tests/test-component-tier-resolution.sh"
+          - "scripts/tests/test-pr-logbook-label-scope.sh"
           - "scripts/lib/**"
           - "artifacts/**"
       - on: push
@@ -718,6 +719,7 @@ capabilities:
           - "scripts/tests/test-assembly-verification.sh"
           - "scripts/tests/test-artifact-build-install-scope.sh"
           - "scripts/tests/test-component-tier-resolution.sh"
+          - "scripts/tests/test-pr-logbook-label-scope.sh"
           - "scripts/lib/**"
           - "artifacts/**"
     portability: portable
@@ -731,6 +733,7 @@ capabilities:
       - bash scripts/tests/test-assembly-verification.sh
       - bash scripts/tests/test-artifact-build-install-scope.sh
       - bash scripts/tests/test-component-tier-resolution.sh
+      - bash scripts/tests/test-pr-logbook-label-scope.sh
 
   - id: markdown-links
     name: "Check relative Markdown link integrity"

--- a/scripts/tests/test-pr-logbook-label-scope.sh
+++ b/scripts/tests/test-pr-logbook-label-scope.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# test-pr-logbook-label-scope.sh — Regression test for spec 0190 (issue #1063).
+#
+# Verifies that pr-logbook skill instructions:
+#   1. Do not instruct adding the `logbook` label to pre-existing feature issues.
+#   2. Instruct creating dedicated logbook issues with the `logbook` label.
+#   3. Carry version 1.3.1 in source and across all compiled CLI outputs.
+#   4. Have zero compilation drift across .claude, .gemini, .github, .agents.
+#
+# Usage:
+#   bash scripts/tests/test-pr-logbook-label-scope.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS  $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $desc"
+    echo "      expected: '$expected'"
+    echo "      actual:   '$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1"
+  local needle="$2"
+  local haystack="$3"
+  if echo "$haystack" | grep -Fq -- "$needle"; then
+    echo "PASS  $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $desc"
+    echo "      expected to contain: '$needle'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1"
+  local needle="$2"
+  local haystack="$3"
+  if echo "$haystack" | grep -Fq -- "$needle"; then
+    echo "FAIL  $desc"
+    echo "      expected NOT to contain: '$needle'"
+    fail=$((fail + 1))
+  else
+    echo "PASS  $desc"
+    pass=$((pass + 1))
+  fi
+}
+
+echo "=== Testing Spec 0190: pr-logbook label scope ==="
+
+# 1. Source skill checks
+SOURCE_SKILL="$REPO_ROOT/artifacts/core/skills/pr-logbook/SKILL.md"
+if [ ! -f "$SOURCE_SKILL" ]; then
+  echo "FATAL: cannot find $SOURCE_SKILL" >&2
+  exit 2
+fi
+
+SOURCE_CONTENT="$(cat "$SOURCE_SKILL")"
+
+assert_not_contains "Source skill does not instruct unconditional add-label logbook" \
+  "--add-label logbook" "$SOURCE_CONTENT"
+
+assert_contains "Source skill explicitly forbids adding logbook label to feature issues" \
+  "Do not add the \`logbook\` label to a pre-existing feature issue." "$SOURCE_CONTENT"
+
+assert_contains "Source skill specifies --label logbook for dedicated logbook issues" \
+  "--label logbook" "$SOURCE_CONTENT"
+
+assert_contains "Source skill version bumped to 1.3.1" \
+  'version: "1.3.1"' "$SOURCE_CONTENT"
+
+# 2. Check compiled files across all 4 CLIs
+for cli_dir in .claude .gemini .github .agents; do
+  cli_path="$REPO_ROOT/$cli_dir/skills/pr-logbook/SKILL.md"
+  cli_name="$cli_dir"
+  if [ ! -f "$cli_path" ]; then
+    echo "FAIL  Compiled skill for $cli_name exists at $cli_path"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  content="$(cat "$cli_path")"
+  assert_not_contains "Compiled skill ($cli_name) does not instruct add-label logbook" \
+    "--add-label logbook" "$content"
+
+  assert_contains "Compiled skill ($cli_name) forbids logbook label on feature issues" \
+    "Do not add the \`logbook\` label to a pre-existing feature issue." "$content"
+
+  assert_contains "Compiled skill ($cli_name) carries version 1.3.1" \
+    'version: "1.3.1"' "$content"
+done
+
+# 3. Check build components check (zero drift)
+if (cd "$REPO_ROOT" && bash scripts/build-components.sh --check >/dev/null 2>&1); then
+  echo "PASS  build-components --check reports zero drift"
+  pass=$((pass + 1))
+else
+  echo "FAIL  build-components --check reported drift"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "Results: $pass passed, $fail failed."
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/specs/0190-pr-logbook-label-scope.md
+++ b/specs/0190-pr-logbook-label-scope.md
@@ -1,7 +1,7 @@
 ---
 id: "0190"
 slug: pr-logbook-label-scope
-status: approved
+status: implemented
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 1063


### PR DESCRIPTION
This pull request updates the `pr-logbook` skill to scope the `logbook` label exclusively to dedicated logbook issues, aligning with `AGENTS.md` Rule A. It removes the unconditional instruction to add the `logbook` label to pre-existing feature issues that serve as their own logbook.

Closes #1063

## How to read this PR?

- Start with `artifacts/core/skills/pr-logbook/SKILL.md` Section 4 to review the updated logbook guidance and version bump to `1.3.1`.
- Inspect the synchronized build outputs in `.claude/`, `.gemini/`, `.github/`, and `.agents/`.
- Review the new regression test suite in `scripts/tests/test-pr-logbook-label-scope.sh`.
- Confirm `specs/0190-pr-logbook-label-scope.md` status is updated to `implemented`.

## How to test this PR?

1. Run `bash scripts/tests/test-pr-logbook-label-scope.sh` and verify all 17 assertions pass.
2. Run `bash scripts/build-components.sh --check` and verify zero drift.
3. Run `bash scripts/check-skill-versions.sh crewrig/main` and verify the version bump passes.

## Detailed description (for agents)

- **Modified** — `artifacts/core/skills/pr-logbook/SKILL.md`:
  - Bumped `metadata.provenance.version` from `1.3.0` to `1.3.1`.
  - Replaced step 2 in Section 4 (*Logbook entries*) with explicit instruction that the feature issue IS the logbook without receiving a `logbook` label (Rule A).
  - Clarified standalone logbook issue instructions to explicitly note `--label logbook`.
- **Generated** — Rebuilt `.claude/skills/pr-logbook/SKILL.md`, `.gemini/skills/pr-logbook/SKILL.md`, `.github/skills/pr-logbook/SKILL.md`, and `.agents/skills/pr-logbook/SKILL.md`.
- **Added** — `scripts/tests/test-pr-logbook-label-scope.sh` asserting compliance and zero drift.
- **Updated** — `specs/0190-pr-logbook-label-scope.md` status flipped from `approved` to `implemented`.