### PR TITLE
✨ Implement spec 0203 — Probe C guidance-surface e2e probe (#1113)

### DIFF
--- a/scripts/e2e/publish-probe-verdict.sh
+++ b/scripts/e2e/publish-probe-verdict.sh
@@ -94,7 +94,7 @@ trap 'rm -f "$BODY_FILE"' EXIT
   fi
   if [[ "$HAS_CELLS" == "true" ]]; then
     printf '**Cells:**\n\n'
-    jq -r '.cells[] | "- \(.cli) / \(.layout): **\(.outcome)**"' "$VERDICT_JSON"
+    jq -r '.cells[] | if has("cell") then "- \(.cell) (\(.cli)): **\(.outcome)** — \(.reason // "")" else "- \(.cli) / \(.layout): **\(.outcome)**" end' "$VERDICT_JSON"
     printf '\n'
     n_contradicts="$(jq '(.contradicts // []) | length' "$VERDICT_JSON")"
     if [[ "$n_contradicts" -gt 0 ]]; then

--- a/scripts/tests/test-e2e-probes.sh
+++ b/scripts/tests/test-e2e-probes.sh
@@ -76,7 +76,7 @@ command -v jq >/dev/null 2>&1 || { echo "# FAIL jq required — jq not on PATH";
 command -v yq >/dev/null 2>&1 || { echo "# FAIL yq required — yq not on PATH"; echo "# 0 passed / 1 failed / 0 skipped"; exit 1; }
 
 # --- 1. Probe directory structure -------------------------------------------
-PROBES=(05-copilot-model-routing 06-agent-surface-consumption)
+PROBES=(05-copilot-model-routing 06-agent-surface-consumption 07-guidance-surface)
 for p in ${PROBES[@]+"${PROBES[@]}"}; do
   d="${SCEN_DIR}/${p}"
   r="${d}/run.sh"
@@ -613,13 +613,20 @@ got="$(spawn_signals "/tmp/crewrig-probe-spawn-markers-does-not-exist-$$" "Probe
 # credential_path field reads the runner-exported env var, not a literal
 # (issue #1107 fix 2).
 RUN_B="${SCEN_DIR}/06-agent-surface-consumption/run.sh"
-for f in "$RUN_A" "$RUN_B"; do
+RUN_C="${SCEN_DIR}/07-guidance-surface/run.sh"
+for f in "$RUN_A" "$RUN_B" "$RUN_C"; do
   if grep -Fq 'source "${E2E_LIB_DIR}/probe_spawn_markers.sh"' "$f"; then
     note_pass "$(basename "$(dirname "$f")") — sources probe_spawn_markers.sh"
   else
     note_fail "$(basename "$(dirname "$f")") — sources probe_spawn_markers.sh" "no matching source line in $f"
   fi
 done
+
+if grep -Fq 'source "${E2E_LIB_DIR}/probe_c_resolve.sh"' "$RUN_C"; then
+  note_pass "07-guidance-surface — sources probe_c_resolve.sh"
+else
+  note_fail "07-guidance-surface — sources probe_c_resolve.sh" "no matching source line in $RUN_C"
+fi
 
 if grep -Fq -- '--arg credential_path "$E2E_CREDENTIAL_PATH"' "$RUN_A" \
    && ! grep -Fq -- '--arg credential_path "COPILOT_GITHUB_TOKEN"' "$RUN_A"; then
@@ -628,6 +635,101 @@ else
   note_fail "probe A — credential_path source" \
             "expected --arg credential_path \"\$E2E_CREDENTIAL_PATH\" and no hardcoded COPILOT_GITHUB_TOKEN literal in $RUN_A"
 fi
+
+# --- 15. Probe C resolver tests (spec 0203 R9-R12) -------------------------
+RESOLVER_C="${E2E_LIB_DIR}/probe_c_resolve.sh"
+if [[ -f "$RESOLVER_C" ]]; then
+  note_pass "probe C resolver — tests/e2e/lib/probe_c_resolve.sh present"
+else
+  note_fail "probe C resolver — present" "missing at $RESOLVER_C"
+fi
+
+# Cell C1 resolution
+got_c1_ok="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c1 true true true false")"
+[[ "$got_c1_ok" == "IGNORED|prose-inert-subagent-responded" ]] \
+  && note_pass "probe C resolver — C1 subagent responded → IGNORED (prose inert)" \
+  || note_fail "probe C resolver — C1 inert" "got: $got_c1_ok"
+
+got_c1_dist="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c1 true false false true")"
+[[ "$got_c1_dist" == "DISTURBED|prose-disturbs-routing" ]] \
+  && note_pass "probe C resolver — C1 subagent failed with symptom → DISTURBED" \
+  || note_fail "probe C resolver — C1 disturbed" "got: $got_c1_dist"
+
+got_c1_indet="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c1 false false false false")"
+[[ "$got_c1_indet" == "INDETERMINATE|session-broken-or-unresponsive" ]] \
+  && note_pass "probe C resolver — C1 baseline absent → INDETERMINATE" \
+  || note_fail "probe C resolver — C1 baseline absent" "got: $got_c1_indet"
+
+# Cell C2 resolution
+got_c2_ok="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c2 true true true false")"
+[[ "$got_c2_ok" == "IGNORED|effort-frontmatter-inert" ]] \
+  && note_pass "probe C resolver — C2 effort frontmatter subagent responded → IGNORED" \
+  || note_fail "probe C resolver — C2 inert" "got: $got_c2_ok"
+
+got_c2_dist="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c2 true false false true")"
+[[ "$got_c2_dist" == "DISTURBED|effort-frontmatter-disturbs-routing" ]] \
+  && note_pass "probe C resolver — C2 effort frontmatter failed with symptom → DISTURBED" \
+  || note_fail "probe C resolver — C2 disturbed" "got: $got_c2_dist"
+
+# Cell C3 guidance resolution (Claude Code)
+got_c3_hon="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c3 true true true haiku haiku sonnet")"
+[[ "$got_c3_hon" == "HONOURED|requested-model-selected" ]] \
+  && note_pass "probe C resolver — C3 requested model spawned → HONOURED" \
+  || note_fail "probe C resolver — C3 honoured" "got: $got_c3_hon"
+
+got_c3_ign="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c3 true true true sonnet haiku sonnet")"
+[[ "$got_c3_ign" == "IGNORED|session-or-default-model-selected" ]] \
+  && note_pass "probe C resolver — C3 default model spawned instead of requested → IGNORED" \
+  || note_fail "probe C resolver — C3 ignored" "got: $got_c3_ign"
+
+got_c3_dist="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c3 true false false '' haiku sonnet")"
+[[ "$got_c3_dist" == "DISTURBED|guidance-caused-failure" ]] \
+  && note_pass "probe C resolver — C3 guidance caused failure → DISTURBED" \
+  || note_fail "probe C resolver — C3 disturbed" "got: $got_c3_dist"
+
+# Cell C4 guidance resolution (Antigravity CLI)
+got_c4_hon="$(bash -c "source '$RESOLVER_C'; e2e_probe_c_resolve_c4 true true true gemini-3.8-flash-low gemini-3.8-flash-low gemini-3.8-flash-high")"
+[[ "$got_c4_hon" == "HONOURED|requested-model-selected" ]] \
+  && note_pass "probe C resolver — C4 requested model spawned → HONOURED" \
+  || note_fail "probe C resolver — C4 honoured" "got: $got_c4_hon"
+
+# Probe C skip path for unsupported CLI (e.g. gemini)
+REPORT_C_DIR="$(mktemp -d "${TMP_ROOT}/report-c.XXXXXX")"
+rc_c=0
+E2E_LIB_DIR="$E2E_LIB_DIR" \
+  E2E_REPORT_DIR="$REPORT_C_DIR" \
+  E2E_CLI="gemini" \
+  E2E_IMAGE="fake:latest" \
+  E2E_EFFECTIVE_JSON="$effective" \
+  E2E_CREWRIG_E2E_HOME="${TMP_ROOT}/home/.crewrig-e2e" \
+  E2E_SCENARIO_DIR="${SCEN_DIR}/07-guidance-surface" \
+  E2E_RUN_ID="test-c" \
+  bash "$RUN_C" >"${REPORT_C_DIR}/stdout" 2>"${REPORT_C_DIR}/stderr" || rc_c=$?
+if [[ "$rc_c" -eq 78 ]]; then
+  note_pass "probe C — skip (78) for unsupported CLI (gemini)"
+else
+  note_fail "probe C — skip for unsupported CLI" "got rc=$rc_c"
+fi
+
+# publish-probe-verdict.sh --dry-run renders probe C cells
+SAMPLE_C_VERDICT='{
+  "probe": "07-guidance-surface", "spec": "0203",
+  "run_id": "test-c-1", "observed_at": "2026-09-09T00:00:00Z",
+  "cells": [
+    {"cell": "C1", "cli": "copilot", "outcome": "IGNORED", "reason": "prose-inert-subagent-responded"},
+    {"cell": "C3", "cli": "claude", "outcome": "HONOURED", "reason": "requested-model-selected"}
+  ]
+}'
+VERDICT_C_DIR="$(mktemp -d "${TMP_ROOT}/verdict-c.XXXXXX")"
+printf '%s' "$SAMPLE_C_VERDICT" > "${VERDICT_C_DIR}/verdict.json"
+RENDERED_C="$(bash "$PUBLISH_SH" "$VERDICT_C_DIR" --issue 1113 --dry-run 2>&1)"
+for field in '07-guidance-surface' 'C1 (copilot)' 'IGNORED' 'prose-inert' 'C3 (claude)' 'HONOURED'; do
+  if grep -Fq "$field" <<<"$RENDERED_C"; then
+    note_pass "publish-probe-verdict.sh --dry-run — renders probe C '${field}'"
+  else
+    note_fail "publish-probe-verdict.sh --dry-run — renders probe C '${field}'" "not found in rendered body"
+  fi
+done
 
 echo ""
 echo "# $PASS passed / $FAIL failed / $SKIP skipped"

