### PR TITLE
📝 Add spec 0191 delta 01 correcting the Gemini rationale and adding the collision fix (issue #1077)

### DIFF
--- a/specs/0191-init-skills-artifact-promotion.delta-01.md
+++ b/specs/0191-init-skills-artifact-promotion.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0191"
 slug: init-skills-artifact-promotion
-status: draft
+status: approved
 complexity: small
 interaction-mode: INTERMEDIATE
 related-issue: 1077

--- a/specs/0191-init-skills-artifact-promotion.delta-01.md
+++ b/specs/0191-init-skills-artifact-promotion.delta-01.md
@@ -1,0 +1,259 @@
+---
+id: "0191"
+slug: init-skills-artifact-promotion
+status: draft
+complexity: small
+interaction-mode: INTERMEDIATE
+related-issue: 1077
+version: 1.1.0
+---
+
+# Promote init-personal-profile and init-soul to single-source artifact components — delta 01
+
+A DEV-stage probe of requirement 5 crossed this spec's contract in two ways, and
+this delta records both. First, Gemini CLI 0.46.0's `SkillCommandLoader` mints an
+invocable `/<name>` slash command from every discovered, non-disabled skill — a
+second path alongside the model-side `activate_skill` activation the vendor
+documentation describes — so requirement 2's rationale, one `## Out of scope`
+bullet and one failure-path scenario each assert something false about that CLI.
+All three are corrected under `## MODIFIED`; requirement 2's normative
+obligation — `type: command` at `artifacts/core/commands/<name>.md` — is
+unchanged, and the `command` kind remains the mandated kind. Second, that same
+minting collides with the native command requirement 3 already emits: both
+Gemini-visible outputs of one command source claim the same bare name, Gemini's
+resolver renames both away rather than picking a winner, and the published
+`gemini "/init-personal-profile"` invocation resolves to nothing. `## ADDED`
+requires the arbitrated fix — a project-scoped Gemini settings file suppressing
+Gemini's skill-command minting for exactly these two names — together with its
+accepted trade-off and its failure path. The probe record is the three DEV
+logbook comments on issue #1077: the collision discovery, probes P1–P3, and
+probes P4–P6.
+
+## ADDED
+
+**Requirements.**
+
+1. **Requirement 14 — the project-scoped Gemini settings file.** The
+   implementation SHALL commit, in the same diff, a `.gemini/settings.json` at
+   the repository root whose `skills.disabled` array names exactly
+   `init-personal-profile` and `init-soul`, so that Gemini CLI does not mint a
+   skill-derived `/<name>` slash command for either and the native
+   `.gemini/commands/<name>.toml` command remains the sole claimant of each bare
+   name. `skills.disabled` is Gemini CLI's own documented setting
+   (`docs/reference/configuration.md`: *"List of disabled skills"*, default
+   `[]`, requires restart), and `.gemini/settings.json` at a project root is the
+   workspace scope that same document defines. The file does not exist in this
+   repository today and is therefore created by this change rather than edited.
+   It SHALL NOT be conflated with `config/gemini/settings.json`, the user-level
+   template this framework deploys to `~/.gemini/settings.json`, which SHALL NOT
+   carry this key: the suppression has to travel with the clone rather than with
+   an adopter's machine.
+2. **Requirement 15 — the disable list SHALL name those two names and nothing
+   else.** The committed `.gemini/settings.json` SHALL list no skill beyond the
+   two this spec promotes, and SHALL declare no Gemini setting other than
+   `skills.disabled`. A blanket or wider suppression is prohibited because every
+   other skill the clone ships depends on the discovery this key removes; a
+   future component needing the same treatment SHALL be added to the list by its
+   own ticket, which is the permitted path for growing it.
+3. **Requirement 16 — the acceptance conditions, live-probed.** In a fresh clone
+   carrying this change, with Gemini CLI launched from the repository root, all
+   three of the following SHALL hold, and each SHALL be confirmed by a live probe
+   of that CLI rather than by documentation inference — the same evidence
+   discipline requirement 5 imposes: (a) Gemini CLI's startup command-registry
+   diagnostics report no `Conflicts detected` entry naming either component;
+   (b) `gemini skills list --all` reports both names as `[Disabled]`; (c)
+   `gemini "/init-personal-profile"` and `gemini "/init-soul"` each resolve under
+   the bare name to the corresponding `.gemini/commands/<name>.toml` workspace
+   command and start the interview.
+4. **Requirement 17 — the other two command-kind outputs SHALL be unaffected,
+   and re-probed to prove it.** This delta SHALL alter neither
+   `.agents/skills/<name>/SKILL.md` nor `.github/skills/<name>/SKILL.md` for
+   either component, and SHALL change no behavior of Antigravity CLI or GitHub
+   Copilot CLI, neither of which reads a Gemini settings file. The four
+   requirement-5 probes for those two CLIs SHALL be re-run on the tree that
+   carries `.gemini/settings.json` rather than inherited from a probe taken
+   before it existed, so that "unaffected" is a measurement rather than an
+   expectation.
+5. **Requirement 18 — the accepted trade-off SHALL be published, not implied.**
+   Disabling the two names on Gemini CLI also suppresses their model-side
+   `activate_skill` path on that CLI, and this spec accepts that loss rather than
+   engineering around it: both components are user-initiated bootstrap
+   interviews a newcomer types by name, not capabilities a model should elect
+   mid-task, and the native slash command is the Gemini path requirement 2
+   mandates. `docs/cli-matrix.md` SHALL record that on Gemini CLI these two
+   components are reachable as the native slash command only, and neither that
+   document nor `README.md` SHALL claim model-side skill activation for them on
+   Gemini CLI.
+6. **Requirement 19 — the workspace-settings row of the CLI matrix SHALL be
+   corrected.** Row 7 of `docs/cli-matrix.md` (*Active workspace settings file*)
+   states for Gemini CLI `❌ (loaded from ~/.gemini/settings.json by the CLI; no
+   in-repo workspace file)`, which requirement 14 falsifies. The same diff SHALL
+   update that cell to record the in-repo `.gemini/settings.json`, the single
+   purpose it serves, and this spec as its origin.
+
+**Scenarios.**
+
+**Scenario:** The collision is suppressed and the bare Gemini name survives
+
+Given a fresh clone of the repository at the merge commit of this change, carrying `.gemini/settings.json` whose `skills.disabled` names `init-personal-profile` and `init-soul`
+When Gemini CLI is launched from the repository root, its startup command-registry diagnostics are read, `gemini skills list --all` is run, and `gemini "/init-personal-profile"` is invoked
+Then no `Conflicts detected` entry names either component, both appear as `[Disabled]` in the skills listing, and the bare `/init-personal-profile` resolves to the `.gemini/commands/init-personal-profile.toml` workspace command and starts the interview
+
+**Scenario (failure path):** The settings file is absent, or a name is dropped from it
+
+Given the implementation tree with `.gemini/settings.json` deleted, or with either name removed from its `skills.disabled` array
+When Gemini CLI is launched from the repository root and the requirement-5 Gemini probe is executed
+Then the startup diagnostics report `Conflicts detected` for the affected name, the workspace command is renamed to `/workspace.<name>` and the skill-derived command to `/<name>1`, no registration keeps the bare `/<name>`, and the probe fails — the change is not merged until the file is restored or the affected invocation is withdrawn from both `README.md` and `docs/cli-matrix.md`
+
+**Scenario (failure path):** The Gemini trade-off is published as if it did not exist
+
+Given the merged implementation
+When `docs/cli-matrix.md` and `README.md` are read for what Gemini CLI can do with these two components
+Then neither document claims model-side skill activation for them on Gemini CLI, the Gemini entry names the native slash command as the only path, and row 7's Gemini cell records the in-repo `.gemini/settings.json` — any of the three missing is a `spec`-class finding against requirements 18 and 19
+
+**Out of scope,** extending the parent spec's own list:
+
+- Any mechanism that restores model-side `activate_skill` for these two names on
+  Gemini CLI while preserving the bare native command. Requirement 18 accepts
+  the loss; recovering it is a different ticket's problem.
+- Changing `build_commands` so that command-kind sources stop emitting
+  `.agents/skills/<name>/SKILL.md`. Probe P1(a) on issue #1077 established that
+  Antigravity CLI does not read `.gemini/commands/*.toml` and resolves these
+  components only through `.agents/skills/`, so the wrapper cannot be dropped
+  without failing requirement 5's Antigravity leg.
+- A mechanical guard asserting that every `artifacts/**/commands/<name>.md`
+  source carries a matching entry in `.gemini/settings.json` → `skills.disabled`.
+  The detector this delta relies on is the requirement-5 Gemini probe, not a CI
+  check; generalising the invariant to future command sources belongs with the
+  guard-coverage follow-up the parent spec's `## Out of scope` already requires.
+- Precedence between a project `.gemini/settings.json` and an adopter's own
+  `~/.gemini/settings.json` when both declare `skills.disabled`. Neither
+  `config/gemini/settings.json` — the template this framework deploys to user
+  level — nor the probe machine's user-level file carries a `skills` block, so
+  the case was never exercised. It is Gemini CLI's own merge semantics and this
+  spec does not constrain it.
+- Renaming either component to decouple the two CLIs' registrations. Probes
+  P2(i) and P2(ii) on issue #1077 established that Gemini CLI and Antigravity
+  CLI both key off the same frontmatter `name:` field of the same generated
+  file, so a rename only moves which CLI loses the bare name.
+
+## MODIFIED
+
+Three statements of the parent spec are falsified by the same probe evidence and
+are replaced below. Requirement 2's normative obligation is untouched in all
+three cases: the `command` kind remains the mandated kind, on a corrected
+rationale.
+
+**1. Requirement 2's rationale.** The original grounds the choice of the
+`command` kind on a claim the probe disproves — that Gemini CLI never exposes a
+skill as `/<name>`. It does, through a second mechanism the vendor documentation
+does not describe. The replacement states the two grounds that do hold, both
+read from the build script and the installed CLI rather than inferred.
+
+Original requirement 2:
+
+```text
+2. Each of the two sources SHALL be declared with `type: command` and SHALL live
+   at `artifacts/core/commands/<name>.md`. The `command` component kind is
+   required rather than the `skill` kind because it is the only kind whose build
+   emits a Gemini CLI native slash-command definition
+   (`.gemini/commands/<name>.toml`), which is the sole carrier of the published
+   `gemini "/init-personal-profile"` invocation; a `skill`-kind source emits
+   `.gemini/skills/<name>/SKILL.md` instead, which Gemini CLI discovers for
+   model-side activation only and never exposes as `/<name>`.
+```
+
+Replacement requirement 2:
+
+```text
+2. Each of the two sources SHALL be declared with `type: command` and SHALL live
+   at `artifacts/core/commands/<name>.md`. The `command` component kind is
+   required rather than the `skill` kind for two reasons, neither of which is
+   that a skill cannot be typed as `/<name>` on Gemini CLI — it can, and the
+   claim to the contrary is withdrawn. First, the command build path is the only
+   one whose GitHub Copilot CLI output carries the source's
+   `claude.allowed-tools` set into `.github/skills/<name>/SKILL.md`; the skill
+   build path emits only `name`, `description`, `license` and `compatibility`
+   there, so requirement 9's obligation that the generated Copilot output carry
+   the interview's tool set is satisfiable by the `command` kind alone. Second,
+   it is the only kind emitting `.gemini/commands/<name>.toml`, whose
+   registration submits the interview prompt directly as the turn's prompt,
+   without depending on Gemini's skills-support or skill-administration
+   settings; the slash command Gemini otherwise mints from a discovered skill
+   reaches the interview indirectly, through the `activate_skill` tool, and is
+   minted only while both of those settings are enabled and the skill is absent
+   from `skills.disabled` — where requirement 14 deliberately places these two
+   names, leaving the native command the sole claimant of the bare `/<name>` on
+   that CLI.
+```
+
+**2. The `## Out of scope` bullet on `init-expertise` and `init-team`.** Its
+second sentence asserts that `gemini "/init-expertise"` is not a slash command
+today. Probe P5 on issue #1077 established that it is one, minted from the
+discovered skill with nothing competing for the name. The exclusion itself
+stands; only its stated reason changes.
+
+Original bullet:
+
+```text
+- Migrating `init-expertise` and `init-team` from the `skill` kind to the
+  `command` kind. `gemini "/init-expertise"` is not a slash command today and
+  this spec does not make it one.
+```
+
+Replacement bullet:
+
+```text
+- Migrating `init-expertise` and `init-team` from the `skill` kind to the
+  `command` kind. `gemini "/init-expertise"` does resolve today — Gemini CLI
+  mints a slash command from every discovered, non-disabled skill, and nothing
+  competes with those two names for it — so such a migration would change how
+  that invocation is served rather than whether it exists, and this spec does
+  not make that change.
+```
+
+**3. The failure-path scenario "A skill-kind source drops the Gemini slash
+command".** Its middle clause states that a skill-kind source leaves
+`gemini "/init-personal-profile"` unresolved. Probe P4 on issue #1077 established
+the opposite: with the native command absent and only the skill wrapper present,
+the bare name resolves cleanly as the skill-minted command. The candidate
+implementation is still rejected, but on the grounds that actually hold — the
+lost native command and the lost Copilot tool set — so requirement 9 replaces
+requirement 5 as the second failing requirement, requirement 5 being one such a
+candidate would in fact pass.
+
+Original scenario:
+
+```text
+**Scenario (failure path):** A skill-kind source drops the Gemini slash command
+
+Given a candidate implementation that promotes the two components as
+`type: skill` sources under `artifacts/core/skills/`
+When the build runs and the Gemini CLI probe of requirement 5 is executed
+Then `.gemini/commands/init-personal-profile.toml` is absent from the build
+output, `gemini "/init-personal-profile"` no longer resolves as a slash command,
+and the candidate implementation is rejected as failing requirement 2 and
+requirement 5
+```
+
+Replacement scenario:
+
+```text
+**Scenario (failure path):** A skill-kind source drops the native Gemini command
+and the Copilot tool set
+
+Given a candidate implementation that promotes the two components as
+`type: skill` sources under `artifacts/core/skills/`
+When the build runs and the Gemini CLI probe of requirement 5 is executed
+Then `.gemini/commands/init-personal-profile.toml` is absent from the build
+output, `.github/skills/init-personal-profile/SKILL.md` carries no
+`allowed-tools` field, and `gemini "/init-personal-profile"` resolves only as the
+command Gemini mints from the discovered skill — reaching the interview through
+the `activate_skill` tool rather than through the native command requirement 2
+mandates — and the candidate implementation is rejected as failing requirement 2
+and requirement 9
+```
+
+## REMOVED
+
+(none)


### PR DESCRIPTION
Corrects three statements in merged spec 0191 that a DEV-stage probe of requirement 5 falsified, and adds the arbitrated fix for the Gemini slash-command collision that same probe discovered. One file, no implementation: this is the SPECS-stage delta that unblocks DEV on issue #1077.

## How to read this PR?

One added file: `specs/0191-init-skills-artifact-promotion.delta-01.md`. Read it top to bottom — the intro paragraph states the two independent findings, then the three delta sections follow the convention in `docs/spec-format.md`.

Read `## MODIFIED` **first** if you only have time for one section. It carries the correction that matters most: requirement 2's rationale claimed that Gemini CLI "discovers [a skill] for model-side activation only and never exposes as `/<name>`". That is false. Gemini CLI 0.46.0's `SkillCommandLoader` unconditionally mints an invocable `/<name>` slash command from every discovered, non-disabled skill — a second path the vendor documentation does not describe, which the SPECS stage could not have seen because it read the docs rather than probing. The same false premise infects an `## Out of scope` bullet and one failure-path scenario; all three are replaced.

The non-obvious decision is **what replaces requirement 2's rationale**. The `command` kind is still mandated — only its justification changes — and the replacement rests on two grounds that were verified against the build script and the installed CLI rather than inferred:

1. **The Copilot tool-set carrier (decisive, and Gemini-independent).** `build_commands` reads `claude.allowed-tools` from the source and emits it into `.github/skills/<name>/SKILL.md`; `build_skills` does not — its Copilot branch emits only `name`, `description`, `license`, `compatibility`. So requirement 9's obligation that the *generated Copilot output* carry the interview's tool set is satisfiable by the `command` kind alone. Verifiable on `main` today: `artifacts/core/skills/init-expertise/SKILL.md` declares five `claude.allowed-tools`, its Claude output carries them, and its Copilot output does not.
2. **The native command's semantics.** Only the `command` kind emits `.gemini/commands/<name>.toml`, whose registration submits the interview prompt directly as the turn's prompt, without depending on Gemini's skills-support or skill-administration settings. The skill-minted command reaches the interview indirectly through `activate_skill`, and only while both settings are enabled and the name is absent from `skills.disabled` — where the new requirement 14 deliberately places these two names.

Then read `## ADDED` for requirements 14–19 (the collision fix), three scenarios, and five out-of-scope bullets. `## REMOVED` is empty.

## How to test this PR?

Prerequisites: a checkout of this branch, `task` and `node` on `PATH`.

```sh
task spec:lint
```

Expected: `Linting passed!`, exit 0.

That green needs a word of explanation, because the parent spec-PR (#1078) **failed** this same check while it carried `status: draft`. This delta also carries `status: draft` and passes, which is correct rather than a regression: the spec-0168 R1 draft gate is explicitly scoped to non-delta specs (`scripts/lib/spec-linter.js:668` — *"Non-delta specs added or modified by this change carry 'status: draft'"*), matching `docs/spec-format.md` → *No spec on `main` is a draft*, which exempts delta-specs per spec 0109.

To confirm the green is not vacuous — that the linter actually examines the new file rather than skipping it:

```sh
sed -i '' 's/^## REMOVED$/## REMOVEDX/' specs/0191-init-skills-artifact-promotion.delta-01.md
task spec:lint    # expect: [FAIL] Heading #3 MUST be "## REMOVED", exit 1
git checkout specs/0191-init-skills-artifact-promotion.delta-01.md
```

To re-derive the load-bearing claim behind the corrected requirement 2 rationale:

```sh
grep -c allowed-tools .claude/skills/init-expertise/SKILL.md   # 1 — the Claude output carries them
grep -c allowed-tools .github/skills/init-expertise/SKILL.md   # 0 — the Copilot output does not
```

## Detailed description (for agents)

**Added — one file:** `specs/0191-init-skills-artifact-promotion.delta-01.md`. Nothing else in the tree is touched; `git status` on this branch lists exactly this file.

**Frontmatter.** `id: "0191"` and `slug: init-skills-artifact-promotion` reuse the parent's by construction (a delta secures no new id, and `scripts/reserve-spec-id.sh` was therefore not called). `status: draft`, flipped to `approved` in a new commit on this branch strictly after the approval event and strictly before merge, per `docs/spec-format.md` → *Merge mechanic*. `version: 1.1.0` — a MINOR bump of the parent's `1.0.0`: requirements 14–19 are additive, requirement 2 keeps its normative obligation while its rationale changes, and no in-flight implementation is invalidated (the DEV branch still ships `type: command` sources; it gains one file to create). `complexity: small` and `interaction-mode: INTERMEDIATE` inherit from the parent. `related-issue: 1077`.

**`## ADDED` — requirements 14–19.**

- **R14** mandates a project-scoped `.gemini/settings.json` at the repository root whose `skills.disabled` names exactly `init-personal-profile` and `init-soul`. The key is Gemini CLI's own documented setting (`docs/reference/configuration.md` in the 0.46.0 bundle: *"List of disabled skills"*, default `[]`, requires restart), and a project-root `.gemini/settings.json` is the workspace scope the same document defines. The requirement states explicitly that the file is created rather than edited (the repository ships none today) and that it SHALL NOT be conflated with `config/gemini/settings.json`, the user-level template deployed to `~/.gemini/settings.json`, which SHALL NOT carry the key — the suppression must travel with the clone, not with an adopter's machine.
- **R15** bounds the list to those two names and to that one setting, so it cannot grow into a blanket suppression of the other skills the clone ships; a future component needing the same treatment is named as the permitted path.
- **R16** states the three acceptance conditions, each requiring a live Gemini probe rather than documentation inference — the same evidence discipline requirement 5 already imposes: no `Conflicts detected` entry for either name at startup, both names `[Disabled]` in `gemini skills list --all`, and the bare `/init-personal-profile` and `/init-soul` resolving to their `.toml` workspace commands.
- **R17** requires that the Antigravity and Copilot outputs be unaltered and that their four requirement-5 probes be **re-run** on the tree carrying the settings file, so "unaffected" is measured rather than assumed.
- **R18** requires the accepted trade-off to be published rather than implied: disabling the two names on Gemini also suppresses their model-side `activate_skill` path there. The spec accepts the loss — both components are user-initiated bootstrap interviews a newcomer types by name, not capabilities a model should elect mid-task — and obliges `docs/cli-matrix.md` to say so, with neither it nor `README.md` claiming model-side activation for them on Gemini.
- **R19** is a grounding finding surfaced while authoring, not part of the routing brief. `docs/cli-matrix.md` row 7 (*Active workspace settings file*) currently reads, for Gemini CLI, `❌ (loaded from ~/.gemini/settings.json by the CLI; no in-repo workspace file)`. R14 falsifies that cell, so R19 requires the same diff to correct it. Without this, DEV would ship a change contradicting a documented matrix claim and REVIEW would raise it as a finding.

Three scenarios accompany them: one happy path (collision suppressed, bare name survives), and two failure paths (settings file absent or a name dropped → the conflict returns and both bare names die, caught by the R5 Gemini probe; and the R18/R19 documentation obligations unmet → a `spec`-class finding).

Five `## Out of scope` bullets extend the parent's list, each carrying the one-line probe reason that rejected the alternative: restoring model-side activation for these two names on Gemini; dropping the `.agents/skills/` wrapper from `build_commands` (impossible — probe P1(a) proved Antigravity does not read `.gemini/commands/*.toml`); a mechanical guard that every command source has a matching `skills.disabled` entry (this delta's detector is the R5 probe, and generalising belongs with the guard-coverage follow-up the parent already requires); user-scope versus project-scope `skills.disabled` precedence (never exercised — neither `config/gemini/settings.json` nor the probe machine's user-level file carries a `skills` block); and renaming to decouple the CLIs (impossible — probes P2(i)/P2(ii) proved both CLIs key off the same frontmatter `name:` field of the same generated file).

**`## MODIFIED` — three replacements, each quoting the original then the replacement in a fenced block.**

1. **Requirement 2's rationale.** Replaced as described in *How to read this PR?*. The withdrawal of the false claim is stated explicitly inside the replacement text, so a later reader of the cumulative spec sees that it was retracted rather than silently dropped.
2. **The `## Out of scope` bullet on `init-expertise` / `init-team`.** Its second sentence claimed `gemini "/init-expertise"` is not a slash command today; probe P5 established it is one, minted from the discovered skill with nothing competing for the name. The exclusion stands; only its stated reason changes.
3. **The failure-path scenario "A skill-kind source drops the Gemini slash command".** Its middle clause claimed a skill-kind source leaves `gemini "/init-personal-profile"` unresolved; probe P4 established the opposite — with the native command absent and only the skill wrapper present, the bare name resolves cleanly. The candidate is still rejected, but on grounds that hold: the lost native command and the lost Copilot tool set. **Requirement 9 replaces requirement 5** as the second failing requirement, because such a candidate would in fact *pass* requirement 5.

**`## REMOVED`** is `(none)` — every correction is a replacement in place.

**Judgment call recorded for the reviewer.** The routing brief named two falsified statements (requirement 2's rationale and the out-of-scope bullet). The third — the failure-path scenario — is falsified by the *same* probe P4/P5 evidence and was corrected on the author's own judgment. Leaving it would have left the merged spec asserting a fact its own DEV stage had disproved, and pre-baked a `spec`-class finding into the next REVIEW pass, which `docs/spec-format.md` → *Open questions* explicitly calls out as wasted iteration.

**Evidence provenance.** Every factual claim in this delta traces to the three DEV logbook comments on issue #1077 (the collision discovery, probes P1–P3, probes P4–P6) or was re-derived while authoring: the `build_commands` / `build_skills` Copilot-branch asymmetry was read from `scripts/build-components.sh` and confirmed against the built `init-expertise` outputs; `FileCommandLoader`'s `submit_prompt` action and the `skills.disabled` documentation were read from the installed Gemini CLI 0.46.0 bundle; the row-7 falsification and the absence of a `skills` block in `config/gemini/settings.json` were read from this repository. `.gemini/settings.json` was confirmed not gitignored, so R14 is implementable.

This PR closes no issue. Issue #1077 stays open as the logbook for the remaining DEV and REVIEW stages.
