### PR TITLE
🔧 Extend check-skill-versions and check-feedback-routing to command-kind sources (spec 0193, issue #1079)

### DIFF
--- a/artifacts/FORMAT.md
+++ b/artifacts/FORMAT.md
@@ -379,12 +379,12 @@ The `metadata.provenance.version` field follows
 | **MINOR** (`1.0.1 → 1.1.0`) | Additive change. New section, new recognition signal, new payload field, new optional behavior. Backward-compatible — agents following `1.0.x` keep working unchanged. |
 | **MAJOR** (`1.1.0 → 2.0.0`) | Breaking contract change. Removed payload fields, renamed required fields, semantics flip. Forks pinning `1.x` need to migrate consciously. |
 
-**Bump rule.** Every PR that touches a `SKILL.md` or `AGENT.md`
-source under any artifact tier — `artifacts/core/`, `artifacts/library/`,
-or `artifacts/community/` — MUST bump `metadata.provenance.version` in the
-same diff. CI enforces this via `scripts/check-skill-versions.sh` (see
-`task check-skill-versions` for the local invocation). The same discipline
-extends to the upstream-owned extension tiers `extensions/core/` and
+**Bump rule.** Every PR that touches a `SKILL.md`, `AGENT.md`, or
+`commands/*.md` source under any artifact tier — `artifacts/core/`,
+`artifacts/library/`, or `artifacts/community/` — MUST bump
+`metadata.provenance.version` in the same diff. CI enforces this via
+`scripts/check-skill-versions.sh` (see `task check-skill-versions` for
+the local invocation). The same discipline extends to the upstream-owned extension tiers `extensions/core/` and
 `extensions/library/`, where the `version` instead rides on the
 provenance carrier (the first-body-line `<!-- crewrig-provenance:
 version="…" … -->` HTML comment per spec 0043, not frontmatter — Gemini

--- a/docs/version-bump-convention.md
+++ b/docs/version-bump-convention.md
@@ -9,6 +9,9 @@ Affected paths:
 - `artifacts/core/skills/*/SKILL.md`
 - `artifacts/library/skills/*/SKILL.md`
 - `artifacts/community/skills/*/SKILL.md`
+- `artifacts/core/commands/*.md`
+- `artifacts/library/commands/*.md`
+- `artifacts/community/commands/*.md`
 - `artifacts/core/agents/*/AGENT.md`
 - `artifacts/library/agents/*/AGENT.md`
 - `artifacts/community/agents/*/AGENT.md`
@@ -23,7 +26,7 @@ comment per spec 0043), NOT in frontmatter — Gemini CLI 0.42.0+ rejects
 non-`name`/`description` frontmatter keys on the in-place source. The bump
 is enforced by `scripts/check-extension-version-bump.sh` (spec 0044), which
 compares the carrier version against the base ref. `extensions/org` is
-adopter-owned and exempt; commands carry no provenance/version.
+adopter-owned and exempt.
 
 **Exemption — new components do not bump in-branch.** Components
 introduced on a feature branch start at `1.0.0` and stay there until the

--- a/scripts/check-feedback-routing.sh
+++ b/scripts/check-feedback-routing.sh
@@ -63,7 +63,7 @@ checked=0
 skipped=0
 failures=()
 
-# Collect every SKILL.md / AGENT.md source under the upstream-owned tiers.
+# Collect every SKILL.md / AGENT.md / commands/*.md source under the upstream-owned tiers.
 # `while read` rather than `mapfile` for bash 3.2 compat (macOS default).
 sources=()
 while IFS= read -r f; do
@@ -72,7 +72,7 @@ while IFS= read -r f; do
 done < <(
   for root in ${TIER_ROOTS[@]+"${TIER_ROOTS[@]}"}; do
     [ -d "$root" ] || continue
-    find "$root" -type f \( -name 'SKILL.md' -o -name 'AGENT.md' \) 2>/dev/null
+    find "$root" -type f \( -name 'SKILL.md' -o -name 'AGENT.md' -o -path '*/commands/*.md' \) 2>/dev/null
   done | sort
 )
 

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# check-skill-versions.sh — Enforce the version-bump rule on skill sources.
+# check-skill-versions.sh — Enforce the version-bump rule on component sources.
 #
 # Per artifacts/FORMAT.md → Version semantics, every PR that touches
-# a skill or agent source under artifacts/core/, artifacts/library/, or
+# a skill, command, or agent source under artifacts/core/, artifacts/library/, or
 # artifacts/community/ MUST bump `metadata.provenance.version` in the same
 # diff. This script enforces the rule.
 #
@@ -35,7 +35,7 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   }
 fi
 