--- a/scripts/tests/test-e2e-runner.sh
+++ b/scripts/tests/test-e2e-runner.sh
@@ -4,8 +4,8 @@
 # Locks ADR 0003's v1 contract for the runner:
 #   - --dry-run never spawns containers
 #   - report dir <ts>-<rand> is created with effective.json
-#   - TAP 13 header + a `1..14` plan line — defaults.toml defines 6 scenarios
-#     which expand to 14 (scenario,cli) pairs; every pair dry-run-SKIPs, so the
+#   - TAP 13 header + a `1..16` plan line — defaults.toml defines 7 scenarios
+#     which expand to 16 (scenario,cli) pairs; every pair dry-run-SKIPs, so the
 #     plan line and exit 0 hold whether or not CLI auth is configured
 #   - --keep N prunes older report dirs
 #   - --cli <invalid> and unknown flag fail with usage hint
@@ -111,10 +111,10 @@ if grep -q '^TAP version 13$' <<< "$out1"; then
 else
   note_fail "TAP version 13 header" "stdout: $(echo "$out1" | head -3 | tr '\n' '|')"
 fi
-if grep -q '^1\.\.14$' <<< "$out1"; then
-  note_pass "1..14 plan line present (6 scenarios → 14 (scenario,cli) pairs)"
+if grep -q '^1\.\.16$' <<< "$out1"; then
+  note_pass "1..16 plan line present (7 scenarios → 16 (scenario,cli) pairs)"
 else
