### PR TITLE
🐛 Extend layered context table to priority 65 (#1072)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ to form the agent's full context:
 | 30 | `config/PROFILE.md` | Personal information |
 | 40 | `config/expertise/<ROLE>.md` | Technical specialization |
 | 50 | `config/teams/<TEAM>.md` | Team practices and norms |
-| 60 | `config/TOOLS.md` | Memory architecture and MCP servers |
+| 60 | `artifacts/core/rules/60-tools.md` | Memory architecture and core tool rules |
+| 65 | `config/TOOLS.md` | Organization-specific tool guidelines |
 
 **Gemini CLI** loads these via numeric-prefix files in `~/.gemini/` with
 enforced priority order. **Claude Code** loads them from `~/.claude/rules/`

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ normatively; the goal here is shared vocabulary, not exhaustive coverage.
 
 An AI assistant's behavior is shaped by a stack of context files, each
 addressing one concern and combined in a fixed priority order. CrewRig organizes
-them with a numeric prefix from `00` to `60`:
+them with a numeric prefix from `00` to `65`:
 
 | Priority | Source | Concern |
 |----------|--------|---------|
@@ -20,7 +20,8 @@ them with a numeric prefix from `00` to `60`:
 | 30 | `config/PROFILE.md` | Personal information |
 | 40 | `config/expertise/<ROLE>.md` | Technical specialization |
 | 50 | `config/teams/<TEAM>.md` | Team practices and norms |
-| 60 | `config/TOOLS.md` | Memory architecture and MCP servers |
+| 60 | `artifacts/core/rules/60-tools.md` | Memory architecture and core tool rules |
+| 65 | `config/TOOLS.md` | Organization-specific tool guidelines |
 
 The four supported tools consume the same source files but load them
 differently: Gemini CLI uses numeric-prefix files in `~/.gemini/` with enforced


### PR DESCRIPTION
Updates `docs/concepts.md` and `README.md` to reflect the 00–65 priority range, distinguishing priority 60 (`artifacts/core/rules/60-tools.md`, core) from priority 65 (`config/TOOLS.md`, overlay), consistent with `docs/cli-matrix.md` row 7b and `docs/layers.md`.

## How to read this PR?

- `docs/concepts.md`: Layered context table range updated to `00–65`; priority 60 and 65 rows clarified.
- `README.md`: Same layered context table update for parity.

## How to test this PR?

```bash
task spec:lint
```

Closes #1072