-# Collect changed skill/agent sources, split by status (A=added, M=modified).
+# Collect changed component sources, split by status (A=added, M=modified).
 # New files (A) start at 1.0.0 by definition — no bump required until they
 # land on the base branch and are subsequently modified. Only modified files
 # (M) are subject to the version-bump rule.
@@ -52,16 +52,19 @@ done < <(git diff --name-status "$BASE_REF" -- \
   'artifacts/core/skills/*/SKILL.md' \
   'artifacts/library/skills/*/SKILL.md' \
   'artifacts/community/skills/*/SKILL.md' \
+  'artifacts/core/commands/*.md' \
+  'artifacts/library/commands/*.md' \
+  'artifacts/community/commands/*.md' \
   'artifacts/core/agents/*/AGENT.md' \
   'artifacts/library/agents/*/AGENT.md' \
   'artifacts/community/agents/*/AGENT.md' 2>/dev/null || true)
 
 if [ "${#modified[@]}" -eq 0 ]; then
-  echo "OK: no existing skill/agent sources modified vs $BASE_REF."
+  echo "OK: no existing component sources modified vs $BASE_REF."
   exit 0
 fi
 
-echo "Checking version bumps on ${#modified[@]} modified skill/agent source(s)..."
+echo "Checking version bumps on ${#modified[@]} modified component source(s)..."
 
 failures=()
 for f in ${modified[@]+"${modified[@]}"}; do
@@ -96,4 +99,4 @@ if [ "${#failures[@]}" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all changed skill/agent sources include a version bump."
+echo "OK: all changed component sources include a version bump."

--- a/scripts/tests/test-check-feedback-routing.sh
+++ b/scripts/tests/test-check-feedback-routing.sh
@@ -70,6 +70,27 @@ Body.
 EOF
 }
 
+# Render a minimal command source with the given feedback value.
+render_command_with_feedback() {
+  local feedback="$1"
+  cat <<EOF
+---
+name: example-cmd
+description: Example command used as a test fixture.
+type: command
+metadata:
+  provenance:
+    canonical: "\${CANONICAL_REPO}"
+    feedback: "$feedback"
+    version: "1.0.0"
+---
+
+# Example Command
+
+Prompt body.
+EOF
+}
+
 # Build a fresh tree root containing one core skill source and return its path.
 new_tree() {
   local dir
@@ -126,6 +147,22 @@ render_skill_with_feedback '${FEEDBACK_REPO}' > "$tree4/artifacts/community/skil
 # Keep the upstream example canonical so only the community source diverges.
 render_skill_with_feedback '${CANONICAL_REPO}' > "$tree4/artifacts/core/skills/example/SKILL.md"
 run_case "Case 4 — adopter-owned tier is exempt" "$tree4" 0
+
+# -------------------------------------------------------------------------
+# Case 5 — upstream command source with feedback == canonical → exit 0
+# -------------------------------------------------------------------------
+tree5="$(new_tree)"
+mkdir -p "$tree5/artifacts/core/commands"
+render_command_with_feedback '${CANONICAL_REPO}' > "$tree5/artifacts/core/commands/example-cmd.md"
+run_case "Case 5 — upstream command feedback == canonical passes" "$tree5" 0
+
+# -------------------------------------------------------------------------
+# Case 6 — upstream command source with feedback != canonical → exit 1
+# -------------------------------------------------------------------------
+tree6="$(new_tree)"
+mkdir -p "$tree6/artifacts/core/commands"
+render_command_with_feedback '${FEEDBACK_REPO}' > "$tree6/artifacts/core/commands/example-cmd.md"
+run_case "Case 6 — upstream command feedback != canonical fails" "$tree6" 1
 
 # -------------------------------------------------------------------------
 # Summary

--- a/scripts/tests/test-check-skill-versions.sh
+++ b/scripts/tests/test-check-skill-versions.sh
@@ -51,6 +51,25 @@ Body.
 EOF
 }
 