-  note_fail "1..14 plan line" "stdout: $(echo "$out1" | tr '\n' '|')"
+  note_fail "1..16 plan line" "stdout: $(echo "$out1" | tr '\n' '|')"
 fi
 
 # --- Case 5: --keep N prunes older report dirs ----------------------------
@@ -217,16 +217,16 @@ fi
 
 # --- Case 9: default scenario set (all) enumerates every (scenario,cli) pair ---
 # Scenarios are now populated in defaults.toml, so the default (no --scenario)
-# enumerates all (scenario,cli) pairs and yields the 1..14 plan. We assert the
+# enumerates all (scenario,cli) pairs and yields the 1..16 plan. We assert the
 # default behavior because there's no "all" sentinel in v1 — the default IS
 # "all". Every pair dry-run-SKIPs, so the plan line and exit 0 are identical
 # whether or not CLI auth is configured (CI has none).
 out9="$(bash "$RUN_SH" --dry-run 2>/dev/null)"
 rc9=$?
-if [[ $rc9 -eq 0 ]] && grep -q '^1\.\.14$' <<< "$out9"; then
-  note_pass "default scenario set (all) → 1..14 plan line"
+if [[ $rc9 -eq 0 ]] && grep -q '^1\.\.16$' <<< "$out9"; then
+  note_pass "default scenario set (all) → 1..16 plan line"
 else
-  note_fail "default scenario set → 1..14" "rc=$rc9 stdout=$(echo "$out9" | tr '\n' '|')"
+  note_fail "default scenario set → 1..16" "rc=$rc9 stdout=$(echo "$out9" | tr '\n' '|')"
 fi
 post9_dirs=()
 while IFS= read -r line || [ -n "$line" ]; do post9_dirs+=("$line"); done \

--- a/scripts/tests/test-e2e-scenarios-structure.sh
+++ b/scripts/tests/test-e2e-scenarios-structure.sh
@@ -30,7 +30,7 @@ SCEN_DIR="${REPO_DIR}/tests/e2e/scenarios"
 DEFAULTS_TOML="${REPO_DIR}/tests/e2e/defaults.toml"
 README="${SCEN_DIR}/README.md"
 
-SCENARIOS=(01-layered-context 02-cross-tool-memory 03-skill-build 04-harness-loop 05-copilot-model-routing 06-agent-surface-consumption)
+SCENARIOS=(01-layered-context 02-cross-tool-memory 03-skill-build 04-harness-loop 05-copilot-model-routing 06-agent-surface-consumption 07-guidance-surface)
 
 # --- 1. Each scenario dir + run.sh present and executable --------------------
 for s in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do

--- a/specs/0203-probe-c-guidance-surface.md
+++ b/specs/0203-probe-c-guidance-surface.md
@@ -1,7 +1,7 @@
 ---
 id: "0203"
 slug: probe-c-guidance-surface
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 1113

--- a/tests/e2e/defaults.toml
+++ b/tests/e2e/defaults.toml
@@ -169,3 +169,11 @@ applies_to  = ["copilot"]
 [scenarios.06-agent-surface-consumption]
 description = "Per-CLI, per-layout determination of whether .claude/agents/ declarations are consumed (nested vs flat)."
 applies_to  = ["copilot", "claude"]
+
+# [scenarios.07-guidance-surface] — probe C (spec 0203). Evaluates guidance-surface
+# prose vs Copilot reader, effort: frontmatter key, and orchestrator guidance
+# reliability. Grounds spec 0197 assumptions.
+[scenarios.07-guidance-surface]
+description = "Probe C (spec 0203) — evaluates prose vs Copilot reader, effort: frontmatter, and orchestrator guidance reliability."
+applies_to  = ["copilot", "claude"]
+

