### PR TITLE
🐛 Describe four supported CLIs in introduction.md and concepts.md (#1068)

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -5,7 +5,8 @@
 Skills, agents, and commands are CrewRig's reusable agent capabilities. The
 core idea is **author once, compile everywhere**: you write a single Markdown
 source file with YAML frontmatter, and `scripts/build-components.sh` generates
-the tool-specific outputs for Gemini CLI, Claude Code, and GitHub Copilot CLI.
+the tool-specific outputs for Gemini CLI, Claude Code, GitHub Copilot CLI, and
+Antigravity CLI.
 This page is the conceptual overview; the normative format contract lives in
 [`artifacts/FORMAT.md`](../artifacts/FORMAT.md).
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -22,12 +22,13 @@ them with a numeric prefix from `00` to `60`:
 | 50 | `config/teams/<TEAM>.md` | Team practices and norms |
 | 60 | `config/TOOLS.md` | Memory architecture and MCP servers |
 
-The three supported tools consume the same source files but load them
+The four supported tools consume the same source files but load them
 differently: Gemini CLI uses numeric-prefix files in `~/.gemini/` with enforced
-priority order, Claude Code combines them additively from `~/.claude/rules/`, and
+priority order, Claude Code combines them additively from `~/.claude/rules/`,
 GitHub Copilot CLI applies them as `*.instructions.md` files in
-`~/.copilot/instructions/`. The build pipeline that reconciles these differences
-is documented in the [CLI support matrix](cli-matrix.md).
+`~/.copilot/instructions/`, and Antigravity CLI loads them from
+`~/.gemini/antigravity-cli/`. The build pipeline that reconciles these
+differences is documented in the [CLI support matrix](cli-matrix.md).
 
 ## Core, overlay, and examples layering
 
@@ -50,12 +51,12 @@ policy for catalogs like `config/expertise/` and `config/teams/` — lives in th
 
 ## Multi-CLI parity
 
-CrewRig implements each feature symmetrically across Gemini CLI, Claude Code, and
-GitHub Copilot CLI. Silent asymmetry is prohibited: where a feature cannot be
-mirrored on a given tool, the gap must be justified with concrete evidence that
-the target tool lacks the mechanism, rather than left unexplained. The per-tool
-integration points, parity checks, and gap-acceptance evidence are tracked in
-the [CLI support matrix](cli-matrix.md).
+CrewRig implements each feature symmetrically across Gemini CLI, Claude Code,
+GitHub Copilot CLI, and Antigravity CLI. Silent asymmetry is prohibited: where
+a feature cannot be mirrored on a given tool, the gap must be justified with
+concrete evidence that the target tool lacks the mechanism, rather than left
+unexplained. The per-tool integration points, parity checks, and
+gap-acceptance evidence are tracked in the [CLI support matrix](cli-matrix.md).
 
 ## Shared cross-tool memory
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,10 +2,11 @@
 
 <!-- crewrig-doc: section=introduction nav_order=10 published=true title="Introduction" -->
 
-CrewRig is a centralized configuration framework for three command-line AI
+CrewRig is a centralized configuration framework for four command-line AI
 coding assistants — [Gemini CLI](https://github.com/google-gemini/gemini-cli),
-[Claude Code](https://claude.ai/code), and
-[GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-in-the-cli).
+[Claude Code](https://claude.ai/code),
+[GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-in-the-cli),
+and [Antigravity CLI](https://antigravity.google).
 Rather than configuring each tool by hand and re-doing the work for every
 teammate and every project, CrewRig holds a single source of truth and compiles
 it into the directory layout each tool expects.
@@ -18,8 +19,9 @@ pillars it stands on, and where to read next.
 CrewRig sits **between** you and the AI assistants. You edit source files once,
 in this repository; build and setup scripts deploy them into each tool's
 configuration directory (`~/.gemini/`, `~/.claude/rules/`,
-`~/.copilot/instructions/` for context, plus project-scoped outputs for skills
-and agents). Three concerns share that pipeline:
+`~/.copilot/instructions/`, `~/.gemini/antigravity-cli/` for context, plus
+project-scoped outputs for skills and agents). Three concerns share that
+pipeline:
 
 - **Who the assistant is for you** — a layered stack of context files that
   encode your identity, seniority, team, role, and tooling.
@@ -46,13 +48,13 @@ load-bearing ideas; the rest of the documentation elaborates them.
    CLI is available in another.
 3. **Skill, agent, and command authoring** — `artifacts/` is the single-source
    zone where these components are written once and compiled by
-   `scripts/build-components.sh` into outputs for all three supported tools.
+   `scripts/build-components.sh` into outputs for all four supported tools.
 4. **Harness engineering** — a built-in feedback loop where agents invoke the
    `harness-report` skill to tag frictions during real work, and the
    `harness-curator` skill clusters those frictions into actionable GitHub
    issues.
 5. **Multi-CLI parity** — features are implemented symmetrically across the
-   three tools. Silent asymmetry is prohibited; every parity gap requires
+   four tools. Silent asymmetry is prohibited; every parity gap requires
    concrete evidence that the missing mechanism does not exist in the target
    tool.
 


### PR DESCRIPTION
Two published docs pages still described CrewRig as a three-CLI framework and omitted Antigravity CLI in places. This PR aligns their wording and CLI list with the current README.md/AGENTS.md phrasing (Gemini CLI, Claude Code, GitHub Copilot CLI, Antigravity CLI).

Closes #1068

## How to read this PR?

Three files changed, all prose-only:

- `docs/introduction.md` — the opening framework description (line 5), the config-directory list and "Three concerns" intro in *The mental model*, and pillars 3 and 5 in *The five pillars*.
- `docs/concepts.md` — *The layered context system* (per-tool loading list) and *Multi-CLI parity* sections. Line 72's memory-tier paragraph already correctly listed four CLIs and was left untouched.
- `docs/authoring.md` — the "author once, compile everywhere" sentence, found during the sweep described below.

Read `docs/introduction.md` first (the framework-level claim), then `docs/concepts.md` (the two sections that had drifted independently), then `docs/authoring.md` (the sweep finding).

## How to test this PR?

1. `git diff origin/main...HEAD -- docs/introduction.md docs/concepts.md docs/authoring.md` and confirm every remaining "three" in those files refers to something other than CLI count (component types, universal frontmatter fields, memory tiers) — none of those were touched.
2. `bash scripts/build-docs-index.sh --check` — confirms `docs/index.json` (36 published pages) needs no regeneration; these are prose-only edits with unchanged frontmatter blocks.
3. Spot-check the new Antigravity CLI link (`https://antigravity.google`) added to `docs/introduction.md` follows the same per-CLI external-link convention as the other three tools in that sentence.

## Detailed description (for agents)

**`docs/introduction.md`:**
- Line 5: "three command-line AI coding assistants" → "four", and added `[Antigravity CLI](https://antigravity.google)` to the tool list (previously absent entirely).
- *The mental model*: added `~/.gemini/antigravity-cli/` to the per-tool configuration-directory list (matches `AGENTS.md` pillar 1's directory enumeration).
- Pillar 3: "outputs for all three supported tools" → "all four supported tools".
- Pillar 5: "symmetrically across the three tools" → "the four tools".

**`docs/concepts.md`:**
- *The layered context system*: "The three supported tools" → "The four supported tools", and added the Antigravity CLI per-tool loading clause (`loads them from ~/.gemini/antigravity-cli/`) alongside the existing Gemini/Claude/Copilot clauses.
- *Multi-CLI parity*: "symmetrically across Gemini CLI, Claude Code, and GitHub Copilot CLI" → added ", and Antigravity CLI".
- Line 72's *Shared cross-tool memory* section already correctly listed four CLIs (Gemini CLI, Claude Code, Copilot CLI, Antigravity CLI) — left as-is.

**`docs/authoring.md`** (sweep finding, same nature as the ticket's two named files):
- "the tool-specific outputs for Gemini CLI, Claude Code, and GitHub Copilot CLI" → added ", and Antigravity CLI".

**Sweep scope and results.** Grepped every page listed in `docs/index.json` (36 published pages, including all `docs/adr/*.md`) for stale CLI-count/CLI-list phrasing beyond the two files named in the issue. Findings:

- `docs/authoring.md` — fixed above.
- `docs/extension-authoring.md` and `docs/extension-mcp-servers.md` already correctly say "four" / list all four CLIs — no change needed.
- `docs/cli-matrix.md` — several "three CLIs" mentions are *not* stale: they describe the e2e test harness, which genuinely covers only claude/gemini/copilot (`tests/e2e/defaults.toml` `applies_to`, no Antigravity Docker image exists under `docker/e2e/`), or are simple arithmetic ("the other three CLIs" after excluding one already-confirmed CLI = 4 − 1 = 3, correct).
- `docs/adr/0001-e2e-docker-images.md` and `docs/adr/0003-e2e-runner-toml.md` — "three CLI(s)" refers to the same e2e-harness scope (3 Docker images exist: claude, gemini, copilot) — accurate, not stale.
- `docs/adr/0004-e2e-assertion-libs.md` — "the three libs" refers to three assertion library *files*, unrelated to CLI count — false positive, no change.
- `docs/adr/0006-chromadb-http-server.md` (Consequences section, "All three CLIs benefit symmetrically") and `docs/adr/0010-spec-plan-review-lifecycle.md` ("compiled to all three CLIs") — **not fixed here**. Both read as likely stale against the current four-CLI state, but they sit inside ADR decision/consequences prose written at the ADR's original decision date, not a live "how it works today" page like `introduction.md`/`concepts.md`/`authoring.md`. Editing historical ADR body text is a different judgment call than a prose docs fix (this repo's convention, per ADR 0006 itself, is to append dated validation evidence rather than rewrite original decision-time prose). Flagged in the issue #1068 logbook comment for the user to decide whether a follow-up ticket is warranted.

No spec or plan stage — this is a trivial-tier docs-only fix per the parent ticket.
