### PR TITLE
✨ Re-rank Antigravity model offerings to resolve to medium/high reasoning variants (#1134)

### DIFF
--- a/.agents/agents/accessibility-auditor/AGENT.md
+++ b/.agents/agents/accessibility-auditor/AGENT.md
@@ -4,7 +4,7 @@ description: "WCAG 2.1 Level AA compliance auditor. Runs an automated baseline s
 manually verifies keyboard navigation, color contrast, interactive element
 accessibility, image alt text quality, ARIA correctness, and motion preferences.
 Produces a structured findings report (violation → warning → informational).
-Does not implement fixes — hands the report to frontend-developer or astro-developer. Run this agent on the gemini-3.8-flash-low model."
+Does not implement fixes — hands the report to frontend-developer or astro-developer. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/accessibility-tester/AGENT.md
+++ b/.agents/agents/accessibility-tester/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility-tester
-description: "Runs WCAG 2.1/2.2 (AA/AAA) compliance checks on a page or user flow using axe-core. Reports violations by impact level with remediation guidance and outputs a CI-ready test suite. Run this agent on the gemini-3.8-flash-low model."
+description: "Runs WCAG 2.1/2.2 (AA/AAA) compliance checks on a page or user flow using axe-core. Reports violations by impact level with remediation guidance and outputs a CI-ready test suite. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/architect/AGENT.md
+++ b/.agents/agents/architect/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius. Run this agent on the gemini-3.1-pro-low model."
+description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius. Run this agent on the gemini-3.1-pro-high model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/astro-developer/AGENT.md
+++ b/.agents/agents/astro-developer/AGENT.md
@@ -4,7 +4,7 @@ description: "Specialist implementer for Astro projects. Scaffolds and configure
 projects, implements pages/layouts/components, wires Content Collections,
 configures integrations, handles deployment, and diagnoses build failures.
 Receives tokens from designer, copy from copywriter, and hands off to
-seo-specialist and accessibility-auditor. Run this agent on the gemini-3.1-pro-low model."
+seo-specialist and accessibility-auditor. Run this agent on the gemini-3.1-pro-high model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/ci-configurator/AGENT.md
+++ b/.agents/agents/ci-configurator/AGENT.md
@@ -4,7 +4,7 @@ description: "Specialist agent for configuring a new CI pipeline for a supported
 engine — GitHub Actions or GitLab CI/CD. Resolves the engine target,
 produces a commit-ready pipeline (hand-authored for GitHub Actions,
 derived from the platform-neutral capability reference for GitLab),
-and validates its own output before delivery. Run this agent on the gemini-3.1-pro-low model."
+and validates its own output before delivery. Run this agent on the gemini-3.1-pro-high model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/ci-debugger/AGENT.md
+++ b/.agents/agents/ci-debugger/AGENT.md
@@ -2,7 +2,7 @@
 name: ci-debugger
 description: "Specialist agent for diagnosing and fixing failing GitHub Actions
 pipelines. Systematically produces a
-symptom → hypothesis → evidence → fix chain. Run this agent on the gemini-3.1-pro-low model."
+symptom → hypothesis → evidence → fix chain. Run this agent on the gemini-3.1-pro-high model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/ci-parity/AGENT.md
+++ b/.agents/agents/ci-parity/AGENT.md
@@ -5,7 +5,7 @@ and reconciling the divergences it reports. Runs the harness,
 interprets its fail-closed output, classifies each divergence by kind,
 and reconciles it — auto-applying only the deterministic
 regenerate-and-re-verify case, and diagnosing-and-proposing for every
-judgment-bearing case. Run this agent on the gemini-3.1-pro-low model."
+judgment-bearing case. Run this agent on the gemini-3.1-pro-high model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/copywriter/AGENT.md
+++ b/.agents/agents/copywriter/AGENT.md
@@ -3,7 +3,7 @@ name: copywriter
 description: "Content production specialist. Interviews the product brief, produces a
 content outline for review, then writes final page copy (hero, features,
 social proof, CTA). Delivers structured Markdown ready for handoff to
-frontend-developer or astro-developer. Does NOT make layout or visual decisions. Run this agent on the gemini-3.8-flash-low model."
+frontend-developer or astro-developer. Does NOT make layout or visual decisions. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/designer/AGENT.md
+++ b/.agents/agents/designer/AGENT.md
@@ -2,7 +2,7 @@
 name: designer
 description: "Visual design specialist. Produces color palette tokens, typographic scale,
 spacing scale, tokens.css, and Tailwind config extensions. Delivers component
-anatomy specifications and design rationale. Does NOT write application code. Run this agent on the gemini-3.1-pro-low model."
+anatomy specifications and design rationale. Does NOT write application code. Run this agent on the gemini-3.1-pro-high model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/developer/AGENT.md
+++ b/.agents/agents/developer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done. Run this agent on the gemini-3.1-pro-low model."
+description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done. Run this agent on the gemini-3.1-pro-high model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/doc-writer/AGENT.md
+++ b/.agents/agents/doc-writer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: doc-writer
-description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimizes for documents that age well and stays close to the code where possible. Run this agent on the gemini-3.8-flash-low model."
+description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimizes for documents that age well and stays close to the code where possible. Run this agent on the gemini-3.8-flash-medium model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/frontend-developer/AGENT.md
+++ b/.agents/agents/frontend-developer/AGENT.md
@@ -3,7 +3,7 @@ name: frontend-developer
 description: "UI implementation specialist. Translates designer token files and component
 anatomy specs into production-ready CSS and markup. Ensures WCAG 2.1 AA
 compliance, optimizes asset delivery, and hands off to astro-developer for
-framework wiring. Does NOT own Astro-specific build concerns. Run this agent on the gemini-3.1-pro-low model."
+framework wiring. Does NOT own Astro-specific build concerns. Run this agent on the gemini-3.1-pro-high model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/pr-logbook/AGENT.md
+++ b/.agents/agents/pr-logbook/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: pr-logbook
-description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions. Run this agent on the gemini-3.8-flash-low model."
+description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions. Run this agent on the gemini-3.8-flash-medium model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/pr-reviewer/AGENT.md
+++ b/.agents/agents/pr-reviewer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: pr-reviewer
-description: "Independent PR reviewer agent. Spawns cold — receives a references-only brief (seat key, PR number, the revision the seat last examined, where its prior verdicts live), never authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`). Run this agent on the gemini-3.1-pro-low model."
+description: "Independent PR reviewer agent. Spawns cold — receives a references-only brief (seat key, PR number, the revision the seat last examined, where its prior verdicts live), never authoring-session context. Activates the pr-reviewer skill to audit the diff, runs linter scripts against changed files, and posts a structured review verdict via the forge CLI (`gh`). Run this agent on the gemini-3.1-pro-high model."
 enable_write_tools: true
 metadata:
   provenance:

--- a/.agents/agents/regression-sentinel/AGENT.md
+++ b/.agents/agents/regression-sentinel/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: regression-sentinel
-description: "Runs a smoke or regression pass against a staging or production URL. Diffs results against a stored baseline and surfaces new failures with screenshots and traces. Run this agent on the gemini-3.8-flash-low model."
+description: "Runs a smoke or regression pass against a staging or production URL. Diffs results against a stored baseline and surfaces new failures with screenshots and traces. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/scenario-author/AGENT.md
+++ b/.agents/agents/scenario-author/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-author
-description: "Writes automated test scenarios from a natural-language description of a user journey. Generates Playwright TypeScript or RobotFramework .robot files with page-object model, fixtures, and meaningful assertions. Run this agent on the gemini-3.8-flash-low model."
+description: "Writes automated test scenarios from a natural-language description of a user journey. Generates Playwright TypeScript or RobotFramework .robot files with page-object model, fixtures, and meaningful assertions. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/security/AGENT.md
+++ b/.agents/agents/security/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked. Run this agent on the gemini-3.1-pro-low model."
+description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked. Run this agent on the gemini-3.1-pro-high model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/seo-specialist/AGENT.md
+++ b/.agents/agents/seo-specialist/AGENT.md
@@ -4,7 +4,7 @@ description: "SEO audit specialist. Audits <head> completeness, Open Graph/Twitt
 structured data (JSON-LD), heading hierarchy, sitemap/robots.txt, internal links,
 and performance signals with direct SEO impact. Produces a prioritized findings
 report (critical → high → low). Does not write copy — hands recommendations to
-copywriter or astro-developer. Run this agent on the gemini-3.8-flash-low model."
+copywriter or astro-developer. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/spec-author/AGENT.md
+++ b/.agents/agents/spec-author/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: spec-author
-description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket. Run this agent on the gemini-3.1-pro-low model."
+description: "Specification authoring agent. Turns a raw user intent into a draft spec file under `/specs/` conforming to `docs/spec-format.md`, in the interaction mode declared by the parent ticket. Run this agent on the gemini-3.1-pro-high model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/tester/AGENT.md
+++ b/.agents/agents/tester/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: tester
-description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug. Run this agent on the gemini-3.1-pro-low model."
+description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug. Run this agent on the gemini-3.1-pro-high model."
 metadata:
   provenance:
     canonical: "https://github.com/crewrig/crewrig"

--- a/.agents/agents/visual-regression-tester/AGENT.md
+++ b/.agents/agents/visual-regression-tester/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: visual-regression-tester
-description: "Detects unintended visual changes between two states of a page by comparing screenshots at multiple viewports. Uses Playwright's toHaveScreenshot or equivalent diff thresholds. Run this agent on the gemini-3.8-flash-low model."
+description: "Detects unintended visual changes between two states of a page by comparing screenshots at multiple viewports. Uses Playwright's toHaveScreenshot or equivalent diff thresholds. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/.agents/agents/web-conformity-checker/AGENT.md
+++ b/.agents/agents/web-conformity-checker/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: web-conformity-checker
-description: "Verifies that a page or site matches a given specification — design system, functional requirements, or API contract. Produces a gap report and optionally a Playwright assertion script. Run this agent on the gemini-3.8-flash-low model."
+description: "Verifies that a page or site matches a given specification — design system, functional requirements, or API contract. Produces a gap report and optionally a Playwright assertion script. Run this agent on the gemini-3.8-flash-medium model."
 license: Apache-2.0
 metadata:
   provenance:

--- a/docs/agent-profile-migration.md
+++ b/docs/agent-profile-migration.md
@@ -19,28 +19,28 @@ source declares one lives in [`docs/authoring.md`](authoring.md).
 
 | Source | Tier before | Rung after | Claude Code | Gemini CLI | GitHub Copilot CLI | Antigravity CLI |
 |---|---|---|---|---|---|---|
-| `accessibility-auditor` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `accessibility-tester` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `architect` | `opus` | `xhigh` | prose, `opus` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `astro-developer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `ci-configurator` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `ci-debugger` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `ci-parity` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `copywriter` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `designer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `developer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `doc-writer` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `frontend-developer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `pr-logbook` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `pr-reviewer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `regression-sentinel` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `scenario-author` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `security` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `seo-specialist` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `spec-author` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `tester` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-low` |
-| `visual-regression-tester` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
-| `web-conformity-checker` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-low` |
+| `accessibility-auditor` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `accessibility-tester` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `architect` | `opus` | `xhigh` | prose, `opus` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `astro-developer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `ci-configurator` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `ci-debugger` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `ci-parity` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `copywriter` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `designer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `developer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `doc-writer` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `frontend-developer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `pr-logbook` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `pr-reviewer` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `regression-sentinel` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `scenario-author` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `security` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `seo-specialist` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `spec-author` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `tester` | `sonnet` | `high` | prose, `sonnet` | `model: gemini-3.1-pro-preview` | unchanged | prose, `gemini-3.1-pro-high` |
+| `visual-regression-tester` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
+| `web-conformity-checker` | `haiku` | `medium` | prose, `haiku` | `model: gemini-3.5-flash` | unchanged | prose, `gemini-3.8-flash-medium` |
 | `harness-curator` | *(none)* | *(none)* | unchanged | unchanged | unchanged | unchanged |
 
 23 rows: 22 migrated sources plus `harness-curator`, the tree's one

--- a/model-mappings/antigravity.yml
+++ b/model-mappings/antigravity.yml
@@ -39,34 +39,8 @@ surfaces:
               no orchestrator behaviour (spec 0197 R43).
 
 offerings:
-  - id: gemini-3.8-flash-low
-    rank: 1
-    native-value: gemini-3.8-flash-low
-    provides:
-      intelligence: medium
-      reasoning: low
-      specialization: general
-    encodes:
-      intelligence: flash
-      reasoning: low
-    supports-reasoning-surface: false
-    grounds:
-      - declares: native-value
-        citation: >-
-          RR -> Antigravity CLI -> Declaration surface: `agy models` lists
-          `gemini-3.8-flash-low` among its fourteen reported identifiers.
-      - declares: provides.intelligence
-        assumption: >-
-          The rung rests on the vendor's own family naming — pro above
-          flash — observable in the identifier but not a capability
-          measurement (spec 0197 `## Open questions`).
-      - declares: provides.reasoning
-        assumption: >-
-          The rung rests on the identifier's own suffix, observable but not a
-          capability measurement, per the same open question.
-
   - id: gemini-3.8-flash-medium
-    rank: 2
+    rank: 1
     native-value: gemini-3.8-flash-medium
     provides:
       intelligence: medium
@@ -81,14 +55,47 @@ offerings:
         citation: >-
           RR -> Antigravity CLI -> Declaration surface: `agy models` lists
           `gemini-3.8-flash-medium` among its fourteen reported identifiers.
+          Rank 1 is the lowest rank this mapping declares, so R23's
+          lowest-rank pick selects this offering whenever the candidate set
+          includes it and reasoning is omitted: at the declared `medium`
+          rung (spec 0197 delta-01, issue #1134).
       - declares: provides.intelligence
         assumption: >-
-          Same ground as `gemini-3.8-flash-low` above: vendor family naming,
+          Same ground as `gemini-3.8-flash-low` below: vendor family naming,
           not a capability measurement.
       - declares: provides.reasoning
         assumption: >-
-          Same ground as `gemini-3.8-flash-low` above: the identifier's own
+          Same ground as `gemini-3.8-flash-low` below: the identifier's own
           suffix, not a capability measurement.
+
+  - id: gemini-3.8-flash-low
+    rank: 2
+    native-value: gemini-3.8-flash-low
+    provides:
+      intelligence: medium
+      reasoning: low
+      specialization: general
+    encodes:
+      intelligence: flash
+      reasoning: low
+    supports-reasoning-surface: false
+    grounds:
+      - declares: native-value
+        citation: >-
+          RR -> Antigravity CLI -> Declaration surface: `agy models` lists
+          `gemini-3.8-flash-low` among its fourteen reported identifiers.
+          Rank 2 is higher than `gemini-3.8-flash-medium` (rank 1), so this
+          offering is reached when R21 narrows to encoded reasoning `low`
+          (spec 0197 delta-01, issue #1134).
+      - declares: provides.intelligence
+        assumption: >-
+          The rung rests on the vendor's own family naming — pro above
+          flash — observable in the identifier but not a capability
+          measurement (spec 0197 `## Open questions`).
+      - declares: provides.reasoning
+        assumption: >-
+          The rung rests on the identifier's own suffix, observable but not a
+          capability measurement, per the same open question.
 
   - id: gemini-3.8-flash-high
     rank: 3
@@ -106,6 +113,8 @@ offerings:
         citation: >-
           RR -> Antigravity CLI -> Declaration surface: `agy models` lists
           `gemini-3.8-flash-high` among its fourteen reported identifiers.
+          Rank 3 is reached when R21 narrows to encoded reasoning `high`
+          at the `medium` intelligence rung (spec 0197 delta-01, issue #1134).
       - declares: provides.intelligence
         assumption: >-
           Same ground as `gemini-3.8-flash-low` above: vendor family naming,
@@ -115,44 +124,8 @@ offerings:
           Same ground as `gemini-3.8-flash-low` above: the identifier's own
           suffix, not a capability measurement.
 
-  - id: gemini-3.1-pro-low
-    rank: 4
-    native-value: gemini-3.1-pro-low
-    provides:
-      intelligence: high
-      reasoning: low
-      specialization: general
-    encodes:
-      intelligence: pro
-      reasoning: low
-    supports-reasoning-surface: false
-    grounds:
-      - declares: native-value
-        citation: >-
-          RR -> Antigravity CLI -> Declaration surface: `agy models` lists
-          `gemini-3.1-pro-low` among its fourteen reported identifiers. Rank 4
-          is the lower of the two ranks this mapping gives its two `high`-rung
-          offerings (`gemini-3.1-pro-low` and `gemini-3.1-pro-high`, the
-          mapping's highest declared rung), so R23's lowest-rank pick selects
-          THIS offering — not `gemini-3.1-pro-high` — whenever the candidate
-          set is the pair of them: at the declared `high` rung itself absent a
-          narrowing `reasoning` declaration, and under R17's ceiling clause
-          for a declared `xhigh`, `xxhigh` or `max` rung, since this mapping
-          declares no higher rung (confirmed by hand, by
-          `scripts/check-model-mappings.sh --print-selection` and by the
-          golden per-rung table in `scripts/tests/test-check-model-mappings.sh`).
-      - declares: provides.intelligence
-        assumption: >-
-          The rung rests on the vendor's own family naming — pro above
-          flash — observable in the identifier but not a capability
-          measurement (spec 0197 `## Open questions`).
-      - declares: provides.reasoning
-        assumption: >-
-          The rung rests on the identifier's own suffix, observable but not a
-          capability measurement, per the same open question.
-
   - id: gemini-3.1-pro-high
-    rank: 5
+    rank: 4
     native-value: gemini-3.1-pro-high
     provides:
       intelligence: high
@@ -166,27 +139,58 @@ offerings:
       - declares: native-value
         citation: >-
           RR -> Antigravity CLI -> Declaration surface: `agy models` lists
-          `gemini-3.1-pro-high` among its fourteen reported identifiers. Rank 5
-          is the HIGHER of this mapping's two `high`-rung ranks, so R23's
-          lowest-rank pick never selects this offering from the intelligence
-          axis alone — `gemini-3.1-pro-low` (rank 4) is selected instead, both
-          at the declared `high` rung and under R17's ceiling clause for a
-          declared `xhigh`, `xxhigh` or `max` rung (confirmed by hand, by
+          `gemini-3.1-pro-high` among its fourteen reported identifiers. Rank 4
+          is the lower of the two ranks this mapping gives its two `high`-rung
+          offerings (`gemini-3.1-pro-high` and `gemini-3.1-pro-low`, the
+          mapping's highest declared rung), so R23's lowest-rank pick selects
+          THIS offering — not `gemini-3.1-pro-low` — whenever the candidate
+          set is the pair of them: at the declared `high` rung itself absent a
+          narrowing `reasoning` declaration, and under R17's ceiling clause
+          for a declared `xhigh`, `xxhigh` or `max` rung, since this mapping
+          declares no higher rung (confirmed by hand, by
           `scripts/check-model-mappings.sh --print-selection` and by the
-          golden per-rung table in `scripts/tests/test-check-model-mappings.sh`
-          — an earlier version of this citation claimed the opposite and was
-          corrected). This offering is reached only through R21's
-          encoded-reasoning narrowing: a profile declaring `reasoning: high`
-          alongside an `intelligence` rung that both `pro-low` and `pro-high`
-          satisfy narrows the `high`-rung candidate set to the offering whose
-          encoded reasoning token matches exactly, which is this one.
+          golden per-rung table in `scripts/tests/test-check-model-mappings.sh`;
+          spec 0197 delta-01, issue #1134).
       - declares: provides.intelligence
         assumption: >-
-          Same ground as `gemini-3.1-pro-low` above: vendor family naming,
+          The rung rests on the vendor's own family naming — pro above
+          flash — observable in the identifier but not a capability
+          measurement (spec 0197 `## Open questions`).
+      - declares: provides.reasoning
+        assumption: >-
+          The rung rests on the identifier's own suffix, observable but not a
+          capability measurement, per the same open question.
+
+  - id: gemini-3.1-pro-low
+    rank: 5
+    native-value: gemini-3.1-pro-low
+    provides:
+      intelligence: high
+      reasoning: low
+      specialization: general
+    encodes:
+      intelligence: pro
+      reasoning: low
+    supports-reasoning-surface: false
+    grounds:
+      - declares: native-value
+        citation: >-
+          RR -> Antigravity CLI -> Declaration surface: `agy models` lists
+          `gemini-3.1-pro-low` among its fourteen reported identifiers. Rank 5
+          is the HIGHER of this mapping's two `high`-rung ranks, so R23's
+          lowest-rank pick never selects this offering from the intelligence
+          axis alone — `gemini-3.1-pro-high` (rank 4) is selected instead, both
+          at the declared `high` rung and under R17's ceiling clause for a
+          declared `xhigh`, `xxhigh` or `max` rung (spec 0197 delta-01,
+          issue #1134). This offering is reached when R21 narrows to encoded
+          reasoning `low` (or as nearest-lower fallback for `medium`).
+      - declares: provides.intelligence
+        assumption: >-
+          Same ground as `gemini-3.1-pro-high` above: vendor family naming,
           not a capability measurement.
       - declares: provides.reasoning
         assumption: >-
-          Same ground as `gemini-3.1-pro-low` above: the identifier's own
+          Same ground as `gemini-3.1-pro-high` above: the identifier's own
           suffix, not a capability measurement.
 
 observed-not-declared:

--- a/scripts/tests/test-agent-profile-migration.sh
+++ b/scripts/tests/test-agent-profile-migration.sh
@@ -174,17 +174,17 @@ assert_copilot() {
 
 assert_claude doc-writer haiku
 assert_gemini doc-writer gemini-3.5-flash
-assert_antigravity doc-writer gemini-3.8-flash-low
+assert_antigravity doc-writer gemini-3.8-flash-medium
 assert_copilot doc-writer
 
 assert_claude developer sonnet
 assert_gemini developer gemini-3.1-pro-preview
-assert_antigravity developer gemini-3.1-pro-low
+assert_antigravity developer gemini-3.1-pro-high
 assert_copilot developer
 
 assert_claude architect opus
 assert_gemini architect gemini-3.1-pro-preview
-assert_antigravity architect gemini-3.1-pro-low
+assert_antigravity architect gemini-3.1-pro-high
 assert_copilot architect
 
 echo ""

--- a/scripts/tests/test-check-model-mappings.sh
+++ b/scripts/tests/test-check-model-mappings.sh
@@ -667,8 +667,8 @@ else
 fi
 
 if assert_selection_table "$REPO_DIR/model-mappings/antigravity.yml" \
-     gemini-3.8-flash-low gemini-3.8-flash-low gemini-3.8-flash-low \
-     gemini-3.1-pro-low gemini-3.1-pro-low gemini-3.1-pro-low gemini-3.1-pro-low; then
+     gemini-3.8-flash-medium gemini-3.8-flash-medium gemini-3.8-flash-medium \
+     gemini-3.1-pro-high gemini-3.1-pro-high gemini-3.1-pro-high gemini-3.1-pro-high; then
   echo "PASS  antigravity.yml golden per-rung table"
   pass=$((pass + 1))
 else
@@ -793,16 +793,16 @@ assert_yq "copilot declares a zero-offerings block" "$COPILOT_MAP" '. | has("zer
 # encodes.
 ANTIGRAVITY_MAP="$REPO_DIR/model-mappings/antigravity.yml"
 assert_yq "antigravity has exactly five offerings" "$ANTIGRAVITY_MAP" '.offerings | length' "5"
-assert_yq "antigravity offering 1 encodes and provides matching reasoning (low)" "$ANTIGRAVITY_MAP" \
-  '.offerings[0].encodes.reasoning + "|" + .offerings[0].provides.reasoning' "low|low"
-assert_yq "antigravity offering 2 encodes and provides matching reasoning (medium)" "$ANTIGRAVITY_MAP" \
-  '.offerings[1].encodes.reasoning + "|" + .offerings[1].provides.reasoning' "medium|medium"
+assert_yq "antigravity offering 1 encodes and provides matching reasoning (medium)" "$ANTIGRAVITY_MAP" \
+  '.offerings[0].encodes.reasoning + "|" + .offerings[0].provides.reasoning' "medium|medium"
+assert_yq "antigravity offering 2 encodes and provides matching reasoning (low)" "$ANTIGRAVITY_MAP" \
+  '.offerings[1].encodes.reasoning + "|" + .offerings[1].provides.reasoning' "low|low"
 assert_yq "antigravity offering 3 encodes and provides matching reasoning (high)" "$ANTIGRAVITY_MAP" \
   '.offerings[2].encodes.reasoning + "|" + .offerings[2].provides.reasoning' "high|high"
-assert_yq "antigravity offering 4 encodes and provides matching reasoning (low)" "$ANTIGRAVITY_MAP" \
-  '.offerings[3].encodes.reasoning + "|" + .offerings[3].provides.reasoning' "low|low"
-assert_yq "antigravity offering 5 encodes and provides matching reasoning (high)" "$ANTIGRAVITY_MAP" \
-  '.offerings[4].encodes.reasoning + "|" + .offerings[4].provides.reasoning' "high|high"
+assert_yq "antigravity offering 4 encodes and provides matching reasoning (high)" "$ANTIGRAVITY_MAP" \
+  '.offerings[3].encodes.reasoning + "|" + .offerings[3].provides.reasoning' "high|high"
+assert_yq "antigravity offering 5 encodes and provides matching reasoning (low)" "$ANTIGRAVITY_MAP" \
+  '.offerings[4].encodes.reasoning + "|" + .offerings[4].provides.reasoning' "low|low"
 
 # Named edit 3 (antigravity half) — the guidance item's ground is an
 # assumption, not a citation.

--- a/scripts/tests/test-model-resolution.sh
+++ b/scripts/tests/test-model-resolution.sh
@@ -103,7 +103,7 @@ model: gemini-3.1-pro-preview'
 
 assert_frontmatter ".agents/agents/architect/AGENT.md" ".agents/agents/architect/AGENT.md" \
 "name: architect
-description: \"Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius. Run this agent on the gemini-3.1-pro-low model.\"
+description: \"Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius. Run this agent on the gemini-3.1-pro-high model.\"
 metadata:
   provenance:
     canonical: \"https://github.com/crewrig/crewrig\"
@@ -282,7 +282,7 @@ if [ "$RESOLVED_OFFERING_ID" = "gemini-3.8-flash-high" ] \
   && [ "${#EMIT_FM_LINES[@]}" -eq 0 ] \
   && [ "$EMIT_PROSE" = "Run this agent on the gemini-3.8-flash-high model." ] \
   && [ "$(diag_count)" -eq 0 ]; then
-  ok "C4 — composite offering: gemini-3.8-flash-high selected (medium-rung floor selects gemini-3.8-flash-low alone), zero records"
+  ok "C4 — composite offering: gemini-3.8-flash-high selected (medium-rung floor selects gemini-3.8-flash-medium alone), zero records"
 else
   bad "C4 — composite offering carries reasoning" "offering=$RESOLVED_OFFERING_ID prose=[$EMIT_PROSE] n_diag=$(diag_count)"
 fi

--- a/specs/0197-model-mapping.delta-01.md
+++ b/specs/0197-model-mapping.delta-01.md
@@ -1,7 +1,7 @@
 ---
 id: "0197"
 slug: model-mapping
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 1134


### PR DESCRIPTION
Re-ranks the model offerings in `model-mappings/antigravity.yml` so that declared intelligence rungs resolve to balanced and capable reasoning variants (`gemini-3.8-flash-medium` for `medium`, `gemini-3.1-pro-high` for `high`/`xhigh`/`xxhigh`/`max`) rather than the lowest-reasoning models (`gemini-3.8-flash-low` and `gemini-3.1-pro-low`) when no explicit reasoning rung is declared. Implements Spec 0197 Delta-01.

Closes #1134

### How to read this PR?
1. Start with `model-mappings/antigravity.yml` to see the re-ordered offerings list (ranks 1 to 5) and updated citations/grounds.
2. Review the regenerated compiled outputs in `.agents/agents/*/AGENT.md` (22 files) showing `gemini-3.8-flash-medium` for the 10 `medium` agents and `gemini-3.1-pro-high` for the 12 `high`/`xhigh` agents.
3. Review `docs/agent-profile-migration.md` updating the Antigravity column to match.
4. Review test suites `scripts/tests/test-check-model-mappings.sh`, `scripts/tests/test-agent-profile-migration.sh`, and `scripts/tests/test-model-resolution.sh`.
5. Review frontmatter status transition in `specs/0197-model-mapping.delta-01.md` (`status: implemented`).

### How to test this PR?
Run the validation and regression suites:
```sh
bash scripts/check-model-mappings.sh
bash scripts/tests/test-check-model-mappings.sh
bash scripts/tests/test-agent-profile-migration.sh
bash scripts/tests/test-model-resolution.sh
bash scripts/build-components.sh --check
```

### Detailed description (for agents)
Under requirement R44 of spec 0197 (modified by spec 0197 delta-01), the Antigravity mapping re-ranks offerings as:
- Rank 1: `gemini-3.8-flash-medium` (intelligence: medium, reasoning: medium)
- Rank 2: `gemini-3.8-flash-low` (intelligence: medium, reasoning: low)
- Rank 3: `gemini-3.8-flash-high` (intelligence: medium, reasoning: high)
- Rank 4: `gemini-3.1-pro-high` (intelligence: high, reasoning: high)
- Rank 5: `gemini-3.1-pro-low` (intelligence: high, reasoning: low)

Consequently:
- Declared `intelligence: medium` profiles without a reasoning specification resolve to `gemini-3.8-flash-medium` (rank 1).
- Declared `high`, `xhigh`, `xxhigh`, `max` profiles resolve to `gemini-3.1-pro-high` (rank 4).
- Explicit `reasoning: ...` declarations continue to select exact or nearest lower rungs via R21.