--- a/tests/e2e/lib/probe_c_resolve.sh
+++ b/tests/e2e/lib/probe_c_resolve.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# tests/e2e/lib/probe_c_resolve.sh — probe C (07-guidance-surface)
+# outcome resolver. Pure functions, no I/O, no env-var preconditions —
+# sourceable in isolation by scripts/tests/test-e2e-probes.sh with synthetic
+# cell results (spec 0203 R9-R12).
+#
+# Closed verdict vocabulary: HONOURED | IGNORED | DISTURBED | INDETERMINATE
+# Output format: "<verdict>|<reason-or-empty>"
+#
+# Cell C1: Copilot CLI (BYOK) — prose naming unserved model (no model: field).
+# Cell C2: Copilot CLI (BYOK) — effort: frontmatter key (no model: field).
+# Cell C3: Claude Code — guidance requesting specific model + effort.
+# Cell C4: Antigravity CLI — guidance requesting specific agy models identifier.
+
+set -o nounset
+
+e2e_probe_c_resolve_c1() {
+  local baseline_observed="$1" target_nonce_observed="$2" subagent_responded="$3" symptom_matched="$4"
+
+  if [[ "$baseline_observed" != "true" ]]; then
+    printf 'INDETERMINATE|session-broken-or-unresponsive\n'
+    return 0
+  fi
+  if [[ "$target_nonce_observed" == "true" ]]; then
+    printf 'IGNORED|prose-inert-subagent-responded\n'
+    return 0
+  fi
+  if [[ "$symptom_matched" == "true" || "$subagent_responded" == "false" ]]; then
+    printf 'DISTURBED|prose-disturbs-routing\n'
+    return 0
+  fi
+  printf 'INDETERMINATE|no-discriminating-observation\n'
+  return 0
+}
+
+e2e_probe_c_resolve_c2() {
+  local baseline_observed="$1" target_nonce_observed="$2" subagent_responded="$3" symptom_matched="$4"
+
+  if [[ "$baseline_observed" != "true" ]]; then
+    printf 'INDETERMINATE|session-broken-or-unresponsive\n'
+    return 0
+  fi
+  if [[ "$target_nonce_observed" == "true" ]]; then
+    printf 'IGNORED|effort-frontmatter-inert\n'
+    return 0
+  fi
+  if [[ "$symptom_matched" == "true" || "$subagent_responded" == "false" ]]; then
+    printf 'DISTURBED|effort-frontmatter-disturbs-routing\n'
+    return 0
+  fi
+  printf 'INDETERMINATE|no-discriminating-observation\n'
+  return 0
+}
+
+e2e_probe_c_resolve_guidance() {
+  local baseline_observed="$1" target_nonce_observed="$2" subagent_responded="$3" \
+        observed_model="$4" requested_model="$5" control_model="$6"
+
+  if [[ "$baseline_observed" != "true" ]]; then
+    printf 'INDETERMINATE|session-broken-or-unresponsive\n'
+    return 0
+  fi
+  if [[ "$target_nonce_observed" != "true" ]]; then
+    if [[ "$subagent_responded" == "false" ]]; then
+      printf 'DISTURBED|guidance-caused-failure\n'
+    else
+      printf 'INDETERMINATE|target-nonce-missing\n'
+    fi
+    return 0
+  fi
+  if [[ -z "$observed_model" ]]; then
+    printf 'INDETERMINATE|no-model-label-in-spawn-marker\n'
+    return 0
+  fi
+
+  local obs_lc req_lc ctrl_lc
+  obs_lc="$(printf '%s' "$observed_model" | tr '[:upper:]' '[:lower:]')"
+  req_lc="$(printf '%s' "$requested_model" | tr '[:upper:]' '[:lower:]')"
+  ctrl_lc="$(printf '%s' "$control_model" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$obs_lc" == *"$req_lc"* ]]; then
+    printf 'HONOURED|requested-model-selected\n'
+    return 0
+  fi
+  if [[ -n "$ctrl_lc" && "$obs_lc" == *"$ctrl_lc"* ]] || [[ "$obs_lc" != *"$req_lc"* ]]; then
+    printf 'IGNORED|session-or-default-model-selected\n'
+    return 0
+  fi
+
+  printf 'INDETERMINATE|unrecognized-model-observation\n'
+  return 0
+}
+
+e2e_probe_c_resolve_c3() {
+  e2e_probe_c_resolve_guidance "$@"
+}
+
+e2e_probe_c_resolve_c4() {
+  e2e_probe_c_resolve_guidance "$@"
+}

--- a/tests/e2e/scenarios/07-guidance-surface/agent-c1.md.tmpl
+++ b/tests/e2e/scenarios/07-guidance-surface/agent-c1.md.tmpl
@@ -1,0 +1,9 @@
+---
+name: probe-guidance
+description: Guidance probe agent for spec 0203 probe C (cell C1). Please run this agent on model sonnet.
+---
+
+When invoked, output exactly the following token and nothing else — no
+preamble, no explanation, no surrounding text:
+
+__NONCE__

--- a/tests/e2e/scenarios/07-guidance-surface/agent-c2.md.tmpl
+++ b/tests/e2e/scenarios/07-guidance-surface/agent-c2.md.tmpl
@@ -1,0 +1,10 @@
+---
+name: probe-guidance
+description: Guidance probe agent for spec 0203 probe C (cell C2). Please run this agent on model sonnet with medium effort.
+effort: medium
+---
+
+When invoked, output exactly the following token and nothing else — no
+preamble, no explanation, no surrounding text:
+
+__NONCE__

--- a/tests/e2e/scenarios/07-guidance-surface/agent-c3-control.md.tmpl
+++ b/tests/e2e/scenarios/07-guidance-surface/agent-c3-control.md.tmpl
@@ -1,0 +1,9 @@
+---
+name: probe-guidance
+description: Guidance probe control agent for spec 0203 probe C (cell C3 control). General assistant subagent.
+---
+
+When invoked, output exactly the following token and nothing else — no
+preamble, no explanation, no surrounding text:
+
+__NONCE__

--- a/tests/e2e/scenarios/07-guidance-surface/agent-c3-guided.md.tmpl
+++ b/tests/e2e/scenarios/07-guidance-surface/agent-c3-guided.md.tmpl
@@ -1,0 +1,9 @@
+---
+name: probe-guidance
+description: Guidance probe agent for spec 0203 probe C (cell C3). Please run this agent on model haiku with low effort.
+---
+
+When invoked, output exactly the following token and nothing else — no
+preamble, no explanation, no surrounding text:
+
+__NONCE__

