### PR TITLE
🐛 Update yq job-list sample in ci-reference-format.md (#1076)

### DIFF
--- a/docs/ci-reference-format.md
+++ b/docs/ci-reference-format.md
@@ -267,13 +267,14 @@ shown with a passing sample.
 $ yq '.jobs | keys' .github/workflows/build.yml
 - build
 - component-drift
-- extension-pivot
+- extension-render
 - extension-provenance
 - extension-manifest
 - extension-install
 - core-paths
 - ci-parity
 - docs-index
+- figure-labels
 - mempalace
 - test-wiring
 - chroma-mcp
@@ -288,8 +289,11 @@ $ yq '.jobs | keys' .github/workflows/build.yml
 - test-harness-curate
 - check-skill-versions
 - check-extension-version-bump
+- check-spec-id-reserved
 - check-agents-size
 - check-feedback-routing
+- gitlab-ci-check
+- check-ci-parity
 ```
 
 The GHA job keys are already valid id syntax and unique by the schema's own


### PR DESCRIPTION
Updates the sample `yq '.jobs | keys' .github/workflows/build.yml` extraction output in `docs/ci-reference-format.md` to accurately list all 29 current GitHub Actions jobs in `.github/workflows/build.yml` (including `extension-render`, `figure-labels`, `check-spec-id-reserved`, `gitlab-ci-check`, and `check-ci-parity`).

## How to read this PR?

- `docs/ci-reference-format.md`: Corrected sample job list to match `.github/workflows/build.yml`.

## How to test this PR?

```bash
task spec:lint
```

Closes #1076