### PR TITLE
✨ Enable reasoning surface on Claude Code haiku offering (#1135)

### DIFF
--- a/model-mappings/claude.yml
+++ b/model-mappings/claude.yml
@@ -99,7 +99,7 @@ offerings:
       specialization: general
     encodes:
       intelligence: haiku
-    supports-reasoning-surface: false
+    supports-reasoning-surface: true
     grounds:
       - declares: native-value
         citation: >-
@@ -111,17 +111,17 @@ offerings:
           Spec 0195 R7's normative anchor table calibrates rung 3 `medium` on
           Claude Code `haiku` (spec 0197 R36).
       - declares: supports-reasoning-surface
-        assumption: >-
-          The per-model fact is unconfirmed: neither `claude --help` nor
-          artifacts/FORMAT.md states an effort carve-out for Haiku either way
-          (RR -> Claude Code -> Per-model constraints). Carried as an
-          assumption on the fact, as spec 0197 R36 requires.
+        citation: >-
+          Live empirical verification on Claude Code 2.1.263: the `haiku` alias
+          resolves to `claude-haiku-4-5-20251001`, which natively supports
+          extended thinking. An agent defined with `model: haiku` and `effort:
+          medium` cleanly executes and emits thinking tokens without error
+          (spec 0197 delta-02 R36).
       - declares: supports-reasoning-surface.behavior
         citation: >-
-          Content gate of issue #1111: the maintainer directed that an
-          unsupported effort be ignored rather than raised as an error, which
-          is the behaviour this `false` encodes (spec 0197 R36). R15 makes both
-          readings of the underlying fact non-blocking either way.
+          Spec 0197 delta-02 R36: with `supports-reasoning-surface: true`,
+          Claude Code directs a declared reasoning rung to `effort:` in
+          frontmatter and to the guidance surface prose without dropping.
   - id: sonnet
     rank: 2
     native-value: sonnet

--- a/scripts/tests/test-check-model-mappings.sh
+++ b/scripts/tests/test-check-model-mappings.sh
@@ -748,12 +748,12 @@ assert_yq "claude offering 4 is fable, rank 4, rung xxhigh" "$CLAUDE_MAP" \
   '.offerings[3].id + "|" + (.offerings[3].rank | tostring) + "|" + .offerings[3].provides.intelligence' \
   "fable|4|xxhigh"
 
-# haiku: supports-reasoning-surface false, with both R36 grounds present and
-# of the right kind (assumption on the fact, citation on the behavior).
-assert_yq "claude haiku supports-reasoning-surface is false" "$CLAUDE_MAP" \
-  '.offerings[0]."supports-reasoning-surface" | tostring' "false"
-assert_yq "claude haiku carries an assumption ground on supports-reasoning-surface" "$CLAUDE_MAP" \
-  '[.offerings[0].grounds[] | select(.declares == "supports-reasoning-surface")] | .[0] | has("assumption")' "true"
+# haiku: supports-reasoning-surface true, with both R36 grounds present and
+# of the right kind (citation on the fact per spec 0197 delta-02, citation on the behavior).
+assert_yq "claude haiku supports-reasoning-surface is true" "$CLAUDE_MAP" \
+  '.offerings[0]."supports-reasoning-surface" | tostring' "true"
+assert_yq "claude haiku carries a citation ground on supports-reasoning-surface" "$CLAUDE_MAP" \
+  '[.offerings[0].grounds[] | select(.declares == "supports-reasoning-surface")] | .[0] | has("citation")' "true"
 assert_yq "claude haiku carries a citation ground on supports-reasoning-surface.behavior" "$CLAUDE_MAP" \
   '[.offerings[0].grounds[] | select(.declares == "supports-reasoning-surface.behavior")] | .[0] | has("citation")' "true"
 

--- a/scripts/tests/test-model-resolution.sh
+++ b/scripts/tests/test-model-resolution.sh
@@ -242,12 +242,11 @@ FIXTURE="$TMP_ROOT/probe.md"
 write_fixture "$FIXTURE" "intelligence: medium" "reasoning: medium"
 resolve_agent probe "$FIXTURE" claude
 if [ "$RESOLVED_OFFERING_ID" = "haiku" ] \
-  && [ "${#EMIT_FM_LINES[@]}" -eq 0 ] \
-  && [ "$EMIT_PROSE" = "Run this agent on the haiku model." ] \
-  && [ "$(diag_count)" -eq 2 ] \
-  && diag_has "$(printf 'model-drop\tprobe\tclaude\tmetadata.model.reasoning\tmedium\tunsupported-on-model')" \
-              "$(printf 'model-note\tprobe\tclaude\tguard-withheld\tterms=defect-not-established-fixed,copilot-reader-consumes-claude-surface surface=guidance')"; then
-  ok "C1 — canonical example: haiku selected, no fm fields, reasoning sentence omitted, one drop + one guard note"
+  && fm_has "effort: medium" \
+  && [ "$EMIT_PROSE" = "Run this agent on the haiku model. Give its work medium reasoning effort." ] \
+  && [ "$(diag_count)" -eq 1 ] \
+  && diag_has "$(printf 'model-note\tprobe\tclaude\tguard-withheld\tterms=defect-not-established-fixed,copilot-reader-consumes-claude-surface surface=guidance')"; then
+  ok "C1 — canonical example: haiku selected, effort: medium in frontmatter, 2-line guidance prose, zero drops + one guard note"
 else
   bad "C1 — canonical example" "offering=$RESOLVED_OFFERING_ID prose=[$EMIT_PROSE] n_fm=${#EMIT_FM_LINES[@]}" "${DIAG_LINES[@]+"${DIAG_LINES[@]}"}"
 fi
@@ -707,14 +706,14 @@ else
   bad "M1 — mutating haiku's native-value" "got prose: [$EMIT_PROSE]"
 fi
 
-# --- M2 — deleting reasoning: medium removes the reasoning drop and adds
-# no other record (the before/after contrast: C1's fixture has 2 records,
-# the reasoning axis removed leaves exactly 1 — the guard note alone).
+# --- M2 — removing reasoning: medium drops the reasoning record and adds
+# no other (the before/after contrast: with unsupported-on-model, 2 records -> 1).
+M2_ROOT="$(mutated_root m2 '.offerings[0]["supports-reasoning-surface"] = false')"
 write_fixture "$FIXTURE" "intelligence: medium" "reasoning: medium"
-resolve_agent probe "$FIXTURE" claude
+REPO_DIR="$M2_ROOT" resolve_agent probe "$FIXTURE" claude
 m2_before_count=$(diag_count)
 write_fixture "$FIXTURE" "intelligence: medium"
-resolve_agent probe "$FIXTURE" claude
+REPO_DIR="$M2_ROOT" resolve_agent probe "$FIXTURE" claude
 m2_after_count=$(diag_count)
 if [ "$m2_before_count" -eq 2 ] && [ "$m2_after_count" -eq 1 ] \
   && ! diag_has "$(printf 'model-drop\tprobe\tclaude\tmetadata.model.reasoning\tmedium\tunsupported-on-model')"; then
@@ -750,19 +749,15 @@ fi
 M5_ROOT="$(mutated_root m5 '(.surfaces[] | select(.id == "guidance") | .template) = "Run this agent on the {{modell}} model.\nGive its work {{reasoning}} reasoning effort.\n"')"
 write_fixture "$FIXTURE" "intelligence: medium" "reasoning: medium"
 REPO_DIR="$M5_ROOT" resolve_agent probe "$FIXTURE" claude
-if [ -z "$EMIT_PROSE" ] || ! grep -qF '{{modell}}' <<< "$EMIT_PROSE"; then
-  if [ -z "$EMIT_PROSE" ]; then
-    ok "M5 — an unrecognised {{modell}} placeholder omits its sentence (both template lines dropped, empty prose)"
-  else
-    bad "M5 — unrecognised placeholder rendered literally" "prose=[$EMIT_PROSE]"
-  fi
+if [ "$EMIT_PROSE" = "Give its work medium reasoning effort." ] && ! grep -qF '{{modell}}' <<< "$EMIT_PROSE"; then
+  ok "M5 — an unrecognised {{modell}} placeholder omits its sentence (line 1 omitted, line 2 survives)"
 else
   bad "M5 — unrecognised placeholder rendered literally" "prose=[$EMIT_PROSE]"
 fi
 
-# --- M6 — haiku encodes reasoning: medium: C1's unsupported-on-model drop
-# disappears (D11's directed-by-selection guard now fires on this cell).
-M6_ROOT="$(mutated_root m6 '.offerings[0].encodes.reasoning = "medium"')"
+# --- M6 — haiku encodes reasoning: medium: with supports-reasoning-surface false,
+# D11's directed-by-selection guard suppresses the unsupported-on-model drop.
+M6_ROOT="$(mutated_root m6 '.offerings[0]["supports-reasoning-surface"] = false | .offerings[0].encodes.reasoning = "medium"')"
 write_fixture "$FIXTURE" "intelligence: medium" "reasoning: medium"
 REPO_DIR="$M6_ROOT" resolve_agent probe "$FIXTURE" claude
 if ! diag_has "$(printf 'model-drop\tprobe\tclaude\tmetadata.model.reasoning\tmedium\tunsupported-on-model')"; then

--- a/specs/0197-model-mapping.delta-02.md
+++ b/specs/0197-model-mapping.delta-02.md
@@ -1,7 +1,7 @@
 ---
 id: "0197"
 slug: model-mapping
-status: approved
+status: implemented
 complexity: small
 interaction-mode: MINIMAL
 related-issue: 1135


### PR DESCRIPTION
Enables the reasoning surface on the `haiku` offering in `model-mappings/claude.yml` (`supports-reasoning-surface: true`), grounding it in live empirical verification of Claude Code 2.1.263 (`claude-haiku-4-5-20251001` natively executing under `effort: medium` and emitting thinking tokens without error). Implements Spec 0197 Delta-02.

Closes #1135

### How to read this PR?
1. Start with `model-mappings/claude.yml` to see the `haiku` offering updated with `supports-reasoning-surface: true` and citation grounds.
2. Review test suite updates in `scripts/tests/test-check-model-mappings.sh` (asserting `supports-reasoning-surface: true` and citation grounds) and `scripts/tests/test-model-resolution.sh` (canonical example C1 now directing `effort: medium` to frontmatter and 2-line guidance prose without dropping).
3. Review `specs/0197-model-mapping.delta-02.md` transitioning to `status: implemented`.

### How to test this PR?
Run the validation and regression test suites:
```sh
bash scripts/check-model-mappings.sh
bash scripts/tests/test-check-model-mappings.sh
bash scripts/tests/test-agent-profile-migration.sh
bash scripts/tests/test-model-resolution.sh
bash scripts/build-components.sh --check
```

### Detailed description (for agents)
Under requirement 36 of spec 0197 (as replaced by spec 0197 delta-02), all four Claude Code offerings declare `supports-reasoning-surface: true`. When a capability profile declaring `intelligence: medium` and an explicit reasoning rung (e.g. `reasoning: medium`) is resolved against Claude Code:
- The offering `haiku` is selected.
- The shared-read guard (spec 0143 delta-01 R8) suppresses only `model:`, keeping it in guidance prose.
- The `effort:` frontmatter key is directed to frontmatter (`effort: medium`).
- Both sentences render in guidance prose (`Run this agent on the haiku model. Give its work medium reasoning effort.`).
- No `unsupported-on-model` drop is emitted.
Zero component drift is verified across the 22 core agents (none declare `metadata.model.reasoning:`).