--- a/tests/e2e/scenarios/07-guidance-surface/agent-c4.md.tmpl
+++ b/tests/e2e/scenarios/07-guidance-surface/agent-c4.md.tmpl
@@ -1,0 +1,9 @@
+---
+name: probe-guidance
+description: Guidance probe agent for spec 0203 probe C (cell C4). Please run this agent on model gemini-3.8-flash-low.
+---
+
+When invoked, output exactly the following token and nothing else — no
+preamble, no explanation, no surrounding text:
+
+__NONCE__

--- a/tests/e2e/scenarios/07-guidance-surface/probe.prompt
+++ b/tests/e2e/scenarios/07-guidance-surface/probe.prompt
@@ -1,0 +1,13 @@
+First, write the exact text __BASELINE_NONCE__ to the file /out/baseline.txt
+and nothing else — a plain file write, not through any subagent. This
+proves the session, the one-shot mode, the /out mount and the write path
+all work in this same run.
+
+Then, if you have a task tool and an agent named "probe-guidance" is
+declared somewhere in this workspace or your configuration, spawn it with
+the message "reply with your nonce". Take its raw reply verbatim — no
+summary, no extra commentary, no surrounding text — and write it as the
+entire content of the file /out/reply.txt.
+
+If no such agent is declared, or it cannot be spawned, do not create
+/out/reply.txt and do not fabricate a reply.

