### PR TITLE
📝 Add spec 0191 for init-personal-profile and init-soul artifact promotion (issue #1077)

### DIFF
--- a/specs/0191-init-skills-artifact-promotion.md
+++ b/specs/0191-init-skills-artifact-promotion.md
@@ -1,7 +1,7 @@
 ---
 id: "0191"
 slug: init-skills-artifact-promotion
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 1077

--- a/specs/0191-init-skills-artifact-promotion.md
+++ b/specs/0191-init-skills-artifact-promotion.md
@@ -1,0 +1,84 @@
+---
+id: "0191"
+slug: init-skills-artifact-promotion
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 1077
+version: 1.0.0
+---
+
+# Promote init-personal-profile and init-soul to single-source artifact components
+
+## Intent
+
+A newcomer who clones the repository and launches any one of the four supported command-line assistants inside it can run the two bootstrap interviews — the one that writes their personal profile and the one that writes the agent identity file — and each interview behaves identically whichever assistant they launched, because both are described once in the repository rather than re-typed per assistant.
+
+## Requirements
+
+1. `init-personal-profile` and `init-soul` SHALL each be defined by exactly one source file under `artifacts/core/`, and after this change no hand-maintained per-CLI definition of either name SHALL remain committed anywhere in the repository. In particular `.gemini/commands/init-personal-profile.toml`, `.gemini/commands/init-soul.toml`, `.claude/skills/init-personal-profile/SKILL.md` and `.claude/skills/init-soul/SKILL.md` SHALL cease to be hand-maintained files and SHALL exist only as regenerated build outputs of the single sources.
+2. Each of the two sources SHALL be declared with `type: command` and SHALL live at `artifacts/core/commands/<name>.md`. The `command` component kind is required rather than the `skill` kind because it is the only kind whose build emits a Gemini CLI native slash-command definition (`.gemini/commands/<name>.toml`), which is the sole carrier of the published `gemini "/init-personal-profile"` invocation; a `skill`-kind source emits `.gemini/skills/<name>/SKILL.md` instead, which Gemini CLI discovers for model-side activation only and never exposes as `/<name>`.
+3. `bash scripts/build-components.sh --target all` SHALL emit, for each of the two names, exactly these four project-scoped outputs, and all eight SHALL be regenerated and committed in the same implementation diff: `.gemini/commands/<name>.toml`, `.claude/skills/<name>/SKILL.md`, `.github/skills/<name>/SKILL.md`, `.agents/skills/<name>/SKILL.md`.
+4. `bash scripts/build-components.sh --target all --check` SHALL exit zero on the resulting tree, so that every committed output is byte-identical to what the two sources produce.
+5. In a fresh clone with no user-level CrewRig installation, with each CLI launched from the repository root, each of the following eight invocations SHALL resolve to the corresponding interview and start it: `claude /init-personal-profile`, `gemini "/init-personal-profile"`, `copilot -i "/init-personal-profile"`, `agy -i "/init-personal-profile"`, and the four `init-soul` equivalents. Each of the eight SHALL be confirmed by a live probe of the CLI concerned; vendor-documentation inference alone SHALL NOT be accepted as evidence that an invocation resolves.
+6. Each source body SHALL be a migration of the current `.claude/skills/<name>/SKILL.md` body, not a rewrite: the same interview phases in the same order, the same template read (`config/PROFILE.md.template`, `config/SOUL.md.template`) and the same file written (`config/PROFILE.md`, `config/SOUL.md`). Where the current Claude body and the current Gemini `.toml` prompt describe divergent behavior for the same step, the Claude body's behavior SHALL be the one retained, and the divergent Gemini-only wording SHALL be dropped rather than merged.
+7. Each source body SHALL state its interactive-question obligation in a form that is actionable on all four CLIs — naming the structured-prompt facility and admitting the host CLI's equivalent — and SHALL contain no `${…}` token whose key is absent from `crewrig.config.toml`, so that no unresolved build placeholder reaches any of the eight outputs.
+8. Each source SHALL declare `metadata.provenance` with `canonical` and `feedback` both set to `"${CANONICAL_REPO}"`, as `artifacts/core` is an upstream-owned tier, and SHALL declare an initial `version` of `1.0.0`.
+9. Each source SHALL declare, under `claude.allowed-tools`, the tool set its interview needs, so that the generated Claude Code and GitHub Copilot CLI outputs carry that tool set.
+10. `docs/cli-matrix.md` SHALL be updated in the same diff to record that `init-personal-profile` and `init-soul` are `core` command sources reaching all four CLI surfaces, and to correct any cell that names only `init-expertise` and `init-team` as the guided bootstrap components.
+11. The `## Quick Start` section of `README.md` SHALL name, for each of the four supported CLIs, the in-project invocation of both components, and SHALL NOT publish an invocation that requirement 5's probe has not confirmed.
+12. No `metadata.provenance.version` of any pre-existing component SHALL be bumped by this change: the two sources are new components introduced within the implementation branch and therefore fall under the new-component in-branch exemption of the Version Bump Convention.
+13. The built outputs of `init-expertise` and `init-team` SHALL be unchanged by this diff, and no source under `artifacts/core/skills/` SHALL be modified by it.
+
+## Scenarios
+
+**Scenario:** Four-CLI in-project probe on a fresh clone
+
+Given a fresh clone of the repository at the merge commit of this change, with no user-level CrewRig installation
+When each of `claude`, `gemini`, `copilot` and `agy` is launched from the repository root and asked for `/init-personal-profile`, then for `/init-soul`
+Then all eight invocations resolve and the corresponding interview starts, and the probe transcript for each of the four CLIs is recorded as the evidence for requirement 5
+
+**Scenario:** Single source, no dual maintenance
+
+Given the merged implementation
+When the repository is searched for a definition of `init-personal-profile` or `init-soul`
+Then exactly one source file per name is found under `artifacts/core/commands/`, and every other file bearing either name is a generated output that `bash scripts/build-components.sh --target all --check` reproduces byte-identically
+
+**Scenario:** Interview behavior preserved
+
+Given the interview started from any one of the four CLIs
+When the interview runs to completion
+Then it reads the same template and writes the same target file as the pre-change Claude Code definition (`config/PROFILE.md.template` → `config/PROFILE.md`, `config/SOUL.md.template` → `config/SOUL.md`), with the same phases in the same order
+
+**Scenario (failure path):** A skill-kind source drops the Gemini slash command
+
+Given a candidate implementation that promotes the two components as `type: skill` sources under `artifacts/core/skills/`
+When the build runs and the Gemini CLI probe of requirement 5 is executed
+Then `.gemini/commands/init-personal-profile.toml` is absent from the build output, `gemini "/init-personal-profile"` no longer resolves as a slash command, and the candidate implementation is rejected as failing requirement 2 and requirement 5
+
+**Scenario (failure path):** A CLI probe does not resolve
+
+Given the implementation branch with all eight outputs built and committed
+When the probe of requirement 5 finds that one CLI does not resolve one of its two invocations
+Then the change is incomplete: neither `docs/cli-matrix.md` nor `README.md` states that this CLI can run the component concerned, and the implementation is not merged until the probe passes or the unsupported invocation is removed from both documents
+
+**Scenario (failure path):** A hand-maintained copy is reintroduced
+
+Given the merged implementation
+When a later change adds a hand-edited `.claude/skills/init-soul/SKILL.md` or `.gemini/commands/init-soul.toml` that the sources do not produce
+Then `bash scripts/build-components.sh --target all --check` reports the drift and exits non-zero
+
+## Out of scope
+
+- The setup-script instruction text tracked in issue #1071. Those printed instructions become true once this change ships, but this spec does not edit the setup scripts.
+- The QuickStart panels of the crewrig.org site, tracked in `crewrig/crewrig-website#45` — a separate repository with its own lifecycle.
+- Extending `scripts/check-skill-versions.sh` and `scripts/check-feedback-routing.sh` to cover command sources. Both guards key on the filenames `SKILL.md` and `AGENT.md`, and `artifacts/FORMAT.md` → *Version semantics* states its bump rule over those same two filenames, so a source at `artifacts/core/commands/<name>.md` is covered by neither guard nor rule. Requirement 8 has the two new sources declare provenance correctly regardless; closing the enforcement gap for the command kind, and the accompanying `artifacts/FORMAT.md` wording, is a separate ticket that the implementation team SHALL open before this ticket closes.
+- Migrating `init-expertise` and `init-team` from the `skill` kind to the `command` kind. `gemini "/init-expertise"` is not a slash command today and this spec does not make it one.
+- Correcting `docs/adoption-guide.md`, which describes "all three supported CLIs" and instructs `/init-expertise` without qualifying which CLIs expose it as a slash command. Pre-existing documentation debt, unchanged by this spec.
+- User-level installation of the two components (`~/.claude/skills/`, `~/.gemini/commands/`, `~/.copilot/skills/`, `~/.gemini/config/skills/`). Both stay project-scoped: the clone is the delivery surface.
+- Any change to the interview questions themselves, to the shape of `config/PROFILE.md` or `config/SOUL.md`, or to their templates.
+- Whether GitHub Copilot CLI's discovery of project skills from `.claude/skills/` — the reason it already resolves both components in-project today, contrary to the original framing of issue #1077 — should be relied upon anywhere else in the framework.
+
+## Open questions
+
+(None.)


### PR DESCRIPTION
Specification for issue `#1077`: promote `init-personal-profile` and `init-soul` to single-source components under `artifacts/core/` so the component build emits project-scoped definitions for all four supported CLIs. This is the SPECS-stage artifact only — one file under `/specs/`, no implementation.

## How to read this PR?

One file: `specs/0191-init-skills-artifact-promotion.md`.

Read `## Requirements` 1–5 first. They carry the one non-obvious design decision, settled from repository and live-probe evidence rather than from the pattern the ticket proposed:

**The two components are qualified as `type: command` sources, not `type: skill`.** The ticket asked for the `init-expertise` / `init-team` pattern, which is a `skill`-kind source. That pattern would regress Gemini CLI:

- `build_commands` in `scripts/build-components.sh` emits four project-scoped outputs for a `command` source — `.gemini/commands/<name>.toml`, `.claude/skills/<name>/SKILL.md`, `.github/skills/<name>/SKILL.md`, `.agents/skills/<name>/SKILL.md`. `build_skills` emits `.gemini/skills/<name>/SKILL.md` instead of the TOML.
- On Gemini CLI 0.46.0 a skill is **not** user-invocable as `/<name>`. The CLI's own installed documentation (`docs/cli/skills.md`, `docs/cli/using-agent-skills.md` in the `gemini-cli` bundle) states that skills are injected into the system prompt at discovery and activated by the model through the `activate_skill` tool; the only skill-related slash command is `/skills`. User-invocable slash commands come from `.gemini/commands/*.toml` (`docs/cli/custom-commands.md`).
- Live confirmation: `.gemini/commands/` on `main` holds exactly `init-personal-profile.toml` and `init-soul.toml` — so `gemini "/init-personal-profile"` (published in `README.md` and by the crewrig.org QuickStart) resolves today *because of the TOML*, while `gemini "/init-expertise"` is not a slash command at all.
- `gemini skills list` run in the repository additionally shows Gemini reading the **Antigravity** output tree (`.agents/skills/`) as a workspace-skill alias, which the vendor doc confirms. So a `command`-kind source gives Gemini both the slash command *and* model-side activation — strictly more than the `skill` kind.

A second finding corrects the ticket's framing and is recorded in the spec's final `## Out of scope` bullet: **GitHub Copilot CLI already resolves both components in-project today.** `copilot skill --help` names `.github/skills/`, `.agents/skills/`, **or `.claude/skills/`** as project skill sources, and `copilot skill list` run in the repository lists `init-personal-profile` and `init-soul` under *Project skills* (19 entries = the 17 in `.github/skills/` plus the two that exist only in `.claude/skills/`). The fix direction is unchanged; only the Copilot half of the problem statement was wrong.

Then read `## Out of scope`. One bullet is load-bearing: `scripts/check-skill-versions.sh` and `scripts/check-feedback-routing.sh` both key on the filenames `SKILL.md` / `AGENT.md`, and `artifacts/FORMAT.md` states its version-bump rule over the same two filenames — so a source at `artifacts/core/commands/<name>.md` is covered by neither guard. Requirement 8 still mandates correct provenance on the two new sources; closing the enforcement gap for the `command` kind is deferred to a follow-up ticket that the implementation team is required to open.

## How to test this PR?

```sh
git fetch crewrig spec/0191-init-skills-artifact-promotion
git worktree add -b review/0191 .worktrees/review-0191 crewrig/spec/0191-init-skills-artifact-promotion
cd .worktrees/review-0191
task spec:lint
```

Expected outcome: `markdownlint-cli` passes on all 252 files and semantic validation passes, with **one** remaining `[FAIL]` — the spec-0168 R1 draft gate:

```text
[FAIL] Non-delta specs added or modified by this change carry 'status: draft' (spec 0168 R1)
```

That failure is the intended state of a spec-PR under review. Per `docs/spec-format.md` → *Recording a status transition* → *Merge mechanic*, `status: draft` flips to `status: approved` in a new commit on this branch strictly **after** the approval event and strictly **before** `scripts/merge-spec-pr.sh` runs; recording `approved` ahead of the approval event is explicitly a violation. No other lint error is present.

To re-verify the design decision behind requirement 2 independently:

```sh
# 1. The command kind is the only one that emits a Gemini slash command.
grep -n 'gemini/commands' scripts/build-components.sh          # build_commands only
grep -n 'gemini/skills'   scripts/build-components.sh          # build_skills only

# 2. Gemini activates skills through a tool, and exposes only /skills as a slash command.
G=$(brew --prefix)/Cellar/gemini-cli/*/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/cli
sed -n '/## How it works/,/## Discovery tiers/p' $G/skills.md
sed -n '1,25p' $G/custom-commands.md

# 3. What resolves in-project today, per CLI.
ls .gemini/commands/                 # exactly the two hand-maintained TOMLs
gemini skills list 2>/dev/null | grep -c 'Location:'
copilot skill --help | sed -n '/discovered from/,/Custom/p'
copilot skill list | sed -n '/Project skills/,/Personal skills/p' | grep -c ' - '
```

## Detailed description (for agents)

**Added** — exactly one file, `specs/0191-init-skills-artifact-promotion.md`:

- Frontmatter: `id: "0191"` (secured on `refs/spec-ids/0191` by `bash scripts/reserve-spec-id.sh --issue 1077`, exit `0`, so no `unsecured-id` mark), `slug: init-skills-artifact-promotion`, `status: draft`, `complexity: small`, `interaction-mode: INTERMEDIATE`, `related-issue: 1077`, `version: 1.0.0`.
- `## Intent` — one paragraph, user-facing: a newcomer clones the repository, launches any of the four assistants inside it, and runs either bootstrap interview with identical behavior.
- `## Requirements` — 13 numbered `SHALL` statements:
  1. one source file per component under `artifacts/core/`; no hand-maintained per-CLI definition of either name remains committed;
  2. both sources are `type: command` at `artifacts/core/commands/<name>.md`, with the Gemini reasoning stated inline;
  3. the four project-scoped outputs per name, regenerated and committed in the same diff;
  4. `scripts/build-components.sh --target all --check` exits zero;
  5. the eight in-project invocations resolve in a fresh clone, each confirmed by a live CLI probe — vendor-documentation inference explicitly rejected as evidence;
  6. content migration, not rewrite: same phases, same template read, same file written; the Claude body wins where the two current bodies diverge;
  7. CLI-neutral phrasing of the interactive-question obligation, and no `${…}` token absent from `crewrig.config.toml`;
  8. `metadata.provenance` with `feedback` equal to `canonical` (`artifacts/core` is an upstream-owned tier per spec 0030) and `version: 1.0.0`;
  9. `claude.allowed-tools` declared, so the Claude and Copilot outputs carry the tool set;
  10. `docs/cli-matrix.md` updated in the same diff (the CLI Matrix Maintenance rule), including cells that currently name only `init-expertise` / `init-team`;
  11. `README.md` → `## Quick Start` names the in-project invocation per CLI for both components, and publishes nothing requirement 5's probe has not confirmed;
  12. no pre-existing `metadata.provenance.version` is bumped — the two sources are new in-branch and fall under the new-component in-branch exemption of the Version Bump Convention;
  13. `init-expertise` / `init-team` outputs unchanged; no source under `artifacts/core/skills/` touched.
- `## Scenarios` — six, in Given/When/Then form: three happy-path (four-CLI fresh-clone probe; single source with no dual maintenance; interview behavior preserved) and three failure-path (a `skill`-kind source drops the Gemini slash command; a CLI probe does not resolve; a hand-maintained copy is reintroduced and `--check` reports drift).
- `## Out of scope` — eight bullets: issue `#1071`'s setup-script text; the `crewrig/crewrig-website#45` QuickStart panels (separate repository); extending the two CI guards and `artifacts/FORMAT.md`'s bump rule to the `command` kind (follow-up ticket required before the ticket closes); migrating `init-expertise` / `init-team` to the `command` kind; `docs/adoption-guide.md`'s stale three-CLI and `/init-expertise` claims; user-level installation of the two components; any change to the interview questions or to the shape of `config/PROFILE.md` / `config/SOUL.md`; and whether Copilot's `.claude/skills/` discovery should be relied on elsewhere.
- `## Open questions` — `(None.)`. No arbitration remained after the evidence above; nothing was silently dropped.

**Modified / removed** — nothing. The one-file rule of `docs/spec-pr-workflow.md` is satisfied: the diff is one added file, 84 insertions, no build outputs and no implementation edits.

**Issue linkage.** This pull request deliberately carries no closing directive for issue `#1077`: that issue is the ticket's own logbook under `AGENTS.md` → *Logbook Issues* → Rule A, and the implementation pull request is the one that will close it after PLAN, DEV and REVIEW have run. Verified with `gh pr view --json closingIssuesReferences` after opening.

Related `#1077`.
