### PR TITLE
📝 Mark spec 0113 delta-02 status approved

### DIFF
--- a/specs/0113-shared-mempalace-mcp-daemon.delta-02.md
+++ b/specs/0113-shared-mempalace-mcp-daemon.delta-02.md
@@ -1,7 +1,7 @@
 ---
 id: "0113"
 slug: shared-mempalace-mcp-daemon
-status: draft
+status: approved
 complexity: standard
 interaction-mode: INTERMEDIATE
 related-issue: 1096


### PR DESCRIPTION
Marks spec 0113 delta-02 `status: approved` following its merge in #1097,
matching the convention applied to delta-01.

## How to read this PR?

One line changed: the `status` frontmatter field of
`specs/0113-shared-mempalace-mcp-daemon.delta-02.md`.

## How to test this PR?

- `node scripts/lib/spec-linter.js specs/0113-shared-mempalace-mcp-daemon.delta-02.md` passes.
- `grep '^status:' specs/0113-shared-mempalace-mcp-daemon.delta-02.md` shows `approved`.

## Detailed description (for agents)

- Post-merge administrative bump only; the spec content is unchanged from the
  gated merge of #1097. Merge-authorization for this one-file spec-PR is
  discharged by the plannotator content-approval of the identical content
  (docs/interaction-modes.md → *User-gate definition*).
- Delta specs are exempt from the base-branch `status: draft` lint failure
  (spec 0109), so no CI breakage exists either way — the bump keeps the
  convention recorded by delta-01.