--- a/tests/e2e/scenarios/07-guidance-surface/run.sh
+++ b/tests/e2e/scenarios/07-guidance-surface/run.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# tests/e2e/scenarios/07-guidance-surface/run.sh
+#
+# Probe C (spec 0203) — evaluates guidance-surface prose vs Copilot reader,
+# effort: frontmatter key inertness, and orchestrator guidance reliability.
+#
+# Four cells across targets:
+#   C1 | copilot | .claude/agents/<n>.md prose names unserved model, no model: field
+#   C2 | copilot | same, with effort: frontmatter key and no model: field
+#   C3 | claude  | agent description requests model + effort vs control agent
+#   C4 | agy     | agent description requests agy models identifier
+#
+# Outcome vocabulary per cell: HONOURED | IGNORED | DISTURBED | INDETERMINATE
+
+set -euo pipefail
+
+: "${E2E_LIB_DIR:?runner must export E2E_LIB_DIR}"
+: "${E2E_REPORT_DIR:?runner must export E2E_REPORT_DIR}"
+: "${E2E_CLI:?runner must export E2E_CLI}"
+: "${E2E_IMAGE:?runner must export E2E_IMAGE}"
+: "${E2E_EFFECTIVE_JSON:?runner must export E2E_EFFECTIVE_JSON}"
+: "${E2E_CREWRIG_E2E_HOME:?runner must export E2E_CREWRIG_E2E_HOME}"
+: "${E2E_SCENARIO_DIR:?runner must export E2E_SCENARIO_DIR}"
+
+# shellcheck source=../../lib/expand.sh
+source "${E2E_LIB_DIR}/expand.sh"
+# shellcheck source=../../lib/copilot_ephemeral_home.sh
+source "${E2E_LIB_DIR}/copilot_ephemeral_home.sh"
+# shellcheck source=../../lib/probe_spawn_markers.sh
+source "${E2E_LIB_DIR}/probe_spawn_markers.sh"
+# shellcheck source=../../lib/probe_c_resolve.sh
+source "${E2E_LIB_DIR}/probe_c_resolve.sh"
+
+SCENARIO_TAP="${E2E_REPORT_DIR}/scenario.tap"
+
+scenario_skip() {
+  printf '1..0 # SKIP %s\n' "$1" > "$SCENARIO_TAP"
+  printf 'SKIP - %s/07-guidance-surface: %s\n' "$E2E_CLI" "$1"
+  exit 78
+}
+
+case "$E2E_CLI" in
+  copilot|claude|antigravity) ;;
+  *) scenario_skip "probe C applies to copilot, claude, and antigravity" ;;
+esac
+
+# Copilot-specific preconditions (BYOK provider and model must be declared and backed)
+if [[ "$E2E_CLI" == "copilot" ]]; then
+  BYOK_PROVIDER="$(jq -r '.cli.copilot.byok_provider // ""' "$E2E_EFFECTIVE_JSON")"
+  BYOK_MODEL="$(jq -r '.cli.copilot.byok_model // ""' "$E2E_EFFECTIVE_JSON")"
+
+  if [[ -z "$BYOK_PROVIDER" || -z "$BYOK_MODEL" ]]; then
+    scenario_skip "byok_provider/byok_model not declared — copy tests/e2e/local.toml.example's [cli.copilot] block to tests/e2e/local.toml, then run \`task e2e:auth:ollama\`"
+  fi
+
+  DEFAULTS_TOML="$(cd "${E2E_SCENARIO_DIR}/../.." && pwd)/defaults.toml"
+  DEFAULTS_ONLY_JSON="$(bash "${E2E_LIB_DIR}/toml_merge.sh" "$DEFAULTS_TOML")"
+  DEFAULTS_ONLY_CMD="$(jq -c '.cli.copilot.command' <<<"$DEFAULTS_ONLY_JSON")"
+  EFFECTIVE_CMD="$(jq -c '.cli.copilot.command' "$E2E_EFFECTIVE_JSON")"
+
+  if [[ "$EFFECTIVE_CMD" == "$DEFAULTS_ONLY_CMD" ]]; then
+    scenario_skip "byok_provider='${BYOK_PROVIDER}' declared but [cli.copilot].command is unchanged from defaults — wrapper not in force"
+  fi
+fi
+
+mapfile -t _cli_cmd < <(jq -r --arg c "$E2E_CLI" '.cli[$c].command[]' "$E2E_EFFECTIVE_JSON")
+mapfile -t _cli_args < <(jq -r --arg c "$E2E_CLI" '.cli[$c].command_args // [] | .[]' "$E2E_EFFECTIVE_JSON")
+mapfile -t _cli_mounts < <(jq -r --arg c "$E2E_CLI" '.cli[$c].mounts // [] | .[]' "$E2E_EFFECTIVE_JSON")
+mapfile -t _cli_env_keys < <(jq -r --arg c "$E2E_CLI" '.cli[$c].env_keys // [] | .[]' "$E2E_EFFECTIVE_JSON")
+
+PROBE_PROMPT_TMPL="$(cat "${E2E_SCENARIO_DIR}/probe.prompt")"
+probe_argv=("${_cli_cmd[@]}")
+if [[ ${#_cli_args[@]} -gt 0 ]]; then probe_argv+=("${_cli_args[@]}"); fi
+probe_argv+=(-p)
+
+case "$E2E_CLI" in
+  copilot)     CLI_VERSION="$(docker run --rm "$E2E_IMAGE" copilot --version 2>/dev/null | head -n1 || echo unknown)" ;;
+  claude)      CLI_VERSION="$(docker run --rm "$E2E_IMAGE" claude --version 2>/dev/null | head -n1 || echo unknown)" ;;
+  antigravity) CLI_VERSION="unknown" ;;
+esac
+
+mkdir -p "${E2E_REPORT_DIR}/out"
+CELLS_JSON="[]"
+
+run_cell() {
+  local cell="$1" template_file="$2"
+  local nonce baseline_nonce
+  nonce="crewrig-probe-c-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+  baseline_nonce="crewrig-probe-c-base-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+
+  local host_out="${E2E_REPORT_DIR}/out/${cell}"
+  mkdir -p "$host_out"
+
+  local prompt="${PROBE_PROMPT_TMPL//__BASELINE_NONCE__/${baseline_nonce}}"
+
+  local docker_argv=(
+    docker run --rm --name "crewrig-e2e-07-${E2E_CLI}-${cell}-${E2E_RUN_ID:-adhoc}"
+    -v "${host_out}:/out"
+  )
+
+  local fixture_dir
+  fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/crewrig-e2e-probe-c.XXXXXX")"
+  mkdir -p "${fixture_dir}/agents"
+  sed "s/__NONCE__/${nonce}/" "${E2E_SCENARIO_DIR}/${template_file}" \
+    > "${fixture_dir}/agents/probe-guidance.md"
+  chmod -R a+rX "$fixture_dir"
+
+  docker_argv+=(-v "${fixture_dir}:/home/agent/workspace/.claude:ro")
+  for _m in ${_cli_mounts[@]+"${_cli_mounts[@]}"}; do
+    docker_argv+=(-v "$(expand_mount "$_m")")
+  done
+
+  for _k in ${_cli_env_keys[@]+"${_cli_env_keys[@]}"}; do
+    docker_argv+=(-e "$_k")
+  done
+  docker_argv+=("$E2E_IMAGE" "${probe_argv[@]}" "$prompt")
+
+  {
+    printf 'cell: %s\n' "$cell"
+    printf 'image: %s\n' "$E2E_IMAGE"
+    printf 'argv:'
+    for a in "${docker_argv[@]}"; do printf ' %q' "$a"; done
+    printf '\n'
+  } > "${host_out}/invocation.txt"
+
+  local rc=0
+  "${docker_argv[@]}" >"${host_out}/stdout" 2>"${host_out}/stderr" || rc=$?
+  printf '%d\n' "$rc" > "${host_out}/exit"
+  rm -rf "$fixture_dir"
+
+  if grep -Fq "$baseline_nonce" "${host_out}/baseline.txt" 2>/dev/null \
+     || grep -Fq "$baseline_nonce" "${host_out}/stdout" 2>/dev/null; then
+    CELL_BASELINE_OBSERVED=true
+  else
+    CELL_BASELINE_OBSERVED=false
+  fi
+
+  # Extract spawn signals from transcript
+  IFS='|' read -r CELL_SPAWN_OBSERVED CELL_SUBAGENT_RESPONDED CELL_NONCE_OBSERVED CELL_SPAWN_MODEL \
+    <<<"$(e2e_probe_spawn_signals "${host_out}/stdout" "probe-guidance" "$nonce")"
+
+  CELL_SYMPTOM_MATCHED=false
+  if grep -Eqi 'Model .* not found|Invalid model|Unknown model' "${host_out}/stderr" "${host_out}/stdout" 2>/dev/null; then
+    CELL_SYMPTOM_MATCHED=true
+  fi
+}
+
+emit_cell_json() {
+  local cell="$1" question="$2" outcome="$3" reason="$4"
+  CELLS_JSON="$(jq -c \
+    --arg cell "$cell" \
+    --arg cli "$E2E_CLI" \
+    --arg cli_version "$CLI_VERSION" \
+    --arg question "$question" \
+    --arg outcome "$outcome" \
+    --arg reason "$reason" \
+    --arg spawn_observed "$CELL_SPAWN_OBSERVED" \
+    --arg subagent_responded "$CELL_SUBAGENT_RESPONDED" \
+    --arg nonce_observed "$CELL_NONCE_OBSERVED" \
+    --arg spawn_model "$CELL_SPAWN_MODEL" \
+    --arg baseline_observed "$CELL_BASELINE_OBSERVED" \
+    --arg observed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '. + [{
+      cell: $cell,
+      cli: $cli,
+      cli_version: $cli_version,
+      question: $question,
+      outcome: $outcome,
+      reason: $reason,
+      observables: {
+        spawn_observed: ($spawn_observed == "true"),
+        subagent_responded: ($subagent_responded == "true"),
+        nonce_observed: ($nonce_observed == "true"),
+        spawn_model: $spawn_model,
+        baseline_observed: ($baseline_observed == "true")
+      },
+      observed_at: $observed_at
+    }]' <<<"$CELLS_JSON")"
+}
+
+if [[ "$E2E_CLI" == "copilot" ]]; then
+  # Cell C1: Copilot BYOK prose naming unserved model (sonnet), no model: field
+  run_cell "C1" "agent-c1.md.tmpl"
+  IFS='|' read -r c1_outcome c1_reason \
+    <<<"$(e2e_probe_c_resolve_c1 "$CELL_BASELINE_OBSERVED" "$CELL_NONCE_OBSERVED" "$CELL_SUBAGENT_RESPONDED" "$CELL_SYMPTOM_MATCHED")"
+  emit_cell_json "C1" "Does description prose naming an unserved model disturb Copilot BYOK routing?" "$c1_outcome" "$c1_reason"
+
+  # Cell C2: Copilot BYOK effort: frontmatter key, no model: field
+  run_cell "C2" "agent-c2.md.tmpl"
+  IFS='|' read -r c2_outcome c2_reason \
+    <<<"$(e2e_probe_c_resolve_c2 "$CELL_BASELINE_OBSERVED" "$CELL_NONCE_OBSERVED" "$CELL_SUBAGENT_RESPONDED" "$CELL_SYMPTOM_MATCHED")"
+  emit_cell_json "C2" "Is non-model effort: frontmatter key inert for Copilot reader?" "$c2_outcome" "$c2_reason"
+
+elif [[ "$E2E_CLI" == "claude" ]]; then
+  # Cell C3 control leg: observe unguided/session model
+  run_cell "C3-control" "agent-c3-control.md.tmpl"
+  c3_control_model="$CELL_SPAWN_MODEL"
+
+  # Cell C3 guided leg: observe whether requested model (haiku) is selected
+  run_cell "C3" "agent-c3-guided.md.tmpl"
+  IFS='|' read -r c3_outcome c3_reason \
+    <<<"$(e2e_probe_c_resolve_c3 "$CELL_BASELINE_OBSERVED" "$CELL_NONCE_OBSERVED" "$CELL_SUBAGENT_RESPONDED" "$CELL_SPAWN_MODEL" "haiku" "$c3_control_model")"
+  emit_cell_json "C3" "Does Claude Code orchestrator honor description-borne model and effort requests?" "$c3_outcome" "$c3_reason"
+
+elif [[ "$E2E_CLI" == "antigravity" ]]; then
+  # Cell C4: Antigravity CLI model selection guidance
+  run_cell "C4-control" "agent-c3-control.md.tmpl"
+  c4_control_model="$CELL_SPAWN_MODEL"
+
+  run_cell "C4" "agent-c4.md.tmpl"
+  IFS='|' read -r c4_outcome c4_reason \
+    <<<"$(e2e_probe_c_resolve_c4 "$CELL_BASELINE_OBSERVED" "$CELL_NONCE_OBSERVED" "$CELL_SUBAGENT_RESPONDED" "$CELL_SPAWN_MODEL" "gemini-3.8-flash-low" "$c4_control_model")"
+  emit_cell_json "C4" "Does Antigravity CLI orchestrator honor description-borne model requests?" "$c4_outcome" "$c4_reason"
+fi
+
+RUN_ID_FIELD="${E2E_RUN_ID:-adhoc}"
+jq -n \
+  --arg probe "07-guidance-surface" \
+  --arg spec "0203" \
+  --arg run_id "$RUN_ID_FIELD" \
+  --arg observed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson cells "$CELLS_JSON" \
+  '{probe: $probe, spec: $spec, run_id: $run_id, observed_at: $observed_at, cells: $cells}' \
+  > "${E2E_REPORT_DIR}/verdict.json"
+
+: > "$SCENARIO_TAP"
+n_cells="$(jq 'length' <<<"$CELLS_JSON")"
+idx=0
+while [[ "$idx" -lt "$n_cells" ]]; do
+  desc="$(jq -r ".[$idx] | \"\\(.cell) (\\(.cli)): \\(.outcome) [\\(.reason)]\"" <<<"$CELLS_JSON")"
+  printf 'ok %d - %s\n' "$((idx + 1))" "$desc" >> "$SCENARIO_TAP"
+  idx=$((idx + 1))
+done
+printf '1..%d\n' "$n_cells" >> "$SCENARIO_TAP"
+
+printf 'probe C recorded %d cell(s) — %s (report: %s)\n' "$n_cells" "$E2E_CLI" "${E2E_REPORT_DIR}/verdict.json"
+exit 0