+# Render a minimal command source with the given version string.
+render_command() {
+  local version="$1"
+  cat <<EOF
+---
+name: example-cmd
+description: Example command used as a test fixture.
+type: command
+metadata:
+  provenance:
+    version: "$version"
+---
+
+# Example Command
+
+Prompt body.
+EOF
+}
+
 # Set up a fresh temp git repo and return its path on stdout.
 new_repo() {
   local dir
@@ -172,6 +191,58 @@ else
   echo "FAIL  Case 4 — remote probing (crewrig, no origin) (expected exit 0, got $actual_exit)"
   fail=$((fail + 1))
 fi
+
+# -------------------------------------------------------------------------
+# Case 5 — Status A: new command source (artifacts/core/commands/*.md) → exit 0
+# -------------------------------------------------------------------------
+repo5="$(new_repo)"
+(
+  cd "$repo5"
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "seed"
+
+  mkdir -p artifacts/core/commands
+  render_command "1.0.0" > artifacts/core/commands/new-cmd.md
+  git add artifacts/core/commands/new-cmd.md
+  git commit -q -m "add new command"
+)
+run_case "Case 5 — new command (status A) requires no bump" "$repo5" 0
+
+# -------------------------------------------------------------------------
+# Case 6 — Status M: existing command modified without bump → exit 1
+# -------------------------------------------------------------------------
+repo6="$(new_repo)"
+(
+  cd "$repo6"
+  mkdir -p artifacts/core/commands
+  render_command "1.0.0" > artifacts/core/commands/old-cmd.md
+  git add artifacts/core/commands/old-cmd.md
+  git commit -q -m "seed old-cmd at 1.0.0"
+
+  printf '\nExtra line.\n' >> artifacts/core/commands/old-cmd.md
+  git add artifacts/core/commands/old-cmd.md
+  git commit -q -m "tweak command, forget version bump"
+)
+run_case "Case 6 — modified command without bump fails" "$repo6" 1
+
+# -------------------------------------------------------------------------
+# Case 7 — Status M: existing command modified with bump → exit 0
+# -------------------------------------------------------------------------
+repo7="$(new_repo)"
+(
+  cd "$repo7"
+  mkdir -p artifacts/core/commands
+  render_command "1.0.0" > artifacts/core/commands/old-cmd.md
+  git add artifacts/core/commands/old-cmd.md
+  git commit -q -m "seed old-cmd at 1.0.0"
+
+  render_command "1.0.1" > artifacts/core/commands/old-cmd.md
+  printf '\nExtra line.\n' >> artifacts/core/commands/old-cmd.md
+  git add artifacts/core/commands/old-cmd.md
+  git commit -q -m "patch bump command"
+)
+run_case "Case 7 — modified command with bump passes" "$repo7" 0
 
 # -------------------------------------------------------------------------
 # Summary

--- a/specs/0193-command-source-provenance-guards.md
+++ b/specs/0193-command-source-provenance-guards.md
@@ -1,7 +1,7 @@
 ---
 id: "0193"
 slug: command-source-provenance-guards
-status: approved
+status: implemented
 complexity: small
 interaction-mode: AUTO
 related-issue: 1079


### PR DESCRIPTION
## Summary

This pull request extends the `check-skill-versions.sh` and `check-feedback-routing.sh` provenance validation guards and accompanying documentation to cover `command`-kind component sources under `artifacts/**/commands/`. It also adds automated regression tests ensuring modified command sources require version bumps and route feedback to canonical upstream repositories.

## How to read this PR?

Inspect `scripts/check-skill-versions.sh` and `scripts/check-feedback-routing.sh` to see the extended paths and find expressions, followed by `artifacts/FORMAT.md` and `docs/version-bump-convention.md` for updated documentation, and the test suites under `scripts/tests/`.

## How to test this PR?

```bash
bash scripts/tests/test-check-skill-versions.sh
bash scripts/tests/test-check-feedback-routing.sh
bash scripts/check-feedback-routing.sh
task spec:lint
```

## Detailed description (for agents)

Closes #1079. Implements spec 0193 (`specs/0193-command-source-provenance-guards.md`).