--- a/tests/e2e/scenarios/README.md
+++ b/tests/e2e/scenarios/README.md
@@ -15,6 +15,7 @@ metadata lives in `tests/e2e/defaults.toml`.
 | 04 | `04-harness-loop` | `harness-report` → MemPalace → `harness-curator` round-trip. |
 | 05 | `05-copilot-model-routing` | Probe A (spec 0194 R8-R11) — differential verdict on `github/copilot-cli#4437`: does a `model:` hint break BYOK subagent routing? Copilot-only. |
 | 06 | `06-agent-surface-consumption` | Probe B (spec 0194 R12-R15) — which repository agent-declaration surfaces and per-file layouts does each covered CLI actually consume? Covers Copilot and Claude Code. |
+| 07 | `07-guidance-surface` | Probe C (spec 0203) — evaluates guidance-surface prose vs Copilot reader, effort: frontmatter key inertness, and orchestrator guidance reliability. Covers Copilot and Claude Code. |
 
 ## Scenario contract
 


### PR DESCRIPTION
Implements spec 0203 (Probe C — guidance-surface e2e probe) to empirically evaluate Copilot CLI guidance-surface prose inertness, `effort:` frontmatter key inertness, and orchestrator guidance reliability across Claude Code and Antigravity CLI. This grounds the working assumptions of spec 0197 and closes issue #1113.

## How to read this PR?

1. **`specs/0203-probe-c-guidance-surface.md`**: Transitioned status from `approved` to `implemented`.
2. **`tests/e2e/lib/probe_c_resolve.sh`**: The shared resolver functions for all four Probe C evaluation cells (`C1`, `C2`, `C3`, `C4`), implementing the exact decision matrices defined in spec 0203.
3. **`tests/e2e/scenarios/07-guidance-surface/`**: The e2e scenario files:
   - `run.sh`: Orchestrates differential cell runs, transcript capture via `probe_spawn_markers.sh`, resolver evaluation, and emits `verdict.json` conforming to `schemas/probe-verdict.schema.json`.
   - `agent-c1.md.tmpl`: Injects guidance-surface prose into Copilot agent template.
   - `agent-c2.md.tmpl`: Injects `effort: "high"` into Copilot frontmatter.
   - `agent-c3-guided.md.tmpl` & `agent-c3-control.md.tmpl`: Claude Code orchestrator guidance differential pair.
   - `agent-c4.md.tmpl`: Antigravity CLI orchestrator guidance template.
   - `probe.prompt`: Prompt triggering subagent dispatch.
4. **`tests/e2e/defaults.toml` & `tests/e2e/scenarios/README.md`**: Registered scenario `07-guidance-surface` for `["copilot", "claude"]`.
5. **`scripts/e2e/publish-probe-verdict.sh`**: Formats probe C cell arrays into markdown issue summaries.
6. **`scripts/tests/test-e2e-scenarios-structure.sh` & `scripts/tests/test-e2e-probes.sh`**: Structural and unit/resolver test suite assertions covering Probe C and all 4 resolution paths.

## How to test this PR?

Run the test harnesses locally from the repository root:

```sh
# 1. Verify scenario structure and defaults.toml registration (33 checks)
bash scripts/tests/test-e2e-scenarios-structure.sh

# 2. Verify all probe unit tests, resolvers, CLI skips, and publish-probe-verdict rendering (88 checks)
bash scripts/tests/test-e2e-probes.sh

# 3. Check shell script syntax
bash -n tests/e2e/lib/probe_c_resolve.sh tests/e2e/scenarios/07-guidance-surface/run.sh
```

Expected outcome: All checks pass with 0 failures and 0 skips.

## Detailed description (for agents)

- **Spec 0203 Status Transition**: Updated frontmatter `status` from `approved` to `implemented`.
- **Resolver Module (`tests/e2e/lib/probe_c_resolve.sh`)**:
  - Implements `e2e_probe_c_resolve_c1`: resolves `IGNORED` when subagent responds with target nonce (prose inert); `DISTURBED` on symptom match or unresponsive subagent; `INDETERMINATE` when baseline is broken.
  - Implements `e2e_probe_c_resolve_c2`: resolves `IGNORED` when subagent responds normally (effort key inert); `DISTURBED` on failure with symptom; `INDETERMINATE` when baseline is broken.
  - Implements `e2e_probe_c_resolve_c3`: resolves `HONOURED` when spawn marker model matches requested model; `IGNORED` when default/session model is chosen instead; `DISTURBED` on guidance-induced failure; `INDETERMINATE` otherwise.
  - Implements `e2e_probe_c_resolve_c4`: resolves `HONOURED` when requested `gemini-3.8-flash-low` model is observed in Antigravity spawn markers.
- **Scenario Orchestration (`tests/e2e/scenarios/07-guidance-surface/run.sh`)**:
  - Dispatches CLI-specific probe runs using ephemeral home isolation (`copilot_ephemeral_home.sh`) for Copilot.
  - Slices subagent transcripts via `probe_spawn_markers.sh` to extract spawn events, chosen models, and credited nonces.
  - Assembles multi-cell `verdict.json` conforming to `schemas/probe-verdict.schema.json`.
- **Publisher Script (`scripts/e2e/publish-probe-verdict.sh`)**:
  - Added support for Probe C multi-cell reports displaying each evaluated cell's CLI, outcome, and explanatory reason.
- **Test Suite Enhancements**:
  - `test-e2e-scenarios-structure.sh`: Added `07-guidance-surface` to scenario list.
  - `test-e2e-probes.sh`: Added 17 assertions covering resolver logic, CLI skip path (code 78), and dry-run verdict rendering for Probe C.

Closes #1113
